### PR TITLE
Scan Status badge should show 'Scheduled' when next_run is set

### DIFF
--- a/frontend/src/pages/Scanner.tsx
+++ b/frontend/src/pages/Scanner.tsx
@@ -514,9 +514,11 @@ const Scanner: React.FC = () => {
                 <span className="text-gray-400">Status</span>
                 <span className={`px-2 py-1 rounded text-xs font-medium ${isScanning
                   ? 'bg-blue-500/20 text-blue-400'
-                  : 'bg-green-500/20 text-green-400'
+                  : statusBlock?.next_run
+                    ? 'bg-purple-500/20 text-purple-400'
+                    : 'bg-green-500/20 text-green-400'
                   }`}>
-                  {isScanning ? 'Running' : 'Ready'}
+                  {isScanning ? 'Running' : statusBlock?.next_run ? 'Scheduled' : 'Ready'}
                 </span>
               </div>
 


### PR DESCRIPTION
## Summary
Automated implementation for issue #16.

## Preview
- Frontend: http://localhost:11633
- Backend API: http://localhost:11680/docs

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #16"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #16"
```

---
*Generated by MarketHawk Dark Factory*