### PR TITLE
Dark factory: fetch PR review comments on Continue

### DIFF
--- a/.archon/workflows/archon-dark-factory.yaml
+++ b/.archon/workflows/archon-dark-factory.yaml
@@ -38,7 +38,15 @@ nodes:
 
   - id: fetch-issue
     bash: |
-      gh issue view $parse-intent.output.issue_number --json title,body,labels,comments
+      N=$parse-intent.output.issue_number
+      ISSUE_DATA=$(gh issue view "$N" --json title,body,labels,comments)
+      PR_NUM=$(gh pr list --head "feat/issue-${N}" --json number --jq '.[0].number // empty')
+      if [ -n "$PR_NUM" ]; then
+        PR_DATA=$(gh pr view "$PR_NUM" --json reviews,comments)
+        echo "$ISSUE_DATA" | jq --argjson pr "$PR_DATA" '. + {pr_reviews: $pr}'
+      else
+        echo "$ISSUE_DATA"
+      fi
     depends_on: [parse-intent]
     timeout: 15000
 


### PR DESCRIPTION
## Summary
Automated implementation for issue omniscient/dark-factory#53.

## Preview
- Frontend: http://localhost:11833
- Backend API: http://localhost:11880/docs

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#53"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#53"
```

---
*Generated by MarketHawk Dark Factory*