### PR TITLE
feat: backlog scheduler — Kanban flow controller for dark factory (closes #2)

### DIFF
--- a/dark-factory/Dockerfile
+++ b/dark-factory/Dockerfile
@@ -63,11 +63,12 @@ RUN git clone https://github.com/coleam00/Archon.git /opt/archon && \
 # Workspace directory
 RUN mkdir -p /workspace
 
-# Copy entrypoint, preview template, and seed data
+# Copy entrypoint, scheduler, preview template, and seed data
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY scheduler.sh /opt/dark-factory/scheduler.sh
 COPY docker-compose.preview.yml /opt/dark-factory/docker-compose.preview.yml
 COPY seed_preview.sql /opt/dark-factory/seed_preview.sql
-RUN chmod +x /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh /opt/dark-factory/scheduler.sh
 
 WORKDIR /workspace
 

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -69,3 +69,85 @@ dispatch() {
   echo "Dispatching: $command"
   docker compose -f /workspace/project/docker-compose.yml --profile factory run -d --rm dark-factory "$command"
 }
+
+# --- Board state ---
+fetch_board_items() {
+  gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 200
+}
+
+get_items_by_status() {
+  local items="$1"
+  local status_name="$2"
+  echo "$items" | jq -c "[.items[] | select(.status == \"$status_name\") | select(.content.type == \"Issue\")]"
+}
+
+has_skip_label() {
+  local item="$1"
+  local labels
+  labels=$(echo "$item" | jq -r '.labels[]?' 2>/dev/null)
+  IFS=',' read -ra SKIP_ARRAY <<< "$SKIP_LABELS"
+  for skip in "${SKIP_ARRAY[@]}"; do
+    if echo "$labels" | grep -qi "$skip"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+get_issue_number() {
+  local item="$1"
+  echo "$item" | jq -r '.content.number'
+}
+
+# --- WIP limits ---
+fetch_wip_limits() {
+  local result
+  result=$(gh api graphql -f query='
+    query {
+      node(id: "'"$PROJECT_ID"'") {
+        ... on ProjectV2 {
+          field(name: "Status") {
+            ... on ProjectV2SingleSelectField {
+              options { id name description }
+            }
+          }
+        }
+      }
+    }
+  ' 2>/dev/null) || true
+  echo "$result"
+}
+
+get_column_limit() {
+  local wip_data="$1"
+  local option_id="$2"
+  local desc
+  desc=$(echo "$wip_data" | jq -r --arg id "$option_id" \
+    '.data.node.field.options[] | select(.id == $id) | .description // ""' 2>/dev/null)
+  if echo "$desc" | grep -qoP 'limit:\s*\K\d+'; then
+    echo "$desc" | grep -oP 'limit:\s*\K\d+'
+  else
+    echo "999"
+  fi
+}
+
+# --- Dependency checking ---
+dependencies_met() {
+  local issue_num="$1"
+  local board_items="$2"
+  local body
+  body=$(gh issue view "$issue_num" --json body -q '.body' 2>/dev/null) || return 0
+  local deps
+  deps=$(echo "$body" | grep -oP 'Depends on:\s*#\K\d+' || true)
+  if [ -z "$deps" ]; then
+    return 0
+  fi
+  while IFS= read -r dep_num; do
+    local dep_status
+    dep_status=$(echo "$board_items" | jq -r ".items[] | select(.content.number == $dep_num) | .status" 2>/dev/null)
+    if [ "$dep_status" != "Done" ]; then
+      return 1
+    fi
+  done <<< "$deps"
+  return 0
+}

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -232,7 +232,7 @@ while true; do
   MAX_IN_REVIEW=$(get_column_limit "$WIP_DATA" "$STATUS_IN_REVIEW")
 
   # --- Priority 1: In Review items with new comments ---
-  for item in $(echo "$IN_REVIEW" | jq -c '.[]'); do
+  while IFS= read -r item; do
     [ -n "$DISPATCHED" ] && break
     ISSUE=$(get_issue_number "$item")
     if has_skip_label "$item"; then continue; fi
@@ -258,10 +258,10 @@ while true; do
         ;;
       SKIP) ;;
     esac
-  done
+  done < <(echo "$IN_REVIEW" | jq -c '.[]')
 
   # --- Priority 2: Blocked items (retry) ---
-  for item in $(echo "$BLOCKED" | jq -c '.[]'); do
+  while IFS= read -r item; do
     [ -n "$DISPATCHED" ] && break
     ISSUE=$(get_issue_number "$item")
     if has_skip_label "$item"; then continue; fi
@@ -273,10 +273,10 @@ while true; do
     increment_retry "$ISSUE"
     dispatch "Fix issue #${ISSUE}"
     DISPATCHED="Fix issue #${ISSUE}"
-  done
+  done < <(echo "$BLOCKED" | jq -c '.[]')
 
   # --- Priority 3: Ready items (new work) ---
-  for item in $(echo "$READY" | jq -c '.[]'); do
+  while IFS= read -r item; do
     [ -n "$DISPATCHED" ] && break
     ISSUE=$(get_issue_number "$item")
     if has_skip_label "$item"; then continue; fi
@@ -287,7 +287,7 @@ while true; do
 
     dispatch "Fix issue #${ISSUE}"
     DISPATCHED="Fix issue #${ISSUE}"
-  done
+  done < <(echo "$READY" | jq -c '.[]')
 
   # --- Log cycle summary ---
   if [ -n "$DISPATCHED" ]; then

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -208,3 +208,93 @@ ${comment_text}"
     *) echo "SKIP" ;;
   esac
 }
+
+# --- Main loop ---
+echo "Backlog scheduler started (poll every ${POLL_INTERVAL}s)"
+
+while true; do
+  DISPATCHED=""
+
+  # Fetch board state
+  BOARD_ITEMS=$(fetch_board_items 2>/dev/null) || { echo "[$(date -u +%FT%TZ)] error=gh_api_failed"; sleep "$POLL_INTERVAL"; continue; }
+
+  IN_REVIEW=$(get_items_by_status "$BOARD_ITEMS" "In Review")
+  BLOCKED=$(get_items_by_status "$BOARD_ITEMS" "Blocked")
+  READY=$(get_items_by_status "$BOARD_ITEMS" "Ready")
+  IN_PROGRESS=$(get_items_by_status "$BOARD_ITEMS" "In Progress")
+
+  IN_PROGRESS_COUNT=$(echo "$IN_PROGRESS" | jq 'length')
+  IN_REVIEW_COUNT=$(echo "$IN_REVIEW" | jq 'length')
+
+  # Read WIP limits
+  WIP_DATA=$(fetch_wip_limits)
+  MAX_IN_PROGRESS=$(get_column_limit "$WIP_DATA" "$STATUS_IN_PROGRESS")
+  MAX_IN_REVIEW=$(get_column_limit "$WIP_DATA" "$STATUS_IN_REVIEW")
+
+  # --- Priority 1: In Review items with new comments ---
+  for item in $(echo "$IN_REVIEW" | jq -c '.[]'); do
+    [ -n "$DISPATCHED" ] && break
+    ISSUE=$(get_issue_number "$item")
+    if has_skip_label "$item"; then continue; fi
+
+    NEW_COMMENTS=$(get_new_comments "$ISSUE")
+    COMMENT_COUNT=$(echo "$NEW_COMMENTS" | jq 'length')
+    if [ "$COMMENT_COUNT" -eq 0 ]; then continue; fi
+
+    TITLE=$(echo "$item" | jq -r '.content.title')
+    VERDICT=$(classify_comments "$ISSUE" "$TITLE" "$NEW_COMMENTS")
+
+    case "$VERDICT" in
+      MERGE)
+        dispatch "Close issue #${ISSUE}"
+        DISPATCHED="Close issue #${ISSUE}"
+        ;;
+      CONTINUE)
+        if ! is_issue_running "$ISSUE"; then
+          dispatch "Continue issue #${ISSUE}"
+          DISPATCHED="Continue issue #${ISSUE}"
+          reset_retry "$ISSUE"
+        fi
+        ;;
+      SKIP) ;;
+    esac
+  done
+
+  # --- Priority 2: Blocked items (retry) ---
+  for item in $(echo "$BLOCKED" | jq -c '.[]'); do
+    [ -n "$DISPATCHED" ] && break
+    ISSUE=$(get_issue_number "$item")
+    if has_skip_label "$item"; then continue; fi
+    if is_issue_running "$ISSUE"; then continue; fi
+
+    RETRIES=$(get_retry_count "$ISSUE")
+    if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then continue; fi
+
+    increment_retry "$ISSUE"
+    dispatch "Fix issue #${ISSUE}"
+    DISPATCHED="Fix issue #${ISSUE}"
+  done
+
+  # --- Priority 3: Ready items (new work) ---
+  for item in $(echo "$READY" | jq -c '.[]'); do
+    [ -n "$DISPATCHED" ] && break
+    ISSUE=$(get_issue_number "$item")
+    if has_skip_label "$item"; then continue; fi
+    if [ "$IN_PROGRESS_COUNT" -ge "$MAX_IN_PROGRESS" ]; then break; fi
+    if [ "$IN_REVIEW_COUNT" -ge "$MAX_IN_REVIEW" ]; then break; fi
+    if ! dependencies_met "$ISSUE" "$BOARD_ITEMS"; then continue; fi
+    if is_issue_running "$ISSUE"; then continue; fi
+
+    dispatch "Fix issue #${ISSUE}"
+    DISPATCHED="Fix issue #${ISSUE}"
+  done
+
+  # --- Log cycle summary ---
+  if [ -n "$DISPATCHED" ]; then
+    echo "[$(date -u +%FT%TZ)] in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} dispatched=\"${DISPATCHED}\""
+  else
+    echo "[$(date -u +%FT%TZ)] in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} skip=nothing_to_do"
+  fi
+
+  sleep "$POLL_INTERVAL"
+done

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -151,3 +151,60 @@ dependencies_met() {
   done <<< "$deps"
   return 0
 }
+
+# --- Comment interpretation ---
+get_new_comments() {
+  local issue_num="$1"
+  local comments
+  comments=$(gh issue view "$issue_num" --json comments -q '.comments' 2>/dev/null) || { echo "[]"; return; }
+
+  local factory_idx
+  factory_idx=$(echo "$comments" | jq 'map(.body) | to_entries | map(select(.value | test("Posted by MarketHawk Dark Factory"))) | last | .key // -1')
+
+  if [ "$factory_idx" = "-1" ]; then
+    echo "[]"
+    return
+  fi
+
+  local start_idx=$((factory_idx + 1))
+  local total
+  total=$(echo "$comments" | jq 'length')
+  if [ "$start_idx" -ge "$total" ]; then
+    echo "[]"
+    return
+  fi
+
+  echo "$comments" | jq --argjson s "$start_idx" '.[$s:]'
+}
+
+classify_comments() {
+  local issue_num="$1"
+  local title="$2"
+  local comments_json="$3"
+
+  local comment_text
+  comment_text=$(echo "$comments_json" | jq -r '.[] | "[\(.author.login)] \(.body)"')
+
+  local prompt
+  prompt="You are a PR comment classifier. Read the comments below and decide
+the intent. Reply with exactly one word: MERGE, CONTINUE, or SKIP.
+
+MERGE — the reviewer approves the PR (e.g. \"looks good\", \"ship it\",
+\"approved\", \"LGTM\", thumbs up, ready to merge)
+CONTINUE — the reviewer wants changes (e.g. \"fix the tests\",
+\"can you rename X\", \"this needs error handling\", specific feedback)
+SKIP — the comment is informational, a question, or unclear intent
+(e.g. \"interesting approach\", \"what does this do?\", bot comments)
+
+PR #${issue_num}: ${title}
+Comments since last factory run:
+${comment_text}"
+
+  local result
+  result=$(echo "$prompt" | claude -p --model haiku 2>/dev/null | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
+
+  case "$result" in
+    MERGE|CONTINUE|SKIP) echo "$result" ;;
+    *) echo "SKIP" ;;
+  esac
+}

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Configuration ---
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+SKIP_LABELS="needs-discussion,epic"
+MAX_RETRIES="${MAX_RETRIES:-3}"
+STATE_FILE="/tmp/scheduler-state.json"
+
+# Board constants
+PROJECT_NUMBER=1
+OWNER="omniscient"
+PROJECT_ID="PVT_kwHOAAFds84BWh4w"
+STATUS_FIELD="PVTSSF_lAHOAAFds84BWh4wzhR1VaA"
+STATUS_READY="61e4505c"
+STATUS_IN_PROGRESS="47fc9ee4"
+STATUS_IN_REVIEW="df73e18b"
+STATUS_BLOCKED="93d87b2f"
+STATUS_DONE="98236657"
+
+# --- Validate required environment ---
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "ERROR: GH_TOKEN is not set. Add it to .archon/.env" >&2
+  exit 1
+fi
+if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "ERROR: Set CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY in .archon/.env" >&2
+  exit 1
+fi
+
+# Initialize retry state
+if [ ! -f "$STATE_FILE" ]; then
+  echo '{}' > "$STATE_FILE"
+fi
+
+# --- Retry tracking ---
+get_retry_count() {
+  local issue_num="$1"
+  jq -r --arg n "$issue_num" '.[$n] // 0' "$STATE_FILE"
+}
+
+increment_retry() {
+  local issue_num="$1"
+  local current
+  current=$(get_retry_count "$issue_num")
+  local new_count=$((current + 1))
+  local tmp
+  tmp=$(mktemp)
+  jq --arg n "$issue_num" --argjson c "$new_count" '.[$n] = $c' "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+}
+
+reset_retry() {
+  local issue_num="$1"
+  local tmp
+  tmp=$(mktemp)
+  jq --arg n "$issue_num" 'del(.[$n])' "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+}
+
+# --- Duplicate dispatch prevention ---
+is_issue_running() {
+  local issue_num="$1"
+  docker ps --format '{{.Command}}' 2>/dev/null | grep -q "#${issue_num}" && return 0
+  return 1
+}
+
+# --- Dispatch ---
+dispatch() {
+  local command="$1"
+  echo "Dispatching: $command"
+  docker compose -f /workspace/project/docker-compose.yml --profile factory run -d --rm dark-factory "$command"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,6 +292,25 @@ services:
     profiles:
       - factory
 
+  # Backlog Scheduler — polls GitHub board and dispatches dark factory runs
+  backlog-scheduler:
+    build:
+      context: ./dark-factory
+      dockerfile: Dockerfile
+    container_name: backlog-scheduler
+    restart: unless-stopped
+    entrypoint: ["/opt/dark-factory/scheduler.sh"]
+    env_file:
+      - path: .archon/.env
+        required: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - .:/workspace/project:ro
+    networks:
+      - factory-network
+    profiles:
+      - scheduler
+
 volumes:
   postgres_data:
     external: true


### PR DESCRIPTION
## Summary

- Adds `dark-factory/scheduler.sh` — a 300-line bash polling loop that reads the GitHub project board every 30s and dispatches dark factory runs based on board state
- Adds `backlog-scheduler` Docker service under the `scheduler` profile with `restart: unless-stopped`
- Implements the full priority waterfall: In Review (comment classification via Claude Haiku) → Blocked (retry up to 3x) → Ready (new work respecting WIP limits and dependencies)

## Key behaviors

- **Comment classification**: Pipes new PR comments to `claude -p --model haiku` for one-word intent (MERGE/CONTINUE/SKIP)
- **WIP limits**: Read from board column descriptions via GraphQL, not hardcoded
- **Dependency checking**: Parses `Depends on: #N` from issue bodies, verifies prereqs are Done
- **Duplicate prevention**: Checks `docker ps` before dispatching
- **Skip labels**: Items with `needs-discussion` or `epic` labels are never picked up
- **One dispatch per cycle**, one-line structured logging per cycle

## Files changed

| File | Change |
|------|--------|
| `dark-factory/scheduler.sh` | New — polling loop and all decision logic |
| `dark-factory/Dockerfile` | Copy + chmod scheduler.sh into image |
| `docker-compose.yml` | Add `backlog-scheduler` service |

## Test plan

- [x] Image builds successfully
- [x] `scheduler.sh` is present and executable in the image at `/opt/dark-factory/scheduler.sh`
- [x] Scheduler starts and prints startup message
- [x] First cycle reads board state (24 items), identifies 2 Ready items
- [x] Dispatches `Fix issue #34` (first eligible Ready item)
- [x] Log line format matches spec: `[timestamp] in_progress=0/999 in_review=0/999 dispatched="Fix issue #34"`
- [x] Fixed bash word-splitting bug found during smoke test (for-in → while-read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)