### PR TITLE
Mocked Polygon news + endpoint tests

### DIFF
--- a/backend/tests/api/test_news.py
+++ b/backend/tests/api/test_news.py
@@ -1,0 +1,263 @@
+"""
+Integration tests for news API endpoints.
+Runs against a real Postgres DB (via testcontainers).
+Polygon is never called — seed_news_articles populates the DB directly,
+and mock_news_provider patches httpx for any test touching POST /refresh.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.main import app
+from app.core.database import get_db
+from tests.fixtures.providers import mock_news_provider, seed_news_articles  # noqa: F401
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/news/recent — list
+# ---------------------------------------------------------------------------
+
+
+def test_recent_empty_db_returns_empty_list(db: Session):
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get("/api/news/recent")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_recent_returns_seeded_articles(db: Session):
+    seed_news_articles(db, count=3)
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get("/api/news/recent")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 3
+
+
+def test_recent_response_shape(db: Session):
+    seed_news_articles(db, count=1)
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get("/api/news/recent")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    article = response.json()[0]
+    assert "id" in article
+    assert "title" in article
+    assert "published_utc" in article
+    assert "article_url" in article
+    assert "tickers" in article
+
+
+def test_recent_ordered_newest_first(db: Session):
+    seed_news_articles(db, count=3)
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get("/api/news/recent")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    articles = response.json()
+    times = [a["published_utc"] for a in articles]
+    assert times == sorted(times, reverse=True)
+
+
+def test_recent_capped_at_100_articles(db: Session):
+    seed_news_articles(db, count=105)
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get("/api/news/recent")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert len(response.json()) == 100
+
+
+# ---------------------------------------------------------------------------
+# GET /api/news/recent?ticker=X — filter by ticker
+# ---------------------------------------------------------------------------
+
+
+def test_recent_ticker_filter_returns_matching_articles(db: Session):
+    seed_news_articles(db, count=2, tickers=["AAPL"])
+    seed_news_articles(db, count=2, tickers=["MSFT"])
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get("/api/news/recent?ticker=AAPL")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    for article in data:
+        assert "AAPL" in article["tickers"]
+
+
+def test_recent_ticker_filter_no_match_returns_empty(db: Session):
+    seed_news_articles(db, count=3, tickers=["NVDA"])
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get("/api/news/recent?ticker=TSLA")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_recent_ticker_filter_is_case_insensitive(db: Session):
+    seed_news_articles(db, count=2, tickers=["AAPL"])
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get("/api/news/recent?ticker=aapl")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert len(response.json()) == 2
+
+
+def test_recent_no_ticker_param_returns_all_articles(db: Session):
+    seed_news_articles(db, count=2, tickers=["AAPL"])
+    seed_news_articles(db, count=2, tickers=["MSFT"])
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get("/api/news/recent")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert len(response.json()) == 4
+
+
+# ---------------------------------------------------------------------------
+# GET /api/news/preferences
+# ---------------------------------------------------------------------------
+
+
+def test_get_preferences_creates_default_when_none(db: Session):
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get("/api/news/preferences")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["tracked_tickers"] == []
+    assert data["tracked_universes"] == []
+
+
+def test_get_preferences_response_shape(db: Session):
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get("/api/news/preferences")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "id" in data
+    assert "tracked_tickers" in data
+    assert "tracked_universes" in data
+    assert "refresh_interval_minutes" in data
+    assert "created_at" in data
+    assert "updated_at" in data
+
+
+def test_get_preferences_idempotent(db: Session):
+    app.dependency_overrides[get_db] = lambda: db
+    r1 = client.get("/api/news/preferences")
+    r2 = client.get("/api/news/preferences")
+    app.dependency_overrides.clear()
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r1.json()["id"] == r2.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/news/preferences
+# ---------------------------------------------------------------------------
+
+
+def test_put_preferences_updates_tracked_tickers(db: Session):
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.put(
+        "/api/news/preferences",
+        json={"tracked_tickers": ["AAPL", "NVDA"], "tracked_universes": []},
+    )
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["tracked_tickers"] == ["AAPL", "NVDA"]
+
+
+def test_put_preferences_updates_refresh_interval(db: Session):
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.put(
+        "/api/news/preferences",
+        json={"tracked_tickers": [], "tracked_universes": [], "refresh_interval_minutes": 15},
+    )
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["refresh_interval_minutes"] == 15
+
+
+def test_put_preferences_persists_on_get(db: Session):
+    app.dependency_overrides[get_db] = lambda: db
+    client.put(
+        "/api/news/preferences",
+        json={"tracked_tickers": ["TSLA"], "tracked_universes": []},
+    )
+    response = client.get("/api/news/preferences")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert "TSLA" in response.json()["tracked_tickers"]
+
+
+def test_put_preferences_creates_if_none_exist(db: Session):
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.put(
+        "/api/news/preferences",
+        json={"tracked_tickers": ["AMD"], "tracked_universes": []},
+    )
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json()["tracked_tickers"] == ["AMD"]
+
+
+# ---------------------------------------------------------------------------
+# POST /api/news/refresh — triggers Celery task (apply_async mocked)
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_returns_ok_and_task_id(mock_news_provider):
+    fake_result = MagicMock()
+    fake_result.id = "test-task-id-abc123"
+
+    with patch("app.tasks.poll_massive_news.apply_async", return_value=fake_result):
+        response = client.post("/api/news/refresh")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert "task_id" in data
+
+
+def test_refresh_polygon_not_called_directly(mock_news_provider):
+    fake_result = MagicMock()
+    fake_result.id = "test-task-id-def456"
+
+    with patch("app.tasks.poll_massive_news.apply_async", return_value=fake_result):
+        client.post("/api/news/refresh")
+
+    mock_news_provider.assert_not_called()

--- a/backend/tests/fixtures/providers.py
+++ b/backend/tests/fixtures/providers.py
@@ -1,14 +1,20 @@
 """
 Provider mock helpers.
 Patches DataProviderFactory so no real Polygon calls are made during tests.
+Also provides news article seeding and a mock for the Polygon news HTTP call.
 """
 
 from datetime import datetime, timezone, timedelta
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+from typing import Optional
 
 import pytest
+from sqlalchemy.orm import Session
+
+import uuid as _uuid
 
 from app.providers import DataProviderFactory
+from app.models.news_article import NewsArticle
 
 
 def _make_canned_bars(ticker: str, count: int = 5) -> list[dict]:
@@ -67,3 +73,86 @@ def mock_polygon_provider():
         DataProviderFactory._providers["massive"] = original
     else:
         DataProviderFactory._providers.pop("massive", None)
+
+
+def seed_news_articles(
+    db: Session,
+    count: int = 3,
+    tickers: Optional[list[str]] = None,
+) -> list[NewsArticle]:
+    """
+    Insert `count` NewsArticle rows into `db`.
+    If `tickers` is provided each article is tagged with all of them;
+    otherwise articles cycle through ["AAPL", "MSFT", "NVDA"].
+    Returns the list of created rows.
+    """
+    default_tickers = ["AAPL", "MSFT", "NVDA"]
+    base_time = datetime.now(timezone.utc) - timedelta(hours=count)
+    rows = []
+    for i in range(count):
+        article_tickers = tickers if tickers is not None else [default_tickers[i % len(default_tickers)]]
+        row = NewsArticle(
+            title=f"Test Article {i + 1}: Market Update",
+            author="Test Author",
+            published_utc=(base_time + timedelta(hours=i)).replace(tzinfo=None),
+            article_url=f"https://test.example.com/news/{_uuid.uuid4()}",
+            image_url=f"https://test.example.com/images/{i + 1}.jpg",
+            description=f"Description for test article {i + 1}.",
+            provider="Test Provider",
+            tickers=article_tickers,
+        )
+        db.add(row)
+        rows.append(row)
+    db.flush()
+    return rows
+
+
+def _make_canned_polygon_news_response(tickers: list[str] | None = None) -> dict:
+    """Return a fake Polygon /v2/reference/news JSON response body."""
+    if tickers is None:
+        tickers = ["AAPL"]
+    now = datetime.now(timezone.utc)
+    return {
+        "results": [
+            {
+                "title": "Canned News Article 1",
+                "author": "Polygon Test",
+                "published_utc": (now - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "article_url": "https://polygon.test/news/canned-1",
+                "image_url": "https://polygon.test/images/canned-1.jpg",
+                "description": "Canned article 1 description.",
+                "publisher": {"name": "PolygonTest"},
+                "tickers": tickers,
+            },
+            {
+                "title": "Canned News Article 2",
+                "author": "Polygon Test",
+                "published_utc": (now - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "article_url": "https://polygon.test/news/canned-2",
+                "image_url": None,
+                "description": "Canned article 2 description.",
+                "publisher": {"name": "PolygonTest"},
+                "tickers": tickers,
+            },
+        ],
+        "status": "OK",
+        "count": 2,
+    }
+
+
+@pytest.fixture
+def mock_news_provider():
+    """
+    Patch httpx.Client.get so poll_massive_news never calls the real Polygon API.
+    Yields the mock for optional assertion in tests.
+    """
+    import json
+    from unittest.mock import MagicMock
+
+    fake_response = MagicMock()
+    fake_response.status_code = 200
+    fake_response.json.return_value = _make_canned_polygon_news_response()
+    fake_response.raise_for_status = MagicMock()
+
+    with patch("httpx.Client.get", return_value=fake_response) as mock_get:
+        yield mock_get


### PR DESCRIPTION
## Summary
Automated implementation for issue #34.

## Preview
- Frontend: http://localhost:13433
- Backend API: http://localhost:13480/docs

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #34"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #34"
```

---
*Generated by MarketHawk Dark Factory*