### PR TITLE
feat: Dynamic volume thresholds via TimesFM (Phase 1)

### DIFF
--- a/backend/Dockerfile.forecast
+++ b/backend/Dockerfile.forecast
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir "timesfm[torch]"
+
+COPY . .
+
+CMD ["celery", "-A", "app.core.celery_app:celery_app", "worker", "-Q", "forecasting", "--concurrency=1", "--loglevel=info"]

--- a/backend/app/alembic/versions/b5e6f7a8b9c0_seed_timesfm_system_config.py
+++ b/backend/app/alembic/versions/b5e6f7a8b9c0_seed_timesfm_system_config.py
@@ -1,0 +1,37 @@
+"""Seed TimesFM system_config rows
+
+Revision ID: b5e6f7a8b9c0
+Revises: a4944daa848d
+Create Date: 2026-05-13 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = 'b5e6f7a8b9c0'
+down_revision: Union[str, None] = 'a4944daa848d'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_ROWS = [
+    ('timesfm_enabled', 'false'),
+    ('timesfm_anomaly_threshold', '2.0'),
+    ('timesfm_min_history_bars', '30'),
+    ('timesfm_fallback_multiplier', '4.0'),
+]
+
+
+def upgrade() -> None:
+    for key, value in _ROWS:
+        op.execute(
+            f"INSERT INTO system_config (key, value, updated_at) "
+            f"VALUES ('{key}', '{value}', NOW()) "
+            f"ON CONFLICT (key) DO NOTHING"
+        )
+
+
+def downgrade() -> None:
+    for key, _ in _ROWS:
+        op.execute(f"DELETE FROM system_config WHERE key = '{key}'")

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -18,8 +18,10 @@ from app.models.stock_aggregate import StockAggregate
 from app.models.monitored_stock import MonitoredStock
 from app.models.ticker_reference import TickerReference
 from app.models.stock_split import StockSplit
+from app.models.system_config import SystemConfig
 from app.services.catalyst_parser import CatalystParser
 from app.services.event_helpers import generate_event_summary, compute_event_severity
+from app.services.timeseries_forecast import get_volume_forecast, compute_anomaly_score
 
 
 class ScannerService:
@@ -259,6 +261,18 @@ class ScannerService:
         day_end_utc = (day_start_et + timedelta(days=1)).astimezone(timezone.utc).replace(tzinfo=None)
         hist_start_utc = (day_start_et - timedelta(days=90)).astimezone(timezone.utc).replace(tzinfo=None)
 
+        # Read TimesFM config once before the ticker loop
+        _timesfm_config_keys = [
+            'timesfm_enabled', 'timesfm_anomaly_threshold',
+            'timesfm_min_history_bars', 'timesfm_fallback_multiplier',
+        ]
+        _cfg_rows = db.query(SystemConfig).filter(SystemConfig.key.in_(_timesfm_config_keys)).all()
+        _cfg = {r.key: r.value for r in _cfg_rows}
+        timesfm_enabled = _cfg.get('timesfm_enabled', 'false').lower() == 'true'
+        anomaly_threshold = float(_cfg.get('timesfm_anomaly_threshold', '2.0'))
+        min_history_bars = int(_cfg.get('timesfm_min_history_bars', '30'))
+        fallback_multiplier = float(_cfg.get('timesfm_fallback_multiplier', '4.0'))
+
         enrichment_batch = await asyncio.to_thread(
             ScannerService._get_batch_enrichment_data, tickers, event_date, db
         )
@@ -301,8 +315,24 @@ class ScannerService:
 
                 relative_volume = pre_market_volume / avg_volume_20d if avg_volume_20d > 0 else 0
 
+                # TimesFM anomaly score — Phase 1a/1b
+                forecast = (
+                    get_volume_forecast(ticker, volumes[-60:])
+                    if len(volumes) >= min_history_bars
+                    else None
+                )
+                anomaly_score = compute_anomaly_score(pre_market_volume, forecast)
+
+                # Phase 1b: dynamic threshold when enabled and score available
+                if timesfm_enabled and anomaly_score is not None:
+                    volume_spike_ok = anomaly_score >= anomaly_threshold
+                    threshold_method = 'timesfm'
+                else:
+                    volume_spike_ok = pre_market_volume > (avg_volume_20d * fallback_multiplier)
+                    threshold_method = 'static_4x'
+
                 criteria_met = {
-                    "volume_spike": pre_market_volume > (avg_volume_20d * 4),
+                    "volume_spike": volume_spike_ok,
                     "minimum_volume": pre_market_volume > 100000,
                     "liquidity": avg_volume_20d > 500000,
                 }
@@ -323,6 +353,10 @@ class ScannerService:
                         "gap_pct": round(gap_pct, 4),
                         "fade_from_high_pct": round(fade_from_high_pct, 4),
                         "day_range_pct": round(day_range_pct, 4),
+                        "volume_anomaly_score": round(anomaly_score, 4) if anomaly_score is not None else None,
+                        "predicted_volume_p50": round(forecast["p50"]) if forecast else None,
+                        "predicted_volume_p90": round(forecast["p90"]) if forecast else None,
+                        "volume_threshold_method": threshold_method,
                     }
 
                     enrichment = enrichment_batch.get(ticker.upper(), {})

--- a/backend/app/services/timeseries_forecast.py
+++ b/backend/app/services/timeseries_forecast.py
@@ -1,0 +1,89 @@
+"""
+TimesFM volume forecast wrapper.
+
+Lazy-loads the model on first use. Returns None gracefully when the library
+is not installed or the model fails to load — callers fall back to static logic.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+_timesfm_model = None
+_timesfm_available: Optional[bool] = None
+
+
+def _get_model():
+    """Lazy-load the TimesFM model exactly once per process."""
+    global _timesfm_model, _timesfm_available
+    if _timesfm_available is None:
+        try:
+            import timesfm  # noqa: PLC0415
+
+            _timesfm_model = timesfm.TimesFm(
+                hparams=timesfm.TimesFmHparams(
+                    backend="torch",
+                    per_core_batch_size=32,
+                    horizon_len=1,
+                ),
+                checkpoint=timesfm.TimesFmCheckpoint(
+                    huggingface_repo_id="google/timesfm-2.5-200m-pytorch"
+                ),
+            )
+            _timesfm_available = True
+            logger.info("TimesFM model loaded successfully")
+        except Exception as exc:
+            logger.warning("TimesFM unavailable — falling back to static threshold: %s", exc)
+            _timesfm_available = False
+
+    return _timesfm_model if _timesfm_available else None
+
+
+def get_volume_forecast(ticker: str, volumes: list[float]) -> Optional[dict]:
+    """
+    Feed up to 60 daily volumes into TimesFM and return a 1-day-ahead forecast.
+
+    Returns a dict with keys: mean, std, p50, p90 (all in raw share volume units).
+    Returns None when the model is unavailable or the input is too short.
+    """
+    model = _get_model()
+    if model is None or len(volumes) < 1:
+        return None
+
+    try:
+        log_vols = np.log1p(volumes).tolist()
+        point_forecast, quantile_forecast = model.forecast(
+            inputs=[log_vols],
+            freq=[0],
+            quantile_levels=[0.25, 0.50, 0.75, 0.90],
+        )
+
+        # quantile_forecast shape: [batch, horizon, n_quantiles]
+        mean_log = float(point_forecast[0][0])
+        p50_log = float(quantile_forecast[0][0][1])   # index 1 → p50
+        p90_log = float(quantile_forecast[0][0][3])   # index 3 → p90
+
+        # Approximate std from p90-mean spread (1.28 σ for normal distribution)
+        std_log = max((p90_log - mean_log) / 1.28, 1e-6)
+
+        return {
+            "mean": float(np.expm1(mean_log)),
+            "std": float(np.expm1(mean_log + std_log) - np.expm1(mean_log)),
+            "p50": float(np.expm1(p50_log)),
+            "p90": float(np.expm1(p90_log)),
+        }
+    except Exception as exc:
+        logger.warning("TimesFM forecast failed for %s: %s", ticker, exc)
+        return None
+
+
+def compute_anomaly_score(actual_volume: float, forecast: dict) -> Optional[float]:
+    """Z-score of actual pre-market volume vs. TimesFM forecast distribution."""
+    if forecast is None or forecast.get("std", 0) <= 0:
+        return None
+    return (actual_volume - forecast["mean"]) / forecast["std"]

--- a/backend/tests/fixtures/providers.py
+++ b/backend/tests/fixtures/providers.py
@@ -141,6 +141,28 @@ def _make_canned_polygon_news_response(tickers: list[str] | None = None) -> dict
 
 
 @pytest.fixture
+def mock_futures_provider():
+    """
+    Replace the 'ibkr' provider in DataProviderFactory with a MagicMock that
+    reports as available and supports futures. Restores the real provider on teardown.
+    """
+    mock = MagicMock()
+    mock.name = "ibkr"
+    mock.supported_asset_classes = ["futures"]
+    mock.is_available.return_value = (True, "Ready (mock)")
+
+    original = DataProviderFactory._providers.get("ibkr")
+    DataProviderFactory._providers["ibkr"] = mock
+
+    yield mock
+
+    if original is not None:
+        DataProviderFactory._providers["ibkr"] = original
+    else:
+        DataProviderFactory._providers.pop("ibkr", None)
+
+
+@pytest.fixture
 def mock_news_provider():
     """
     Patch httpx.Client.get so poll_massive_news never calls the real Polygon API.

--- a/backend/tests/services/test_scanner_refactor.py
+++ b/backend/tests/services/test_scanner_refactor.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from app.services.scanner import ScannerService
 from app.models.stock_aggregate import StockAggregate
+from app.models.system_config import SystemConfig
 
 
 def _make_daily_bar(ticker, timestamp_utc, close, volume):
@@ -23,7 +24,8 @@ def _make_daily_bar(ticker, timestamp_utc, close, volume):
     return b
 
 
-def _mock_db_for_pre_market(ticker, event_date, daily_closes, daily_volumes, pm_volume):
+def _mock_db_for_pre_market(ticker, event_date, daily_closes, daily_volumes, pm_volume,
+                             system_config_rows=None):
     """Return a mock DB session wired for run_pre_market_scan."""
     from datetime import timedelta
     from zoneinfo import ZoneInfo
@@ -35,15 +37,22 @@ def _mock_db_for_pre_market(ticker, event_date, daily_closes, daily_volumes, pm_
         for i, (c, v) in enumerate(zip(daily_closes, daily_volumes))
     ]
 
+    # Default: no system_config rows → scanner falls back to static 4× defaults
+    cfg_rows = system_config_rows if system_config_rows is not None else []
+
     db = MagicMock()
 
     def query_side_effect(model):
         mock_q = MagicMock()
         mock_q.filter.return_value = mock_q
         mock_q.order_by.return_value = mock_q
-        if model is StockAggregate:
+        if model is SystemConfig:
+            mock_q.all.return_value = cfg_rows
+        elif model is StockAggregate:
             mock_q.all.return_value = daily_bars
+            mock_q.scalar.return_value = pm_volume
         else:
+            # func.sum(StockAggregate.volume) path
             mock_q.scalar.return_value = pm_volume
         return mock_q
 
@@ -192,3 +201,119 @@ def test_liquidity_hunt_for_date_wrapper_exists_in_new_module():
     import asyncio
     from app.services.liquidity_hunt import run_liquidity_hunt_scan_for_date
     assert asyncio.iscoroutinefunction(run_liquidity_hunt_scan_for_date)
+
+
+# ---------------------------------------------------------------------------
+# TimesFM anomaly score integration tests
+# ---------------------------------------------------------------------------
+
+def test_pre_market_scan_includes_anomaly_indicators_when_timesfm_unavailable():
+    """When TimesFM is unavailable, indicators still include the anomaly fields (None/static_4x)."""
+    ticker = "METRIC"
+    event_date = date(2025, 4, 1)
+    daily_closes = [100.0] * 25
+    daily_volumes = [1_000_000] * 25
+    pm_volume = 5_000_000  # 5x → passes static 4x threshold
+
+    db = _mock_db_for_pre_market(ticker, event_date, daily_closes, daily_volumes, pm_volume)
+
+    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value={ticker: {}}), \
+         patch.object(ScannerService, 'calculate_day_metrics', return_value={
+             "closing_price": 102.0, "pre_market_close": 101.0,
+             "opening_price": 101.0, "regular_high": 103.0, "regular_low": 99.0,
+         }), \
+         patch.object(ScannerService, '_save_event', return_value={"id": 1}) as mock_save:
+
+        asyncio.run(ScannerService.run_pre_market_scan([ticker], db, event_date=event_date))
+
+    indicators = mock_save.call_args.kwargs["indicators"]
+    assert "volume_anomaly_score" in indicators
+    assert "predicted_volume_p50" in indicators
+    assert "predicted_volume_p90" in indicators
+    assert indicators["volume_threshold_method"] == "static_4x"
+    # TimesFM not installed → score is None
+    assert indicators["volume_anomaly_score"] is None
+
+
+def test_pre_market_scan_uses_timesfm_threshold_when_enabled():
+    """Phase 1b: with timesfm_enabled=true, a stock below 4x but with z-score >= 2.0 is detected."""
+    ticker = "LOWVOL"
+    event_date = date(2025, 4, 2)
+    daily_closes = [50.0] * 25
+    daily_volumes = [2_000_000] * 25
+    # pre_market_volume is only 2x avg (< 4x) — would fail static threshold
+    pm_volume = 4_000_000
+
+    # Inject system_config rows enabling TimesFM
+    def _make_cfg(key, value):
+        row = MagicMock(spec=SystemConfig)
+        row.key = key
+        row.value = value
+        return row
+
+    cfg_rows = [
+        _make_cfg('timesfm_enabled', 'true'),
+        _make_cfg('timesfm_anomaly_threshold', '2.0'),
+        _make_cfg('timesfm_min_history_bars', '10'),
+        _make_cfg('timesfm_fallback_multiplier', '4.0'),
+    ]
+
+    db = _mock_db_for_pre_market(ticker, event_date, daily_closes, daily_volumes, pm_volume,
+                                 system_config_rows=cfg_rows)
+
+    # Provide a mocked forecast that gives anomaly_score = 3.0 (≥ 2.0 → passes)
+    mock_forecast = {"mean": 1_000_000.0, "std": 1_000_000.0, "p50": 900_000.0, "p90": 2_000_000.0}
+
+    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value={ticker: {}}), \
+         patch.object(ScannerService, 'calculate_day_metrics', return_value={
+             "closing_price": 52.0, "pre_market_close": 51.0,
+             "opening_price": 51.0, "regular_high": 53.0, "regular_low": 49.0,
+         }), \
+         patch('app.services.scanner.get_volume_forecast', return_value=mock_forecast), \
+         patch.object(ScannerService, '_save_event', return_value={"id": 2}) as mock_save:
+
+        results = asyncio.run(ScannerService.run_pre_market_scan([ticker], db, event_date=event_date))
+
+    # anomaly_score = (4_000_000 - 1_000_000) / 1_000_000 = 3.0 ≥ 2.0 → detected
+    mock_save.assert_called_once()
+    indicators = mock_save.call_args.kwargs["indicators"]
+    assert indicators["volume_threshold_method"] == "timesfm"
+    assert indicators["volume_anomaly_score"] == 3.0
+    assert len(results) == 1
+
+
+def test_pre_market_scan_static_fallback_when_timesfm_score_below_threshold():
+    """Phase 1b: with timesfm_enabled=true but anomaly_score < 2.0, event is not saved."""
+    ticker = "QUIET"
+    event_date = date(2025, 4, 3)
+    daily_closes = [50.0] * 25
+    daily_volumes = [1_000_000] * 25
+    pm_volume = 1_200_000  # only 1.2x avg → score would be low
+
+    def _make_cfg(key, value):
+        row = MagicMock(spec=SystemConfig)
+        row.key = key
+        row.value = value
+        return row
+
+    cfg_rows = [
+        _make_cfg('timesfm_enabled', 'true'),
+        _make_cfg('timesfm_anomaly_threshold', '2.0'),
+        _make_cfg('timesfm_min_history_bars', '10'),
+        _make_cfg('timesfm_fallback_multiplier', '4.0'),
+    ]
+
+    db = _mock_db_for_pre_market(ticker, event_date, daily_closes, daily_volumes, pm_volume,
+                                 system_config_rows=cfg_rows)
+
+    # Forecast gives score = (1_200_000 - 1_000_000) / 500_000 = 0.4 → below 2.0
+    mock_forecast = {"mean": 1_000_000.0, "std": 500_000.0, "p50": 950_000.0, "p90": 1_500_000.0}
+
+    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value={ticker: {}}), \
+         patch('app.services.scanner.get_volume_forecast', return_value=mock_forecast), \
+         patch.object(ScannerService, '_save_event', return_value={"id": 3}) as mock_save:
+
+        results = asyncio.run(ScannerService.run_pre_market_scan([ticker], db, event_date=event_date))
+
+    mock_save.assert_not_called()
+    assert results == []

--- a/backend/tests/services/test_timeseries_forecast.py
+++ b/backend/tests/services/test_timeseries_forecast.py
@@ -1,0 +1,131 @@
+# backend/tests/services/test_timeseries_forecast.py
+"""
+Unit tests for the timeseries_forecast service.
+TimesFM itself is never installed in the test environment, so all tests
+exercise the graceful-fallback and pure-math paths only.
+"""
+
+import numpy as np
+from unittest.mock import MagicMock, patch
+
+from app.services import timeseries_forecast as tf_module
+from app.services.timeseries_forecast import get_volume_forecast, compute_anomaly_score
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reset_model_cache():
+    """Reset the module-level lazy-load state between tests."""
+    tf_module._timesfm_model = None
+    tf_module._timesfm_available = None
+
+
+def _make_forecast(mean=1_000_000.0, std=200_000.0, p50=950_000.0, p90=1_300_000.0):
+    return {"mean": mean, "std": std, "p50": p50, "p90": p90}
+
+
+# ---------------------------------------------------------------------------
+# get_volume_forecast — model unavailable (no timesfm installed)
+# ---------------------------------------------------------------------------
+
+def test_get_volume_forecast_returns_none_when_timesfm_missing():
+    _reset_model_cache()
+    # No mock needed — timesfm is not installed in the test environment
+    result = get_volume_forecast("AAPL", [500_000.0] * 60)
+    assert result is None
+
+
+def test_get_volume_forecast_returns_none_for_empty_volumes():
+    _reset_model_cache()
+    result = get_volume_forecast("AAPL", [])
+    assert result is None
+
+
+def test_get_volume_forecast_caches_unavailable_state():
+    """After one failed import, subsequent calls do not re-attempt the import."""
+    _reset_model_cache()
+    get_volume_forecast("X", [1.0])  # triggers the failed import
+    assert tf_module._timesfm_available is False
+
+    # Second call must not change the flag (no re-import attempt)
+    get_volume_forecast("X", [1.0])
+    assert tf_module._timesfm_available is False
+
+
+# ---------------------------------------------------------------------------
+# get_volume_forecast — model available (mocked)
+# ---------------------------------------------------------------------------
+
+def test_get_volume_forecast_with_mocked_model():
+    _reset_model_cache()
+
+    mean_log = np.log1p(1_000_000)
+    p50_log = np.log1p(900_000)
+    p90_log = np.log1p(1_300_000)
+
+    mock_model = MagicMock()
+    mock_model.forecast.return_value = (
+        [[mean_log]],                          # point_forecast[0][0]
+        [[[0.0, p50_log, 0.0, p90_log]]],     # quantile_forecast[0][0][1,3]
+    )
+
+    tf_module._timesfm_model = mock_model
+    tf_module._timesfm_available = True
+
+    result = get_volume_forecast("AAPL", [500_000.0] * 60)
+
+    assert result is not None
+    assert "mean" in result and "std" in result and "p50" in result and "p90" in result
+    assert result["mean"] > 0
+    assert result["std"] > 0
+    assert result["p50"] > 0
+    assert result["p90"] > result["p50"]
+
+    _reset_model_cache()
+
+
+def test_get_volume_forecast_returns_none_on_model_exception():
+    _reset_model_cache()
+
+    mock_model = MagicMock()
+    mock_model.forecast.side_effect = RuntimeError("GPU OOM")
+
+    tf_module._timesfm_model = mock_model
+    tf_module._timesfm_available = True
+
+    result = get_volume_forecast("CRASH", [500_000.0] * 60)
+    assert result is None
+
+    _reset_model_cache()
+
+
+# ---------------------------------------------------------------------------
+# compute_anomaly_score
+# ---------------------------------------------------------------------------
+
+def test_compute_anomaly_score_positive():
+    forecast = _make_forecast(mean=1_000_000, std=200_000)
+    score = compute_anomaly_score(1_500_000, forecast)
+    assert abs(score - 2.5) < 1e-9
+
+
+def test_compute_anomaly_score_negative():
+    forecast = _make_forecast(mean=1_000_000, std=200_000)
+    score = compute_anomaly_score(600_000, forecast)
+    assert abs(score - (-2.0)) < 1e-9
+
+
+def test_compute_anomaly_score_returns_none_for_none_forecast():
+    assert compute_anomaly_score(1_000_000, None) is None
+
+
+def test_compute_anomaly_score_returns_none_for_zero_std():
+    forecast = _make_forecast(std=0)
+    assert compute_anomaly_score(1_000_000, forecast) is None
+
+
+def test_compute_anomaly_score_zero_when_equal_to_mean():
+    forecast = _make_forecast(mean=1_000_000, std=200_000)
+    assert compute_anomaly_score(1_000_000, forecast) == 0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -311,6 +311,33 @@ services:
     profiles:
       - scheduler
 
+  # TimesFM forecast worker — dedicated Celery worker for the 'forecasting' queue.
+  # The 200M-parameter model requires ~32GB RAM; limit is set to 36GB for headroom.
+  # Model weights (~800MB) are downloaded once from Hugging Face and cached in a volume.
+  forecast-worker:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.forecast
+    container_name: stockscanner-forecast-worker
+    command: celery -A app.core.celery_app:celery_app worker -Q forecasting --concurrency=1 --loglevel=info
+    env_file:
+      - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    deploy:
+      resources:
+        limits:
+          memory: 36G
+    volumes:
+      - timesfm_cache:/root/.cache/huggingface
+    networks:
+      - stockscanner-network
+    profiles:
+      - forecasting
+
 volumes:
   postgres_data:
     external: true
@@ -327,6 +354,7 @@ volumes:
   ib_gateway_settings:
     external: true
     name: markethawk_ib_gateway_settings
+  timesfm_cache:
 
 
 networks:


### PR DESCRIPTION
## Summary
Automated implementation for issue #20.

## Preview
- Frontend: http://localhost:12033
- Backend API: http://localhost:12080/docs

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #20"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #20"
```

---
*Generated by MarketHawk Dark Factory*