### PR TITLE
Auto-refinement pipeline: multi-agent brainstorming for backlog issues

### DIFF
--- a/.archon/commands/dark-factory-plan.md
+++ b/.archon/commands/dark-factory-plan.md
@@ -1,0 +1,73 @@
+---
+description: Generate an implementation plan from an approved spec, validated by an architect subagent
+argument-hint: (no arguments - reads issue context from workflow)
+---
+
+# Dark Factory — Plan
+
+**Workflow ID**: $WORKFLOW_ID
+
+---
+
+## Phase 1: LOAD
+
+1. Read `CLAUDE.md` for development rules, architecture, and conventions
+2. The issue context has been fetched by the workflow. It is available in the conversation.
+3. Read `/opt/refinement-skills/architect-prompt.md` — you will pass this to the review subagent
+4. Find the spec file: look in `Docs/superpowers/specs/` for a file matching this issue's topic, or check the issue comments for a "Refinement Pipeline — Spec Generated" report that names the spec path
+5. Read the spec file
+
+## Phase 2: PLAN WRITING
+
+Write a full implementation plan following these conventions:
+- Save to `Docs/superpowers/plans/YYYY-MM-DD-<feature>.md`
+- Start with the standard plan header (Goal, Architecture, Tech Stack)
+- Include a File Structure table
+- Break into bite-sized tasks (each step is one 2-5 minute action)
+- Every task has: Files list, TDD steps (write failing test → verify fail → implement → verify pass → commit)
+- No placeholders — every step has actual code blocks and exact file paths
+- Exact commands with expected output
+
+## Phase 3: ARCHITECT REVIEW
+
+Spawn an architect subagent using the Agent tool:
+- `description`: "Architect review: validate plan against spec"
+- `prompt`: Content of `architect-prompt.md` with $SPEC_CONTENT and $PLAN_CONTENT replaced with the actual file contents
+
+### If architect returns "Issues Found":
+1. Fix each issue in the plan
+2. Re-spawn the architect subagent for re-review
+3. Repeat until approved (max 3 cycles)
+4. If still not approved after 3 cycles:
+   - Post the plan + architect feedback as an issue comment
+   - Add `needs-discussion` label: `gh issue edit $ISSUE_NUM --add-label needs-discussion`
+   - Exit cleanly
+
+### If architect returns "Approved":
+Proceed to publish.
+
+## Phase 4: PUBLISH
+
+1. Commit the plan
+2. Post a summary comment on the issue:
+   ```
+   ## Refinement Pipeline — Plan Generated
+
+   **Plan:** `<plan-file-path>`
+   **Branch:** `<branch-name>`
+   **Tasks:** <count> tasks, <total-steps> steps
+
+   ### Task Overview
+   <numbered list of task names>
+
+   ---
+   *Posted by MarketHawk Refinement Pipeline*
+   ```
+3. Write status to `$ARTIFACTS_DIR/refinement-status.md`:
+   ```
+   STATUS: PLAN_COMPLETE
+   PLAN_PATH: <path>
+   BRANCH: <branch>
+   TASKS: <count>
+   ARCHITECT_CYCLES: <count>
+   ```

--- a/.archon/commands/dark-factory-refine.md
+++ b/.archon/commands/dark-factory-refine.md
@@ -1,0 +1,106 @@
+---
+description: Refine a GitHub issue into a design spec using multi-agent brainstorming
+argument-hint: (no arguments - reads issue context from workflow)
+---
+
+# Dark Factory — Refine
+
+**Workflow ID**: $WORKFLOW_ID
+
+---
+
+## CRITICAL: Skip Guard
+
+If the issue has any of these labels, STOP immediately and exit with code 0 (not an error):
+- `spec-pending-review` — already processed
+- `needs-discussion` — waiting for human input
+- `epic` — needs manual decomposition
+
+## Phase 1: LOAD
+
+1. Read `CLAUDE.md` for development rules, architecture, and conventions
+2. Read `ARCHITECTURE.md` for service topology and module map
+3. The issue context has been fetched by the workflow. It is available in the conversation.
+4. Read `/opt/refinement-skills/orchestrator-prompt.md` for your process instructions
+5. Read `/opt/refinement-skills/product-owner-prompt.md` — you will pass this to subagents
+6. Read `/opt/refinement-skills/config.yaml` for pipeline configuration
+
+### If this is a re-run (feedback present in issue comments after a previous refinement report)
+
+Read the latest comments after any "Refinement Pipeline" report. Treat these as additional requirements from the user. Do NOT start from scratch — build on the previous spec if one exists on this branch.
+
+## Phase 2: PRE-FLIGHT
+
+Check the issue body length. If fewer than 20 characters:
+1. Post a comment: "This issue needs more detail before it can be refined. Please add a description of what you'd like to build and any constraints."
+2. Add `needs-discussion` label: `gh issue edit $ISSUE_NUM --add-label needs-discussion`
+3. Exit cleanly
+
+## Phase 3: CONTEXT ASSEMBLY
+
+Build a context package by exploring the codebase:
+1. Identify which area of the codebase the issue touches (backend models? services? frontend pages?)
+2. Read the relevant existing files to understand current patterns
+3. Assemble this into a context summary you will pass to every product-owner subagent
+
+## Phase 4: BRAINSTORMING LOOP
+
+Follow the process in `orchestrator-prompt.md`:
+1. Formulate one clarifying question at a time
+2. For each question, spawn a product-owner subagent using the Agent tool:
+   - `description`: "Product owner: <short question summary>"
+   - `prompt`: Content of `product-owner-prompt.md` with the $ISSUE_CONTEXT, $QA_HISTORY, and $QUESTION placeholders replaced with actual values
+   - The subagent needs Glob, Grep, and Read tools to explore the codebase
+3. If the subagent returns a response starting with `UNCERTAIN:`:
+   - Post a comment on the issue explaining the question and context gathered so far
+   - Run: `gh issue edit $ISSUE_NUM --add-label needs-discussion`
+   - Write a brief summary to `$ARTIFACTS_DIR/refinement-status.md` noting the abort reason
+   - Exit cleanly (exit code 0)
+4. Record the answer and continue until you have enough information
+
+## Phase 5: SPEC WRITING
+
+1. Propose 2-3 approaches with trade-offs
+2. Select the best approach based on Q&A answers and codebase patterns
+3. Write the spec to `Docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` following existing spec format:
+   - Overview / problem statement
+   - Requirements (from Q&A)
+   - Architecture / approach
+   - Alternatives considered
+   - Open questions (non-blocking)
+   - Assumptions (flagged)
+4. Self-review: placeholder scan, consistency check, scope check, ambiguity check. Fix inline.
+5. Commit the spec
+
+## Phase 6: PUBLISH
+
+1. Post a summary comment on the issue:
+   ```
+   ## Refinement Pipeline — Spec Generated
+
+   **Spec:** `<spec-file-path>`
+   **Branch:** `<branch-name>`
+
+   ### Summary
+   <2-3 sentence overview>
+
+   ### Requirements
+   <bulleted list of key requirements>
+
+   ### Approach
+   <1-2 sentences on chosen approach>
+
+   ### Assumptions
+   <bulleted list if any>
+
+   ---
+   *Posted by MarketHawk Refinement Pipeline*
+   ```
+2. Add label: `gh issue edit $ISSUE_NUM --add-label spec-pending-review`
+3. Write status to `$ARTIFACTS_DIR/refinement-status.md`:
+   ```
+   STATUS: SPEC_COMPLETE
+   SPEC_PATH: <path>
+   BRANCH: <branch>
+   QUESTIONS_ASKED: <count>
+   ```

--- a/.archon/workflows/archon-dark-factory.yaml
+++ b/.archon/workflows/archon-dark-factory.yaml
@@ -1,9 +1,9 @@
 name: archon-dark-factory
 description: |
   Use when: Running inside the dark-factory Docker container to implement a GitHub issue.
-  Triggers: "Fix issue", "Continue issue", "Close issue".
-  Does: Parses intent -> fetches issue context -> branches -> implements with TDD ->
-        spins up preview stack -> validates against preview -> pushes and creates PR.
+  Triggers: "Fix issue", "Continue issue", "Close issue", "Refine issue", "Plan issue".
+  Does: Parses intent -> fetches issue context -> branches -> implements/refines/plans ->
+        spins up preview stack (implement only) -> validates -> pushes and creates PR/spec/plan.
   NOT for: Running outside the dark-factory container.
 
 provider: claude
@@ -18,12 +18,12 @@ nodes:
     prompt: |
       Parse this command and extract two things:
       1. The GitHub issue number
-      2. The intent: "new" (first time working on this issue), "continue" (iterate on existing work), or "close" (merge and tear down)
+      2. The intent: "new" (first time working on this issue), "continue" (iterate on existing work), "close" (merge and tear down), "refine" (generate a design spec), or "plan" (generate an implementation plan)
 
       Command: $ARGUMENTS
 
       Output ONLY valid JSON, nothing else:
-      {"issue_number": <int>, "intent": "<new|continue|close>"}
+      {"issue_number": <int>, "intent": "<new|continue|close|refine|plan>"}
     allowed_tools: []
     model: haiku
     output_format:
@@ -33,7 +33,7 @@ nodes:
           type: integer
         intent:
           type: string
-          enum: [new, continue, close]
+          enum: [new, continue, close, refine, plan]
       required: [issue_number, intent]
 
   - id: fetch-issue
@@ -174,14 +174,86 @@ nodes:
       fi
       echo "$BRANCH"
     depends_on: [parse-intent, fetch-issue]
-    when: "$parse-intent.output.intent != 'close'"
+    when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
     timeout: 15000
+
+  # Refinement branch setup (refine/issue-N-slug)
+  - id: setup-refine-branch
+    bash: |
+      ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
+      SLUG=$(echo $fetch-issue.output | jq -r '.title // "feature"' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | head -c 40)
+      BRANCH="refine/issue-${ISSUE}-${SLUG}"
+
+      EXISTING=$(git branch -r --list "origin/$BRANCH" 2>/dev/null)
+      if [ -n "$EXISTING" ]; then
+        git fetch origin "$BRANCH" && git checkout "$BRANCH"
+      else
+        git checkout -b "$BRANCH"
+      fi
+      echo "$BRANCH"
+    depends_on: [parse-intent, fetch-issue]
+    when: "$parse-intent.output.intent == 'refine' || $parse-intent.output.intent == 'plan'"
+    timeout: 15000
+
+  # Layer 2a: Refine — generate spec via multi-agent brainstorming
+  - id: refine
+    command: dark-factory-refine
+    depends_on: [setup-refine-branch, fetch-issue]
+    when: "$parse-intent.output.intent == 'refine'"
+    idle_timeout: 600000
+
+  # Layer 2b: Plan — generate implementation plan with architect review
+  - id: plan
+    command: dark-factory-plan
+    depends_on: [setup-refine-branch, fetch-issue]
+    when: "$parse-intent.output.intent == 'plan'"
+    idle_timeout: 600000
+
+  # Push refine branch after spec generation
+  - id: refine-push
+    bash: |
+      ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
+      BRANCH=$(git branch --show-current)
+
+      git push -u origin "$BRANCH"
+      echo "Pushed $BRANCH for issue #$ISSUE"
+    depends_on: [refine]
+    when: "$parse-intent.output.intent == 'refine'"
+    timeout: 30000
+
+  # Push plan branch and advance issue to Ready
+  - id: plan-push-and-advance
+    bash: |
+      ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
+      BRANCH=$(git branch --show-current)
+
+      git push -u origin "$BRANCH"
+
+      # Move issue to Ready
+      ITEM_ID=$(gh project item-list 1 --owner omniscient --format json --limit 200 \
+        | jq -r ".items[] | select(.content.number == $ISSUE and .content.type == \"Issue\") | .id")
+      if [ -n "$ITEM_ID" ]; then
+        gh project item-edit \
+          --project-id PVT_kwHOAAFds84BWh4w \
+          --id "$ITEM_ID" \
+          --field-id PVTSSF_lAHOAAFds84BWh4wzhR1VaA \
+          --single-select-option-id 61e4505c
+        echo "Moved issue #$ISSUE to Ready"
+      fi
+
+      gh issue comment "$ISSUE" --body "Refinement pipeline complete. Spec and plan are on branch \`$BRANCH\`. Issue moved to **Ready** for implementation.
+
+      ---
+      *Posted by MarketHawk Refinement Pipeline*"
+    depends_on: [plan]
+    when: "$parse-intent.output.intent == 'plan'"
+    timeout: 30000
 
   # Layer 2: Implement the feature (status set to "In Progress" by entrypoint or epic resolver)
   - id: implement
     command: dark-factory-implement
     depends_on: [setup-branch, fetch-issue]
-    when: "$parse-intent.output.intent != 'close'"
+    when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
     idle_timeout: 600000
 
   # Layer 3: Spin up preview and validate
@@ -229,13 +301,13 @@ nodes:
       docker network disconnect "$PREVIEW_NET" "$(hostname)" 2>/dev/null || true
       exit 1
     depends_on: [implement]
-    when: "$parse-intent.output.intent != 'close'"
+    when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
     timeout: 300000
 
   - id: validate
     command: dark-factory-validate
     depends_on: [preview-up]
-    when: "$parse-intent.output.intent != 'close'"
+    when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
     idle_timeout: 300000
 
   # Layer 4: Push and create PR
@@ -280,7 +352,7 @@ nodes:
         echo "Created PR: $PR_URL"
       fi
     depends_on: [validate]
-    when: "$parse-intent.output.intent != 'close'"
+    when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
     timeout: 30000
 
   # Layer 5: Move to "In review" and post report
@@ -300,7 +372,7 @@ nodes:
         echo "WARNING: Issue #$ISSUE not found on project board"
       fi
     depends_on: [push-and-pr]
-    when: "$parse-intent.output.intent != 'close'"
+    when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
     timeout: 15000
 
   - id: report
@@ -360,5 +432,5 @@ nodes:
 
       echo "Report posted to issue #${ISSUE}"
     depends_on: [status-in-review]
-    when: "$parse-intent.output.intent != 'close'"
+    when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
     timeout: 15000

--- a/.claude/skills/refinement/SKILL.md
+++ b/.claude/skills/refinement/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: refinement
+description: >
+  Multi-agent refinement pipeline for GitHub issues. Drives brainstorming via an
+  orchestrator + product-owner subagent pair, produces specs, then generates
+  implementation plans validated by an architect subagent. Integrates with the
+  backlog scheduler for automatic processing.
+---
+
+# Refinement Pipeline
+
+Invoke this skill to refine a GitHub issue into a complete spec and implementation plan.
+
+## Usage
+
+Manual invocation (in Claude Code session):
+```
+Refine issue #<number>
+```
+
+Automated invocation (via scheduler or dark factory):
+```bash
+docker compose --profile factory run --rm dark-factory "Refine issue #12"
+docker compose --profile factory run --rm dark-factory "Plan issue #12"
+```
+
+## What It Does
+
+**Phase 1 — Spec Generation (`refine` intent):**
+1. Reads the issue and explores the codebase
+2. Asks clarifying questions via product-owner subagent
+3. Selects best approach from 2-3 alternatives
+4. Writes and self-reviews the spec
+5. Posts spec to the issue, adds `spec-pending-review` label
+
+**Phase 2 — Plan Generation (`plan` intent):**
+1. Reads the approved spec
+2. Writes a full implementation plan (TDD, bite-sized tasks)
+3. Validates via architect subagent
+4. Posts plan to the issue, moves to Ready
+
+## Configuration
+
+See `config.yaml` for tunable parameters.
+
+## Prompt Files
+
+- `product-owner-prompt.md` — Persona for the Q&A subagent (adjustable)
+- `architect-prompt.md` — Persona for the plan reviewer (adjustable)
+- `orchestrator-prompt.md` — Instructions for the brainstorming orchestrator

--- a/.claude/skills/refinement/architect-prompt.md
+++ b/.claude/skills/refinement/architect-prompt.md
@@ -34,6 +34,9 @@ Flag any: "TBD", "TODO", "implement later", "add appropriate error handling", "s
 
 ## Output Format
 
+Your response must follow this exact structure:
+
+```
 ## Architect Review
 
 **Status:** Approved | Issues Found
@@ -43,6 +46,7 @@ Flag any: "TBD", "TODO", "implement later", "add appropriate error handling", "s
 
 **Recommendations (advisory, do not block approval):**
 - [suggestions]
+```
 
 ## Context
 

--- a/.claude/skills/refinement/architect-prompt.md
+++ b/.claude/skills/refinement/architect-prompt.md
@@ -1,0 +1,53 @@
+# Architect Reviewer — MarketHawk
+
+You are an architect reviewing an implementation plan for the MarketHawk stock scanning platform.
+
+## Your Role
+
+Validate that the implementation plan is complete, consistent, and follows codebase conventions. You are the last gate before the plan is handed to an autonomous agent for implementation.
+
+## What to Check
+
+### 1. Spec Coverage
+Read the spec (provided below). For each requirement, verify there is a corresponding task in the plan. List any requirements that have no task.
+
+### 2. File Path Consistency
+Check that file paths, function names, and interfaces used in later tasks match what was defined in earlier tasks. Flag any mismatches.
+
+### 3. Task Decomposition
+Each task should:
+- Be self-contained (produces a working, testable change)
+- Follow TDD (test first, then implementation)
+- Include exact file paths and code blocks
+- Have a commit step
+
+Flag tasks that are too large (should be split) or too vague (missing code blocks).
+
+### 4. Codebase Conventions
+Verify the plan follows patterns from the existing codebase:
+- Backend: FastAPI routers, SQLAlchemy models, Pydantic schemas, service layer
+- Frontend: React components, React Query hooks, Axios API layer
+- Testing: pytest for backend, tsc for frontend
+
+### 5. No Placeholders
+Flag any: "TBD", "TODO", "implement later", "add appropriate error handling", "similar to Task N", or steps without code blocks.
+
+## Output Format
+
+## Architect Review
+
+**Status:** Approved | Issues Found
+
+**Issues (if any):**
+- [Task N / Section]: [specific issue] — [why it matters]
+
+**Recommendations (advisory, do not block approval):**
+- [suggestions]
+
+## Context
+
+### Spec
+$SPEC_CONTENT
+
+### Plan
+$PLAN_CONTENT

--- a/.claude/skills/refinement/config.yaml
+++ b/.claude/skills/refinement/config.yaml
@@ -1,0 +1,11 @@
+# .claude/skills/refinement/config.yaml
+refine:
+  wip_limit: 2
+  skip_labels:
+    - needs-discussion
+    - epic
+    - spec-pending-review
+  min_issue_body_length: 20
+
+plan:
+  auto_advance_to_ready: true

--- a/.claude/skills/refinement/orchestrator-prompt.md
+++ b/.claude/skills/refinement/orchestrator-prompt.md
@@ -1,0 +1,73 @@
+# Refinement Orchestrator
+
+You are a brainstorming agent that refines raw GitHub issues into complete design specs for the MarketHawk stock scanning platform.
+
+## Your Process
+
+### Phase 1: Context Gathering
+1. Read the GitHub issue (title, body, labels, comments)
+2. Read `CLAUDE.md` for tech stack, architecture, and conventions
+3. Read `ARCHITECTURE.md` for service topology and module map
+4. Explore the codebase areas relevant to the issue (models, services, routers, frontend components)
+5. Build a mental model of what already exists and what the issue is asking for
+
+### Phase 2: Clarifying Questions
+Ask questions one at a time to refine the idea. For each question:
+1. Formulate a clear, specific question (prefer multiple choice when possible)
+2. Spawn a product-owner subagent with the question and full context
+3. Record the answer
+4. If the product owner returns `UNCERTAIN: <reason>`:
+   - Post a comment on the issue with the question, context gathered so far, and what you need to proceed
+   - Add `needs-discussion` label to the issue
+   - Exit immediately
+5. Continue until you have enough information to write the spec
+
+Focus questions on:
+- Purpose and success criteria
+- Scope boundaries (what's in, what's out)
+- Integration points with existing code
+- Data model decisions
+- UI/UX requirements (if applicable)
+- Error handling and edge cases
+
+### Phase 3: Approach Selection
+Propose 2-3 approaches with trade-offs. Select the best one based on:
+- Product owner answers
+- Codebase conventions and existing patterns
+- YAGNI — remove unnecessary features
+- Simplicity and maintainability
+
+### Phase 4: Spec Writing
+Write the spec to `Docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` following the existing spec format. Include:
+- Overview (problem statement from issue)
+- Requirements (distilled from Q&A)
+- Architecture / approach
+- Alternatives considered (from Phase 3)
+- Open questions (non-blocking)
+- Assumptions (flagged explicitly)
+
+### Phase 5: Self-Review
+Run this checklist on the spec:
+1. Placeholder scan — any "TBD", "TODO", incomplete sections?
+2. Internal consistency — do sections contradict each other?
+3. Scope check — focused enough for a single implementation plan?
+4. Ambiguity check — could any requirement be interpreted two different ways?
+Fix issues inline.
+
+### Phase 6: Publish
+1. Commit the spec to the current branch
+2. Post a summary comment on the issue with the spec highlights
+3. Add `spec-pending-review` label to the issue
+
+## Subagent Invocation
+
+To ask the product owner a question, spawn a subagent with:
+- Description: "Product owner: <short question summary>"
+- Prompt: The full content of `product-owner-prompt.md` with $ISSUE_CONTEXT, $QA_HISTORY, and $QUESTION replaced
+- The subagent should have access to Read, Grep, and Glob tools for codebase exploration
+
+## Issue Context
+$ISSUE_CONTEXT
+
+## Feedback (if re-run after changes requested)
+$FEEDBACK

--- a/.claude/skills/refinement/orchestrator-prompt.md
+++ b/.claude/skills/refinement/orchestrator-prompt.md
@@ -61,7 +61,7 @@ Fix issues inline.
 
 ## Subagent Invocation
 
-To ask the product owner a question, spawn a subagent with:
+Use the Agent tool to spawn a product-owner subagent for each question:
 - Description: "Product owner: <short question summary>"
 - Prompt: The full content of `product-owner-prompt.md` with $ISSUE_CONTEXT, $QA_HISTORY, and $QUESTION replaced
 - The subagent should have access to Read, Grep, and Glob tools for codebase exploration

--- a/.claude/skills/refinement/product-owner-prompt.md
+++ b/.claude/skills/refinement/product-owner-prompt.md
@@ -1,0 +1,49 @@
+# Product Owner — MarketHawk
+
+You are the product owner for MarketHawk, a full-stack stock scanning platform that identifies pre-market volume spikes and unusual trading patterns.
+
+## Your Role
+
+You answer clarifying questions from a brainstorming agent that is refining a feature idea into a spec. Base your answers on:
+
+1. **The GitHub issue** — title, body, labels, comments (provided below)
+2. **The codebase** — explore files, read existing patterns, check architecture
+3. **Domain documentation** — CLAUDE.md, ARCHITECTURE.md, and any docs referenced in the issue
+4. **The Q&A history** — stay consistent with your earlier answers
+
+## How to Answer
+
+- Be concrete and specific. "Use PostgreSQL" not "use a database."
+- Reference existing codebase patterns when relevant. "Follow the ScannerEvent model pattern in backend/app/models/scanner.py."
+- If the issue or codebase clearly implies an answer, state it directly.
+- If you need to make a judgment call, explain your reasoning briefly.
+- Keep answers focused — 2-5 sentences is usually enough.
+
+## When You Cannot Answer
+
+If the question requires information that is NOT available in the issue, codebase, or documentation — and answering would require guessing about business intent, user preferences, or external constraints — respond with exactly:
+
+```
+UNCERTAIN: <one-sentence explanation of what information is missing>
+```
+
+Examples of UNCERTAIN situations:
+- "What's the expected SLA for this endpoint?" (no SLA docs exist)
+- "Should this be behind a feature flag?" (no feature flag policy documented)
+- "What's the priority relative to issue #X?" (requires human judgment)
+
+Examples where you SHOULD answer (not UNCERTAIN):
+- "What database should this use?" → PostgreSQL, it's the existing stack
+- "Should this be a Celery task?" → Yes, it's async and matches existing patterns
+- "What's the API route convention?" → Follow /api/{resource} pattern from existing routers
+
+## Context
+
+### Issue
+$ISSUE_CONTEXT
+
+### Q&A History
+$QA_HISTORY
+
+### Question
+$QUESTION

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Dark factory build context — only include what the Dockerfile needs
+*
+!dark-factory/
+!.claude/skills/refinement/

--- a/Docs/superpowers/plans/2026-05-13-auto-refinement-pipeline.md
+++ b/Docs/superpowers/plans/2026-05-13-auto-refinement-pipeline.md
@@ -1,0 +1,1138 @@
+# Auto-Refinement Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a multi-agent refinement pipeline that automatically produces specs and implementation plans from raw GitHub issues, integrated into the existing backlog scheduler.
+
+**Architecture:** An orchestrator agent drives brainstorming and spawns stateless product-owner subagents to answer clarifying questions. After human approval, a plan-writing stage with architect validation advances the issue to Ready. The pipeline integrates into `scheduler.sh` as new waterfall tiers for Backlog and Refined columns.
+
+**Tech Stack:** Bash (scheduler integration), Claude Code Agent tool (orchestrator/subagent communication), Archon workflow YAML (intent routing), GitHub CLI (issue/board manipulation)
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `.claude/skills/refinement/SKILL.md` | Skill entry point — loaded when manually invoking refinement |
+| `.claude/skills/refinement/product-owner-prompt.md` | Product owner persona for answering brainstorming questions |
+| `.claude/skills/refinement/architect-prompt.md` | Architect persona for validating implementation plans |
+| `.claude/skills/refinement/orchestrator-prompt.md` | Orchestrator instructions for driving the brainstorming loop |
+| `.claude/skills/refinement/config.yaml` | Tunable parameters (WIP limits, skip labels, thresholds) |
+| `.archon/commands/dark-factory-refine.md` | Archon command for Phase 1 (spec generation) |
+| `.archon/commands/dark-factory-plan.md` | Archon command for Phase 2 (plan generation) |
+| `.archon/workflows/archon-dark-factory.yaml` | Modified: add `refine` and `plan` intents |
+| `dark-factory/scheduler.sh` | Modified: add Backlog and Refined waterfall tiers |
+| `dark-factory/Dockerfile` | Modified: copy refinement skill files into image |
+| `dark-factory/entrypoint.sh` | Modified: handle `refine` and `plan` intents |
+
+---
+
+### Task 1: Refinement Skill Files
+
+Create the four prompt files and config that define the refinement pipeline's behavior. These are the adjustable building blocks.
+
+**Files:**
+- Create: `.claude/skills/refinement/SKILL.md`
+- Create: `.claude/skills/refinement/product-owner-prompt.md`
+- Create: `.claude/skills/refinement/architect-prompt.md`
+- Create: `.claude/skills/refinement/orchestrator-prompt.md`
+- Create: `.claude/skills/refinement/config.yaml`
+
+- [ ] **Step 1: Create the config file**
+
+```yaml
+# .claude/skills/refinement/config.yaml
+refine:
+  wip_limit: 2
+  skip_labels:
+    - needs-discussion
+    - epic
+    - spec-pending-review
+  min_issue_body_length: 20
+
+plan:
+  auto_advance_to_ready: true
+```
+
+- [ ] **Step 2: Create the product owner prompt**
+
+```markdown
+<!-- .claude/skills/refinement/product-owner-prompt.md -->
+
+# Product Owner — MarketHawk
+
+You are the product owner for MarketHawk, a full-stack stock scanning platform that identifies pre-market volume spikes and unusual trading patterns.
+
+## Your Role
+
+You answer clarifying questions from a brainstorming agent that is refining a feature idea into a spec. Base your answers on:
+
+1. **The GitHub issue** — title, body, labels, comments (provided below)
+2. **The codebase** — explore files, read existing patterns, check architecture
+3. **Domain documentation** — CLAUDE.md, ARCHITECTURE.md, and any docs referenced in the issue
+4. **The Q&A history** — stay consistent with your earlier answers
+
+## How to Answer
+
+- Be concrete and specific. "Use PostgreSQL" not "use a database."
+- Reference existing codebase patterns when relevant. "Follow the ScannerEvent model pattern in backend/app/models/scanner.py."
+- If the issue or codebase clearly implies an answer, state it directly.
+- If you need to make a judgment call, explain your reasoning briefly.
+- Keep answers focused — 2-5 sentences is usually enough.
+
+## When You Cannot Answer
+
+If the question requires information that is NOT available in the issue, codebase, or documentation — and answering would require guessing about business intent, user preferences, or external constraints — respond with exactly:
+
+```
+UNCERTAIN: <one-sentence explanation of what information is missing>
+```
+
+Examples of UNCERTAIN situations:
+- "What's the expected SLA for this endpoint?" (no SLA docs exist)
+- "Should this be behind a feature flag?" (no feature flag policy documented)
+- "What's the priority relative to issue #X?" (requires human judgment)
+
+Examples where you SHOULD answer (not UNCERTAIN):
+- "What database should this use?" → PostgreSQL, it's the existing stack
+- "Should this be a Celery task?" → Yes, it's async and matches existing patterns
+- "What's the API route convention?" → Follow /api/{resource} pattern from existing routers
+
+## Context
+
+### Issue
+$ISSUE_CONTEXT
+
+### Q&A History
+$QA_HISTORY
+
+### Question
+$QUESTION
+```
+
+- [ ] **Step 3: Create the architect prompt**
+
+```markdown
+<!-- .claude/skills/refinement/architect-prompt.md -->
+
+# Architect Reviewer — MarketHawk
+
+You are an architect reviewing an implementation plan for the MarketHawk stock scanning platform.
+
+## Your Role
+
+Validate that the implementation plan is complete, consistent, and follows codebase conventions. You are the last gate before the plan is handed to an autonomous agent for implementation.
+
+## What to Check
+
+### 1. Spec Coverage
+Read the spec (provided below). For each requirement, verify there is a corresponding task in the plan. List any requirements that have no task.
+
+### 2. File Path Consistency
+Check that file paths, function names, and interfaces used in later tasks match what was defined in earlier tasks. Flag any mismatches.
+
+### 3. Task Decomposition
+Each task should:
+- Be self-contained (produces a working, testable change)
+- Follow TDD (test first, then implementation)
+- Include exact file paths and code blocks
+- Have a commit step
+
+Flag tasks that are too large (should be split) or too vague (missing code blocks).
+
+### 4. Codebase Conventions
+Verify the plan follows patterns from the existing codebase:
+- Backend: FastAPI routers, SQLAlchemy models, Pydantic schemas, service layer
+- Frontend: React components, React Query hooks, Axios API layer
+- Testing: pytest for backend, tsc for frontend
+
+### 5. No Placeholders
+Flag any: "TBD", "TODO", "implement later", "add appropriate error handling", "similar to Task N", or steps without code blocks.
+
+## Output Format
+
+## Architect Review
+
+**Status:** Approved | Issues Found
+
+**Issues (if any):**
+- [Task N / Section]: [specific issue] — [why it matters]
+
+**Recommendations (advisory, do not block approval):**
+- [suggestions]
+
+## Context
+
+### Spec
+$SPEC_CONTENT
+
+### Plan
+$PLAN_CONTENT
+```
+
+- [ ] **Step 4: Create the orchestrator prompt**
+
+```markdown
+<!-- .claude/skills/refinement/orchestrator-prompt.md -->
+
+# Refinement Orchestrator
+
+You are a brainstorming agent that refines raw GitHub issues into complete design specs for the MarketHawk stock scanning platform.
+
+## Your Process
+
+### Phase 1: Context Gathering
+1. Read the GitHub issue (title, body, labels, comments)
+2. Read `CLAUDE.md` for tech stack, architecture, and conventions
+3. Read `ARCHITECTURE.md` for service topology
+4. Explore the codebase areas relevant to the issue (models, services, routers, frontend components)
+5. Build a mental model of what already exists and what the issue is asking for
+
+### Phase 2: Clarifying Questions
+Ask questions one at a time to refine the idea. For each question:
+1. Formulate a clear, specific question (prefer multiple choice when possible)
+2. Spawn a product-owner subagent with the question and full context
+3. Record the answer
+4. If the product owner returns `UNCERTAIN: <reason>`:
+   - Post a comment on the issue with the question, context gathered so far, and what you need to proceed
+   - Add `needs-discussion` label to the issue
+   - Exit immediately
+5. Continue until you have enough information to write the spec
+
+Focus questions on:
+- Purpose and success criteria
+- Scope boundaries (what's in, what's out)
+- Integration points with existing code
+- Data model decisions
+- UI/UX requirements (if applicable)
+- Error handling and edge cases
+
+### Phase 3: Approach Selection
+Propose 2-3 approaches with trade-offs. Select the best one based on:
+- Product owner answers
+- Codebase conventions and existing patterns
+- YAGNI — remove unnecessary features
+- Simplicity and maintainability
+
+### Phase 4: Spec Writing
+Write the spec to `Docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` following the existing spec format. Include:
+- Overview (problem statement from issue)
+- Requirements (distilled from Q&A)
+- Architecture / approach
+- Alternatives considered (from Phase 3)
+- Open questions (non-blocking)
+- Assumptions (flagged explicitly)
+
+### Phase 5: Self-Review
+Run this checklist on the spec:
+1. Placeholder scan — any "TBD", "TODO", incomplete sections?
+2. Internal consistency — do sections contradict each other?
+3. Scope check — focused enough for a single implementation plan?
+4. Ambiguity check — could any requirement be interpreted two different ways?
+Fix issues inline.
+
+### Phase 6: Publish
+1. Commit the spec to the current branch
+2. Post a summary comment on the issue with the spec highlights
+3. Add `spec-pending-review` label to the issue
+
+## Subagent Invocation
+
+To ask the product owner a question, spawn a subagent with:
+- Description: "Product owner: <short question summary>"
+- Prompt: The full content of `product-owner-prompt.md` with $ISSUE_CONTEXT, $QA_HISTORY, and $QUESTION replaced
+- The subagent should have access to Read, Grep, and Glob tools for codebase exploration
+
+## Issue Context
+$ISSUE_CONTEXT
+
+## Feedback (if re-run after changes requested)
+$FEEDBACK
+```
+
+- [ ] **Step 5: Create the SKILL.md entry point**
+
+```markdown
+<!-- .claude/skills/refinement/SKILL.md -->
+---
+name: refinement
+description: >
+  Multi-agent refinement pipeline for GitHub issues. Drives brainstorming via an
+  orchestrator + product-owner subagent pair, produces specs, then generates
+  implementation plans validated by an architect subagent. Integrates with the
+  backlog scheduler for automatic processing.
+---
+
+# Refinement Pipeline
+
+Invoke this skill to refine a GitHub issue into a complete spec and implementation plan.
+
+## Usage
+
+Manual invocation (in Claude Code session):
+```
+Refine issue #<number>
+```
+
+Automated invocation (via scheduler or dark factory):
+```bash
+docker compose --profile factory run --rm dark-factory "Refine issue #12"
+docker compose --profile factory run --rm dark-factory "Plan issue #12"
+```
+
+## What It Does
+
+**Phase 1 — Spec Generation (`refine` intent):**
+1. Reads the issue and explores the codebase
+2. Asks clarifying questions via product-owner subagent
+3. Selects best approach from 2-3 alternatives
+4. Writes and self-reviews the spec
+5. Posts spec to the issue, adds `spec-pending-review` label
+
+**Phase 2 — Plan Generation (`plan` intent):**
+1. Reads the approved spec
+2. Writes a full implementation plan (TDD, bite-sized tasks)
+3. Validates via architect subagent
+4. Posts plan to the issue, moves to Ready
+
+## Configuration
+
+See `config.yaml` for tunable parameters.
+
+## Prompt Files
+
+- `product-owner-prompt.md` — Persona for the Q&A subagent (adjustable)
+- `architect-prompt.md` — Persona for the plan reviewer (adjustable)
+- `orchestrator-prompt.md` — Instructions for the brainstorming orchestrator
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .claude/skills/refinement/
+git commit -m "feat(refinement): add skill files for auto-refinement pipeline (issue #52)
+
+Create product-owner, architect, and orchestrator prompts plus config.
+These are the adjustable building blocks of the refinement pipeline."
+```
+
+---
+
+### Task 2: Archon Commands for Refine and Plan
+
+Create the two Archon command files that Claude executes inside the dark factory container — one for spec generation (Phase 1), one for plan generation (Phase 2).
+
+**Files:**
+- Create: `.archon/commands/dark-factory-refine.md`
+- Create: `.archon/commands/dark-factory-plan.md`
+
+- [ ] **Step 1: Create the refine command**
+
+```markdown
+<!-- .archon/commands/dark-factory-refine.md -->
+---
+description: Refine a GitHub issue into a design spec using multi-agent brainstorming
+argument-hint: (no arguments - reads issue context from workflow)
+---
+
+# Dark Factory — Refine
+
+**Workflow ID**: $WORKFLOW_ID
+
+---
+
+## CRITICAL: Skip Guard
+
+If the issue has any of these labels, STOP immediately and exit with code 0 (not an error):
+- `spec-pending-review` — already processed
+- `needs-discussion` — waiting for human input
+- `epic` — needs manual decomposition
+
+## Phase 1: LOAD
+
+1. Read `CLAUDE.md` for development rules, architecture, and conventions
+2. Read `ARCHITECTURE.md` for service topology and module map
+3. The issue context has been fetched by the workflow. It is available in the conversation.
+4. Read `.claude/skills/refinement/orchestrator-prompt.md` for your process instructions
+5. Read `.claude/skills/refinement/product-owner-prompt.md` — you will pass this to subagents
+6. Read `.claude/skills/refinement/config.yaml` for pipeline configuration
+
+### If this is a re-run (feedback present in issue comments after a previous refinement report)
+
+Read the latest comments after any "Refinement Pipeline" report. Treat these as additional requirements from the user. Do NOT start from scratch — build on the previous spec if one exists on this branch.
+
+## Phase 2: PRE-FLIGHT
+
+Check the issue body length. If fewer than 20 characters:
+1. Post a comment: "This issue needs more detail before it can be refined. Please add a description of what you'd like to build and any constraints."
+2. Add `needs-discussion` label: `gh issue edit $ISSUE_NUM --add-label needs-discussion`
+3. Exit cleanly
+
+## Phase 3: CONTEXT ASSEMBLY
+
+Build a context package by exploring the codebase:
+1. Identify which area of the codebase the issue touches (backend models? services? frontend pages?)
+2. Read the relevant existing files to understand current patterns
+3. Assemble this into a context summary you will pass to every product-owner subagent
+
+## Phase 4: BRAINSTORMING LOOP
+
+Follow the process in `orchestrator-prompt.md`:
+1. Formulate one clarifying question at a time
+2. For each question, spawn a product-owner subagent using the Agent tool:
+   - `description`: "Product owner: <short question summary>"
+   - `prompt`: Content of `product-owner-prompt.md` with the $ISSUE_CONTEXT, $QA_HISTORY, and $QUESTION placeholders replaced with actual values
+   - The subagent needs Glob, Grep, and Read tools to explore the codebase
+3. If the subagent returns a response starting with `UNCERTAIN:`:
+   - Post a comment on the issue explaining the question and context gathered so far
+   - Run: `gh issue edit $ISSUE_NUM --add-label needs-discussion`
+   - Write a brief summary to `$ARTIFACTS_DIR/refinement-status.md` noting the abort reason
+   - Exit cleanly (exit code 0)
+4. Record the answer and continue until you have enough information
+
+## Phase 5: SPEC WRITING
+
+1. Propose 2-3 approaches with trade-offs
+2. Select the best approach based on Q&A answers and codebase patterns
+3. Write the spec to `Docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` following existing spec format:
+   - Overview / problem statement
+   - Requirements (from Q&A)
+   - Architecture / approach
+   - Alternatives considered
+   - Open questions (non-blocking)
+   - Assumptions (flagged)
+4. Self-review: placeholder scan, consistency check, scope check, ambiguity check. Fix inline.
+5. Commit the spec
+
+## Phase 6: PUBLISH
+
+1. Post a summary comment on the issue:
+   ```
+   ## Refinement Pipeline — Spec Generated
+
+   **Spec:** `<spec-file-path>`
+   **Branch:** `<branch-name>`
+
+   ### Summary
+   <2-3 sentence overview>
+
+   ### Requirements
+   <bulleted list of key requirements>
+
+   ### Approach
+   <1-2 sentences on chosen approach>
+
+   ### Assumptions
+   <bulleted list if any>
+
+   ---
+   *Posted by MarketHawk Refinement Pipeline*
+   ```
+2. Add label: `gh issue edit $ISSUE_NUM --add-label spec-pending-review`
+3. Write status to `$ARTIFACTS_DIR/refinement-status.md`:
+   ```
+   STATUS: SPEC_COMPLETE
+   SPEC_PATH: <path>
+   BRANCH: <branch>
+   QUESTIONS_ASKED: <count>
+   ```
+```
+
+- [ ] **Step 2: Create the plan command**
+
+```markdown
+<!-- .archon/commands/dark-factory-plan.md -->
+---
+description: Generate an implementation plan from an approved spec, validated by an architect subagent
+argument-hint: (no arguments - reads issue context from workflow)
+---
+
+# Dark Factory — Plan
+
+**Workflow ID**: $WORKFLOW_ID
+
+---
+
+## Phase 1: LOAD
+
+1. Read `CLAUDE.md` for development rules, architecture, and conventions
+2. The issue context has been fetched by the workflow. It is available in the conversation.
+3. Read `.claude/skills/refinement/architect-prompt.md` — you will pass this to the review subagent
+4. Find the spec file: look in `Docs/superpowers/specs/` for a file matching this issue's topic, or check the issue comments for a "Refinement Pipeline — Spec Generated" report that names the spec path
+5. Read the spec file
+
+## Phase 2: PLAN WRITING
+
+Write a full implementation plan following these conventions:
+- Save to `Docs/superpowers/plans/YYYY-MM-DD-<feature>.md`
+- Start with the standard plan header (Goal, Architecture, Tech Stack)
+- Include a File Structure table
+- Break into bite-sized tasks (each step is one 2-5 minute action)
+- Every task has: Files list, TDD steps (write failing test → verify fail → implement → verify pass → commit)
+- No placeholders — every step has actual code blocks and exact file paths
+- Exact commands with expected output
+
+## Phase 3: ARCHITECT REVIEW
+
+Spawn an architect subagent using the Agent tool:
+- `description`: "Architect review: validate plan against spec"
+- `prompt`: Content of `architect-prompt.md` with $SPEC_CONTENT and $PLAN_CONTENT replaced with the actual file contents
+
+### If architect returns "Issues Found":
+1. Fix each issue in the plan
+2. Re-spawn the architect subagent for re-review
+3. Repeat until approved (max 3 cycles)
+4. If still not approved after 3 cycles:
+   - Post the plan + architect feedback as an issue comment
+   - Add `needs-discussion` label: `gh issue edit $ISSUE_NUM --add-label needs-discussion`
+   - Exit cleanly
+
+### If architect returns "Approved":
+Proceed to publish.
+
+## Phase 4: PUBLISH
+
+1. Commit the plan
+2. Post a summary comment on the issue:
+   ```
+   ## Refinement Pipeline — Plan Generated
+
+   **Plan:** `<plan-file-path>`
+   **Branch:** `<branch-name>`
+   **Tasks:** <count> tasks, <total-steps> steps
+
+   ### Task Overview
+   <numbered list of task names>
+
+   ---
+   *Posted by MarketHawk Refinement Pipeline*
+   ```
+3. Write status to `$ARTIFACTS_DIR/refinement-status.md`:
+   ```
+   STATUS: PLAN_COMPLETE
+   PLAN_PATH: <path>
+   BRANCH: <branch>
+   TASKS: <count>
+   ARCHITECT_CYCLES: <count>
+   ```
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .archon/commands/dark-factory-refine.md .archon/commands/dark-factory-plan.md
+git commit -m "feat(refinement): add Archon commands for refine and plan intents (issue #52)
+
+dark-factory-refine.md drives Phase 1 (spec generation with product-owner subagent).
+dark-factory-plan.md drives Phase 2 (plan generation with architect validation)."
+```
+
+---
+
+### Task 3: Extend the Archon Workflow with Refine and Plan Intents
+
+Modify the dark factory Archon workflow to route `refine` and `plan` intents alongside the existing `new`/`continue`/`close` intents.
+
+**Files:**
+- Modify: `.archon/workflows/archon-dark-factory.yaml`
+
+- [ ] **Step 1: Update the parse-intent node to recognize refine and plan**
+
+In `.archon/workflows/archon-dark-factory.yaml`, replace the `parse-intent` node's prompt and output_format:
+
+```yaml
+  - id: parse-intent
+    prompt: |
+      Parse this command and extract two things:
+      1. The GitHub issue number
+      2. The intent: "new" (first time working on this issue), "continue" (iterate on existing work), "close" (merge and tear down), "refine" (generate a design spec), or "plan" (generate an implementation plan)
+
+      Command: $ARGUMENTS
+
+      Output ONLY valid JSON, nothing else:
+      {"issue_number": <int>, "intent": "<new|continue|close|refine|plan>"}
+    allowed_tools: []
+    model: haiku
+    output_format:
+      type: object
+      properties:
+        issue_number:
+          type: integer
+        intent:
+          type: string
+          enum: [new, continue, close, refine, plan]
+      required: [issue_number, intent]
+```
+
+- [ ] **Step 2: Add refine-specific branch setup node**
+
+Add this node after the existing `setup-branch` node:
+
+```yaml
+  - id: setup-refine-branch
+    bash: |
+      ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
+      INTENT=$parse-intent.output.intent
+      SLUG=$(echo $fetch-issue.output | jq -r '.title // "feature"' | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | head -c 40)
+      BRANCH="refine/issue-${ISSUE}-${SLUG}"
+
+      EXISTING=$(git branch -r --list "origin/$BRANCH" 2>/dev/null)
+      if [ -n "$EXISTING" ]; then
+        git fetch origin "$BRANCH" && git checkout "$BRANCH"
+      else
+        git checkout -b "$BRANCH"
+      fi
+      echo "$BRANCH"
+    depends_on: [parse-intent, fetch-issue]
+    when: "$parse-intent.output.intent == 'refine' || $parse-intent.output.intent == 'plan'"
+    timeout: 15000
+```
+
+- [ ] **Step 3: Add the refine node**
+
+Add after `setup-refine-branch`:
+
+```yaml
+  - id: refine
+    command: dark-factory-refine
+    depends_on: [setup-refine-branch, fetch-issue]
+    when: "$parse-intent.output.intent == 'refine'"
+    idle_timeout: 600000
+```
+
+- [ ] **Step 4: Add the plan node**
+
+Add after `refine`:
+
+```yaml
+  - id: plan
+    command: dark-factory-plan
+    depends_on: [setup-refine-branch, fetch-issue]
+    when: "$parse-intent.output.intent == 'plan'"
+    idle_timeout: 600000
+```
+
+- [ ] **Step 5: Add the refine push-and-label node**
+
+Add after the plan node. This handles pushing the refine/plan branches (no PR creation — just push and label):
+
+```yaml
+  - id: refine-push
+    bash: |
+      ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
+      BRANCH=$(git branch --show-current)
+
+      git push -u origin "$BRANCH"
+      echo "Pushed $BRANCH for issue #$ISSUE"
+    depends_on: [refine]
+    when: "$parse-intent.output.intent == 'refine'"
+    timeout: 30000
+
+  - id: plan-push-and-advance
+    bash: |
+      ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
+      BRANCH=$(git branch --show-current)
+
+      git push -u origin "$BRANCH"
+
+      # Move issue to Ready
+      ITEM_ID=$(gh project item-list 1 --owner omniscient --format json --limit 200 \
+        | jq -r ".items[] | select(.content.number == $ISSUE and .content.type == \"Issue\") | .id")
+      if [ -n "$ITEM_ID" ]; then
+        gh project item-edit \
+          --project-id PVT_kwHOAAFds84BWh4w \
+          --id "$ITEM_ID" \
+          --field-id PVTSSF_lAHOAAFds84BWh4wzhR1VaA \
+          --single-select-option-id 61e4505c
+        echo "Moved issue #$ISSUE to Ready"
+      fi
+
+      gh issue comment "$ISSUE" --body "Refinement pipeline complete. Spec and plan are on branch \`$BRANCH\`. Issue moved to **Ready** for implementation.
+
+      ---
+      *Posted by MarketHawk Refinement Pipeline*"
+    depends_on: [plan]
+    when: "$parse-intent.output.intent == 'plan'"
+    timeout: 30000
+```
+
+- [ ] **Step 6: Update the existing setup-branch 'when' clause**
+
+The existing `setup-branch` node currently uses `when: "$parse-intent.output.intent != 'close'"`. Update it to exclude refine and plan intents too:
+
+```yaml
+  - id: setup-branch
+    # ... existing bash unchanged ...
+    when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
+```
+
+- [ ] **Step 7: Update existing implement, preview-up, validate, push-and-pr, status-in-review, report nodes**
+
+Each of these nodes currently has `when: "$parse-intent.output.intent != 'close'"`. Update them all to:
+
+```yaml
+    when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
+```
+
+This ensures the dark factory's implementation/preview/PR pipeline only runs for `new` and `continue` intents, not for `refine` or `plan`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .archon/workflows/archon-dark-factory.yaml
+git commit -m "feat(refinement): extend Archon workflow with refine and plan intents (issue #52)
+
+Add refine/plan branch setup, refine and plan command nodes, push nodes,
+and update existing nodes to only trigger on new/continue intents."
+```
+
+---
+
+### Task 4: Update the Entrypoint for Refine and Plan Intents
+
+The dark factory `entrypoint.sh` currently parses `fix`, `continue`, and `close` intents from the command string and moves the issue to "In Progress". For `refine` and `plan`, the issue should NOT move to "In Progress" — it stays in its current column (Backlog or Refined).
+
+**Files:**
+- Modify: `dark-factory/entrypoint.sh:43-68`
+
+- [ ] **Step 1: Update intent parsing to recognize refine and plan**
+
+In `dark-factory/entrypoint.sh`, replace line 44:
+
+```bash
+INTENT=$(echo "$ARGUMENTS" | grep -oiP '^\s*\K(fix|continue|close)' | head -1 | tr '[:upper:]' '[:lower:]')
+```
+
+with:
+
+```bash
+INTENT=$(echo "$ARGUMENTS" | grep -oiP '^\s*\K(fix|continue|close|refine|plan)' | head -1 | tr '[:upper:]' '[:lower:]')
+```
+
+- [ ] **Step 2: Update the "move to In Progress" guard**
+
+Replace line 65-68:
+
+```bash
+if [ -n "$ISSUE_NUM" ] && [ "$INTENT" != "close" ]; then
+  echo "Moving issue #$ISSUE_NUM to In Progress..."
+  set_board_status "$STATUS_IN_PROGRESS" || echo "WARNING: Could not update project board"
+fi
+```
+
+with:
+
+```bash
+if [ -n "$ISSUE_NUM" ] && [ "$INTENT" != "close" ] && [ "$INTENT" != "refine" ] && [ "$INTENT" != "plan" ]; then
+  echo "Moving issue #$ISSUE_NUM to In Progress..."
+  set_board_status "$STATUS_IN_PROGRESS" || echo "WARNING: Could not update project board"
+fi
+```
+
+- [ ] **Step 3: Update the failure handler to handle refine/plan differently**
+
+Replace the `on_failure` function (lines 71-89):
+
+```bash
+on_failure() {
+  local EXIT_CODE=$?
+  if [ -n "${ISSUE_NUM:-}" ] && [ "$INTENT" != "close" ]; then
+    if [ "$INTENT" = "refine" ] || [ "$INTENT" = "plan" ]; then
+      echo "Refinement pipeline failed (exit $EXIT_CODE) for issue #$ISSUE_NUM"
+      gh issue comment "$ISSUE_NUM" --body "## Refinement Pipeline — Failed
+
+The refinement pipeline encountered an error (exit code $EXIT_CODE) and could not complete.
+
+\`\`\`bash
+# Retry
+docker compose --profile factory run --rm dark-factory \"$ARGUMENTS\"
+\`\`\`
+
+---
+*Posted by MarketHawk Refinement Pipeline*" 2>/dev/null || true
+    else
+      echo "Dark factory failed (exit $EXIT_CODE). Moving issue #$ISSUE_NUM back to Ready..."
+      set_board_status "$STATUS_BLOCKED" 2>/dev/null || true
+      gh issue comment "$ISSUE_NUM" --body "## Dark Factory Run — Failed
+
+The dark factory encountered an error (exit code $EXIT_CODE) and could not complete.
+Issue has been moved to **Blocked**.
+
+\`\`\`bash
+# Retry
+docker compose --profile factory run --rm dark-factory \"$ARGUMENTS\"
+\`\`\`
+
+---
+*Posted by MarketHawk Dark Factory*" 2>/dev/null || true
+    fi
+  fi
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dark-factory/entrypoint.sh
+git commit -m "feat(refinement): handle refine/plan intents in entrypoint.sh (issue #52)
+
+Skip In Progress move for refine/plan. Separate failure handler for
+refinement pipeline errors (no Blocked move, different report signature)."
+```
+
+---
+
+### Task 5: Add Backlog and Refined Tiers to Scheduler
+
+Add the two new waterfall tiers to `scheduler.sh` — Backlog items trigger refinement, Refined items trigger plan generation.
+
+**Files:**
+- Modify: `dark-factory/scheduler.sh:1-19` (add constants)
+- Modify: `dark-factory/scheduler.sh:59-64` (extend `is_issue_running`)
+- Modify: `dark-factory/scheduler.sh:80-95` (extend `has_skip_label`)
+- Modify: `dark-factory/scheduler.sh:213-300` (add waterfall tiers)
+
+- [ ] **Step 1: Add board constants for Backlog and Refined**
+
+In `dark-factory/scheduler.sh`, after line 19 (`STATUS_DONE="98236657"`), add:
+
+```bash
+STATUS_BACKLOG="f75ad846"
+STATUS_REFINED="0c79ebe5"
+
+# Refinement pipeline configuration
+REFINE_WIP_LIMIT="${REFINE_WIP_LIMIT:-2}"
+REFINE_SKIP_LABELS="needs-discussion,epic,spec-pending-review"
+```
+
+- [ ] **Step 2: Add a function to count running refinement containers**
+
+After the `is_issue_running` function (after line 64), add:
+
+```bash
+count_refine_running() {
+  docker ps --format '{{.Command}}' 2>/dev/null | grep -c '"Refine issue\|"Plan issue' || echo "0"
+}
+
+has_refine_skip_label() {
+  local item="$1"
+  local labels
+  labels=$(echo "$item" | jq -r '.labels[]?' 2>/dev/null)
+  IFS=',' read -ra SKIP_ARRAY <<< "$REFINE_SKIP_LABELS"
+  for skip in "${SKIP_ARRAY[@]}"; do
+    if echo "$labels" | grep -qi "$skip"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+has_new_comment_after_report() {
+  local issue_num="$1"
+  local report_marker="$2"
+  local comments
+  comments=$(gh issue view "$issue_num" --json comments -q '.comments' 2>/dev/null) || { echo "no"; return; }
+
+  local report_idx
+  report_idx=$(echo "$comments" | jq "map(.body) | to_entries | map(select(.value | test(\"$report_marker\"))) | last | .key // -1")
+
+  if [ "$report_idx" = "-1" ]; then
+    echo "no"
+    return
+  fi
+
+  local total
+  total=$(echo "$comments" | jq 'length')
+  local next_idx=$((report_idx + 1))
+  if [ "$next_idx" -lt "$total" ]; then
+    echo "yes"
+  else
+    echo "no"
+  fi
+}
+```
+
+- [ ] **Step 3: Add Backlog and Refined item fetching in the main loop**
+
+In the main loop, after line 224 (`IN_PROGRESS=$(get_items_by_status "$BOARD_ITEMS" "In Progress")`), add:
+
+```bash
+  BACKLOG=$(get_items_by_status "$BOARD_ITEMS" "Backlog")
+  REFINED=$(get_items_by_status "$BOARD_ITEMS" "Refined")
+
+  BACKLOG_COUNT=$(echo "$BACKLOG" | jq 'length')
+  REFINED_COUNT=$(echo "$REFINED" | jq 'length')
+  REFINE_RUNNING=$(count_refine_running)
+```
+
+- [ ] **Step 4: Add Priority 0 — Backlog items (refinement)**
+
+Insert BEFORE the existing "Priority 1: In Review" block (before line 235). The new block:
+
+```bash
+  # --- Priority 0: Backlog items (refinement) ---
+  while IFS= read -r item; do
+    [ -n "$DISPATCHED" ] && break
+    ISSUE=$(get_issue_number "$item")
+    if has_refine_skip_label "$item"; then continue; fi
+    if is_issue_running "$ISSUE"; then continue; fi
+    if [ "$REFINE_RUNNING" -ge "$REFINE_WIP_LIMIT" ]; then break; fi
+
+    # Check for spec-pending-review items with new human comments (re-run refinement)
+    ITEM_LABELS=$(echo "$item" | jq -r '.labels[]?' 2>/dev/null)
+    if echo "$ITEM_LABELS" | grep -qi "spec-pending-review"; then
+      HAS_NEW=$(has_new_comment_after_report "$ISSUE" "Posted by MarketHawk Refinement Pipeline")
+      if [ "$HAS_NEW" = "yes" ]; then
+        gh issue edit "$ISSUE" --remove-label "spec-pending-review" 2>/dev/null || true
+        dispatch "Refine issue #${ISSUE}"
+        DISPATCHED="Refine issue #${ISSUE}"
+        REFINE_RUNNING=$((REFINE_RUNNING + 1))
+      fi
+      continue
+    fi
+
+    dispatch "Refine issue #${ISSUE}"
+    DISPATCHED="Refine issue #${ISSUE}"
+    REFINE_RUNNING=$((REFINE_RUNNING + 1))
+  done < <(echo "$BACKLOG" | jq -c '.[]')
+
+  # --- Priority 0.5: Refined items (plan generation) ---
+  while IFS= read -r item; do
+    [ -n "$DISPATCHED" ] && break
+    ISSUE=$(get_issue_number "$item")
+    if has_skip_label "$item"; then continue; fi
+    if is_issue_running "$ISSUE"; then continue; fi
+    if [ "$REFINE_RUNNING" -ge "$REFINE_WIP_LIMIT" ]; then break; fi
+
+    dispatch "Plan issue #${ISSUE}"
+    DISPATCHED="Plan issue #${ISSUE}"
+    REFINE_RUNNING=$((REFINE_RUNNING + 1))
+  done < <(echo "$REFINED" | jq -c '.[]')
+```
+
+- [ ] **Step 5: Update the log line to include refinement counts**
+
+Replace the log lines at the end of the loop (lines 293-297):
+
+```bash
+  if [ -n "$DISPATCHED" ]; then
+    echo "[$(date -u +%FT%TZ)] backlog=${BACKLOG_COUNT} refined=${REFINED_COUNT} in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} refine_running=${REFINE_RUNNING}/${REFINE_WIP_LIMIT} dispatched=\"${DISPATCHED}\""
+  else
+    echo "[$(date -u +%FT%TZ)] backlog=${BACKLOG_COUNT} refined=${REFINED_COUNT} in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} refine_running=${REFINE_RUNNING}/${REFINE_WIP_LIMIT} skip=nothing_to_do"
+  fi
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dark-factory/scheduler.sh
+git commit -m "feat(refinement): add Backlog and Refined tiers to scheduler waterfall (issue #52)
+
+Backlog items dispatch 'Refine issue #N' for spec generation.
+Refined items dispatch 'Plan issue #N' for implementation planning.
+Separate WIP limit for refinement containers (default 2).
+Detects human comments on spec-pending-review items for re-runs."
+```
+
+---
+
+### Task 6: Update Dockerfile to Copy Skill Files
+
+The dark factory Dockerfile needs to copy the refinement skill files into the container image so the Archon commands can read them.
+
+**Files:**
+- Modify: `dark-factory/Dockerfile:66-71`
+
+- [ ] **Step 1: Add COPY for refinement skill files**
+
+In `dark-factory/Dockerfile`, after line 69 (`COPY seed_preview.sql /opt/dark-factory/seed_preview.sql`), add:
+
+```dockerfile
+COPY ../claude/skills/refinement/ /opt/refinement-skills/
+```
+
+Wait — the Dockerfile build context is `./dark-factory`, so it can't reach `../.claude/`. We need to either change the build context or copy the files into `dark-factory/` during build. The cleaner approach: add a `pre-build` step in docker-compose that copies, or change the build context.
+
+Actually, looking at the existing Dockerfile, the build context is `./dark-factory`. The simplest approach is to copy the skill files into the dark factory directory as part of the build context. But that creates duplication.
+
+Better approach: change the Dockerfile build context to the project root and adjust paths:
+
+In `docker-compose.yml`, the `dark-factory` service has:
+```yaml
+    build:
+      context: ./dark-factory
+      dockerfile: Dockerfile
+```
+
+Change to:
+```yaml
+    build:
+      context: .
+      dockerfile: dark-factory/Dockerfile
+```
+
+Then in the Dockerfile, update all COPY commands to use `dark-factory/` prefix, and add the skill files copy.
+
+Replace lines 67-70 of `dark-factory/Dockerfile`:
+
+```dockerfile
+COPY dark-factory/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY dark-factory/scheduler.sh /opt/dark-factory/scheduler.sh
+COPY dark-factory/docker-compose.preview.yml /opt/dark-factory/docker-compose.preview.yml
+COPY dark-factory/seed_preview.sql /opt/dark-factory/seed_preview.sql
+COPY .claude/skills/refinement/ /opt/refinement-skills/
+RUN chmod +x /usr/local/bin/entrypoint.sh /opt/dark-factory/scheduler.sh
+```
+
+And update both services in `docker-compose.yml`:
+
+For `dark-factory`:
+```yaml
+  dark-factory:
+    build:
+      context: .
+      dockerfile: dark-factory/Dockerfile
+```
+
+For `backlog-scheduler`:
+```yaml
+  backlog-scheduler:
+    build:
+      context: .
+      dockerfile: dark-factory/Dockerfile
+```
+
+- [ ] **Step 2: Update the refine and plan Archon commands to reference the correct path**
+
+The commands reference `.claude/skills/refinement/*.md` — inside the container these will be at `/opt/refinement-skills/`. Update the paths in `.archon/commands/dark-factory-refine.md`:
+
+Replace:
+```
+4. Read `.claude/skills/refinement/orchestrator-prompt.md` for your process instructions
+5. Read `.claude/skills/refinement/product-owner-prompt.md` — you will pass this to subagents
+6. Read `.claude/skills/refinement/config.yaml` for pipeline configuration
+```
+
+with:
+```
+4. Read `/opt/refinement-skills/orchestrator-prompt.md` for your process instructions
+5. Read `/opt/refinement-skills/product-owner-prompt.md` — you will pass this to subagents
+6. Read `/opt/refinement-skills/config.yaml` for pipeline configuration
+```
+
+And in `.archon/commands/dark-factory-plan.md`, replace:
+```
+3. Read `.claude/skills/refinement/architect-prompt.md` — you will pass this to the review subagent
+```
+
+with:
+```
+3. Read `/opt/refinement-skills/architect-prompt.md` — you will pass this to the review subagent
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dark-factory/Dockerfile docker-compose.yml .archon/commands/dark-factory-refine.md .archon/commands/dark-factory-plan.md
+git commit -m "feat(refinement): update Dockerfile and build context for skill files (issue #52)
+
+Change build context from ./dark-factory to project root so we can COPY
+.claude/skills/refinement/ into the image at /opt/refinement-skills/.
+Update Archon command paths to match container layout."
+```
+
+---
+
+### Task 7: Smoke Test — Manual Refine Invocation
+
+Verify the full pipeline works end-to-end by manually refining a test issue.
+
+**Files:**
+- No new files
+
+- [ ] **Step 1: Rebuild the dark factory image**
+
+```bash
+docker compose --profile factory build dark-factory
+```
+
+Expected: Build completes without errors. The output should show the COPY step for refinement skills.
+
+- [ ] **Step 2: Create a test issue (or use an existing Backlog item)**
+
+```bash
+gh issue create --repo omniscient/markethawk \
+  --title "Test: auto-refinement smoke test" \
+  --body "Add a simple health check endpoint that returns the current server timestamp and version number. This should be accessible without authentication."
+```
+
+Note the issue number.
+
+- [ ] **Step 3: Run the refine intent manually**
+
+```bash
+docker compose --profile factory run --rm dark-factory "Refine issue #<NUMBER>"
+```
+
+Expected:
+- Container starts and clones the repo
+- Orchestrator reads issue and starts asking questions
+- Product-owner subagent answers each question
+- Spec is written and committed
+- Issue gets a "Refinement Pipeline — Spec Generated" comment
+- Issue gets `spec-pending-review` label
+
+- [ ] **Step 4: Verify the outputs**
+
+```bash
+# Check the label was added
+gh issue view <NUMBER> --json labels --jq '.labels[].name'
+# Expected: spec-pending-review
+
+# Check the comment was posted
+gh issue view <NUMBER> --json comments --jq '.comments[-1].body' | head -20
+# Expected: starts with "## Refinement Pipeline — Spec Generated"
+
+# Check the branch exists
+git fetch origin
+git branch -r | grep "refine/issue-<NUMBER>"
+# Expected: shows the refine branch
+```
+
+- [ ] **Step 5: Test the plan intent**
+
+Simulate approval by moving the issue to Refined:
+```bash
+# Move to Refined on the board
+ITEM_ID=$(gh project item-list 1 --owner omniscient --format json --limit 200 \
+  | jq -r ".items[] | select(.content.number == <NUMBER> and .content.type == \"Issue\") | .id")
+gh project item-edit --project-id PVT_kwHOAAFds84BWh4w --id "$ITEM_ID" \
+  --field-id PVTSSF_lAHOAAFds84BWh4wzhR1VaA \
+  --single-select-option-id 0c79ebe5
+
+# Run the plan intent
+docker compose --profile factory run --rm dark-factory "Plan issue #<NUMBER>"
+```
+
+Expected:
+- Orchestrator reads the spec
+- Plan is written following TDD conventions
+- Architect subagent reviews and approves
+- Issue moves to Ready
+- Comment posted with plan summary
+
+- [ ] **Step 6: Clean up test issue**
+
+```bash
+gh issue close <NUMBER> --comment "Smoke test complete — closing."
+```
+
+- [ ] **Step 7: Commit any fixes discovered during smoke test**
+
+If the smoke test revealed issues, fix them and commit:
+
+```bash
+git add -A
+git commit -m "fix(refinement): address issues found during smoke test (issue #52)"
+```

--- a/Docs/superpowers/plans/2026-05-13-backlog-scheduler.md
+++ b/Docs/superpowers/plans/2026-05-13-backlog-scheduler.md
@@ -1,0 +1,550 @@
+# Backlog Scheduler Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a Docker-based Kanban flow controller that polls the GitHub project board every 30 seconds and dispatches dark factory runs based on board state.
+
+**Architecture:** A single bash script (`scheduler.sh`) runs an infinite polling loop. Each cycle reads board state via `gh`, classifies PR comments via `claude -p` (Haiku), and dispatches dark factory containers via `docker compose`. A new `backlog-scheduler` Docker service reuses the existing dark-factory image with an entrypoint override.
+
+**Tech Stack:** Bash, `gh` CLI (GitHub Projects GraphQL API), `claude` CLI (Haiku model), `jq`, Docker CLI
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `dark-factory/scheduler.sh` | Create | Polling loop, board state reading, comment classification, dispatch logic, retry tracking |
+| `dark-factory/Dockerfile` | Modify | Copy `scheduler.sh` into image |
+| `docker-compose.yml` | Modify | Add `backlog-scheduler` service under `scheduler` profile |
+
+---
+
+### Task 1: Create `scheduler.sh` — Configuration and Helpers
+
+**Files:**
+- Create: `dark-factory/scheduler.sh`
+
+- [ ] **Step 1: Create the script with configuration block and environment validation**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --- Configuration ---
+POLL_INTERVAL="${POLL_INTERVAL:-30}"
+SKIP_LABELS="needs-discussion,epic"
+MAX_RETRIES="${MAX_RETRIES:-3}"
+STATE_FILE="/tmp/scheduler-state.json"
+
+# Board constants
+PROJECT_NUMBER=1
+OWNER="omniscient"
+PROJECT_ID="PVT_kwHOAAFds84BWh4w"
+STATUS_FIELD="PVTSSF_lAHOAAFds84BWh4wzhR1VaA"
+STATUS_READY="61e4505c"
+STATUS_IN_PROGRESS="47fc9ee4"
+STATUS_IN_REVIEW="df73e18b"
+STATUS_BLOCKED="93d87b2f"
+STATUS_DONE="98236657"
+
+# --- Validate required environment ---
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "ERROR: GH_TOKEN is not set. Add it to .archon/.env" >&2
+  exit 1
+fi
+if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "ERROR: Set CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY in .archon/.env" >&2
+  exit 1
+fi
+
+# Initialize retry state
+if [ ! -f "$STATE_FILE" ]; then
+  echo '{}' > "$STATE_FILE"
+fi
+```
+
+- [ ] **Step 2: Add helper functions for retry tracking**
+
+Append to `dark-factory/scheduler.sh`:
+
+```bash
+# --- Retry tracking ---
+get_retry_count() {
+  local issue_num="$1"
+  jq -r --arg n "$issue_num" '.[$n] // 0' "$STATE_FILE"
+}
+
+increment_retry() {
+  local issue_num="$1"
+  local current
+  current=$(get_retry_count "$issue_num")
+  local new_count=$((current + 1))
+  local tmp
+  tmp=$(mktemp)
+  jq --arg n "$issue_num" --argjson c "$new_count" '.[$n] = $c' "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+}
+
+reset_retry() {
+  local issue_num="$1"
+  local tmp
+  tmp=$(mktemp)
+  jq --arg n "$issue_num" 'del(.[$n])' "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+}
+```
+
+- [ ] **Step 3: Add helper function to check for running dark-factory containers**
+
+Append to `dark-factory/scheduler.sh`:
+
+```bash
+# --- Duplicate dispatch prevention ---
+is_issue_running() {
+  local issue_num="$1"
+  docker ps --format '{{.Command}}' 2>/dev/null | grep -q "#${issue_num}" && return 0
+  return 1
+}
+```
+
+- [ ] **Step 4: Add dispatch helper**
+
+Append to `dark-factory/scheduler.sh`:
+
+```bash
+# --- Dispatch ---
+dispatch() {
+  local command="$1"
+  echo "Dispatching: $command"
+  docker compose -f /workspace/project/docker-compose.yml --profile factory run -d --rm dark-factory "$command"
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dark-factory/scheduler.sh
+git commit -m "feat(scheduler): add configuration, helpers, and dispatch logic (issue #2)"
+```
+
+---
+
+### Task 2: Board State Reading
+
+**Files:**
+- Modify: `dark-factory/scheduler.sh`
+
+- [ ] **Step 1: Add function to fetch all board items with their status and labels**
+
+Append to `dark-factory/scheduler.sh`:
+
+```bash
+# --- Board state ---
+fetch_board_items() {
+  gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 200
+}
+
+get_items_by_status() {
+  local items="$1"
+  local status_name="$2"
+  echo "$items" | jq -c "[.items[] | select(.status == \"$status_name\") | select(.content.type == \"Issue\")]"
+}
+
+has_skip_label() {
+  local item="$1"
+  local labels
+  labels=$(echo "$item" | jq -r '.labels[]?' 2>/dev/null)
+  IFS=',' read -ra SKIP_ARRAY <<< "$SKIP_LABELS"
+  for skip in "${SKIP_ARRAY[@]}"; do
+    if echo "$labels" | grep -qi "$skip"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+get_issue_number() {
+  local item="$1"
+  echo "$item" | jq -r '.content.number'
+}
+```
+
+- [ ] **Step 2: Add WIP limit reading via GraphQL**
+
+Append to `dark-factory/scheduler.sh`:
+
+```bash
+# --- WIP limits ---
+fetch_wip_limits() {
+  local result
+  result=$(gh api graphql -f query='
+    query {
+      node(id: "'"$PROJECT_ID"'") {
+        ... on ProjectV2 {
+          field(name: "Status") {
+            ... on ProjectV2SingleSelectField {
+              options { id name description }
+            }
+          }
+        }
+      }
+    }
+  ' 2>/dev/null) || true
+  echo "$result"
+}
+
+get_column_limit() {
+  local wip_data="$1"
+  local option_id="$2"
+  local desc
+  desc=$(echo "$wip_data" | jq -r --arg id "$option_id" \
+    '.data.node.field.options[] | select(.id == $id) | .description // ""' 2>/dev/null)
+  if echo "$desc" | grep -qoP 'limit:\s*\K\d+'; then
+    echo "$desc" | grep -oP 'limit:\s*\K\d+'
+  else
+    echo "999"
+  fi
+}
+```
+
+- [ ] **Step 3: Add dependency checking**
+
+Append to `dark-factory/scheduler.sh`:
+
+```bash
+# --- Dependency checking ---
+dependencies_met() {
+  local issue_num="$1"
+  local board_items="$2"
+  local body
+  body=$(gh issue view "$issue_num" --json body -q '.body' 2>/dev/null) || return 0
+  local deps
+  deps=$(echo "$body" | grep -oP 'Depends on:\s*#\K\d+' || true)
+  if [ -z "$deps" ]; then
+    return 0
+  fi
+  while IFS= read -r dep_num; do
+    local dep_status
+    dep_status=$(echo "$board_items" | jq -r ".items[] | select(.content.number == $dep_num) | .status" 2>/dev/null)
+    if [ "$dep_status" != "Done" ]; then
+      return 1
+    fi
+  done <<< "$deps"
+  return 0
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dark-factory/scheduler.sh
+git commit -m "feat(scheduler): add board state reading, WIP limits, and dependency checks (issue #2)"
+```
+
+---
+
+### Task 3: Comment Classification
+
+**Files:**
+- Modify: `dark-factory/scheduler.sh`
+
+- [ ] **Step 1: Add function to detect new human comments on a PR**
+
+Append to `dark-factory/scheduler.sh`:
+
+```bash
+# --- Comment interpretation ---
+get_new_comments() {
+  local issue_num="$1"
+  local comments
+  comments=$(gh issue view "$issue_num" --json comments -q '.comments' 2>/dev/null) || { echo "[]"; return; }
+
+  local factory_idx
+  factory_idx=$(echo "$comments" | jq 'map(.body) | to_entries | map(select(.value | test("Posted by MarketHawk Dark Factory"))) | last | .key // -1')
+
+  if [ "$factory_idx" = "-1" ]; then
+    echo "[]"
+    return
+  fi
+
+  local start_idx=$((factory_idx + 1))
+  local total
+  total=$(echo "$comments" | jq 'length')
+  if [ "$start_idx" -ge "$total" ]; then
+    echo "[]"
+    return
+  fi
+
+  echo "$comments" | jq --argjson s "$start_idx" '.[$s:]'
+}
+```
+
+- [ ] **Step 2: Add Claude Haiku classification function**
+
+Append to `dark-factory/scheduler.sh`:
+
+```bash
+classify_comments() {
+  local issue_num="$1"
+  local title="$2"
+  local comments_json="$3"
+
+  local comment_text
+  comment_text=$(echo "$comments_json" | jq -r '.[] | "[\(.author.login)] \(.body)"')
+
+  local prompt
+  prompt="You are a PR comment classifier. Read the comments below and decide
+the intent. Reply with exactly one word: MERGE, CONTINUE, or SKIP.
+
+MERGE — the reviewer approves the PR (e.g. \"looks good\", \"ship it\",
+\"approved\", \"LGTM\", thumbs up, ready to merge)
+CONTINUE — the reviewer wants changes (e.g. \"fix the tests\",
+\"can you rename X\", \"this needs error handling\", specific feedback)
+SKIP — the comment is informational, a question, or unclear intent
+(e.g. \"interesting approach\", \"what does this do?\", bot comments)
+
+PR #${issue_num}: ${title}
+Comments since last factory run:
+${comment_text}"
+
+  local result
+  result=$(echo "$prompt" | claude -p --model haiku 2>/dev/null | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
+
+  case "$result" in
+    MERGE|CONTINUE|SKIP) echo "$result" ;;
+    *) echo "SKIP" ;;
+  esac
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dark-factory/scheduler.sh
+git commit -m "feat(scheduler): add comment detection and Haiku classification (issue #2)"
+```
+
+---
+
+### Task 4: Main Polling Loop
+
+**Files:**
+- Modify: `dark-factory/scheduler.sh`
+
+- [ ] **Step 1: Add the main loop with the priority waterfall**
+
+Append to `dark-factory/scheduler.sh`:
+
+```bash
+# --- Main loop ---
+echo "Backlog scheduler started (poll every ${POLL_INTERVAL}s)"
+
+while true; do
+  DISPATCHED=""
+
+  # Fetch board state
+  BOARD_ITEMS=$(fetch_board_items 2>/dev/null) || { echo "[$(date -u +%FT%TZ)] error=gh_api_failed"; sleep "$POLL_INTERVAL"; continue; }
+
+  IN_REVIEW=$(get_items_by_status "$BOARD_ITEMS" "In Review")
+  BLOCKED=$(get_items_by_status "$BOARD_ITEMS" "Blocked")
+  READY=$(get_items_by_status "$BOARD_ITEMS" "Ready")
+  IN_PROGRESS=$(get_items_by_status "$BOARD_ITEMS" "In Progress")
+
+  IN_PROGRESS_COUNT=$(echo "$IN_PROGRESS" | jq 'length')
+  IN_REVIEW_COUNT=$(echo "$IN_REVIEW" | jq 'length')
+
+  # Read WIP limits
+  WIP_DATA=$(fetch_wip_limits)
+  MAX_IN_PROGRESS=$(get_column_limit "$WIP_DATA" "$STATUS_IN_PROGRESS")
+  MAX_IN_REVIEW=$(get_column_limit "$WIP_DATA" "$STATUS_IN_REVIEW")
+
+  # --- Priority 1: In Review items with new comments ---
+  for item in $(echo "$IN_REVIEW" | jq -c '.[]'); do
+    [ -n "$DISPATCHED" ] && break
+    ISSUE=$(get_issue_number "$item")
+    if has_skip_label "$item"; then continue; fi
+
+    NEW_COMMENTS=$(get_new_comments "$ISSUE")
+    COMMENT_COUNT=$(echo "$NEW_COMMENTS" | jq 'length')
+    if [ "$COMMENT_COUNT" -eq 0 ]; then continue; fi
+
+    TITLE=$(echo "$item" | jq -r '.content.title')
+    VERDICT=$(classify_comments "$ISSUE" "$TITLE" "$NEW_COMMENTS")
+
+    case "$VERDICT" in
+      MERGE)
+        dispatch "Close issue #${ISSUE}"
+        DISPATCHED="Close issue #${ISSUE}"
+        ;;
+      CONTINUE)
+        if ! is_issue_running "$ISSUE"; then
+          dispatch "Continue issue #${ISSUE}"
+          DISPATCHED="Continue issue #${ISSUE}"
+          reset_retry "$ISSUE"
+        fi
+        ;;
+      SKIP) ;;
+    esac
+  done
+
+  # --- Priority 2: Blocked items (retry) ---
+  for item in $(echo "$BLOCKED" | jq -c '.[]'); do
+    [ -n "$DISPATCHED" ] && break
+    ISSUE=$(get_issue_number "$item")
+    if has_skip_label "$item"; then continue; fi
+    if is_issue_running "$ISSUE"; then continue; fi
+
+    RETRIES=$(get_retry_count "$ISSUE")
+    if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then continue; fi
+
+    increment_retry "$ISSUE"
+    dispatch "Fix issue #${ISSUE}"
+    DISPATCHED="Fix issue #${ISSUE}"
+  done
+
+  # --- Priority 3: Ready items (new work) ---
+  for item in $(echo "$READY" | jq -c '.[]'); do
+    [ -n "$DISPATCHED" ] && break
+    ISSUE=$(get_issue_number "$item")
+    if has_skip_label "$item"; then continue; fi
+    if [ "$IN_PROGRESS_COUNT" -ge "$MAX_IN_PROGRESS" ]; then break; fi
+    if [ "$IN_REVIEW_COUNT" -ge "$MAX_IN_REVIEW" ]; then break; fi
+    if ! dependencies_met "$ISSUE" "$BOARD_ITEMS"; then continue; fi
+    if is_issue_running "$ISSUE"; then continue; fi
+
+    dispatch "Fix issue #${ISSUE}"
+    DISPATCHED="Fix issue #${ISSUE}"
+  done
+
+  # --- Log cycle summary ---
+  if [ -n "$DISPATCHED" ]; then
+    echo "[$(date -u +%FT%TZ)] in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} dispatched=\"${DISPATCHED}\""
+  else
+    echo "[$(date -u +%FT%TZ)] in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} skip=nothing_to_do"
+  fi
+
+  sleep "$POLL_INTERVAL"
+done
+```
+
+- [ ] **Step 2: Make the script executable**
+
+```bash
+chmod +x dark-factory/scheduler.sh
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dark-factory/scheduler.sh
+git commit -m "feat(scheduler): add main polling loop with priority waterfall (issue #2)"
+```
+
+---
+
+### Task 5: Dockerfile and Docker Compose Updates
+
+**Files:**
+- Modify: `dark-factory/Dockerfile:66-70`
+- Modify: `docker-compose.yml:293` (insert after dark-factory service)
+
+- [ ] **Step 1: Add `scheduler.sh` to the Dockerfile**
+
+In `dark-factory/Dockerfile`, after the line that copies `entrypoint.sh`, add the copy for `scheduler.sh`:
+
+```dockerfile
+COPY scheduler.sh /opt/dark-factory/scheduler.sh
+```
+
+And after the `chmod` line for `entrypoint.sh`, add:
+
+```dockerfile
+RUN chmod +x /opt/dark-factory/scheduler.sh
+```
+
+The relevant section should become:
+
+```dockerfile
+# Copy entrypoint, preview template, seed data, and scheduler
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY scheduler.sh /opt/dark-factory/scheduler.sh
+COPY docker-compose.preview.yml /opt/dark-factory/docker-compose.preview.yml
+COPY seed_preview.sql /opt/dark-factory/seed_preview.sql
+RUN chmod +x /usr/local/bin/entrypoint.sh /opt/dark-factory/scheduler.sh
+```
+
+- [ ] **Step 2: Add `backlog-scheduler` service to `docker-compose.yml`**
+
+Insert after the `dark-factory` service block (after line 293) and before the `volumes:` block:
+
+```yaml
+  # Backlog Scheduler — polls GitHub board and dispatches dark factory runs
+  backlog-scheduler:
+    build:
+      context: ./dark-factory
+      dockerfile: Dockerfile
+    container_name: backlog-scheduler
+    restart: unless-stopped
+    entrypoint: ["/opt/dark-factory/scheduler.sh"]
+    env_file:
+      - path: .archon/.env
+        required: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - .:/workspace/project:ro
+    networks:
+      - factory-network
+    profiles:
+      - scheduler
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dark-factory/Dockerfile docker-compose.yml
+git commit -m "feat(scheduler): add backlog-scheduler service to Docker stack (issue #2)"
+```
+
+---
+
+### Task 6: Manual Smoke Test
+
+- [ ] **Step 1: Build the image**
+
+```bash
+docker compose --profile scheduler build backlog-scheduler
+```
+
+Expected: Build completes successfully, `scheduler.sh` is copied into the image.
+
+- [ ] **Step 2: Verify the script is in the image**
+
+```bash
+docker compose --profile scheduler run --rm --entrypoint cat backlog-scheduler /opt/dark-factory/scheduler.sh | head -5
+```
+
+Expected: First 5 lines of `scheduler.sh` printed.
+
+- [ ] **Step 3: Start the scheduler and watch one cycle**
+
+```bash
+docker compose --profile scheduler up -d backlog-scheduler
+docker compose logs -f backlog-scheduler
+```
+
+Expected: See the startup message `Backlog scheduler started (poll every 30s)` followed by a log line like:
+```
+[2026-05-13T...Z] in_progress=N/M in_review=N/M skip=nothing_to_do
+```
+
+- [ ] **Step 4: Stop the scheduler**
+
+```bash
+docker compose --profile scheduler down
+```
+
+- [ ] **Step 5: Final commit (if any fixups were needed)**
+
+```bash
+git add -A
+git commit -m "fix(scheduler): smoke test fixups (issue #2)"
+```

--- a/Docs/superpowers/plans/2026-05-13-dark-factory-progress.md
+++ b/Docs/superpowers/plans/2026-05-13-dark-factory-progress.md
@@ -1,0 +1,268 @@
+# Dark Factory Progress Visibility — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add progress signals to the dark factory's "continue" and "close" flows so the user isn't left in the dark between kickoff and completion.
+
+**Architecture:** Three new Archon workflow nodes (`summarize-feedback`, `acknowledge-continue`, `close-announce`) inserted into the existing dependency graph, plus terminal echo additions to four existing nodes. All changes are in a single YAML file.
+
+**Tech Stack:** Archon workflow YAML, GitHub CLI (`gh`), Haiku model for feedback summarization
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `.archon/workflows/archon-dark-factory.yaml` | Modify | Add 3 new nodes, update 5 existing nodes |
+
+---
+
+### Task 1: Add `summarize-feedback` and `acknowledge-continue` nodes (continue flow)
+
+**Files:**
+- Modify: `.archon/workflows/archon-dark-factory.yaml` (insert after `fetch-issue` node, before `setup-branch` node — around line 120)
+
+- [ ] **Step 1: Add `summarize-feedback` prompt node**
+
+Insert this node between the `fetch-issue` node (ends at line 119) and the `# Layer 1: Route based on intent` comment (line 121). Place it right before the comment:
+
+```yaml
+  - id: summarize-feedback
+    prompt: |
+      You are reviewing feedback on a GitHub pull request. Below is the full issue context as JSON, including PR reviews, PR inline comments, and issue comments.
+
+      Focus ONLY on human-authored feedback posted AFTER the most recent comment that contains "Dark Factory Run" or "Dark Factory —". Ignore all comments ending with "*Posted by MarketHawk Dark Factory*" — those are automated.
+
+      If there are PR inline comments (pr_inline_comments), pay special attention to those — they are the most specific feedback.
+
+      Summarize the user's feedback in 2-3 sentences. What specifically are they asking to be changed or fixed?
+
+      Issue context:
+      $fetch-issue.output
+    allowed_tools: []
+    model: haiku
+    depends_on: [fetch-issue]
+    when: "$parse-intent.output.intent == 'continue'"
+```
+
+- [ ] **Step 2: Add `acknowledge-continue` bash node**
+
+Insert immediately after the `summarize-feedback` node:
+
+```yaml
+  - id: acknowledge-continue
+    bash: |
+      ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
+
+      gh issue comment "$ISSUE" --body "## Dark Factory — Resuming work
+
+      **Feedback understood:**
+      $summarize-feedback.output
+
+      Working on it now. Next update when implementation is complete.
+
+      ---
+      *Posted by MarketHawk Dark Factory*"
+
+      echo "Posted feedback acknowledgment to issue #$ISSUE"
+    depends_on: [summarize-feedback]
+    when: "$parse-intent.output.intent == 'continue'"
+    timeout: 15000
+```
+
+- [ ] **Step 3: Update `setup-branch` dependencies**
+
+Change the `setup-branch` node's `depends_on` from:
+
+```yaml
+    depends_on: [parse-intent, fetch-issue]
+```
+
+to:
+
+```yaml
+    depends_on: [parse-intent, fetch-issue, acknowledge-continue]
+```
+
+When intent is `new`, `acknowledge-continue` is skipped (its `when` condition is false), and Archon resolves skipped nodes as satisfied dependencies. When intent is `continue`, `setup-branch` waits for the acknowledgment comment to post before starting work.
+
+- [ ] **Step 4: Verify YAML syntax**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.archon/workflows/archon-dark-factory.yaml')); print('YAML valid')"
+```
+
+Expected: `YAML valid`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .archon/workflows/archon-dark-factory.yaml
+git commit -m "feat(factory): add feedback acknowledgment for continue flow (issue #48)"
+```
+
+---
+
+### Task 2: Add `close-announce` node (close flow)
+
+**Files:**
+- Modify: `.archon/workflows/archon-dark-factory.yaml` (insert before `close-preview` node)
+
+- [ ] **Step 1: Add `close-announce` bash node**
+
+Insert immediately before the `close-preview` node (currently the first node under `# Layer 1: Route based on intent`):
+
+```yaml
+  - id: close-announce
+    bash: |
+      ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
+
+      echo "Closing issue #$ISSUE — merging PR and tearing down preview..."
+
+      gh issue comment "$ISSUE" --body "## Dark Factory — Closing issue
+
+      Merging PR and tearing down preview environment. This usually takes under a minute.
+
+      ---
+      *Posted by MarketHawk Dark Factory*"
+    depends_on: [parse-intent, fetch-issue]
+    when: "$parse-intent.output.intent == 'close'"
+    timeout: 15000
+```
+
+- [ ] **Step 2: Update `close-preview` dependencies**
+
+Change the `close-preview` node's `depends_on` from:
+
+```yaml
+    depends_on: [parse-intent, fetch-issue]
+```
+
+to:
+
+```yaml
+    depends_on: [parse-intent, fetch-issue, close-announce]
+```
+
+- [ ] **Step 3: Verify YAML syntax**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.archon/workflows/archon-dark-factory.yaml')); print('YAML valid')"
+```
+
+Expected: `YAML valid`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .archon/workflows/archon-dark-factory.yaml
+git commit -m "feat(factory): add close-announce progress signal (issue #48)"
+```
+
+---
+
+### Task 3: Add terminal echoes to existing nodes
+
+**Files:**
+- Modify: `.archon/workflows/archon-dark-factory.yaml` (four existing nodes)
+
+- [ ] **Step 1: Add echo to `setup-branch`**
+
+Add this line as the first line of the `setup-branch` bash script (before `ISSUE=$(echo ...)`):
+
+```bash
+      echo "Setting up branch for issue #$(echo $fetch-issue.output | jq -r '.resolved_number')..."
+```
+
+The full node bash block should start with:
+
+```yaml
+    bash: |
+      echo "Setting up branch for issue #$(echo $fetch-issue.output | jq -r '.resolved_number')..."
+      ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
+```
+
+- [ ] **Step 2: Add echo to `push-and-pr`**
+
+Add this line as the first line of the `push-and-pr` bash script:
+
+```bash
+      echo "Pushing branch and creating/updating PR for issue #$(echo $fetch-issue.output | jq -r '.resolved_number')..."
+```
+
+The full node bash block should start with:
+
+```yaml
+    bash: |
+      echo "Pushing branch and creating/updating PR for issue #$(echo $fetch-issue.output | jq -r '.resolved_number')..."
+      ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
+```
+
+- [ ] **Step 3: Add echo to `status-in-review`**
+
+Add this line as the first line of the `status-in-review` bash script:
+
+```bash
+      echo "Moving issue #$(echo $fetch-issue.output | jq -r '.resolved_number') to In Review..."
+```
+
+The full node bash block should start with:
+
+```yaml
+    bash: |
+      echo "Moving issue #$(echo $fetch-issue.output | jq -r '.resolved_number') to In Review..."
+      ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
+```
+
+- [ ] **Step 4: Add echo to `report`**
+
+Add this line as the first line of the `report` bash script:
+
+```bash
+      echo "Posting summary to issue #$(echo $fetch-issue.output | jq -r '.resolved_number')..."
+```
+
+The full node bash block should start with:
+
+```yaml
+    bash: |
+      echo "Posting summary to issue #$(echo $fetch-issue.output | jq -r '.resolved_number')..."
+      ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
+```
+
+- [ ] **Step 5: Verify YAML syntax**
+
+Run:
+```bash
+python -c "import yaml; yaml.safe_load(open('.archon/workflows/archon-dark-factory.yaml')); print('YAML valid')"
+```
+
+Expected: `YAML valid`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .archon/workflows/archon-dark-factory.yaml
+git commit -m "feat(factory): add terminal echoes to workflow nodes (issue #48)"
+```
+
+---
+
+### Task 4: Post plan summary to GitHub issue
+
+- [ ] **Step 1: Post implementation summary to issue #48**
+
+```bash
+gh issue comment 48 --body "## Implementation Plan
+
+Plan saved to \`docs/superpowers/plans/2026-05-13-dark-factory-progress.md\`. Three tasks:
+
+1. **Continue flow** — \`summarize-feedback\` (Haiku) + \`acknowledge-continue\` (bash) nodes, update \`setup-branch\` deps
+2. **Close flow** — \`close-announce\` (bash) node, update \`close-preview\` deps
+3. **Terminal echoes** — add echo lines to \`setup-branch\`, \`push-and-pr\`, \`status-in-review\`, \`report\`
+
+All changes in \`.archon/workflows/archon-dark-factory.yaml\`."
+```

--- a/Docs/superpowers/specs/2026-05-13-auto-refinement-pipeline-design.md
+++ b/Docs/superpowers/specs/2026-05-13-auto-refinement-pipeline-design.md
@@ -1,0 +1,254 @@
+# Auto-Refinement Pipeline Design
+
+**Date:** 2026-05-13
+
+## Overview
+
+A multi-agent pipeline that automatically refines raw GitHub issues into reviewed specs and implementation plans. Two AI agents collaborate — a brainstormer orchestrator that drives requirements discovery, and a product-owner subagent that answers clarifying questions using issue context, codebase patterns, and domain documentation. The pipeline integrates into the existing backlog scheduler as a new tier in the priority waterfall.
+
+## Architecture
+
+### Agent Model: Orchestrator + Stateless Subagents
+
+The pipeline uses a single orchestrator (brainstormer role) that maintains conversational state across the refinement session. For each clarifying question, it spawns a stateless product-owner subagent via the Claude Code Agent tool. This asymmetry — stateful orchestrator, stateless responders — maps naturally to the problem: the brainstormer needs an evolving understanding of the feature, but each product-owner answer is independent.
+
+```
+Orchestrator (brainstormer):
+  ├─ Reads issue, codebase, docs
+  ├─ Formulates question 1
+  │   └─ Agent("product-owner") → answer 1
+  ├─ Formulates question 2
+  │   └─ Agent("product-owner") → answer 2
+  ├─ ... (until converged)
+  ├─ Proposes 2-3 approaches, selects best
+  ├─ Writes spec
+  ├─ Self-reviews spec
+  └─ Posts to issue, labels spec-pending-review
+```
+
+After spec approval, a second stage triggers:
+
+```
+Orchestrator (plan writer):
+  ├─ Reads approved spec
+  ├─ Writes implementation plan (writing-plans skill logic)
+  ├─ Spawns architect subagent for validation
+  │   └─ Agent("architect") → approval or issues
+  ├─ Fixes issues if any, re-submits
+  └─ Commits plan, moves issue to Ready
+```
+
+### Trigger Mechanisms
+
+**Manual:** Direct invocation via the dark factory container:
+```bash
+docker compose --profile factory run --rm dark-factory "Refine issue #12"
+```
+
+**Scheduled:** A new tier in the existing `scheduler.sh` priority waterfall. Scans for Backlog items that qualify for refinement on each polling cycle.
+
+### Pipeline Phases
+
+The pipeline has two distinct phases, separated by a human approval gate:
+
+**Phase 1: Spec Generation (Backlog → spec-pending-review)**
+
+Triggered when an issue is in the Backlog column without exclusion labels.
+
+1. **Parse & fetch** — Extract issue number and intent. Fetch issue data via `gh issue view`.
+
+2. **Pre-flight checks** — Skip if:
+   - Issue has `spec-pending-review` label (already processed)
+   - Issue has `needs-discussion` label (waiting for human input)
+   - Issue has `epic` label (needs manual decomposition)
+   - Issue body is empty or trivially short (< 20 chars) — add `needs-discussion` label with a comment requesting more detail
+
+3. **Context assembly** — Build a context package (assembled once, passed to every subagent):
+   - Issue content: title, body, labels, comments
+   - CLAUDE.md: tech stack, architecture, conventions
+   - ARCHITECTURE.md: service topology, module map
+   - Relevant existing code discovered by exploring the area the issue touches
+
+4. **Question loop** — The orchestrator formulates clarifying questions one at a time. For each question, it spawns a product-owner subagent with:
+   - The product-owner prompt (read from `product-owner-prompt.md`)
+   - The context package
+   - The full Q&A history so far
+   - The current question
+
+   The product-owner subagent reads the codebase and docs as needed. It returns either a concrete answer or `UNCERTAIN: <reason>`.
+
+   If `UNCERTAIN` is returned, the orchestrator:
+   - Posts a comment on the issue with the specific question and context gathered so far
+   - Adds `needs-discussion` label
+   - Exits the pipeline
+
+   The orchestrator decides when it has enough information to proceed — no fixed question cap.
+
+5. **Approach selection** — The orchestrator proposes 2-3 approaches internally, evaluates trade-offs against the Q&A answers and codebase patterns, and selects the best. Reasoning is captured in an "Alternatives Considered" section of the spec.
+
+6. **Spec writing** — Output follows the existing spec format in `Docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`. Contents:
+   - Problem statement (from issue)
+   - Requirements (distilled from Q&A)
+   - Architecture / approach
+   - Alternatives considered
+   - Open questions (non-blocking)
+   - Assumptions made (flagged explicitly)
+
+7. **Self-review** — Placeholder scan, internal consistency check, scope check, ambiguity check. Fixes inline.
+
+8. **Publish** — Commits the spec to a `refine/issue-<N>` branch. Posts a summary comment on the issue with the spec content. Adds `spec-pending-review` label. Issue stays in Backlog.
+
+**Human Approval Gate**
+
+The issue sits in Backlog with `spec-pending-review` until the user acts:
+
+- **Approve:** Remove `spec-pending-review` label and move issue to Refined. The scheduler detects the column change on the next cycle and triggers Phase 2.
+- **Request changes:** Post a comment with feedback on the issue. The scheduler detects a new human comment (after the pipeline's report) on a `spec-pending-review` issue, removes the label via `gh issue edit --remove-label`, and re-dispatches the refinement pipeline with the feedback included in the context.
+- **Reject:** Close the issue or add `needs-discussion`. No further automation.
+
+For `needs-discussion` issues: when the user answers the question and removes the label, the scheduler picks the issue up again on the next cycle.
+
+**Phase 2: Plan Generation (Refined → Ready)**
+
+Triggered when the scheduler detects an issue in the Refined column.
+
+1. **Plan writing** — The orchestrator reads the approved spec and produces a full implementation plan following writing-plans skill conventions. Output: `Docs/superpowers/plans/YYYY-MM-DD-<feature>.md` with bite-sized TDD tasks, exact file paths, and code blocks.
+
+2. **Architect review** — A subagent with an architect persona validates the plan:
+   - Does every spec requirement map to a task?
+   - Are file paths and interfaces consistent across tasks?
+   - Is the task decomposition appropriately scoped?
+   - Does the plan follow codebase conventions?
+
+   The architect prompt is loaded from `architect-prompt.md` (adjustable).
+
+3. **Fix loop** — If the architect flags issues, the orchestrator fixes them and re-submits. Repeat until approved.
+
+4. **Publish** — Commits the plan to the same `refine/issue-<N>` branch. Posts a summary comment on the issue. Moves the issue to Ready. The dark factory can now pick it up with a complete spec + plan.
+
+## Scheduler Integration
+
+### Updated Priority Waterfall
+
+```
+┌──────────────────────────────────────────────────┐
+│                 Every 60 seconds                  │
+├──────────────────────────────────────────────────┤
+│ 0. BACKLOG items (NEW)                            │
+│    For each (board order):                        │
+│    - No skip labels? Not already running?         │
+│    - Refine WIP < limit?                          │
+│    → dispatch "Refine issue #N"                   │
+│                                                   │
+│ 1. REFINED items (NEW)                            │
+│    For each (board order):                        │
+│    - Not already running?                         │
+│    → dispatch "Plan issue #N"                     │
+│                                                   │
+│ 2. IN REVIEW items                                │
+│    (existing logic — classify comments)           │
+│                                                   │
+│ 3. BLOCKED items                                  │
+│    (existing logic — retry failed issues)         │
+│                                                   │
+│ 4. READY items                                    │
+│    (existing logic — dispatch dark factory)       │
+│                                                   │
+│ 5. Nothing to do → sleep 60s                      │
+└──────────────────────────────────────────────────┘
+```
+
+### Concurrency
+
+- Refinement containers count toward a separate WIP limit (configurable, default 2) so they don't starve the dark factory
+- Each refinement run is checked via `docker ps` to prevent duplicate dispatches per issue
+- Refinement is lightweight (no preview stack, no Docker-in-Docker) — safe to run as first priority
+
+### Intent Routing
+
+The dark factory's `parse-intent` node gains two new intents alongside `new`/`continue`/`close`:
+
+| Intent | Trigger | Action |
+|--------|---------|--------|
+| `refine` | `"Refine issue #N"` | Run Phase 1 (spec generation) |
+| `plan` | `"Plan issue #N"` | Run Phase 2 (plan generation) |
+| `new` | `"Fix issue #N"` | Existing: implement from spec+plan |
+| `continue` | `"Continue issue #N"` | Existing: iterate on feedback |
+| `close` | `"Close issue #N"` | Existing: merge and tear down |
+
+## File Layout
+
+```
+.claude/skills/refinement/
+├── SKILL.md                    # Skill definition for manual invocation
+├── product-owner-prompt.md     # Product owner persona (adjustable)
+├── architect-prompt.md         # Architect reviewer persona (adjustable)
+├── orchestrator-prompt.md      # Brainstormer/orchestrator instructions
+└── config.yaml                 # Tunable parameters
+```
+
+### config.yaml
+
+```yaml
+refine:
+  wip_limit: 2
+  skip_labels:
+    - needs-discussion
+    - epic
+    - spec-pending-review
+  min_issue_body_length: 20
+
+plan:
+  auto_advance_to_ready: true
+```
+
+### Modified Existing Files
+
+| File | Change |
+|------|--------|
+| `dark-factory/scheduler.sh` | Add Backlog and Refined tiers to waterfall |
+| `dark-factory/Dockerfile` | Copy skill files into container image |
+| `docker-compose.yml` | No changes needed (scheduler service already exists) |
+
+### Output Locations
+
+| Artifact | Path |
+|----------|------|
+| Specs | `Docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md` |
+| Plans | `Docs/superpowers/plans/YYYY-MM-DD-<topic>.md` |
+| Branch | `refine/issue-<N>` |
+
+## Board Constants
+
+| Constant | Value |
+|----------|-------|
+| Project ID | `PVT_kwHOAAFds84BWh4w` |
+| Status Field ID | `PVTSSF_lAHOAAFds84BWh4wzhR1VaA` |
+| Backlog | `f75ad846` |
+| Refined | `0c79ebe5` |
+| Ready | `61e4505c` |
+| In Progress | `47fc9ee4` |
+| In Review | `df73e18b` |
+| Blocked | `93d87b2f` |
+| Done | `98236657` |
+
+## Failure Handling
+
+### Refinement pipeline fails
+The container exits with an error. The scheduler logs it and retries on the next cycle, up to `MAX_RETRIES` (3). After that, the issue is skipped and a warning is logged. Retry counter resets when the issue gets new human comments.
+
+### Product owner returns UNCERTAIN
+Not a failure — this is the designed abort path. The question is posted to the issue, `needs-discussion` is added, and the pipeline exits cleanly. The scheduler skips the issue until the label is removed.
+
+### Architect rejects plan repeatedly
+After 3 rejection cycles, the pipeline posts the latest plan + architect feedback as an issue comment, adds `needs-discussion`, and exits. Human intervention needed.
+
+### Scheduler crashes
+`restart: unless-stopped` handles recovery. The scheduler is stateless — reads board state fresh each cycle. Only retry counters are lost on restart.
+
+## Assumptions
+
+- The dark factory Docker image will be extended to support `refine` and `plan` intents (same image, new code paths)
+- The product-owner subagent runs inside the same Claude Code session as the orchestrator (Agent tool, not a separate container)
+- Issue bodies contain enough seed information (at minimum a title and a few sentences) for the brainstormer to start meaningful questions
+- The existing `refine/issue-<N>` branch naming won't conflict with `feat/issue-<N>` branches used by the dark factory

--- a/Docs/superpowers/specs/2026-05-13-dark-factory-progress-design.md
+++ b/Docs/superpowers/specs/2026-05-13-dark-factory-progress-design.md
@@ -1,0 +1,95 @@
+# Dark Factory Progress Visibility
+
+**Issue:** #48 — Dark Factory should be a bit more verbose as it progresses  
+**Date:** 2026-05-13  
+**Approach:** Workflow-level GitHub comments + terminal echoes (Approach A)
+
+## Problem
+
+The dark factory has two blind spots where the user gets no feedback:
+
+1. **"Continue" flow**: After leaving PR feedback and running `Continue issue #N`, there's no acknowledgment of what feedback was understood, and the board status doesn't visibly reset (it stays "In Progress" from the entrypoint, but was "In Review" — the user can't tell anything changed).
+2. **"Close" flow**: After running `Close issue #N`, there's silence between kickoff and the final "Done" comment. The user doesn't know if the merge/teardown process started.
+
+The existing status moves (In Progress, In Review, Done) are fine for the main "new" flow. This design only targets the two gaps above, plus minor terminal echo improvements.
+
+## Changes
+
+### 1. New node: `acknowledge-continue`
+
+**File:** `.archon/workflows/archon-dark-factory.yaml`  
+**Position:** After `fetch-issue`, before `setup-branch`  
+**Condition:** `intent == 'continue'`
+
+This is implemented as two sequential nodes (Archon nodes are either `prompt` or `bash`, not both):
+
+**Node 1a: `summarize-feedback` (Haiku prompt node):**  
+Receives the PR review comments, PR inline comments, and latest issue comments from `fetch-issue` output. The prompt instructs Haiku to focus on human-authored comments posted after the most recent "Dark Factory Run" or "Dark Factory — " comment (ignoring factory-posted comments). Produces a 2-3 sentence summary of what the user is requesting.
+
+**Node 1b: `acknowledge-continue` (bash node):**  
+Posts a GitHub comment to the issue using the summary from `summarize-feedback`:
+
+```markdown
+## Dark Factory — Resuming work
+
+**Feedback understood:**
+[Haiku-generated summary from summarize-feedback node]
+
+Working on it now. Next update when implementation is complete.
+
+---
+*Posted by MarketHawk Dark Factory*
+```
+
+**Terminal:** `echo "Posted feedback acknowledgment to issue #N"`
+
+**Board status:** The entrypoint already moves the ticket to "In Progress" for all non-close intents (line 65-68 of `entrypoint.sh`), so this is covered. No additional board logic needed.
+
+**Dependency chain:** `fetch-issue` -> `summarize-feedback` -> `acknowledge-continue` -> `setup-branch` (existing nodes unchanged, just new dependencies inserted).
+
+### 2. New node: `close-announce`
+
+**File:** `.archon/workflows/archon-dark-factory.yaml`  
+**Position:** After `fetch-issue`, before `close-preview`  
+**Condition:** `intent == 'close'`
+
+A bash node that posts a GitHub comment:
+
+```markdown
+## Dark Factory — Closing issue
+
+Merging PR and tearing down preview environment. This usually takes under a minute.
+
+---
+*Posted by MarketHawk Dark Factory*
+```
+
+**Terminal:** `echo "Closing issue #N — merging PR and tearing down preview..."`
+
+**Dependency chain:** `fetch-issue` -> `close-announce` -> `close-preview` (existing `close-preview` logic unchanged).
+
+### 3. Terminal echo additions
+
+Minor `echo` lines added to existing workflow nodes that currently run silently:
+
+| Node | Echo added |
+|------|------------|
+| `setup-branch` | `echo "Setting up branch for issue #N..."` |
+| `push-and-pr` | `echo "Pushing branch and creating/updating PR..."` |
+| `status-in-review` | `echo "Moving issue #N to In Review..."` |
+| `report` | `echo "Posting summary to issue #N..."` |
+
+Nodes that already echo (`preview-up`, `close-preview`) and Archon command nodes (`implement`, `validate`) are left unchanged.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `.archon/workflows/archon-dark-factory.yaml` | Add `summarize-feedback` node (Haiku prompt), add `acknowledge-continue` node (bash), add `close-announce` node (bash), update dependency chains, add echo lines to `setup-branch`, `push-and-pr`, `status-in-review`, `report` |
+
+## Not in Scope
+
+- Richer progress for the "new" flow (board status moves already cover it)
+- Single-comment-with-live-updates pattern (over-engineered for 2 blind spots)
+- Changes to `entrypoint.sh` (its existing echoes and board logic are sufficient)
+- Changes to Archon commands (`dark-factory-implement.md`, `dark-factory-validate.md`)

--- a/dark-factory/.dockerignore
+++ b/dark-factory/.dockerignore
@@ -1,4 +1,0 @@
-.git
-node_modules
-__pycache__
-*.pyc

--- a/dark-factory/Dockerfile
+++ b/dark-factory/Dockerfile
@@ -64,10 +64,11 @@ RUN git clone https://github.com/coleam00/Archon.git /opt/archon && \
 RUN mkdir -p /workspace
 
 # Copy entrypoint, scheduler, preview template, and seed data
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-COPY scheduler.sh /opt/dark-factory/scheduler.sh
-COPY docker-compose.preview.yml /opt/dark-factory/docker-compose.preview.yml
-COPY seed_preview.sql /opt/dark-factory/seed_preview.sql
+COPY dark-factory/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY dark-factory/scheduler.sh /opt/dark-factory/scheduler.sh
+COPY dark-factory/docker-compose.preview.yml /opt/dark-factory/docker-compose.preview.yml
+COPY dark-factory/seed_preview.sql /opt/dark-factory/seed_preview.sql
+COPY .claude/skills/refinement/ /opt/refinement-skills/
 RUN chmod +x /usr/local/bin/entrypoint.sh /opt/dark-factory/scheduler.sh
 
 WORKDIR /workspace

--- a/dark-factory/entrypoint.sh
+++ b/dark-factory/entrypoint.sh
@@ -41,7 +41,7 @@ fi
 
 # --- Extract issue number and intent immediately (no AI needed) ---
 ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oP '#\K\d+' | head -1)
-INTENT=$(echo "$ARGUMENTS" | grep -oiP '^\s*\K(fix|continue|close)' | head -1 | tr '[:upper:]' '[:lower:]')
+INTENT=$(echo "$ARGUMENTS" | grep -oiP '^\s*\K(fix|continue|close|refine|plan)' | head -1 | tr '[:upper:]' '[:lower:]')
 INTENT=${INTENT:-fix}
 
 # --- Helper: look up project board item for this issue ---
@@ -62,7 +62,7 @@ set_board_status() {
 }
 
 # --- Move to "In Progress" immediately (skip for close) ---
-if [ -n "$ISSUE_NUM" ] && [ "$INTENT" != "close" ]; then
+if [ -n "$ISSUE_NUM" ] && [ "$INTENT" != "close" ] && [ "$INTENT" != "refine" ] && [ "$INTENT" != "plan" ]; then
   echo "Moving issue #$ISSUE_NUM to In Progress..."
   set_board_status "$STATUS_IN_PROGRESS" || echo "WARNING: Could not update project board"
 fi
@@ -71,9 +71,23 @@ fi
 on_failure() {
   local EXIT_CODE=$?
   if [ -n "${ISSUE_NUM:-}" ] && [ "$INTENT" != "close" ]; then
-    echo "Dark factory failed (exit $EXIT_CODE). Moving issue #$ISSUE_NUM back to Ready..."
-    set_board_status "$STATUS_BLOCKED" 2>/dev/null || true
-    gh issue comment "$ISSUE_NUM" --body "## Dark Factory Run — Failed
+    if [ "$INTENT" = "refine" ] || [ "$INTENT" = "plan" ]; then
+      echo "Refinement pipeline failed (exit $EXIT_CODE) for issue #$ISSUE_NUM"
+      gh issue comment "$ISSUE_NUM" --body "## Refinement Pipeline — Failed
+
+The refinement pipeline encountered an error (exit code $EXIT_CODE) and could not complete.
+
+\`\`\`bash
+# Retry
+docker compose --profile factory run --rm dark-factory \"$ARGUMENTS\"
+\`\`\`
+
+---
+*Posted by MarketHawk Refinement Pipeline*" 2>/dev/null || true
+    else
+      echo "Dark factory failed (exit $EXIT_CODE). Moving issue #$ISSUE_NUM back to Ready..."
+      set_board_status "$STATUS_BLOCKED" 2>/dev/null || true
+      gh issue comment "$ISSUE_NUM" --body "## Dark Factory Run — Failed
 
 The dark factory encountered an error (exit code $EXIT_CODE) and could not complete.
 Issue has been moved to **Blocked**.
@@ -85,6 +99,7 @@ docker compose --profile factory run --rm dark-factory \"$ARGUMENTS\"
 
 ---
 *Posted by MarketHawk Dark Factory*" 2>/dev/null || true
+    fi
   fi
 }
 trap on_failure ERR

--- a/dark-factory/entrypoint.sh
+++ b/dark-factory/entrypoint.sh
@@ -36,6 +36,8 @@ if [ -z "$ARGUMENTS" ]; then
   echo "Usage: docker compose --profile factory run --rm dark-factory \"Fix issue #3\""
   echo "       docker compose --profile factory run --rm dark-factory \"Continue issue #3\""
   echo "       docker compose --profile factory run --rm dark-factory \"Close issue #3\""
+  echo "       docker compose --profile factory run --rm dark-factory \"Refine issue #3\""
+  echo "       docker compose --profile factory run --rm dark-factory \"Plan issue #3\""
   exit 1
 fi
 

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -6,6 +6,7 @@ POLL_INTERVAL="${POLL_INTERVAL:-30}"
 SKIP_LABELS="needs-discussion,epic"
 MAX_RETRIES="${MAX_RETRIES:-3}"
 STATE_FILE="/tmp/scheduler-state.json"
+RATE_LIMIT_FLOOR="${RATE_LIMIT_FLOOR:-200}"
 
 # Board constants
 PROJECT_NUMBER=1
@@ -32,6 +33,24 @@ fi
 if [ ! -f "$STATE_FILE" ]; then
   echo '{}' > "$STATE_FILE"
 fi
+
+# --- Rate limit guard ---
+check_rate_limit() {
+  local rate_json
+  rate_json=$(gh api rate_limit --jq '.resources.graphql' 2>/dev/null) || return 0
+  local remaining reset_at
+  remaining=$(echo "$rate_json" | jq -r '.remaining')
+  reset_at=$(echo "$rate_json" | jq -r '.reset')
+  if [ "$remaining" -le "$RATE_LIMIT_FLOOR" ]; then
+    local now
+    now=$(date +%s)
+    local wait=$((reset_at - now + 5))
+    if [ "$wait" -gt 0 ]; then
+      echo "[$(date -u +%FT%TZ)] rate_limit remaining=${remaining} sleeping=${wait}s until_reset"
+      sleep "$wait"
+    fi
+  fi
+}
 
 # --- Retry tracking ---
 get_retry_count() {
@@ -214,6 +233,9 @@ echo "Backlog scheduler started (poll every ${POLL_INTERVAL}s)"
 
 while true; do
   DISPATCHED=""
+
+  # Guard against rate limit exhaustion (REST call, doesn't cost GraphQL points)
+  check_rate_limit
 
   # Fetch board state
   BOARD_ITEMS=$(fetch_board_items 2>/dev/null) || { echo "[$(date -u +%FT%TZ)] error=gh_api_failed"; sleep "$POLL_INTERVAL"; continue; }

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -313,10 +313,11 @@ while true; do
   done < <(echo "$READY" | jq -c '.[]')
 
   # --- Log cycle summary ---
+  BUDGET=$(gh api rate_limit --jq '.resources.graphql | "\(.used)/\(.limit)"' 2>/dev/null) || BUDGET="?"
   if [ -n "$DISPATCHED" ]; then
-    echo "[$(date -u +%FT%TZ)] in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} dispatched=\"${DISPATCHED}\""
+    echo "[$(date -u +%FT%TZ)] in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} dispatched=\"${DISPATCHED}\" graphql=${BUDGET}"
   else
-    echo "[$(date -u +%FT%TZ)] in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} skip=nothing_to_do"
+    echo "[$(date -u +%FT%TZ)] in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} skip=nothing_to_do graphql=${BUDGET}"
   fi
 
   sleep "$POLL_INTERVAL"

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -182,7 +182,7 @@ dependencies_met() {
   local issue_num="$1"
   local board_items="$2"
   local body
-  body=$(gh issue view "$issue_num" --json body -q '.body' 2>/dev/null) || return 0
+  body=$(gh issue view "$issue_num" --repo "${OWNER}/markethawk" --json body -q '.body' 2>/dev/null) || return 0
   local deps
   deps=$(echo "$body" | grep -oP 'Depends on:\s*#\K\d+' || true)
   if [ -z "$deps" ]; then
@@ -202,13 +202,13 @@ dependencies_met() {
 get_new_comments() {
   local issue_num="$1"
   local comments
-  comments=$(gh issue view "$issue_num" --json comments -q '.comments' 2>/dev/null) || { echo "[]"; return; }
+  comments=$(gh issue view "$issue_num" --repo "${OWNER}/markethawk" --json comments -q '.comments' 2>/dev/null) || { echo "[]"; return; }
 
   local factory_idx
   factory_idx=$(echo "$comments" | jq 'map(.body) | to_entries | map(select(.value | test("Posted by MarketHawk Dark Factory"))) | last | .key // -1')
 
   if [ "$factory_idx" = "-1" ]; then
-    echo "[]"
+    echo "$comments"
     return
   fi
 
@@ -273,10 +273,10 @@ while true; do
   # Fetch board state
   BOARD_ITEMS=$(fetch_board_items 2>/dev/null) || { echo "[$(date -u +%FT%TZ)] error=gh_api_failed"; sleep "$POLL_INTERVAL"; continue; }
 
-  IN_REVIEW=$(get_items_by_status "$BOARD_ITEMS" "In Review")
+  IN_REVIEW=$(get_items_by_status "$BOARD_ITEMS" "In review")
   BLOCKED=$(get_items_by_status "$BOARD_ITEMS" "Blocked")
   READY=$(get_items_by_status "$BOARD_ITEMS" "Ready")
-  IN_PROGRESS=$(get_items_by_status "$BOARD_ITEMS" "In Progress")
+  IN_PROGRESS=$(get_items_by_status "$BOARD_ITEMS" "In progress")
 
   IN_PROGRESS_COUNT=$(echo "$IN_PROGRESS" | jq 'length')
   IN_REVIEW_COUNT=$(echo "$IN_REVIEW" | jq 'length')

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -18,6 +18,12 @@ STATUS_IN_PROGRESS="47fc9ee4"
 STATUS_IN_REVIEW="df73e18b"
 STATUS_BLOCKED="93d87b2f"
 STATUS_DONE="98236657"
+STATUS_BACKLOG="f75ad846"
+STATUS_REFINED="0c79ebe5"
+
+# Refinement pipeline configuration
+REFINE_WIP_LIMIT="${REFINE_WIP_LIMIT:-2}"
+REFINE_SKIP_LABELS="needs-discussion,epic,spec-pending-review"
 
 # --- Validate required environment ---
 if [ -z "${GH_TOKEN:-}" ]; then
@@ -80,6 +86,47 @@ is_issue_running() {
   local issue_num="$1"
   docker ps --format '{{.Command}}' 2>/dev/null | grep -q "#${issue_num}" && return 0
   return 1
+}
+
+count_refine_running() {
+  docker ps --format '{{.Command}}' 2>/dev/null | grep -c '"Refine issue\|"Plan issue' || echo "0"
+}
+
+has_refine_skip_label() {
+  local item="$1"
+  local labels
+  labels=$(echo "$item" | jq -r '.labels[]?' 2>/dev/null)
+  IFS=',' read -ra SKIP_ARRAY <<< "$REFINE_SKIP_LABELS"
+  for skip in "${SKIP_ARRAY[@]}"; do
+    if echo "$labels" | grep -qi "$skip"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+has_new_comment_after_report() {
+  local issue_num="$1"
+  local report_marker="$2"
+  local comments
+  comments=$(gh issue view "$issue_num" --repo "${OWNER}/markethawk" --json comments -q '.comments' 2>/dev/null) || { echo "no"; return; }
+
+  local report_idx
+  report_idx=$(echo "$comments" | jq "map(.body) | to_entries | map(select(.value | test(\"$report_marker\"))) | last | .key // -1")
+
+  if [ "$report_idx" = "-1" ]; then
+    echo "no"
+    return
+  fi
+
+  local total
+  total=$(echo "$comments" | jq 'length')
+  local next_idx=$((report_idx + 1))
+  if [ "$next_idx" -lt "$total" ]; then
+    echo "yes"
+  else
+    echo "no"
+  fi
 }
 
 # --- Dispatch ---
@@ -278,8 +325,53 @@ while true; do
   READY=$(get_items_by_status "$BOARD_ITEMS" "Ready")
   IN_PROGRESS=$(get_items_by_status "$BOARD_ITEMS" "In progress")
 
+  BACKLOG=$(get_items_by_status "$BOARD_ITEMS" "Backlog")
+  REFINED=$(get_items_by_status "$BOARD_ITEMS" "Refined")
+
   IN_PROGRESS_COUNT=$(echo "$IN_PROGRESS" | jq 'length')
   IN_REVIEW_COUNT=$(echo "$IN_REVIEW" | jq 'length')
+  BACKLOG_COUNT=$(echo "$BACKLOG" | jq 'length')
+  REFINED_COUNT=$(echo "$REFINED" | jq 'length')
+  REFINE_RUNNING=$(count_refine_running)
+
+  # --- Priority 0: Backlog items (refinement) ---
+  while IFS= read -r item; do
+    [ -n "$DISPATCHED" ] && break
+    ISSUE=$(get_issue_number "$item")
+    if has_refine_skip_label "$item"; then continue; fi
+    if is_issue_running "$ISSUE"; then continue; fi
+    if [ "$REFINE_RUNNING" -ge "$REFINE_WIP_LIMIT" ]; then break; fi
+
+    # Check for spec-pending-review items with new human comments (re-run refinement)
+    ITEM_LABELS=$(echo "$item" | jq -r '.labels[]?' 2>/dev/null)
+    if echo "$ITEM_LABELS" | grep -qi "spec-pending-review"; then
+      HAS_NEW=$(has_new_comment_after_report "$ISSUE" "Posted by MarketHawk Refinement Pipeline")
+      if [ "$HAS_NEW" = "yes" ]; then
+        gh issue edit "$ISSUE" --repo "${OWNER}/markethawk" --remove-label "spec-pending-review" 2>/dev/null || true
+        dispatch "Refine issue #${ISSUE}"
+        DISPATCHED="Refine issue #${ISSUE}"
+        REFINE_RUNNING=$((REFINE_RUNNING + 1))
+      fi
+      continue
+    fi
+
+    dispatch "Refine issue #${ISSUE}"
+    DISPATCHED="Refine issue #${ISSUE}"
+    REFINE_RUNNING=$((REFINE_RUNNING + 1))
+  done < <(echo "$BACKLOG" | jq -c '.[]')
+
+  # --- Priority 0.5: Refined items (plan generation) ---
+  while IFS= read -r item; do
+    [ -n "$DISPATCHED" ] && break
+    ISSUE=$(get_issue_number "$item")
+    if has_skip_label "$item"; then continue; fi
+    if is_issue_running "$ISSUE"; then continue; fi
+    if [ "$REFINE_RUNNING" -ge "$REFINE_WIP_LIMIT" ]; then break; fi
+
+    dispatch "Plan issue #${ISSUE}"
+    DISPATCHED="Plan issue #${ISSUE}"
+    REFINE_RUNNING=$((REFINE_RUNNING + 1))
+  done < <(echo "$REFINED" | jq -c '.[]')
 
   # --- Priority 1: In Review items with new comments ---
   while IFS= read -r item; do
@@ -342,9 +434,9 @@ while true; do
   # --- Log cycle summary ---
   BUDGET=$(gh api rate_limit --jq '.resources.graphql | "\(.used)/\(.limit)"' 2>/dev/null) || BUDGET="?"
   if [ -n "$DISPATCHED" ]; then
-    echo "[$(date -u +%FT%TZ)] in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} dispatched=\"${DISPATCHED}\" graphql=${BUDGET}"
+    echo "[$(date -u +%FT%TZ)] backlog=${BACKLOG_COUNT} refined=${REFINED_COUNT} in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} refine_running=${REFINE_RUNNING}/${REFINE_WIP_LIMIT} dispatched=\"${DISPATCHED}\" graphql=${BUDGET}"
   else
-    echo "[$(date -u +%FT%TZ)] in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} skip=nothing_to_do graphql=${BUDGET}"
+    echo "[$(date -u +%FT%TZ)] backlog=${BACKLOG_COUNT} refined=${REFINED_COUNT} in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} refine_running=${REFINE_RUNNING}/${REFINE_WIP_LIMIT} skip=nothing_to_do graphql=${BUDGET}"
   fi
 
   sleep "$POLL_INTERVAL"

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -89,7 +89,7 @@ is_issue_running() {
 }
 
 count_refine_running() {
-  docker ps --format '{{.Command}}' 2>/dev/null | grep -c '"Refine issue\|"Plan issue' || echo "0"
+  docker ps --format '{{.Command}}' 2>/dev/null | grep -cE 'Refine issue|Plan issue' || true
 }
 
 has_refine_skip_label() {
@@ -338,22 +338,25 @@ while true; do
   while IFS= read -r item; do
     [ -n "$DISPATCHED" ] && break
     ISSUE=$(get_issue_number "$item")
-    if has_refine_skip_label "$item"; then continue; fi
-    if is_issue_running "$ISSUE"; then continue; fi
-    if [ "$REFINE_RUNNING" -ge "$REFINE_WIP_LIMIT" ]; then break; fi
 
-    # Check for spec-pending-review items with new human comments (re-run refinement)
+    # Handle spec-pending-review items first (before skip-label check would filter them)
     ITEM_LABELS=$(echo "$item" | jq -r '.labels[]?' 2>/dev/null)
     if echo "$ITEM_LABELS" | grep -qi "spec-pending-review"; then
-      HAS_NEW=$(has_new_comment_after_report "$ISSUE" "Posted by MarketHawk Refinement Pipeline")
-      if [ "$HAS_NEW" = "yes" ]; then
-        gh issue edit "$ISSUE" --repo "${OWNER}/markethawk" --remove-label "spec-pending-review" 2>/dev/null || true
-        dispatch "Refine issue #${ISSUE}"
-        DISPATCHED="Refine issue #${ISSUE}"
-        REFINE_RUNNING=$((REFINE_RUNNING + 1))
+      if ! is_issue_running "$ISSUE" && [ "$REFINE_RUNNING" -lt "$REFINE_WIP_LIMIT" ]; then
+        HAS_NEW=$(has_new_comment_after_report "$ISSUE" "Posted by MarketHawk Refinement Pipeline")
+        if [ "$HAS_NEW" = "yes" ]; then
+          gh issue edit "$ISSUE" --repo "${OWNER}/markethawk" --remove-label "spec-pending-review" 2>/dev/null || true
+          dispatch "Refine issue #${ISSUE}"
+          DISPATCHED="Refine issue #${ISSUE}"
+          REFINE_RUNNING=$((REFINE_RUNNING + 1))
+        fi
       fi
       continue
     fi
+
+    if has_refine_skip_label "$item"; then continue; fi
+    if is_issue_running "$ISSUE"; then continue; fi
+    if [ "$REFINE_RUNNING" -ge "$REFINE_WIP_LIMIT" ]; then break; fi
 
     dispatch "Refine issue #${ISSUE}"
     DISPATCHED="Refine issue #${ISSUE}"
@@ -364,7 +367,7 @@ while true; do
   while IFS= read -r item; do
     [ -n "$DISPATCHED" ] && break
     ISSUE=$(get_issue_number "$item")
-    if has_skip_label "$item"; then continue; fi
+    if has_refine_skip_label "$item"; then continue; fi
     if is_issue_running "$ISSUE"; then continue; fi
     if [ "$REFINE_RUNNING" -ge "$REFINE_WIP_LIMIT" ]; then break; fi
 

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # --- Configuration ---
-POLL_INTERVAL="${POLL_INTERVAL:-30}"
+POLL_INTERVAL="${POLL_INTERVAL:-60}"
 SKIP_LABELS="needs-discussion,epic"
 MAX_RETRIES="${MAX_RETRIES:-3}"
 STATE_FILE="/tmp/scheduler-state.json"
@@ -228,6 +228,12 @@ ${comment_text}"
   esac
 }
 
+# --- Fetch WIP limits once at startup (cached until restart) ---
+WIP_DATA=$(fetch_wip_limits)
+MAX_IN_PROGRESS=$(get_column_limit "$WIP_DATA" "$STATUS_IN_PROGRESS")
+MAX_IN_REVIEW=$(get_column_limit "$WIP_DATA" "$STATUS_IN_REVIEW")
+echo "WIP limits: in_progress=${MAX_IN_PROGRESS} in_review=${MAX_IN_REVIEW}"
+
 # --- Main loop ---
 echo "Backlog scheduler started (poll every ${POLL_INTERVAL}s)"
 
@@ -247,11 +253,6 @@ while true; do
 
   IN_PROGRESS_COUNT=$(echo "$IN_PROGRESS" | jq 'length')
   IN_REVIEW_COUNT=$(echo "$IN_REVIEW" | jq 'length')
-
-  # Read WIP limits
-  WIP_DATA=$(fetch_wip_limits)
-  MAX_IN_PROGRESS=$(get_column_limit "$WIP_DATA" "$STATUS_IN_PROGRESS")
-  MAX_IN_REVIEW=$(get_column_limit "$WIP_DATA" "$STATUS_IN_REVIEW")
 
   # --- Priority 1: In Review items with new comments ---
   while IFS= read -r item; do

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -91,7 +91,34 @@ dispatch() {
 
 # --- Board state ---
 fetch_board_items() {
-  gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 30
+  local raw
+  raw=$(gh api graphql -f query='
+    query {
+      node(id: "'"$PROJECT_ID"'") {
+        ... on ProjectV2 {
+          items(first: 50) {
+            nodes {
+              fieldValueByName(name: "Status") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+              content {
+                ... on Issue {
+                  number
+                  title
+                  labels(first: 10) { nodes { name } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ')
+  echo "$raw" | jq '{items: [.data.node.items.nodes[]
+    | select(.content.number != null)
+    | {content: {number: .content.number, title: .content.title, type: "Issue"},
+       labels: [.content.labels.nodes[].name],
+       status: .fieldValueByName.name}]}'
 }
 
 get_items_by_status() {

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -91,7 +91,7 @@ dispatch() {
 
 # --- Board state ---
 fetch_board_items() {
-  gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 200
+  gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 30
 }
 
 get_items_by_status() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -279,8 +279,8 @@ services:
   # Dark Factory — autonomous development agent (run on demand)
   dark-factory:
     build:
-      context: ./dark-factory
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: dark-factory/Dockerfile
     container_name: markethawk-dark-factory
     env_file:
       - path: .archon/.env
@@ -295,8 +295,8 @@ services:
   # Backlog Scheduler — polls GitHub board and dispatches dark factory runs
   backlog-scheduler:
     build:
-      context: ./dark-factory
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: dark-factory/Dockerfile
     container_name: backlog-scheduler
     restart: unless-stopped
     entrypoint: ["/opt/dark-factory/scheduler.sh"]


### PR DESCRIPTION
## Summary

- Adds a multi-agent refinement pipeline that automatically produces specs and implementation plans from raw GitHub issues
- Two AI agents collaborate: a brainstormer orchestrator drives requirements discovery, a product-owner subagent answers clarifying questions using issue context + codebase + docs
- Integrates into the existing backlog scheduler as new priority tiers in the waterfall (Backlog → refine, Refined → plan)
- After spec approval, an architect subagent validates the implementation plan before advancing to Ready

## What Changed

### New files
- `.claude/skills/refinement/` — Adjustable prompt files (product-owner, architect, orchestrator) + config
- `.archon/commands/dark-factory-refine.md` — Archon command for Phase 1 (spec generation)
- `.archon/commands/dark-factory-plan.md` — Archon command for Phase 2 (plan generation)
- `.dockerignore` — Limits build context to only needed files
- `Docs/superpowers/specs/2026-05-13-auto-refinement-pipeline-design.md` — Design spec
- `Docs/superpowers/plans/2026-05-13-auto-refinement-pipeline.md` — Implementation plan

### Modified files
- `.archon/workflows/archon-dark-factory.yaml` — Added `refine`/`plan` intents, branch setup, command nodes; updated existing when-clauses to only fire on `new`/`continue`
- `dark-factory/entrypoint.sh` — Handles refine/plan intents (skip In Progress move, separate failure handler)
- `dark-factory/scheduler.sh` — New Backlog and Refined waterfall tiers with separate WIP limits, spec-pending-review re-run detection
- `dark-factory/Dockerfile` — Build context changed to project root to COPY skill files
- `docker-compose.yml` — Updated build context for both dark-factory and backlog-scheduler services

### Board flow
```
Backlog ──[refine]──→ Backlog (spec-pending-review)
                          │
                     user approves
                          │
                          ▼
                       Refined ──[plan]──→ Ready ──[dark factory]──→ ...
```

### Manual usage
```bash
docker compose --profile factory run --rm dark-factory "Refine issue omniscient/markethawk#12"
docker compose --profile factory run --rm dark-factory "Plan issue omniscient/markethawk#12"
```

## Test plan

- [ ] Rebuild dark factory image: `docker compose --profile factory build dark-factory`
- [ ] Verify Dockerfile COPY succeeds for refinement skills
- [ ] Manual smoke test: `docker compose --profile factory run --rm dark-factory "Refine issue omniscient/dark-factory#57"`
- [ ] Verify spec is posted to issue with `spec-pending-review` label
- [ ] Verify scheduler picks up Backlog items on next cycle
- [ ] Verify scheduler picks up Refined items for plan generation
- [ ] Verify spec-pending-review re-run works when human posts feedback comment
- [ ] Verify `needs-discussion` abort path when product owner returns UNCERTAIN

Closes omniscient/dark-factory#57

🤖 Generated with [Claude Code](https://claude.com/claude-code)