### PR TITLE
feat(phase-2a): Feature enrichment at signal time

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,10 +58,10 @@ A full pre-market scan proceeds as follows:
 
 | File | Responsibility |
 |------|---------------|
-| `scanner.py` | Core scan orchestration: `ScannerService`, `calculate_day_metrics()`, semaphore-bounded async fetch. |
+| `scanner.py` | Core scan orchestration: `ScannerService`, `calculate_day_metrics()`, `_get_batch_enrichment_data()` (returns 3-tuple with ES/NQ market context and sector ETF pct changes), Phase 2a 19-key feature enrichment in `run_pre_market_scan()`. |
 | `stock_data.py` | Historical OHLCV fetch, gap percentage calculation, per-ticker session flag logic. |
 | `discovery_service.py` | Bulk ticker sync from Polygon: paginated reference data, rate-limit-aware batching. |
-| `catalyst_parser.py` | Batch 72-hour news analysis for catalyst detection. Joins articles to tickers in memory. |
+| `catalyst_parser.py` | Batch 72-hour news analysis for catalyst detection. Joins articles to tickers in memory. Returns `latest_article_utc` per ticker for catalyst recency enrichment. |
 | `futures_data.py` | Futures contract data (ES, NQ, etc.), rollover date tracking. |
 | `chart_indicators.py` | Technical indicator computation (e.g., VWAP, moving averages) for chart endpoints. |
 | `journal_service.py` | Trade journal CRUD operations. |

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -55,10 +55,10 @@ MarketHawk/
 │   │   │   ├── active_watchlist.py     # ActiveWatchlistAdd / ActiveWatchlistUpdate / ActiveWatchlistItem
 │   │   │   └── stock.py                # Pydantic request/response models
 │   │   ├── services/
-│   │   │   ├── scanner.py              # Core scan logic; ScannerService; asyncio.Semaphore(10)
+│   │   │   ├── scanner.py              # Core scan logic; ScannerService; Phase 2a 19-key feature enrichment per signal
 │   │   │   ├── stock_data.py           # OHLCV fetch, gap calculation, session flags
 │   │   │   ├── discovery_service.py    # Bulk ticker sync from Polygon; rate-limit-aware paging
-│   │   │   ├── catalyst_parser.py      # Batch 72-hour news analysis for catalyst detection
+│   │   │   ├── catalyst_parser.py      # Batch 72-hour news analysis; returns latest_article_utc for recency enrichment
 │   │   │   ├── futures_data.py         # Futures contract data and rollover logic
 │   │   │   ├── chart_indicators.py     # Technical indicators (VWAP, MAs) for chart endpoints
 │   │   │   ├── journal_service.py      # Trade journal CRUD

--- a/backend/app/alembic/versions/b1c2d3e4f5a6_seed_sector_etfs_universe.py
+++ b/backend/app/alembic/versions/b1c2d3e4f5a6_seed_sector_etfs_universe.py
@@ -1,0 +1,46 @@
+"""seed_sector_etfs_universe
+
+Revision ID: b1c2d3e4f5a6
+Revises: fa2957d31876
+Create Date: 2026-05-14 12:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'b1c2d3e4f5a6'
+down_revision: Union[str, None] = 'b5e6f7a8b9c0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(sa.text("""
+        INSERT INTO stock_universes (id, name, description, criteria, is_active)
+        VALUES (2, :name, :desc, CAST(:criteria AS json), true)
+        ON CONFLICT (id) DO NOTHING
+    """), {
+        "name": "Sector ETFs",
+        "desc": "11 SPDR sector ETFs for pre-market momentum context",
+        "criteria": '{"type": "sector_etfs"}',
+    })
+
+    conn.execute(sa.text("""
+        INSERT INTO stock_universe_tickers (universe_id, ticker, asset_class, data_source)
+        SELECT 2, v.ticker, 'stocks', 'massive'
+        FROM (VALUES
+            ('XLK'), ('XLF'), ('XLV'), ('XLY'), ('XLP'),
+            ('XLE'), ('XLI'), ('XLB'), ('XLRE'), ('XLU'), ('XLC')
+        ) AS v(ticker)
+        WHERE NOT EXISTS (
+            SELECT 1 FROM stock_universe_tickers sut
+            WHERE sut.universe_id = 2 AND sut.ticker = v.ticker
+        )
+    """))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(sa.text("DELETE FROM stock_universe_tickers WHERE universe_id = 2"))
+    conn.execute(sa.text("DELETE FROM stock_universes WHERE id = 2"))

--- a/backend/app/services/catalyst_parser.py
+++ b/backend/app/services/catalyst_parser.py
@@ -50,7 +50,7 @@ class CatalystParser:
             NewsArticle.published_utc <= end_time
         ).all()
         
-        results = {t.upper(): {"tags": [], "summary": None} for t in tickers}
+        results = {t.upper(): {"tags": [], "summary": None, "latest_article_utc": None} for t in tickers}
         ticker_set = set(t.upper() for t in tickers)
         
         # Map articles to tickers
@@ -91,7 +91,8 @@ class CatalystParser:
             
             results[ticker] = {
                 "tags": list(tags),
-                "summary": summary
+                "summary": summary,
+                "latest_article_utc": recent_news[0].published_utc,
             }
             
         return results

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -4,10 +4,10 @@ Scanner Service - Pre-market volume scanning logic.
 
 import logging
 import asyncio
-from datetime import datetime, date, timedelta, timezone
+from datetime import datetime, date, time, timedelta, timezone
 from zoneinfo import ZoneInfo
 from app.utils.session import get_market_today
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional, Tuple
 
 import pandas as pd
 from sqlalchemy.orm import Session
@@ -15,6 +15,7 @@ from sqlalchemy import func, desc, or_
 
 from app.models.scanner_event import ScannerEvent
 from app.models.stock_aggregate import StockAggregate
+from app.models.futures_aggregate import FuturesAggregate
 from app.models.monitored_stock import MonitoredStock
 from app.models.ticker_reference import TickerReference
 from app.models.stock_split import StockSplit
@@ -22,6 +23,24 @@ from app.models.system_config import SystemConfig
 from app.services.catalyst_parser import CatalystParser
 from app.services.event_helpers import generate_event_summary, compute_event_severity
 from app.services.timeseries_forecast import get_volume_forecast, compute_anomaly_score
+
+_ET = ZoneInfo("America/New_York")
+
+_SECTOR_ETF_MAP: Dict[str, str] = {
+    "Technology": "XLK",
+    "Financials": "XLF",
+    "Health Care": "XLV",
+    "Consumer Discretionary": "XLY",
+    "Consumer Staples": "XLP",
+    "Energy": "XLE",
+    "Industrials": "XLI",
+    "Materials": "XLB",
+    "Real Estate": "XLRE",
+    "Utilities": "XLU",
+    "Communication Services": "XLC",
+}
+
+_SECTOR_ETF_SYMBOLS = list(_SECTOR_ETF_MAP.values())
 
 
 class ScannerService:
@@ -139,16 +158,26 @@ class ScannerService:
         return metrics
 
     @staticmethod
-    def _get_batch_enrichment_data(tickers: List[str], event_date: date, db: Session) -> Dict[str, Dict[str, Any]]:
-        """Fetch common enrichment data for a list of tickers in one batch."""
+    def _get_batch_enrichment_data(
+        tickers: List[str], event_date: date, db: Session
+    ) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Any], Dict[str, Optional[float]]]:
+        """Fetch common enrichment data for a list of tickers in one batch.
+
+        Returns a 3-tuple: (ticker_batch_data, market_context_dict, sector_etf_pct_dict)
+        """
+        day_start_et = datetime.combine(event_date, datetime.min.time(), tzinfo=_ET)
+        day_start_utc = day_start_et.astimezone(timezone.utc).replace(tzinfo=None)
+        day_end_utc = (day_start_et + timedelta(days=1)).astimezone(timezone.utc).replace(tzinfo=None)
+        prev_day_start_utc = (day_start_et - timedelta(days=1)).astimezone(timezone.utc).replace(tzinfo=None)
+
         # 1. Fetch MonitoredStock records
         monitored_records = db.query(MonitoredStock).filter(MonitoredStock.ticker.in_(tickers)).all()
         monitored_map = {r.ticker: r for r in monitored_records}
-        
+
         # 2. Fetch TickerReference records
         ref_records = db.query(TickerReference).filter(TickerReference.ticker.in_(tickers)).all()
         ref_map = {r.ticker: r for r in ref_records}
-        
+
         # 3. Recent Splits
         six_months_prior = event_date - timedelta(days=180)
         split_records = db.query(StockSplit).filter(
@@ -156,31 +185,123 @@ class ScannerService:
             StockSplit.execution_date <= event_date,
             StockSplit.execution_date >= six_months_prior
         ).order_by(desc(StockSplit.execution_date)).all()
-        
+
         split_map = {}
         for s in split_records:
             if s.ticker not in split_map:
                 split_map[s.ticker] = s.execution_date.isoformat()
-        
+
         # 4. Catalyst lookup via optimized batch analyzer
         catalyst_batch = CatalystParser.batch_analyze(tickers, event_date, db)
-        
+
         batch_data = {}
         for ticker in tickers:
             t_upper = ticker.upper()
             monitored = monitored_map.get(t_upper)
             ref = ref_map.get(t_upper)
-            cat = catalyst_batch.get(t_upper, {"tags": [], "summary": None})
-            
+            cat = catalyst_batch.get(t_upper, {"tags": [], "summary": None, "latest_article_utc": None})
+
             batch_data[t_upper] = {
                 "market_cap": float(monitored.market_cap) if monitored and monitored.market_cap else None,
                 "outstanding_shares": float(ref.share_class_shares_outstanding) if ref and ref.share_class_shares_outstanding else None,
                 "recent_split_date": split_map.get(t_upper),
                 "catalyst_tags": cat.get("tags", []),
                 "catalyst_summary": cat.get("summary"),
+                "catalyst_latest_utc": cat.get("latest_article_utc"),
+                "sector": ref.sector if ref else None,
             }
-            
-        return batch_data
+
+        # 5. ES/NQ market context — two most recent daily bars per symbol
+        market_context_dict: Dict[str, Any] = {
+            "es_pct_from_prev_close": None,
+            "nq_pct_from_prev_close": None,
+            "market_context": None,
+        }
+        try:
+            futures_bars = (
+                db.query(FuturesAggregate)
+                .filter(
+                    FuturesAggregate.symbol.in_(["ES", "NQ"]),
+                    FuturesAggregate.timespan == "day",
+                    FuturesAggregate.timestamp < day_end_utc,
+                )
+                .order_by(FuturesAggregate.symbol, FuturesAggregate.timestamp.desc())
+                .all()
+            )
+            symbol_bars: Dict[str, list] = {}
+            for bar in futures_bars:
+                symbol_bars.setdefault(bar.symbol, []).append(bar)
+
+            pct_changes: Dict[str, float] = {}
+            for sym in ("ES", "NQ"):
+                bars = symbol_bars.get(sym, [])
+                if len(bars) >= 2:
+                    current = float(bars[0].close)
+                    previous = float(bars[1].close)
+                    if previous > 0:
+                        pct_changes[sym] = round((current - previous) / previous * 100, 4)
+
+            if "ES" in pct_changes:
+                market_context_dict["es_pct_from_prev_close"] = pct_changes["ES"]
+            if "NQ" in pct_changes:
+                market_context_dict["nq_pct_from_prev_close"] = pct_changes["NQ"]
+
+            if "ES" in pct_changes and "NQ" in pct_changes:
+                es, nq = pct_changes["ES"], pct_changes["NQ"]
+                if es > 0.1 and nq > 0.1:
+                    market_context_dict["market_context"] = "risk_on"
+                elif es < -0.1 and nq < -0.1:
+                    market_context_dict["market_context"] = "risk_off"
+                else:
+                    market_context_dict["market_context"] = "neutral"
+        except Exception:
+            pass
+
+        # 6. Sector ETF pre-market bars
+        sector_etf_pct_dict: Dict[str, Optional[float]] = {s: None for s in _SECTOR_ETF_SYMBOLS}
+        try:
+            etf_daily = (
+                db.query(StockAggregate)
+                .filter(
+                    StockAggregate.ticker.in_(_SECTOR_ETF_SYMBOLS),
+                    StockAggregate.timespan == "day",
+                    StockAggregate.timestamp >= prev_day_start_utc,
+                    StockAggregate.timestamp < day_start_utc,
+                )
+                .order_by(StockAggregate.ticker, StockAggregate.timestamp.desc())
+                .all()
+            )
+            etf_prev_closes: Dict[str, float] = {}
+            for bar in etf_daily:
+                if bar.ticker not in etf_prev_closes:
+                    etf_prev_closes[bar.ticker] = float(bar.close)
+
+            etf_pm = (
+                db.query(StockAggregate)
+                .filter(
+                    StockAggregate.ticker.in_(_SECTOR_ETF_SYMBOLS),
+                    StockAggregate.timespan == "minute",
+                    StockAggregate.is_pre_market == True,
+                    StockAggregate.timestamp >= day_start_utc,
+                    StockAggregate.timestamp < day_end_utc,
+                )
+                .order_by(StockAggregate.ticker, StockAggregate.timestamp.asc())
+                .all()
+            )
+            etf_last_bar: Dict[str, StockAggregate] = {}
+            for bar in etf_pm:
+                etf_last_bar[bar.ticker] = bar  # ascending order → last write wins
+
+            for etf_sym in _SECTOR_ETF_SYMBOLS:
+                if etf_sym in etf_last_bar and etf_sym in etf_prev_closes:
+                    current = float(etf_last_bar[etf_sym].close)
+                    prev = etf_prev_closes[etf_sym]
+                    if prev > 0:
+                        sector_etf_pct_dict[etf_sym] = round((current - prev) / prev * 100, 4)
+        except Exception:
+            pass
+
+        return batch_data, market_context_dict, sector_etf_pct_dict
 
     @staticmethod
     def _save_event(
@@ -273,7 +394,7 @@ class ScannerService:
         min_history_bars = int(_cfg.get('timesfm_min_history_bars', '30'))
         fallback_multiplier = float(_cfg.get('timesfm_fallback_multiplier', '4.0'))
 
-        enrichment_batch = await asyncio.to_thread(
+        enrichment_batch, market_context_dict, sector_etf_pct_dict = await asyncio.to_thread(
             ScannerService._get_batch_enrichment_data, tickers, event_date, db
         )
 
@@ -365,6 +486,102 @@ class ScannerService:
                             pre_market_volume / enrichment["outstanding_shares"] * 100, 4
                         )
 
+                    # --- Phase 2a feature enrichment ---
+
+                    # Market context (batch-level, zero cost here)
+                    indicators["es_pct_from_prev_close"] = market_context_dict.get("es_pct_from_prev_close")
+                    indicators["nq_pct_from_prev_close"] = market_context_dict.get("nq_pct_from_prev_close")
+                    indicators["market_context"] = market_context_dict.get("market_context")
+
+                    # Sector features
+                    _sector = enrichment.get("sector")
+                    _sector_etf = _SECTOR_ETF_MAP.get(_sector) if _sector else None
+                    indicators["sector"] = _sector
+                    indicators["sector_etf"] = _sector_etf
+                    indicators["sector_etf_pct_change"] = (
+                        sector_etf_pct_dict.get(_sector_etf) if _sector_etf else None
+                    )
+
+                    # Timing features — derived from last pre-market bar, never datetime.now()
+                    _last_pre = (
+                        db.query(StockAggregate)
+                        .filter(
+                            StockAggregate.ticker == ticker,
+                            StockAggregate.timespan == "minute",
+                            StockAggregate.is_pre_market == True,
+                            StockAggregate.timestamp >= day_start_utc,
+                            StockAggregate.timestamp < day_end_utc,
+                        )
+                        .order_by(desc(StockAggregate.timestamp))
+                        .first()
+                    )
+                    if _last_pre:
+                        _bar_ts = _last_pre.timestamp
+                        if _bar_ts.tzinfo is None:
+                            _bar_ts = _bar_ts.replace(tzinfo=timezone.utc)
+                        _bar_ts_et = _bar_ts.astimezone(_ET)
+                        _pm_open_et = datetime.combine(event_date, time(4, 0), tzinfo=_ET)
+                        indicators["minutes_since_premarket_open"] = round(
+                            (_bar_ts_et - _pm_open_et).total_seconds() / 60, 2
+                        )
+                        indicators["day_of_week"] = _bar_ts_et.weekday()
+                        indicators["is_monday"] = _bar_ts_et.weekday() == 0
+                        indicators["is_friday"] = _bar_ts_et.weekday() == 4
+                    else:
+                        indicators["minutes_since_premarket_open"] = None
+                        indicators["day_of_week"] = None
+                        indicators["is_monday"] = False
+                        indicators["is_friday"] = False
+
+                    # Volatility regime — ATR_10 percentile rank within 60-day window
+                    _atr_rank: Optional[float] = None
+                    _vol_regime: Optional[str] = None
+                    if len(daily_bars) >= 11:
+                        _df = pd.DataFrame([{
+                            "H": float(b.high), "L": float(b.low), "C": float(b.close)
+                        } for b in daily_bars])
+                        _df["tr"] = pd.DataFrame({
+                            "a": _df["H"] - _df["L"],
+                            "b": (_df["H"] - _df["C"].shift(1)).abs(),
+                            "c": (_df["L"] - _df["C"].shift(1)).abs(),
+                        }).max(axis=1)
+                        _df["atr10"] = _df["tr"].rolling(window=10).mean()
+                        _window = _df["atr10"].dropna().tail(60)
+                        if len(_window) >= 10:
+                            _rank_pct = _window.rank(pct=True).iloc[-1]
+                            _atr_rank = round(float(_rank_pct) * 100, 2)
+                            if _rank_pct < 0.25:
+                                _vol_regime = "compressed"
+                            elif _rank_pct > 0.75:
+                                _vol_regime = "expanded"
+                            else:
+                                _vol_regime = "normal"
+                    indicators["atr_percentile_rank"] = _atr_rank
+                    indicators["volatility_regime"] = _vol_regime
+
+                    # Catalyst enrichment features
+                    _cat_tags = enrichment.get("catalyst_tags", [])
+                    _cat_latest = enrichment.get("catalyst_latest_utc")
+                    indicators["has_news_catalyst"] = bool(_cat_tags)
+                    indicators["catalyst_tag_count"] = len(_cat_tags)
+                    if _cat_latest is not None and _last_pre is not None:
+                        _ref_ts = _last_pre.timestamp
+                        if _ref_ts.tzinfo is None:
+                            _ref_ts = _ref_ts.replace(tzinfo=timezone.utc)
+                        if _cat_latest.tzinfo is None:
+                            _cat_latest = _cat_latest.replace(tzinfo=timezone.utc)
+                        indicators["catalyst_recency_hours"] = round(
+                            (_ref_ts - _cat_latest).total_seconds() / 3600, 2
+                        )
+                    else:
+                        indicators["catalyst_recency_hours"] = None
+
+                    # TimesFM price forecast keys (deferred — Phase 1 dependency #20)
+                    indicators["price_direction"] = None
+                    indicators["price_confidence"] = None
+                    indicators["price_forecast_4h"] = None
+                    indicators["price_forecast_1d"] = None
+
                     event_dict = ScannerService._save_event(
                         db=db,
                         ticker=ticker,
@@ -398,7 +615,7 @@ class ScannerService:
         day_end_utc = (day_start_et + timedelta(days=1)).astimezone(timezone.utc).replace(tzinfo=None)
         hist_start_utc = (day_start_et - timedelta(days=90)).astimezone(timezone.utc).replace(tzinfo=None)
 
-        enrichment_batch = await asyncio.to_thread(
+        enrichment_batch, _, _ = await asyncio.to_thread(
             ScannerService._get_batch_enrichment_data, tickers, event_date, db
         )
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,9 +1,11 @@
+import os
 import pytest
 import logging as _logging
 from typing import Generator
+from contextlib import contextmanager
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy.orm import Session
 from testcontainers.postgres import PostgresContainer
 
 from app.core.database import Base, get_db
@@ -14,26 +16,39 @@ _conftest_logger = _logging.getLogger(__name__)
 POSTGRES_IMAGE = "postgres:15-alpine"
 
 
+@contextmanager
+def _testcontainers_url():
+    with PostgresContainer(POSTGRES_IMAGE) as container:
+        yield container.get_connection_url()
+
+
+@contextmanager
+def _env_url(url: str):
+    yield url
+
+
 @pytest.fixture(scope="session")
 def pg_container():
-    with PostgresContainer(POSTGRES_IMAGE) as container:
-        yield container
+    # Yield a sentinel; real connection URL is resolved in db_engine.
+    yield None
 
 
 @pytest.fixture(scope="session")
 def db_engine(pg_container):
-    url = pg_container.get_connection_url()
-    engine = create_engine(url)
-    try:
-        Base.metadata.create_all(bind=engine)
-    except Exception as exc:
-        _conftest_logger.warning(f"db_engine: create_all failed ({exc})")
-        raise
-    yield engine
-    try:
-        Base.metadata.drop_all(bind=engine)
-    except Exception as exc:
-        _conftest_logger.warning(f"db_engine: drop_all skipped ({exc})")
+    test_url = os.environ.get("TEST_DATABASE_URL")
+    ctx = _env_url(test_url) if test_url else _testcontainers_url()
+    with ctx as url:
+        engine = create_engine(url)
+        try:
+            Base.metadata.create_all(bind=engine)
+        except Exception as exc:
+            _conftest_logger.warning(f"db_engine: create_all failed ({exc})")
+            raise
+        yield engine
+        try:
+            Base.metadata.drop_all(bind=engine)
+        except Exception as exc:
+            _conftest_logger.warning(f"db_engine: drop_all skipped ({exc})")
 
 
 @pytest.fixture(scope="function")

--- a/backend/tests/services/test_catalyst_parser_enrichment.py
+++ b/backend/tests/services/test_catalyst_parser_enrichment.py
@@ -1,0 +1,40 @@
+from datetime import date, datetime
+from unittest.mock import MagicMock
+
+from app.services.catalyst_parser import CatalystParser
+from app.models.news_article import NewsArticle
+
+
+def _make_article(ticker, title, published_utc):
+    a = NewsArticle()
+    a.tickers = [ticker]
+    a.title = title
+    a.description = ""
+    a.published_utc = published_utc
+    return a
+
+
+def test_batch_analyze_returns_latest_article_utc():
+    pub_utc = datetime(2025, 3, 10, 8, 0, 0)
+    article = _make_article("AAPL", "Apple acquires company", pub_utc)
+
+    db = MagicMock()
+    mq = MagicMock()
+    mq.filter.return_value = mq
+    mq.all.return_value = [article]
+    db.query.return_value = mq
+
+    result = CatalystParser.batch_analyze(["AAPL"], date(2025, 3, 10), db)
+    assert "latest_article_utc" in result["AAPL"]
+    assert result["AAPL"]["latest_article_utc"] == pub_utc
+
+
+def test_batch_analyze_latest_article_utc_null_when_no_news():
+    db = MagicMock()
+    mq = MagicMock()
+    mq.filter.return_value = mq
+    mq.all.return_value = []
+    db.query.return_value = mq
+
+    result = CatalystParser.batch_analyze(["AAPL"], date(2025, 3, 10), db)
+    assert result["AAPL"]["latest_article_utc"] is None

--- a/backend/tests/services/test_feature_enrichment.py
+++ b/backend/tests/services/test_feature_enrichment.py
@@ -1,0 +1,207 @@
+import asyncio
+import pytest
+from datetime import date, datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from app.services.scanner import ScannerService
+from app.models.stock_aggregate import StockAggregate
+from app.models.system_config import SystemConfig
+
+
+def _make_daily_bar(ticker, timestamp_utc, close, volume=1_000_000):
+    b = StockAggregate()
+    b.ticker = ticker
+    b.timestamp = timestamp_utc
+    b.timespan = "day"
+    b.multiplier = 1
+    b.open = close
+    b.high = close * 1.02
+    b.low = close * 0.98
+    b.close = close
+    b.volume = volume
+    b.is_pre_market = False
+    b.is_after_market = False
+    return b
+
+
+def _make_pm_bar(ticker, timestamp_utc, close=100.0):
+    b = StockAggregate()
+    b.ticker = ticker
+    b.timestamp = timestamp_utc
+    b.timespan = "minute"
+    b.multiplier = 1
+    b.open = close
+    b.high = close * 1.01
+    b.low = close * 0.99
+    b.close = close
+    b.volume = 50_000
+    b.is_pre_market = True
+    b.is_after_market = False
+    return b
+
+
+PHASE_2A_FEATURE_KEYS = [
+    "es_pct_from_prev_close", "nq_pct_from_prev_close", "market_context",
+    "sector", "sector_etf", "sector_etf_pct_change",
+    "minutes_since_premarket_open", "day_of_week", "is_monday", "is_friday",
+    "atr_percentile_rank", "volatility_regime",
+    "has_news_catalyst", "catalyst_tag_count", "catalyst_recency_hours",
+    "price_direction", "price_confidence", "price_forecast_4h", "price_forecast_1d",
+]
+
+
+def test_run_pre_market_scan_indicators_contain_all_feature_keys():
+    """All 19 Phase 2a feature keys must appear in indicators after a detected signal."""
+    ticker = "NVDA"
+    event_date = date(2026, 5, 14)  # Thursday
+
+    base_utc = datetime(2026, 4, 15, 20, 0, 0)
+    daily_bars = [
+        _make_daily_bar(ticker, base_utc + timedelta(days=i), 100.0 + i * 0.1)
+        for i in range(25)
+    ]
+    # 8:30 AM UTC = 4:30 AM ET
+    pm_bar = _make_pm_bar(ticker, datetime(2026, 5, 14, 8, 30, 0), close=105.0)
+
+    db = MagicMock()
+
+    def query_side(model):
+        mq = MagicMock()
+        mq.filter.return_value = mq
+        mq.order_by.return_value = mq
+        mq.limit.return_value = mq
+        mq.first.return_value = pm_bar
+        if model is SystemConfig:
+            mq.all.return_value = []
+        elif model is StockAggregate:
+            mq.all.return_value = daily_bars
+            mq.scalar.return_value = 5_000_000
+        else:
+            mq.all.return_value = []
+            mq.scalar.return_value = 5_000_000
+        return mq
+
+    db.query.side_effect = query_side
+
+    batch_enrichment = {
+        "NVDA": {
+            "market_cap": 2_000_000_000_000,
+            "outstanding_shares": 24_000_000_000,
+            "recent_split_date": None,
+            "catalyst_tags": ["earnings_beat"],
+            "catalyst_summary": "NVDA beats estimates",
+            "catalyst_latest_utc": datetime(2026, 5, 14, 3, 0, 0),
+            "sector": "Technology",
+        }
+    }
+    market_ctx = {
+        "es_pct_from_prev_close": 0.3,
+        "nq_pct_from_prev_close": 0.2,
+        "market_context": "risk_on",
+    }
+    etf_pcts = {s: None for s in ["XLK", "XLF", "XLV", "XLY", "XLP", "XLE", "XLI", "XLB", "XLRE", "XLU", "XLC"]}
+    etf_pcts["XLK"] = 0.4
+
+    saved_indicators = {}
+
+    def capture_save(**kwargs):
+        saved_indicators.update(kwargs.get("indicators", {}))
+        return {"id": 1}
+
+    with patch.object(ScannerService, '_get_batch_enrichment_data',
+                      return_value=(batch_enrichment, market_ctx, etf_pcts)), \
+         patch.object(ScannerService, 'calculate_day_metrics', return_value={
+             "closing_price": 106.0, "pre_market_close": 105.0,
+             "opening_price": 101.0, "regular_high": 107.0, "regular_low": 99.0,
+         }), \
+         patch.object(ScannerService, '_save_event', side_effect=capture_save):
+        asyncio.run(ScannerService.run_pre_market_scan([ticker], db, event_date=event_date))
+
+    assert saved_indicators, "_save_event was never called — signal not detected"
+
+    for key in PHASE_2A_FEATURE_KEYS:
+        assert key in saved_indicators, f"missing feature key: {key}"
+
+    assert saved_indicators["es_pct_from_prev_close"] == 0.3
+    assert saved_indicators["nq_pct_from_prev_close"] == 0.2
+    assert saved_indicators["market_context"] == "risk_on"
+    assert saved_indicators["sector"] == "Technology"
+    assert saved_indicators["sector_etf"] == "XLK"
+    assert saved_indicators["sector_etf_pct_change"] == 0.4
+    assert saved_indicators["day_of_week"] == 3        # Thursday
+    assert saved_indicators["is_monday"] is False
+    assert saved_indicators["is_friday"] is False
+    assert saved_indicators["minutes_since_premarket_open"] == pytest.approx(30.0, abs=1.0)
+    assert saved_indicators["has_news_catalyst"] is True
+    assert saved_indicators["catalyst_tag_count"] == 1
+    assert saved_indicators["price_direction"] is None
+    assert saved_indicators["price_confidence"] is None
+    assert saved_indicators["price_forecast_4h"] is None
+    assert saved_indicators["price_forecast_1d"] is None
+
+
+def test_run_pre_market_scan_features_null_when_no_pm_bar():
+    """Timing features are null when no pre-market bar exists for the ticker."""
+    ticker = "SPARSE"
+    event_date = date(2026, 5, 13)
+
+    base_utc = datetime(2026, 4, 1, 20, 0, 0)
+    daily_bars = [
+        _make_daily_bar(ticker, base_utc + timedelta(days=i), 50.0)
+        for i in range(25)
+    ]
+
+    db = MagicMock()
+
+    def query_side(model):
+        mq = MagicMock()
+        mq.filter.return_value = mq
+        mq.order_by.return_value = mq
+        mq.limit.return_value = mq
+        mq.first.return_value = None  # no pre-market bar
+        if model is SystemConfig:
+            mq.all.return_value = []
+        elif model is StockAggregate:
+            mq.all.return_value = daily_bars
+            mq.scalar.return_value = 5_000_000
+        else:
+            mq.all.return_value = []
+            mq.scalar.return_value = 5_000_000
+        return mq
+
+    db.query.side_effect = query_side
+
+    batch_enrichment = {
+        "SPARSE": {
+            "market_cap": None, "outstanding_shares": None,
+            "recent_split_date": None, "catalyst_tags": [],
+            "catalyst_summary": None, "catalyst_latest_utc": None,
+            "sector": None,
+        }
+    }
+
+    saved_indicators = {}
+
+    def capture_save(**kwargs):
+        saved_indicators.update(kwargs.get("indicators", {}))
+        return {"id": 2}
+
+    with patch.object(ScannerService, '_get_batch_enrichment_data',
+                      return_value=(batch_enrichment, {}, {})), \
+         patch.object(ScannerService, 'calculate_day_metrics', return_value={
+             "closing_price": 52.0, "pre_market_close": 51.0,
+             "opening_price": 51.0, "regular_high": 53.0, "regular_low": 49.0,
+         }), \
+         patch.object(ScannerService, '_save_event', side_effect=capture_save):
+        asyncio.run(ScannerService.run_pre_market_scan([ticker], db, event_date=event_date))
+
+    if saved_indicators:
+        assert saved_indicators["minutes_since_premarket_open"] is None
+        assert saved_indicators["day_of_week"] is None
+        assert saved_indicators["is_monday"] is False
+        assert saved_indicators["is_friday"] is False
+        assert saved_indicators["catalyst_recency_hours"] is None
+        assert saved_indicators["has_news_catalyst"] is False
+        assert saved_indicators["catalyst_tag_count"] == 0
+        assert saved_indicators["es_pct_from_prev_close"] is None
+        assert saved_indicators["market_context"] is None

--- a/backend/tests/services/test_scanner_refactor.py
+++ b/backend/tests/services/test_scanner_refactor.py
@@ -72,7 +72,7 @@ def test_pre_market_scan_detects_spike_from_db():
 
     db = _mock_db_for_pre_market(ticker, event_date, daily_closes, daily_volumes, pm_volume)
 
-    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value={ticker: {}}), \
+    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value=({ticker: {}}, {}, {})), \
          patch.object(ScannerService, 'calculate_day_metrics', return_value={
              "closing_price": 102.0, "pre_market_close": 101.0,
              "opening_price": 101.0, "regular_high": 103.0, "regular_low": 99.0,
@@ -96,7 +96,7 @@ def test_pre_market_scan_skips_insufficient_daily_bars():
 
     db = _mock_db_for_pre_market(ticker, event_date, [100.0] * 5, [1_000_000] * 5, 5_000_000)
 
-    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value={ticker: {}}), \
+    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value=({ticker: {}}, {}, {})), \
          patch.object(ScannerService, '_save_event') as mock_save:
 
         results = asyncio.run(ScannerService.run_pre_market_scan([ticker], db, event_date=event_date))
@@ -147,7 +147,7 @@ def test_oversold_bounce_detects_rsi_crossover():
     mock_q.all.return_value = daily_bars
     db.query.return_value = mock_q
 
-    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value={ticker: {}}), \
+    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value=({ticker: {}}, {}, {})), \
          patch.object(ScannerService, 'calculate_day_metrics', return_value={
              "closing_price": 100.0, "pre_market_close": 99.0,
              "opening_price": 100.0, "regular_high": 101.0, "regular_low": 99.0,
@@ -176,7 +176,7 @@ def test_oversold_bounce_skips_with_insufficient_bars():
     mock_q.all.return_value = daily_bars
     db.query.return_value = mock_q
 
-    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value={ticker: {}}), \
+    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value=({ticker: {}}, {}, {})), \
          patch.object(ScannerService, '_save_event') as mock_save:
 
         results = asyncio.run(
@@ -217,7 +217,7 @@ def test_pre_market_scan_includes_anomaly_indicators_when_timesfm_unavailable():
 
     db = _mock_db_for_pre_market(ticker, event_date, daily_closes, daily_volumes, pm_volume)
 
-    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value={ticker: {}}), \
+    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value=({ticker: {}}, {}, {})), \
          patch.object(ScannerService, 'calculate_day_metrics', return_value={
              "closing_price": 102.0, "pre_market_close": 101.0,
              "opening_price": 101.0, "regular_high": 103.0, "regular_low": 99.0,
@@ -264,7 +264,7 @@ def test_pre_market_scan_uses_timesfm_threshold_when_enabled():
     # Provide a mocked forecast that gives anomaly_score = 3.0 (≥ 2.0 → passes)
     mock_forecast = {"mean": 1_000_000.0, "std": 1_000_000.0, "p50": 900_000.0, "p90": 2_000_000.0}
 
-    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value={ticker: {}}), \
+    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value=({ticker: {}}, {}, {})), \
          patch.object(ScannerService, 'calculate_day_metrics', return_value={
              "closing_price": 52.0, "pre_market_close": 51.0,
              "opening_price": 51.0, "regular_high": 53.0, "regular_low": 49.0,
@@ -309,7 +309,7 @@ def test_pre_market_scan_static_fallback_when_timesfm_score_below_threshold():
     # Forecast gives score = (1_200_000 - 1_000_000) / 500_000 = 0.4 → below 2.0
     mock_forecast = {"mean": 1_000_000.0, "std": 500_000.0, "p50": 950_000.0, "p90": 1_500_000.0}
 
-    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value={ticker: {}}), \
+    with patch.object(ScannerService, '_get_batch_enrichment_data', return_value=({ticker: {}}, {}, {})), \
          patch('app.services.scanner.get_volume_forecast', return_value=mock_forecast), \
          patch.object(ScannerService, '_save_event', return_value={"id": 3}) as mock_save:
 

--- a/dark-factory/seed_preview.sql
+++ b/dark-factory/seed_preview.sql
@@ -37,6 +37,33 @@ VALUES
   (1, 'META', 'stocks', 'massive')
 ON CONFLICT DO NOTHING;
 
+-- Universe: Sector ETFs
+INSERT INTO stock_universes (id, name, description, criteria, is_active)
+VALUES (
+  2,
+  'Sector ETFs',
+  '11 SPDR sector ETFs for pre-market momentum context',
+  '{"type": "sector_etfs"}',
+  true
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Sector ETF universe tickers
+INSERT INTO stock_universe_tickers (universe_id, ticker, asset_class, data_source)
+VALUES
+  (2, 'XLK',  'stocks', 'massive'),
+  (2, 'XLF',  'stocks', 'massive'),
+  (2, 'XLV',  'stocks', 'massive'),
+  (2, 'XLY',  'stocks', 'massive'),
+  (2, 'XLP',  'stocks', 'massive'),
+  (2, 'XLE',  'stocks', 'massive'),
+  (2, 'XLI',  'stocks', 'massive'),
+  (2, 'XLB',  'stocks', 'massive'),
+  (2, 'XLRE', 'stocks', 'massive'),
+  (2, 'XLU',  'stocks', 'massive'),
+  (2, 'XLC',  'stocks', 'massive')
+ON CONFLICT DO NOTHING;
+
 -- Scanner config: Pre-Market Volume scanner
 INSERT INTO scanner_configs (id, name, description, scanner_type, parameters, criteria, is_active)
 VALUES (


### PR DESCRIPTION
Closes #21

## Summary

- Enriches every `ScannerEvent.indicators` with a 19-key Phase 2a feature vector at signal creation time — no model, no training, pure data collection for Phase 2b statistical discovery
- Adds ES/NQ market context (`risk_on`/`risk_off`/`neutral`) derived from `futures_aggregates` daily bars
- Adds sector and sector ETF pre-market % change using a new "Sector ETFs" universe (11 SPDR ETFs) and existing `stock_aggregates` pipeline
- Adds timing features (minutes since pre-market open, day of week, is_monday, is_friday) from last pre-market bar — never `datetime.now()`
- Adds volatility regime (ATR_10 percentile rank + `compressed`/`normal`/`expanded` label) from existing 90-day daily bars
- Adds catalyst enrichment features (`has_news_catalyst`, `catalyst_tag_count`, `catalyst_recency_hours`) extending `CatalystParser.batch_analyze()` to return `latest_article_utc`
- Adds null placeholders for TimesFM price forecast keys (deferred to Phase 1 #20)
- Seeds "Sector ETFs" universe via Alembic data migration + `seed_preview.sql`
- All features degrade gracefully to `null` when their data source is unavailable
- `run_oversold_bounce_scan` is unchanged (only pre-market volume spike scanner is enriched)

## Test plan

- [ ] `docker compose exec -T backend python -m pytest tests/services/ -v` — all 49 service tests pass
- [ ] `docker compose exec backend python -m alembic upgrade heads` — migration applies cleanly
- [ ] Check Sector ETFs universe appears in the Universes UI (id=2)
- [ ] Trigger a scanner run and inspect `ScannerEvent.indicators` via pgAdmin — all 19 Phase 2a keys should be present

🤖 Generated with [Claude Code](https://claude.com/claude-code)