### PR TITLE
feat: scanner validation skill — guided day-by-day QA walkthrough

### DIFF
--- a/.claude/skills/validate-scanner/SKILL.md
+++ b/.claude/skills/validate-scanner/SKILL.md
@@ -1,0 +1,329 @@
+---
+name: validate-scanner
+description: |
+  Guided day-by-day review of scanner signals against real market data. Walks through
+  one trading day at a time, presents each signal with indicator values and a chart URL,
+  accepts confirm/reject/enhance/skip/quit verdicts, persists verdicts to signal_reviews
+  DB table, and generates a summary report. Also handles /validate-scanner report for
+  on-demand reporting from prior sessions.
+argument-hint: "<scanner_type> [start_date] [end_date] | report"
+---
+
+# /validate-scanner
+
+Interactive QA skill for scanner output. Reviews signals one trading day at a time.
+
+## Invocation
+
+```
+/validate-scanner <scanner_type> [start_date] [end_date]
+/validate-scanner report
+```
+
+**Known scanner types:** `pre_market_volume_spike`, `oversold_bounce`, `liquidity_hunt`
+(alias for `liquidity_hunt_pre` + `liquidity_hunt_post`), `live_volume_spike`, `live_price_move`
+
+**Live types** (`live_volume_spike`, `live_price_move`) produce events only during live
+sessions and will likely return no historical results — warn the user if selected.
+
+---
+
+## Execution Steps
+
+### Phase 1: Parse Arguments
+
+1. Parse skill args. If `args[0]` is `"report"`, jump to **Phase 5: Report**.
+2. If `scanner_type` is missing, display this menu and prompt:
+   ```
+   Known scanner types:
+     1. pre_market_volume_spike
+     2. oversold_bounce
+     3. liquidity_hunt  (covers liquidity_hunt_pre + liquidity_hunt_post)
+     4. live_volume_spike  ⚠️  historical events unlikely
+     5. live_price_move    ⚠️  historical events unlikely
+   Enter scanner type:
+   ```
+3. Validate `scanner_type` is in the known set. Reject unknown types with an error.
+4. If `start_date` or `end_date` is missing, prompt:
+   ```
+   Start date (YYYY-MM-DD):
+   End date   (YYYY-MM-DD):
+   ```
+5. Prompt for a universe_id to enable live re-scan in the enhance flow:
+   ```
+   Universe ID for re-scan (optional — press Enter to skip live re-scan):
+   ```
+   Store as `session_universe_id` (None if skipped). When None, the enhance flow will record suggestions but skip the live PATCH + re-scan step.
+6. If `scanner_type` is `liquidity_hunt`, internally expand to query for
+   `liquidity_hunt_pre` AND `liquidity_hunt_post` by using the existing API alias
+   (`GET /api/scanner/results?scanner_type=liquidity_hunt` — the backend handles expansion).
+
+---
+
+### Phase 2: Load or Create Cursor
+
+The cursor file path is: `Docs/scanner-validation/{scanner_type}_progress.json`
+
+**If the file exists AND `scanner_type`/`start_date`/`end_date` match:**
+- Load it and resume from `current_day` at `current_signal_index`.
+- Print: `Resuming from {current_day} (signal {current_signal_index + 1})…`
+
+**If the file exists but date range differs:**
+- Show the existing session info and ask:
+  ```
+  Found existing session: {existing_start} → {existing_end} (last day: {current_day})
+  New range requested:    {start_date} → {end_date}
+  [r] Resume existing session
+  [n] Start fresh (existing progress preserved in DB)
+  ```
+- If `n`, overwrite the cursor file with the new session.
+
+**If no file exists:**
+- Create the cursor file:
+  ```json
+  {
+    "scanner_type": "<scanner_type>",
+    "start_date": "<start_date>",
+    "end_date": "<end_date>",
+    "days_completed": [],
+    "current_day": "<start_date>",
+    "current_signal_index": 0,
+    "enhance_suggestions": []
+  }
+  ```
+
+---
+
+### Phase 3: Day Loop
+
+Enumerate trading days in `[start_date, end_date]`:
+- Skip Saturdays and Sundays.
+- Skip days in the `market_holidays` table: query
+  `GET /api/system/market-holidays` if that endpoint exists;
+  otherwise query the DB directly via a bash command:
+  ```bash
+  docker compose exec backend python -c "
+  from app.core.database import SessionLocal
+  from app.models.market_holiday import MarketHoliday
+  db = SessionLocal()
+  holidays = [str(h.date) for h in db.query(MarketHoliday).all()]
+  db.close()
+  print(' '.join(holidays))
+  "
+  ```
+  Store the list at session start; skip any day that appears in it.
+
+For each trading day **starting at `current_day`**:
+
+#### 3a. Fetch signals for the day
+
+```bash
+curl -s "http://localhost:8000/api/scanner/results?scanner_type={scanner_type}&start_date={day}&end_date={day}&limit=200" | python3 -m json.tool
+```
+
+If the array is empty, print:
+```
+── {day} — No signals ──
+```
+Update cursor: mark day complete, advance `current_day`. Save cursor JSON. Continue.
+
+#### 3b. Signal loop
+
+For each event in the array, starting at `current_signal_index`:
+
+**Print the signal block:**
+```
+─────────────────────────────────────────────────────────────
+{ticker}  │  {event_date}  │  {scanner_type}  │  {severity.upper()}
+Prior close: ${previous_close}   Open: ${opening_price}   ({gap_pct:+.1f}%)
+
+Indicators:
+  {key}: {value}   (for each key, value in event["indicators"].items())
+
+Criteria met:
+  {key}: ✓ / ✗    (for each key, value in event["criteria_met"].items())
+```
+
+Then fetch outcome data:
+```bash
+curl -s "http://localhost:8000/api/outcomes/event/{event_id}" | python3 -m json.tool
+```
+If `summary` is not null, print:
+```
+Outcome:  MFE: {mfe_pct:+.1f}% at {mfe_interval}  │  MAE: {mae_pct:+.1f}%  │  EOD: {eod_pct:+.1f}%
+```
+Otherwise print: `Outcome: not yet tracked`
+
+Print the chart URL:
+```
+Chart:  http://localhost:3333/stock/{ticker}?date={event_date}
+─────────────────────────────────────────────────────────────
+Signal {signal_idx + 1}/{total_signals} on {day}
+```
+
+**Prompt the user:**
+```
+[c] confirm   [r] reject <reason>   [e] enhance   [s] skip   [q] quit
+Verdict: _
+```
+
+**Handle input:**
+
+| Input | Action |
+|-------|--------|
+| `c` | Write `verdict=confirmed` to DB (POST /api/signal-reviews). Advance index. |
+| `r noise` / `r too_late` / `r stale_data` / `r split_artifact` / `r threshold_too_loose` / `r other` | Write `verdict=rejected, reject_reason=<reason>`. Advance. |
+| `r` (no reason) | Prompt: `Reason [noise/too_late/stale_data/split_artifact/threshold_too_loose/other]: ` then proceed as above. |
+| `e` | Run enhance flow (see §3c). Advance. |
+| `s` | Skip — do NOT write to DB. Advance index. |
+| `q` | Save cursor, print session summary so far, exit. |
+
+**After each verdict (except skip/quit), POST to DB:**
+```bash
+curl -s -X POST http://localhost:8000/api/signal-reviews \
+  -H "Content-Type: application/json" \
+  -d '{
+    "scanner_event_id": {event_id},
+    "verdict": "{verdict}",
+    "reject_reason": "{reject_reason_or_null}",
+    "notes": "{notes_or_null}",
+    "enhance_suggestion": {enhance_suggestion_or_null}
+  }' | python3 -m json.tool
+```
+
+**Save cursor JSON after every verdict** (not just at day end):
+```json
+{
+  "scanner_type": "...",
+  "start_date": "...",
+  "end_date": "...",
+  "days_completed": ["2025-01-02", ...],
+  "current_day": "2025-01-06",
+  "current_signal_index": 3,
+  "enhance_suggestions": [...]
+}
+```
+
+#### 3c. Enhance flow
+
+When the user selects `e`:
+
+1. Ask: `What would you like to improve? (free text description):`
+2. Determine whether the threshold is `SystemConfig`-backed or hardcoded:
+
+   **SystemConfig-backed thresholds** (live-patchable):
+   | Key | Description |
+   |-----|-------------|
+   | `timesfm_fallback_multiplier` | Volume multiplier (default 4.0) |
+   | `timesfm_anomaly_threshold` | Score cutoff (default 2.0) |
+   | `timesfm_min_history_bars` | Min history bars (default 30) |
+   | `timesfm_enabled` | Use ML vs static multiplier |
+
+   If the user's description mentions one of these, proceed with live-patch:
+   - Get current value: `curl -s http://localhost:8000/api/system/config | python3 -m json.tool`
+   - Ask: `Proposed value for {key} (current: {current_value}):`
+   - Apply: `curl -s -X PATCH http://localhost:8000/api/system/config -H "Content-Type: application/json" -d '{"<key>": <value>}'`
+   - If `session_universe_id` is set, re-run that day:
+     ```bash
+     curl -s -X POST http://localhost:8000/api/scanner/run \
+       -H "Content-Type: application/json" \
+       -d '{"universe_id": {session_universe_id}, "start_date": "{day}", "end_date": "{day}"}'
+     ```
+     Poll status: `curl -s http://localhost:8000/api/scanner/runs/{scan_id}/status` every 3s until `status == "completed"`.
+     Fetch updated results and show before/after event counts.
+   - If `session_universe_id` is None, print: `Re-scan skipped (no universe_id provided at session start). Config patched — run a manual scan to see the effect.`
+   - Record in `enhance_suggestions` array in cursor:
+     ```json
+     {"type": "systemconfig", "key": "timesfm_fallback_multiplier",
+      "old_value": "4.0", "new_value": "3.5", "day": "2025-01-06",
+      "before_events": 12, "after_events": 8}
+     ```
+
+   **Hardcoded thresholds** (suggestion-only):
+   - Ask: `Which threshold? (e.g. pre_market_volume, avg_volume_20d, rsi_threshold):`
+   - Ask: `Current value (from scanner.py):`
+   - Ask: `Proposed value:`
+   - Ask: `Rationale:`
+   - Record in cursor `enhance_suggestions`:
+     ```json
+     {"type": "hardcoded", "threshold": "pre_market_volume",
+      "current_value": "100000", "proposed_value": "200000",
+      "rationale": "Too many noise signals in low-float stocks",
+      "file": "backend/app/services/scanner.py", "line_hint": "search for 100000"}
+     ```
+   - Print: `Suggestion recorded. Will appear in session summary.`
+
+3. Write `verdict=enhanced` with `enhance_suggestion` JSON to DB.
+
+#### 3d. Day completion
+
+After all signals for a day are processed, print a day summary:
+```
+── Day complete: {day} ──
+  {n_confirmed} confirmed, {n_rejected} rejected, {n_enhanced} enhanced, {n_skipped} skipped
+  Top reject reason: {most_common_reason or "n/a"}
+```
+
+Mark day complete in cursor: add to `days_completed`, set `current_day` to next trading day, reset `current_signal_index` to 0. Save cursor.
+
+---
+
+### Phase 4: Session Completion
+
+When all days in the range are done (or the user quits):
+
+Print:
+```
+════════════════════════════════════════
+Session complete. Generating report…
+════════════════════════════════════════
+```
+
+Then run **Phase 5: Report**.
+
+---
+
+### Phase 5: Report
+
+1. Read cursor from `Docs/scanner-validation/{scanner_type}_progress.json` if it exists.
+   - If invoked as `/validate-scanner report` with no scanner_type, list available `*.json` files in `Docs/scanner-validation/` and prompt the user to select one.
+
+2. Fetch all reviews from DB:
+   ```bash
+   curl -s "http://localhost:8000/api/signal-reviews?scanner_type={scanner_type}&start_date={start_date}&end_date={end_date}" | python3 -m json.tool
+   ```
+
+3. Print the report:
+   ```
+   ════════════════════════════════════════
+   SCANNER VALIDATION REPORT
+   Type:  {scanner_type}
+   Range: {start_date} → {end_date}
+   ════════════════════════════════════════
+
+   Days reviewed:  {len(days_completed)}
+   Total signals:  {total}
+   ─────────────────────────────────────────
+   Confirmed:      {n_confirmed} ({pct:.0%})
+   Rejected:       {n_rejected} ({pct:.0%})
+   Enhanced:       {n_enhanced} ({pct:.0%})
+   Skipped:        {n_skipped} (not in DB)
+   ─────────────────────────────────────────
+
+   Top Rejection Reasons:
+   {ranked list of reason: count}
+
+   Enhance Suggestions ({n_hardcoded} hardcoded, {n_systemconfig} applied):
+   {for each suggestion: threshold, current→proposed, rationale, affected_days}
+
+   ════════════════════════════════════════
+   ```
+
+---
+
+## Error Handling
+
+- If the backend is unreachable: print `Backend not responding. Is docker compose up?` and exit.
+- If an event has no `indicators` key: treat as empty dict; print `(no indicators)`.
+- If outcome fetch returns 404: treat as `Outcome: not yet tracked`.
+- If `Docs/scanner-validation/` directory doesn't exist: create it with `mkdir -p Docs/scanner-validation`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -85,7 +85,7 @@ A full pre-market scan proceeds as follows:
 
 | File | Endpoints |
 |------|-----------|
-| `scanner.py` | `/api/scanner/run`, `/api/scanner/results` (default sort: `signal_quality_score DESC`), `/api/scanner/history`, `/api/scanner/signal-quality-distribution` |
+| `scanner.py` | `/api/scanner/run`, `/api/scanner/results` (default sort: `signal_quality_score DESC`; supports `start_date`/`end_date` filters), `/api/scanner/history`, `/api/scanner/signal-quality-distribution` |
 | `universe.py` | `/api/universe/*` — CRUD for stock universes and memberships |
 | `stocks.py` | `/api/stocks/*` — historical data, ticker search, stock details |
 | `news.py` | `/api/news/*` — news articles and preferences |
@@ -96,6 +96,7 @@ A full pre-market scan proceeds as follows:
 | `health.py` | `GET /health` — liveness probe |
 | `system.py` | `/api/system/*` — configuration, status |
 | `outcomes.py` | `/api/outcomes/*` — scorecard, intervals, distribution, edge decay, signals, event detail, backfill; `POST /analyze` (trigger analysis), `GET /correlations`, `GET /analysis/latest` |
+| `signal_reviews.py` | `POST /api/signal-reviews` (201) — persist confirm/reject/enhanced verdict; `GET /api/signal-reviews?scanner_type=` — list reviews with joined event fields, `liquidity_hunt` alias expansion |
 
 ### Database Models (`app/models/`)
 
@@ -122,6 +123,7 @@ A full pre-market scan proceeds as follows:
 | `UniverseQualityReport` | `universe_quality_reports` | Data quality audit results per universe |
 | `SignalAnalysisRun` | `signal_analysis_runs` | Anchor table for each statistical analysis execution; stores `correlation_matrix` and `feature_weights` as JSONB, status, event count |
 | `SignalCluster` | `signal_clusters` | One K-means cluster archetype per analysis run; stores centroid, return_profile (per-interval stats), event count, auto-generated label |
+| `SignalReview` | `signal_reviews` | User-submitted verdict (confirmed/rejected/enhanced) on a `ScannerEvent`; FK → `scanner_events.id` CASCADE; supports `reject_reason` and `enhance_suggestion` JSONB. Written by `/validate-scanner` skill. |
 
 ## Frontend Architecture
 
@@ -143,7 +145,7 @@ A full pre-market scan proceeds as follows:
 | `ActiveWatchlist` | `/watchlist` | Live-monitored symbols: add/remove, real-time price + session data, alert badges. Connects to `/api/live/ws/watchlist` WebSocket. |
 | `Journal` | `/journal` | Trade journal entry and review |
 | `Alerts` | `/alerts` | Alert configuration and history |
-| `StockDetailPage` | `/stock/:ticker` | Per-ticker chart, metrics, and news |
+| `StockDetailPage` | `/stock/:ticker` | Per-ticker chart, metrics, and news. Supports `?date=YYYY-MM-DD` to initialise `highlightDate` and centre the chart on that date. |
 | `Settings` | `/settings` | System configuration |
 
 ### Charting Libraries

--- a/Docs/scanner-validation/.gitignore
+++ b/Docs/scanner-validation/.gitignore
@@ -1,0 +1,2 @@
+# Ignore runtime cursor files — verdicts are canonical in the DB
+*.json

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -40,6 +40,7 @@ MarketHawk/
 │   │   │   ├── universe_quality_report.py # UniverseQualityReport — data quality audits
 │   │   │   ├── signal_analysis_run.py  # SignalAnalysisRun — Phase 2b analysis execution anchor; stores correlation_matrix + feature_weights as JSONB
 │   │   │   ├── signal_cluster.py       # SignalCluster — K-means cluster archetype per analysis run; centroid + return_profile
+│   │   │   ├── signal_review.py        # SignalReview — user verdict (confirmed/rejected/enhanced) on a ScannerEvent; written by /validate-scanner skill
 │   │   │   └── __init__.py             # Re-exports all models (required for Alembic autogenerate)
 │   │   ├── routers/
 │   │   │   ├── scanner.py              # /api/scanner/* — run, results (sort by signal_quality_score), history, signal-quality-distribution
@@ -52,6 +53,7 @@ MarketHawk/
 │   │   │   ├── watchlist.py            # /api/watchlist/* — active watchlist CRUD
 │   │   │   ├── health.py               # GET /health — liveness probe
 │   │   │   ├── outcomes.py             # /api/outcomes/* — scorecard, signals, backfill; Phase 2b: analyze, correlations, analysis/latest
+│   │   │   ├── signal_reviews.py       # POST /api/signal-reviews (201); GET /api/signal-reviews?scanner_type= — verdict persistence for /validate-scanner skill
 │   │   │   ├── system.py               # /api/system/* — configuration and status
 │   │   │   └── __init__.py
 │   │   ├── schemas/

--- a/backend/app/alembic/versions/b3e8f2a1c9d7_add_signal_reviews.py
+++ b/backend/app/alembic/versions/b3e8f2a1c9d7_add_signal_reviews.py
@@ -1,0 +1,42 @@
+"""add_signal_reviews
+
+Revision ID: b3e8f2a1c9d7
+Revises: fa2957d31876
+Create Date: 2026-05-22 19:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'b3e8f2a1c9d7'
+down_revision: Union[str, None] = 'fa2957d31876'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'signal_reviews',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('scanner_event_id', sa.Integer(), nullable=False),
+        sa.Column('verdict', sa.String(length=20), nullable=False),
+        sa.Column('reject_reason', sa.String(length=50), nullable=True),
+        sa.Column('notes', sa.String(length=1000), nullable=True),
+        sa.Column('enhance_suggestion', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column('reviewed_at', sa.DateTime(), nullable=False),
+        sa.Column('reviewed_by', sa.String(length=100), nullable=True),
+        sa.ForeignKeyConstraint(['scanner_event_id'], ['scanner_events.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_signal_reviews_id'), 'signal_reviews', ['id'], unique=False)
+    op.create_index(op.f('ix_signal_reviews_scanner_event_id'), 'signal_reviews', ['scanner_event_id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_signal_reviews_scanner_event_id'), table_name='signal_reviews')
+    op.drop_index(op.f('ix_signal_reviews_id'), table_name='signal_reviews')
+    op.drop_table('signal_reviews')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from fastapi.middleware.gzip import GZipMiddleware
 from app.core.config import settings
 from app.core.database import engine, Base
 from app.core.error_tracking import ErrorTrackerFactory
-from app.routers import health_router, scanner_router, universe_router, stocks_router, news_router, live_data_router, journal_router, system_router, futures_router, alerts_router, watchlist_router, auto_trading_router, outcomes_router
+from app.routers import health_router, scanner_router, universe_router, stocks_router, news_router, live_data_router, journal_router, system_router, futures_router, alerts_router, watchlist_router, auto_trading_router, outcomes_router, signal_reviews_router
 from app.core.celery_app import celery_app as celery
 from app.services.websocket_manager import websocket_manager
 
@@ -181,6 +181,7 @@ def create_app() -> FastAPI:
     app.include_router(watchlist_router)
     app.include_router(auto_trading_router)
     app.include_router(outcomes_router)
+    app.include_router(signal_reviews_router)
 
     # Log a clear warning at startup whenever trace-exposure mode is enabled
     _expose_traces = settings.ENVIRONMENT.lower() in ("development", "debug")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -31,6 +31,7 @@ from app.models.scanner_outcome_snapshot import ScannerOutcomeSnapshot
 from app.models.scanner_outcome_summary import ScannerOutcomeSummary
 from app.models.signal_analysis_run import SignalAnalysisRun
 from app.models.signal_cluster import SignalCluster
+from app.models.signal_review import SignalReview
 
 __all__ = [
     "StockUniverse",
@@ -64,4 +65,5 @@ __all__ = [
     "ScannerOutcomeSummary",
     "SignalAnalysisRun",
     "SignalCluster",
+    "SignalReview",
 ]

--- a/backend/app/models/scanner_event.py
+++ b/backend/app/models/scanner_event.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 import uuid
 from sqlalchemy import Column, Integer, String, DateTime, Date, Numeric, Float, ForeignKey, Uuid as UUID, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import relationship
 
 from app.core.database import Base
 
@@ -45,6 +46,8 @@ class ScannerEvent(Base):
 
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc).replace(tzinfo=None))
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc).replace(tzinfo=None), onupdate=lambda: datetime.now(timezone.utc).replace(tzinfo=None))
+
+    reviews = relationship("SignalReview", back_populates="event", cascade="all, delete-orphan")
 
     __table_args__ = (
         UniqueConstraint('ticker', 'event_date', 'scanner_type', name='uq_scanner_event'),

--- a/backend/app/models/signal_review.py
+++ b/backend/app/models/signal_review.py
@@ -1,0 +1,31 @@
+"""
+SignalReview SQLAlchemy model.
+"""
+
+from datetime import datetime, timezone
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import relationship
+
+from app.core.database import Base
+
+
+class SignalReview(Base):
+    __tablename__ = "signal_reviews"
+
+    id = Column(Integer, primary_key=True, index=True)
+    scanner_event_id = Column(
+        Integer, ForeignKey("scanner_events.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    verdict = Column(String(20), nullable=False)          # confirmed | rejected | enhanced
+    reject_reason = Column(String(50), nullable=True)     # noise | too_late | stale_data | split_artifact | threshold_too_loose | other
+    notes = Column(String(1000), nullable=True)
+    enhance_suggestion = Column(JSONB, nullable=True)     # {threshold, current_value, proposed_value, rationale, file, line_hint}
+    reviewed_at = Column(
+        DateTime,
+        default=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+        nullable=False,
+    )
+    reviewed_by = Column(String(100), nullable=True)      # reserved for future multi-user
+
+    event = relationship("ScannerEvent", back_populates="reviews")

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -15,6 +15,7 @@ from app.routers.alerts import router as alerts_router
 from app.routers.watchlist import router as watchlist_router
 from app.routers.auto_trading import router as auto_trading_router
 from app.routers.outcomes import router as outcomes_router
+from app.routers.signal_reviews import router as signal_reviews_router
 
 __all__ = [
     "health_router",
@@ -30,4 +31,5 @@ __all__ = [
     "watchlist_router",
     "auto_trading_router",
     "outcomes_router",
+    "signal_reviews_router",
 ]

--- a/backend/app/routers/scanner.py
+++ b/backend/app/routers/scanner.py
@@ -2,11 +2,11 @@
 Scanner router - endpoints for running and viewing scanner results.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import List, Optional
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect
 from sqlalchemy.orm import Session
 from sqlalchemy import cast
 from sqlalchemy.dialects.postgresql import JSONB
@@ -347,6 +347,8 @@ def get_scanner_results(
     sort_order: Optional[str] = "desc",
     limit: int = 100,
     offset: int = 0,
+    start_date: Optional[date] = Query(None),
+    end_date: Optional[date] = Query(None),
     db: Session = Depends(get_db),
 ):
     """Get scanner results with filtering."""
@@ -368,10 +370,15 @@ def get_scanner_results(
 
     if universe_id:
         query = query.join(
-            MonitoredStock, 
-            (ScannerEvent.ticker == MonitoredStock.ticker) & 
+            MonitoredStock,
+            (ScannerEvent.ticker == MonitoredStock.ticker) &
             (MonitoredStock.universe_id == universe_id)
         )
+
+    if start_date:
+        query = query.filter(ScannerEvent.event_date >= start_date)
+    if end_date:
+        query = query.filter(ScannerEvent.event_date <= end_date)
 
     # Sorting logic
     try:

--- a/backend/app/routers/signal_reviews.py
+++ b/backend/app/routers/signal_reviews.py
@@ -1,0 +1,75 @@
+"""
+Signal reviews router — POST/GET /api/signal-reviews.
+"""
+from datetime import date
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.models.scanner_event import ScannerEvent
+from app.models.signal_review import SignalReview
+from app.schemas.signal_review import SignalReviewCreate, SignalReviewResponse
+
+router = APIRouter(prefix="/api/signal-reviews", tags=["signal-reviews"])
+
+
+@router.post("", response_model=SignalReviewResponse, status_code=201)
+def create_signal_review(payload: SignalReviewCreate, db: Session = Depends(get_db)):
+    event = db.query(ScannerEvent).filter(ScannerEvent.id == payload.scanner_event_id).first()
+    if not event:
+        raise HTTPException(status_code=404, detail="ScannerEvent not found")
+
+    review = SignalReview(
+        scanner_event_id=payload.scanner_event_id,
+        verdict=payload.verdict,
+        reject_reason=payload.reject_reason,
+        notes=payload.notes,
+        enhance_suggestion=payload.enhance_suggestion,
+    )
+    db.add(review)
+    db.commit()
+    db.refresh(review)
+    return review
+
+
+@router.get("", response_model=List[SignalReviewResponse])
+def list_signal_reviews(
+    scanner_type: str = Query(...),
+    start_date: Optional[date] = Query(None),
+    end_date: Optional[date] = Query(None),
+    db: Session = Depends(get_db),
+):
+    query = (
+        db.query(SignalReview, ScannerEvent.ticker, ScannerEvent.event_date, ScannerEvent.scanner_type)
+        .join(ScannerEvent, SignalReview.scanner_event_id == ScannerEvent.id)
+    )
+    # Mirror the liquidity_hunt alias expansion from GET /api/scanner/results
+    if scanner_type == "liquidity_hunt":
+        query = query.filter(ScannerEvent.scanner_type.in_(["liquidity_hunt", "liquidity_hunt_pre", "liquidity_hunt_post"]))
+    else:
+        query = query.filter(ScannerEvent.scanner_type == scanner_type)
+    if start_date:
+        query = query.filter(ScannerEvent.event_date >= start_date)
+    if end_date:
+        query = query.filter(ScannerEvent.event_date <= end_date)
+
+    rows = query.order_by(ScannerEvent.event_date, ScannerEvent.ticker).all()
+
+    results = []
+    for review, ticker, event_date, stype in rows:
+        results.append(SignalReviewResponse(
+            id=review.id,
+            scanner_event_id=review.scanner_event_id,
+            verdict=review.verdict,
+            reject_reason=review.reject_reason,
+            notes=review.notes,
+            enhance_suggestion=review.enhance_suggestion,
+            reviewed_at=review.reviewed_at,
+            reviewed_by=review.reviewed_by,
+            ticker=ticker,
+            event_date=str(event_date),
+            scanner_type=stype,
+        ))
+    return results

--- a/backend/app/schemas/signal_review.py
+++ b/backend/app/schemas/signal_review.py
@@ -1,0 +1,54 @@
+"""
+Pydantic schemas for signal review endpoints.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+VALID_VERDICTS = {"confirmed", "rejected", "enhanced"}
+VALID_REJECT_REASONS = {"noise", "too_late", "stale_data", "split_artifact", "threshold_too_loose", "other"}
+
+
+class SignalReviewCreate(BaseModel):
+    scanner_event_id: int
+    verdict: str
+    reject_reason: Optional[str] = None
+    notes: Optional[str] = None
+    enhance_suggestion: Optional[Dict[str, Any]] = None
+
+    @field_validator("verdict")
+    @classmethod
+    def verdict_must_be_valid(cls, v: str) -> str:
+        if v not in VALID_VERDICTS:
+            raise ValueError(f"verdict must be one of {VALID_VERDICTS}")
+        return v
+
+    @field_validator("reject_reason")
+    @classmethod
+    def reject_reason_must_be_valid(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in VALID_REJECT_REASONS:
+            raise ValueError(f"reject_reason must be one of {VALID_REJECT_REASONS}")
+        return v
+
+    def model_post_init(self, __context: Any) -> None:
+        if self.verdict == "rejected" and not self.reject_reason:
+            raise ValueError("reject_reason is required when verdict is 'rejected'")
+
+
+class SignalReviewResponse(BaseModel):
+    id: int
+    scanner_event_id: int
+    verdict: str
+    reject_reason: Optional[str]
+    notes: Optional[str]
+    enhance_suggestion: Optional[Dict[str, Any]]
+    reviewed_at: datetime
+    reviewed_by: Optional[str]
+    # Joined fields from ScannerEvent (populated in GET list endpoint)
+    ticker: Optional[str] = None
+    event_date: Optional[str] = None
+    scanner_type: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/tests/api/test_scanner.py
+++ b/backend/tests/api/test_scanner.py
@@ -4,11 +4,13 @@ Runs against a real Postgres DB (via testcontainers).
 """
 
 import pytest
+from datetime import timedelta
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.main import app
 from app.core.database import get_db
+from app.utils.session import get_market_today
 from tests.fixtures.core import seed_universes, seed_tickers, seed_scanner_configs, seed_monitored_stocks
 from tests.fixtures.scanner import seed_scanner_runs, seed_scanner_events
 
@@ -276,3 +278,53 @@ def test_stats_today_events(db: Session):
     data = response.json()
     # seed_scanner_events seeds events on today's date — at least 5 of them
     assert data["todayEvents"] >= 5
+
+
+# ---------------------------------------------------------------------------
+# GET /api/scanner/results — date range filters
+# ---------------------------------------------------------------------------
+
+
+def test_results_filter_by_start_date(db: Session):
+    seed_scanner_events(db)
+    today = get_market_today()
+    today_str = str(today)
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get(f"/api/scanner/results?start_date={today_str}")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) > 0
+    assert all(e["event_date"] >= today_str for e in data)
+
+
+def test_results_filter_by_end_date(db: Session):
+    seed_scanner_events(db)
+    today = get_market_today()
+    two_days_ago = str(today - timedelta(days=2))
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get(f"/api/scanner/results?end_date={two_days_ago}")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) > 0
+    assert all(e["event_date"] <= two_days_ago for e in data)
+
+
+def test_results_filter_by_date_range(db: Session):
+    seed_scanner_events(db)
+    today = get_market_today()
+    yesterday = str(today - timedelta(days=1))
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get(f"/api/scanner/results?start_date={yesterday}&end_date={yesterday}")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) > 0
+    assert all(e["event_date"] == yesterday for e in data)

--- a/backend/tests/api/test_signal_reviews.py
+++ b/backend/tests/api/test_signal_reviews.py
@@ -1,0 +1,142 @@
+"""
+Integration tests for POST/GET /api/signal-reviews.
+"""
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.main import app
+from app.core.database import get_db
+from app.models.scanner_event import ScannerEvent
+from tests.fixtures.scanner import seed_scanner_events
+
+client = TestClient(app)
+
+
+def _get_first_event_id(db: Session) -> int:
+    seed_scanner_events(db)
+    event = db.query(ScannerEvent).first()
+    return event.id
+
+
+def test_create_confirmed_review(db: Session):
+    event_id = _get_first_event_id(db)
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.post("/api/signal-reviews", json={
+        "scanner_event_id": event_id,
+        "verdict": "confirmed",
+    })
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["verdict"] == "confirmed"
+    assert data["scanner_event_id"] == event_id
+    assert data["id"] > 0
+
+
+def test_create_rejected_review_requires_reason(db: Session):
+    event_id = _get_first_event_id(db)
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.post("/api/signal-reviews", json={
+        "scanner_event_id": event_id,
+        "verdict": "rejected",
+        # missing reject_reason
+    })
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 422
+
+
+def test_create_rejected_review_with_reason(db: Session):
+    event_id = _get_first_event_id(db)
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.post("/api/signal-reviews", json={
+        "scanner_event_id": event_id,
+        "verdict": "rejected",
+        "reject_reason": "noise",
+        "notes": "Volume spike was a data artifact",
+    })
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["reject_reason"] == "noise"
+
+
+def test_create_review_invalid_event_id(db: Session):
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.post("/api/signal-reviews", json={
+        "scanner_event_id": 999999,
+        "verdict": "confirmed",
+    })
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 404
+
+
+def test_create_review_invalid_verdict(db: Session):
+    event_id = _get_first_event_id(db)
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.post("/api/signal-reviews", json={
+        "scanner_event_id": event_id,
+        "verdict": "maybe",
+    })
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 422
+
+
+def test_list_reviews_by_scanner_type(db: Session):
+    event_id = _get_first_event_id(db)
+    event = db.query(ScannerEvent).filter(ScannerEvent.id == event_id).first()
+    scanner_type = event.scanner_type
+
+    from app.models.signal_review import SignalReview
+    review = SignalReview(scanner_event_id=event_id, verdict="confirmed")
+    db.add(review)
+    db.flush()
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get(f"/api/signal-reviews?scanner_type={scanner_type}")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) >= 1
+    assert all(r["scanner_type"] == scanner_type for r in data)
+
+
+def test_list_reviews_liquidity_hunt_alias(db: Session):
+    # seed_scanner_events creates liquidity_hunt_pre events; querying with
+    # the 'liquidity_hunt' umbrella alias must return them
+    seed_scanner_events(db)
+    lh_event = (
+        db.query(ScannerEvent)
+        .filter(ScannerEvent.scanner_type == "liquidity_hunt_pre")
+        .first()
+    )
+    from app.models.signal_review import SignalReview
+    review = SignalReview(scanner_event_id=lh_event.id, verdict="confirmed")
+    db.add(review)
+    db.flush()
+
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get("/api/signal-reviews?scanner_type=liquidity_hunt")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) >= 1
+    assert all(r["scanner_type"] in ("liquidity_hunt", "liquidity_hunt_pre", "liquidity_hunt_post") for r in data)
+
+
+def test_list_reviews_missing_scanner_type(db: Session):
+    app.dependency_overrides[get_db] = lambda: db
+    response = client.get("/api/signal-reviews")
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 422

--- a/frontend/src/pages/StockDetailPage.tsx
+++ b/frontend/src/pages/StockDetailPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useSearchParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { 
   ArrowLeft, 
@@ -35,12 +35,15 @@ import { runScannerRange } from '../api/scanner';
 const StockDetailPage: React.FC = () => {
   const { ticker } = useParams<{ ticker: string }>();
   const symbol = ticker?.toUpperCase() || '';
+  const [searchParams] = useSearchParams();
   const [period, setPeriod] = React.useState(localStorage.getItem('stock_detail_period') || '1y');
   const [timespan, setTimespan] = React.useState(localStorage.getItem('stock_detail_timespan') || 'day');
   const [wsResolution, setWsResolution] = React.useState<'minute' | 'second'>(
     (localStorage.getItem('stock_detail_ws_res') as 'minute' | 'second') || 'minute'
   );
-  const [highlightDate, setHighlightDate] = React.useState<string | undefined>(undefined);
+  const [highlightDate, setHighlightDate] = React.useState<string | undefined>(
+    searchParams.get('date') ?? undefined
+  );
   const [catchingUp, setCatchingUp] = React.useState(false);
   const [showST, setShowST] = React.useState(localStorage.getItem('show_double_st') === 'true');
   const [scanDialogOpen, setScanDialogOpen] = React.useState(false);


### PR DESCRIPTION
## Summary

Closes #5.

Implements the `/validate-scanner` Claude Code skill plus the backend infrastructure it depends on:

- **`GET /api/scanner/results`** now accepts `start_date` / `end_date` query params (needed to fetch per-day signal slices)
- **`SignalReview` model + migration** — new `signal_reviews` table (FK → `scanner_events.id` CASCADE) storing confirm/reject/enhanced verdicts with optional `reject_reason` and `enhance_suggestion` JSONB
- **`POST /api/signal-reviews`** — write a verdict; **`GET /api/signal-reviews?scanner_type=`** — list with joined event fields, `liquidity_hunt` alias expansion mirrors `scanner.py`
- **`StockDetailPage`** now reads `?date=YYYY-MM-DD` from the URL and initialises `highlightDate`, centering the chart on that date (used by the skill's per-signal chart URL)
- **`/validate-scanner` skill** (`SKILL.md`) — 5-phase interactive session: parse args → load/create cursor JSON → day loop (fetch signals, display block, accept verdict, enhance flow) → session summary → report generation
- **`Docs/scanner-validation/`** directory — tracked in git, runtime `*.json` cursor files gitignored

## Test plan

- [ ] `cd backend && python -m pytest tests/api/test_scanner.py tests/api/test_signal_reviews.py` — 29 tests pass
- [ ] `cd frontend && npx tsc --noEmit` — no TypeScript errors
- [ ] Invoke `/validate-scanner pre_market_volume_spike 2025-01-15 2025-01-15` in a session with data — skill walks through signals, prompts for verdict, and persists to DB
- [ ] Confirm `Docs/scanner-validation/pre_market_volume_spike_progress.json` is created
- [ ] Navigate to `http://localhost:3333/stock/AAPL?date=2025-01-15` — chart centres on Jan 15
- [ ] `/validate-scanner report` lists available sessions and prints summary

## Migration note

Migration `b3e8f2a1c9d7_add_signal_reviews.py` was written manually — the running dev DB had a local uncommitted revision (`83cdd681f14c`) that made `autogenerate` fail. The migration is correct and will apply cleanly on a fresh database (and on main after `upgrade head`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)