### PR TITLE
Deepen the Scanner module into a Scan Orchestrator with registry

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,7 +58,10 @@ A full pre-market scan proceeds as follows:
 
 | File | Responsibility |
 |------|---------------|
-| `scanner.py` | Core scan orchestration: `ScannerService`, `calculate_day_metrics()`, `_get_batch_enrichment_data()` (returns 3-tuple with ES/NQ market context and sector ETF pct changes), Phase 2a 19-key feature enrichment in `run_pre_market_scan()`. Loads `signal_ranker_config` once per scan; passes to `_save_event()` for scoring. |
+| `scan_orchestrator.py` | Scanner registry and orchestrator. `ScannerDescriptor` frozen dataclass; `_REGISTRY` populated via `register()` at import time. `run(scanner_type, tickers, db, event_date)` is the single dispatch entry point from `tasks.py`. `get_all()` enumerates entries for `GET /api/scanner/types`. |
+| `pre_market_scan.py` | Self-registers `"pre_market_volume_spike"` in the orchestrator. Delegates to `ScannerService.run_pre_market_scan` (interim; body inlined in Task 8). |
+| `oversold_bounce_scan.py` | Self-registers `"oversold_bounce"` in the orchestrator. Delegates to `ScannerService.run_oversold_bounce_scan` (interim). |
+| `scanner.py` | `ScannerService` — `calculate_day_metrics()`, `_get_batch_enrichment_data()` (3-tuple with ES/NQ context and sector ETF changes), Phase 2a 19-key feature enrichment. `_save_event()` now delegates to `alert_service.save_event`. |
 | `signal_ranker.py` | Phase 2c signal quality scorer. `compute_signal_quality_score()` — weighted sum of normalized indicators (re-normalizes over present features). `load_ranker_config()` — reads `signal_ranker_enabled`, `signal_ranker_weights`, `signal_ranker_version` from `SystemConfig`. Weights updatable without redeploy. |
 | `stock_data.py` | Historical OHLCV fetch, gap percentage calculation, per-ticker session flag logic. |
 | `discovery_service.py` | Bulk ticker sync from Polygon: paginated reference data, rate-limit-aware batching. |

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -60,7 +60,10 @@ MarketHawk/
 │   │   │   ├── active_watchlist.py     # ActiveWatchlistAdd / ActiveWatchlistUpdate / ActiveWatchlistItem
 │   │   │   └── stock.py                # Pydantic request/response models
 │   │   ├── services/
-│   │   │   ├── scanner.py              # Core scan logic; ScannerService; Phase 2a 19-key feature enrichment; loads signal ranker config once per scan
+│   │   │   ├── scan_orchestrator.py    # Scanner registry (ScannerDescriptor, _REGISTRY, register, get_all, run); single dispatch entry point
+│   │   │   ├── pre_market_scan.py      # Self-registers "pre_market_volume_spike" in orchestrator
+│   │   │   ├── oversold_bounce_scan.py # Self-registers "oversold_bounce" in orchestrator
+│   │   │   ├── scanner.py              # ScannerService; calculate_day_metrics; _save_event delegates to alert_service.save_event
 │   │   │   ├── stock_data.py           # OHLCV fetch, gap calculation, session flags
 │   │   │   ├── discovery_service.py    # Bulk ticker sync from Polygon; rate-limit-aware paging
 │   │   │   ├── catalyst_parser.py      # Batch 72-hour news analysis; returns latest_article_utc for recency enrichment

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -183,6 +183,13 @@ def create_app() -> FastAPI:
     app.include_router(outcomes_router)
     app.include_router(signal_reviews_router)
 
+    # Populate scan_orchestrator registry — must be after router includes.
+    # importlib avoids the local variable `app` shadowing the package name.
+    import importlib
+    importlib.import_module("app.services.pre_market_scan")
+    importlib.import_module("app.services.oversold_bounce_scan")
+    importlib.import_module("app.services.liquidity_hunt")
+
     # Log a clear warning at startup whenever trace-exposure mode is enabled
     _expose_traces = settings.ENVIRONMENT.lower() in ("development", "debug")
     if _expose_traces:

--- a/backend/app/routers/scanner.py
+++ b/backend/app/routers/scanner.py
@@ -46,6 +46,21 @@ def _last_completed_weekday() -> "date":
     return d
 
 
+@router.get("/types")
+def list_scanner_types():
+    """Return all registered scanner types for frontend scanner pickers."""
+    from app.services.scan_orchestrator import get_all
+    return [
+        {
+            "key": d.key,
+            "display_name": d.display_name,
+            "description": d.description,
+            "supports_date_range": d.supports_date_range,
+        }
+        for d in get_all()
+    ]
+
+
 @router.post("/run", response_model=ScannerRunAsyncResponse, status_code=202)
 def run_scanner(
     request: ScannerRunRequest,

--- a/backend/app/services/alert_service.py
+++ b/backend/app/services/alert_service.py
@@ -12,10 +12,10 @@ import json
 import logging
 import smtplib
 import ssl
-from datetime import datetime, timezone, timedelta
+from datetime import date, datetime, timezone, timedelta
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 from sqlalchemy.orm import Session
@@ -324,3 +324,78 @@ class NotificationDispatcher:
             "event_date": str(event.event_date),
             "indicators": event.indicators or {},
         }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scanner Event Persistence
+# ──────────────────────────────────────────────────────────────────────────────
+
+def trigger_scanner_alert(event_id: int) -> None:
+    """Enqueue alert evaluation for a newly persisted ScannerEvent."""
+    from app.tasks import evaluate_scanner_alerts
+    evaluate_scanner_alerts.delay(event_id)
+
+
+def save_event(
+    db: Session,
+    ticker: str,
+    event_date: date,
+    scanner_type: str,
+    indicators: Dict[str, Any],
+    criteria_met: Dict[str, Any],
+    enrichment: Dict[str, Any],
+    previous_close: float = None,
+    opening_price: float = None,
+    closing_price: float = None,
+    ranker_config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Persist a ScannerEvent and enqueue alert evaluation for new events."""
+    from app.services.event_helpers import generate_event_summary, compute_event_severity
+    from app.services.signal_ranker import compute_signal_quality_score
+
+    summary = generate_event_summary(scanner_type, indicators)
+    severity = compute_event_severity(scanner_type, indicators)
+
+    score = None
+    if ranker_config and ranker_config.get("enabled") and ranker_config.get("weights"):
+        score = compute_signal_quality_score(indicators, ranker_config["weights"])
+
+    event_dict = {
+        "ticker": ticker,
+        "event_date": event_date,
+        "scanner_type": scanner_type,
+        "summary": summary,
+        "severity": severity,
+        "previous_close": previous_close,
+        "opening_price": opening_price,
+        "closing_price": closing_price,
+        "indicators": indicators,
+        "criteria_met": criteria_met,
+        "metadata": enrichment,
+        "signal_quality_score": score,
+    }
+
+    existing = db.query(ScannerEvent).filter(
+        ScannerEvent.ticker == ticker,
+        ScannerEvent.event_date == event_date,
+        ScannerEvent.scanner_type == scanner_type,
+    ).first()
+
+    if existing:
+        for key, value in event_dict.items():
+            if key == "metadata":
+                setattr(existing, "metadata_", value)
+            else:
+                setattr(existing, key, value)
+        db.flush()
+        event_dict["id"] = existing.id
+    else:
+        model_data = event_dict.copy()
+        model_data["metadata_"] = model_data.pop("metadata")
+        new_event = ScannerEvent(**model_data)
+        db.add(new_event)
+        db.flush()
+        event_dict["id"] = new_event.id
+        trigger_scanner_alert(new_event.id)
+
+    return event_dict

--- a/backend/app/services/liquidity_hunt.py
+++ b/backend/app/services/liquidity_hunt.py
@@ -26,7 +26,7 @@ from app.models.monitored_stock import MonitoredStock
 from app.models.ticker_reference import TickerReference
 from app.models.stock_split import StockSplit
 from app.services.catalyst_parser import CatalystParser
-from app.services.scanner import ScannerService
+from app.services.alert_service import save_event as _save_event
 from app.utils.session import get_market_today
 
 _ET = ZoneInfo("America/New_York")
@@ -528,7 +528,7 @@ async def run_liquidity_hunt_scan(
                         enrichment, event_date,
                         session_metrics["pre_vol"],
                     )
-                    event_dict = ScannerService._save_event(
+                    event_dict = _save_event(
                         db=db,
                         ticker=ticker,
                         event_date=event_date,
@@ -565,7 +565,7 @@ async def run_liquidity_hunt_scan(
                             enrichment, event_date,
                             session_metrics["post_vol"],
                         )
-                        event_dict = ScannerService._save_event(
+                        event_dict = _save_event(
                             db=db,
                             ticker=ticker,
                             event_date=event_date,
@@ -620,3 +620,27 @@ async def run_liquidity_hunt_scan_for_date(
     return await run_liquidity_hunt_scan(
         [ticker], db, start_date=event_date, end_date=event_date
     )
+
+
+# ── Orchestrator self-registration ────────────────────────────────────────────
+
+from app.services.scan_orchestrator import ScannerDescriptor, register
+
+
+async def _orchestrator_run(tickers: list, db: Any, event_date: date) -> list[dict]:
+    """Adapter: maps the standard ScannerFn signature to run_liquidity_hunt_scan."""
+    return await run_liquidity_hunt_scan(
+        tickers=tickers,
+        db=db,
+        start_date=event_date,
+        end_date=event_date,
+    )
+
+
+for _key, _display, _desc in [
+    ("liquidity_hunt", "Liquidity Hunt", "Intraday liquidity concentration scanner."),
+    ("liquidity_hunt_pre", "Liquidity Hunt (Pre-Market)", "Pre-market liquidity concentration scanner."),
+    ("liquidity_hunt_post", "Liquidity Hunt (Post-Market)", "Post-market liquidity concentration scanner."),
+]:
+    # All three keys share the same _orchestrator_run — run_liquidity_hunt_scan emits all variant types.
+    register(ScannerDescriptor(key=_key, display_name=_display, description=_desc, run=_orchestrator_run, supports_date_range=True))

--- a/backend/app/services/oversold_bounce_scan.py
+++ b/backend/app/services/oversold_bounce_scan.py
@@ -1,0 +1,20 @@
+from datetime import date
+from typing import Any
+
+from app.services.scan_orchestrator import ScannerDescriptor, register
+
+
+async def _run(tickers: list[str], db: Any, event_date: date) -> list[dict]:
+    from app.services.scanner import ScannerService
+    return await ScannerService.run_oversold_bounce_scan(tickers, db, event_date=event_date)
+
+
+register(
+    ScannerDescriptor(
+        key="oversold_bounce",
+        display_name="Oversold Bounce",
+        description="Identifies oversold stocks showing early reversal signals.",
+        run=_run,
+        supports_date_range=True,
+    )
+)

--- a/backend/app/services/pre_market_scan.py
+++ b/backend/app/services/pre_market_scan.py
@@ -1,0 +1,20 @@
+from datetime import date
+from typing import Any
+
+from app.services.scan_orchestrator import ScannerDescriptor, register
+
+
+async def _run(tickers: list[str], db: Any, event_date: date) -> list[dict]:
+    from app.services.scanner import ScannerService
+    return await ScannerService.run_pre_market_scan(tickers, db, event_date=event_date)
+
+
+register(
+    ScannerDescriptor(
+        key="pre_market_volume_spike",
+        display_name="Pre-Market Volume Spike",
+        description="Detects stocks with >4x average volume in the pre-market window.",
+        run=_run,
+        supports_date_range=True,
+    )
+)

--- a/backend/app/services/scan_orchestrator.py
+++ b/backend/app/services/scan_orchestrator.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Awaitable, Callable
+
+ScannerFn = Callable[[list[str], Any, date], Awaitable[list[dict]]]
+
+_REGISTRY: dict[str, "ScannerDescriptor"] = {}
+
+
+@dataclass(frozen=True)
+class ScannerDescriptor:
+    key: str
+    display_name: str
+    description: str
+    run: ScannerFn
+    supports_date_range: bool = True
+
+
+def register(descriptor: "ScannerDescriptor") -> "ScannerDescriptor":
+    _REGISTRY[descriptor.key] = descriptor
+    return descriptor
+
+
+def get_all() -> list["ScannerDescriptor"]:
+    return list(_REGISTRY.values())
+
+
+async def run(
+    scanner_type: str,
+    tickers: list[str],
+    db: Any,
+    event_date: date,
+) -> list[dict]:
+    descriptor = _REGISTRY.get(scanner_type)
+    if descriptor is None:
+        raise ValueError(
+            f"Unknown scanner type: {scanner_type!r}. Registered: {list(_REGISTRY)}"
+        )
+    return await descriptor.run(tickers, db, event_date)

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -318,62 +318,13 @@ class ScannerService:
         closing_price: float = None,
         ranker_config: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        """Generalized method to save or update a ScannerEvent."""
-
-        # Calculate summary and severity
-        summary = generate_event_summary(scanner_type, indicators)
-        severity = compute_event_severity(scanner_type, indicators)
-
-        # Compute signal quality score if ranker is enabled
-        score = None
-        if ranker_config and ranker_config.get("enabled") and ranker_config.get("weights"):
-            score = compute_signal_quality_score(indicators, ranker_config["weights"])
-
-        # Prepare data dict
-        event_dict = {
-            "ticker": ticker,
-            "event_date": event_date,
-            "scanner_type": scanner_type,
-            "summary": summary,
-            "severity": severity,
-            "previous_close": previous_close,
-            "opening_price": opening_price,
-            "closing_price": closing_price,
-            "indicators": indicators,
-            "criteria_met": criteria_met,
-            "metadata": enrichment,
-            "signal_quality_score": score,
-        }
-        
-        # Check for existing event
-        existing = db.query(ScannerEvent).filter(
-            ScannerEvent.ticker == ticker,
-            ScannerEvent.event_date == event_date,
-            ScannerEvent.scanner_type == scanner_type
-        ).first()
-        
-        if existing:
-            for key, value in event_dict.items():
-                if key == "metadata":
-                    setattr(existing, "metadata_", value)
-                else:
-                    setattr(existing, key, value)
-            db.flush()
-            event_dict["id"] = existing.id
-        else:
-            # SQLAlchemy model uses 'metadata_' to avoid conflict with Base.metadata
-            model_data = event_dict.copy()
-            model_data["metadata_"] = model_data.pop("metadata")
-            new_event = ScannerEvent(**model_data)
-            db.add(new_event)
-            db.flush()
-            event_dict["id"] = new_event.id
-
-            # Trigger alert evaluation for new events
-            from app.tasks import evaluate_scanner_alerts
-            evaluate_scanner_alerts.delay(new_event.id)
-            
-        return event_dict
+        from app.services.alert_service import save_event
+        return save_event(
+            db=db, ticker=ticker, event_date=event_date, scanner_type=scanner_type,
+            indicators=indicators, criteria_met=criteria_met, enrichment=enrichment,
+            previous_close=previous_close, opening_price=opening_price,
+            closing_price=closing_price, ranker_config=ranker_config,
+        )
 
     @staticmethod
     async def run_pre_market_scan(

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1356,8 +1356,10 @@ def run_universe_scan(
     """
     from datetime import date as _date, timedelta as _td
     from app.models.scanner_run import ScannerRun
-    from app.services.scanner import ScannerService
-    from app.services.liquidity_hunt import run_liquidity_hunt_scan
+    import app.services.pre_market_scan  # noqa: F401 — triggers self-registration
+    import app.services.oversold_bounce_scan  # noqa: F401
+    import app.services.liquidity_hunt  # noqa: F401
+    import app.services.scan_orchestrator as _orchestrator
 
     task_id = self.request.id
     r = redis.Redis.from_url(settings.REDIS_URL, decode_responses=True)
@@ -1467,20 +1469,10 @@ def run_universe_scan(
                 "total_days": len(trading_days),
             })
 
-            day_diag: dict = {}
             try:
-                if scanner_type in ("liquidity_hunt", "liquidity_hunt_pre", "liquidity_hunt_post"):
-                    day_events = asyncio.run(run_liquidity_hunt_scan(
-                        tickers, db, start_date=day, end_date=day, diagnostics_out=day_diag,
-                    ))
-                elif scanner_type == "oversold_bounce":
-                    day_events = asyncio.run(
-                        ScannerService.run_oversold_bounce_scan(tickers, db, event_date=day)
-                    )
-                else:
-                    day_events = asyncio.run(
-                        ScannerService.run_pre_market_scan(tickers, db, event_date=day)
-                    )
+                day_events = asyncio.run(
+                    _orchestrator.run(scanner_type, tickers, db=db, event_date=day)
+                )
             except Exception as e:
                 cum["errors"] += 1
                 logger.exception("run_universe_scan: day %s failed", day)
@@ -1488,9 +1480,6 @@ def run_universe_scan(
                 continue
 
             events_total += len(day_events)
-            for k in ("evaluated", "no_data", "no_prior_close", "no_baseline",
-                      "errors", "fired_pre", "fired_post"):
-                cum[k] += int(day_diag.get(k, 0))
 
             run.events_detected = events_total
             db.commit()

--- a/backend/tests/api/test_scanner.py
+++ b/backend/tests/api/test_scanner.py
@@ -328,3 +328,28 @@ def test_results_filter_by_date_range(db: Session):
     data = response.json()
     assert len(data) > 0
     assert all(e["event_date"] == yesterday for e in data)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/scanner/types
+# ---------------------------------------------------------------------------
+
+
+def test_list_scanner_types():
+    import app.services.pre_market_scan  # noqa: F401
+    import app.services.oversold_bounce_scan  # noqa: F401
+    import app.services.liquidity_hunt  # noqa: F401
+
+    response = client.get("/api/scanner/types")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    keys = [item["key"] for item in data]
+    assert "pre_market_volume_spike" in keys
+    assert "oversold_bounce" in keys
+    assert "liquidity_hunt" in keys
+    assert "liquidity_hunt_pre" in keys
+    assert "liquidity_hunt_post" in keys
+    for item in data:
+        assert {"key", "display_name", "description", "supports_date_range"} == set(item)
+        assert isinstance(item["supports_date_range"], bool)

--- a/backend/tests/services/test_liquidity_hunt.py
+++ b/backend/tests/services/test_liquidity_hunt.py
@@ -433,7 +433,7 @@ def test_scan_fires_liquidity_hunt_pre():
          patch("app.services.liquidity_hunt._get_event_date_regular_close", return_value=11.10), \
          patch("app.services.liquidity_hunt._get_rolling_baselines", return_value=_SCAN_BASELINES), \
          patch("app.services.liquidity_hunt._get_enrichment", return_value=_mock_enrichment()), \
-         patch("app.services.scanner.ScannerService._save_event", return_value={"id": 1}) as mock_save:
+         patch("app.services.liquidity_hunt._save_event", return_value={"id": 1}) as mock_save:
 
         results = _run(run_liquidity_hunt_scan(
             ["TEST"], db, start_date=EVENT_DATE, end_date=EVENT_DATE
@@ -452,7 +452,7 @@ def test_scan_fires_both_variants():
          patch("app.services.liquidity_hunt._get_event_date_regular_close", return_value=11.10), \
          patch("app.services.liquidity_hunt._get_rolling_baselines", return_value=_SCAN_BASELINES), \
          patch("app.services.liquidity_hunt._get_enrichment", return_value=_mock_enrichment()), \
-         patch("app.services.scanner.ScannerService._save_event", return_value={"id": 1}) as mock_save:
+         patch("app.services.liquidity_hunt._save_event", return_value={"id": 1}) as mock_save:
 
         _run(run_liquidity_hunt_scan(
             ["TEST"], db, start_date=EVENT_DATE, end_date=EVENT_DATE
@@ -471,7 +471,7 @@ def test_scan_skips_ticker_when_sparse_history():
          patch("app.services.liquidity_hunt._get_event_date_regular_close", return_value=11.10), \
          patch("app.services.liquidity_hunt._get_rolling_baselines", return_value=None), \
          patch("app.services.liquidity_hunt._get_enrichment", return_value=_mock_enrichment()), \
-         patch("app.services.scanner.ScannerService._save_event") as mock_save:
+         patch("app.services.liquidity_hunt._save_event") as mock_save:
 
         results = _run(run_liquidity_hunt_scan(
             ["TEST"], db, start_date=EVENT_DATE, end_date=EVENT_DATE
@@ -489,7 +489,7 @@ def test_scan_skips_ticker_when_no_prior_close():
          patch("app.services.liquidity_hunt._get_event_date_regular_close", return_value=11.10), \
          patch("app.services.liquidity_hunt._get_rolling_baselines", return_value=_SCAN_BASELINES), \
          patch("app.services.liquidity_hunt._get_enrichment", return_value=_mock_enrichment()), \
-         patch("app.services.scanner.ScannerService._save_event") as mock_save:
+         patch("app.services.liquidity_hunt._save_event") as mock_save:
 
         results = _run(run_liquidity_hunt_scan(
             ["TEST"], db, start_date=EVENT_DATE, end_date=EVENT_DATE
@@ -509,7 +509,7 @@ def test_split_in_lookback_flag():
          patch("app.services.liquidity_hunt._get_event_date_regular_close", return_value=11.10), \
          patch("app.services.liquidity_hunt._get_rolling_baselines", return_value=_SCAN_BASELINES), \
          patch("app.services.liquidity_hunt._get_enrichment", return_value=enrichment_with_split), \
-         patch("app.services.scanner.ScannerService._save_event", return_value={"id": 1}) as mock_save:
+         patch("app.services.liquidity_hunt._save_event", return_value={"id": 1}) as mock_save:
 
         _run(run_liquidity_hunt_scan(
             ["TEST"], db, start_date=EVENT_DATE, end_date=EVENT_DATE
@@ -532,7 +532,7 @@ def test_scan_fires_post_only_when_pre_does_not_qualify():
          patch("app.services.liquidity_hunt._get_event_date_regular_close", return_value=11.10), \
          patch("app.services.liquidity_hunt._get_rolling_baselines", return_value=_SCAN_BASELINES), \
          patch("app.services.liquidity_hunt._get_enrichment", return_value=_mock_enrichment()), \
-         patch("app.services.scanner.ScannerService._save_event", return_value={"id": 1}) as mock_save:
+         patch("app.services.liquidity_hunt._save_event", return_value={"id": 1}) as mock_save:
 
         results = _run(run_liquidity_hunt_scan(
             ["TEST"], db, start_date=EVENT_DATE, end_date=EVENT_DATE
@@ -561,7 +561,7 @@ def test_scan_fires_events_despite_high_regular_vol():
          patch("app.services.liquidity_hunt._get_event_date_regular_close", return_value=11.10), \
          patch("app.services.liquidity_hunt._get_rolling_baselines", return_value=_SCAN_BASELINES), \
          patch("app.services.liquidity_hunt._get_enrichment", return_value=_mock_enrichment()), \
-         patch("app.services.scanner.ScannerService._save_event") as mock_save:
+         patch("app.services.liquidity_hunt._save_event") as mock_save:
 
         _run(run_liquidity_hunt_scan(
             ["TEST"], db, start_date=EVENT_DATE, end_date=EVENT_DATE

--- a/backend/tests/services/test_scan_orchestrator.py
+++ b/backend/tests/services/test_scan_orchestrator.py
@@ -57,3 +57,11 @@ def test_register_returns_descriptor():
     desc = ScannerDescriptor(key="ret", display_name="R", description="d", run=fn)
     returned = register(desc)
     assert returned is desc
+
+
+def test_pre_market_scanner_registered():
+    import app.services.pre_market_scan  # noqa: F401
+    assert "pre_market_volume_spike" in orchestrator._REGISTRY
+    desc = orchestrator._REGISTRY["pre_market_volume_spike"]
+    assert desc.display_name == "Pre-Market Volume Spike"
+    assert desc.supports_date_range is True

--- a/backend/tests/services/test_scan_orchestrator.py
+++ b/backend/tests/services/test_scan_orchestrator.py
@@ -65,3 +65,11 @@ def test_pre_market_scanner_registered():
     desc = orchestrator._REGISTRY["pre_market_volume_spike"]
     assert desc.display_name == "Pre-Market Volume Spike"
     assert desc.supports_date_range is True
+
+
+def test_oversold_bounce_scanner_registered():
+    import app.services.oversold_bounce_scan  # noqa: F401
+    assert "oversold_bounce" in orchestrator._REGISTRY
+    desc = orchestrator._REGISTRY["oversold_bounce"]
+    assert desc.display_name == "Oversold Bounce"
+    assert desc.supports_date_range is True

--- a/backend/tests/services/test_scan_orchestrator.py
+++ b/backend/tests/services/test_scan_orchestrator.py
@@ -73,3 +73,9 @@ def test_oversold_bounce_scanner_registered():
     desc = orchestrator._REGISTRY["oversold_bounce"]
     assert desc.display_name == "Oversold Bounce"
     assert desc.supports_date_range is True
+
+
+def test_liquidity_hunt_variants_registered():
+    import app.services.liquidity_hunt  # noqa: F401
+    for key in ("liquidity_hunt", "liquidity_hunt_pre", "liquidity_hunt_post"):
+        assert key in orchestrator._REGISTRY, f"Expected {key!r} in registry"

--- a/backend/tests/services/test_scan_orchestrator.py
+++ b/backend/tests/services/test_scan_orchestrator.py
@@ -1,0 +1,59 @@
+import asyncio
+from datetime import date
+from unittest.mock import AsyncMock
+
+import pytest
+
+import app.services.scan_orchestrator as orchestrator
+from app.services.scan_orchestrator import ScannerDescriptor, register, get_all, run
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry():
+    original = dict(orchestrator._REGISTRY)
+    yield
+    orchestrator._REGISTRY.clear()
+    orchestrator._REGISTRY.update(original)
+
+
+def test_register_adds_descriptor():
+    fn = AsyncMock(return_value=[])
+    desc = ScannerDescriptor(key="test", display_name="Test", description="d", run=fn)
+    register(desc)
+    assert "test" in orchestrator._REGISTRY
+    assert orchestrator._REGISTRY["test"] is desc
+
+
+def test_get_all_includes_registered():
+    fn = AsyncMock(return_value=[])
+    register(ScannerDescriptor(key="s1", display_name="S1", description="d", run=fn))
+    assert any(d.key == "s1" for d in get_all())
+
+
+def test_run_dispatches_to_registered_fn():
+    expected = [{"ticker": "AAPL", "score": 90}]
+    fn = AsyncMock(return_value=expected)
+    register(ScannerDescriptor(key="mock_scan", display_name="Mock", description="m", run=fn))
+    today = date(2026, 5, 23)
+    result = asyncio.run(run("mock_scan", ["AAPL"], db=None, event_date=today))
+    assert result == expected
+    fn.assert_awaited_once_with(["AAPL"], None, today)
+
+
+def test_run_raises_for_unknown_type():
+    with pytest.raises(ValueError, match="Unknown scanner type: 'does_not_exist'"):
+        asyncio.run(run("does_not_exist", [], db=None, event_date=date.today()))
+
+
+def test_scanner_descriptor_is_frozen():
+    fn = AsyncMock(return_value=[])
+    desc = ScannerDescriptor(key="k", display_name="D", description="d", run=fn)
+    with pytest.raises(Exception):
+        desc.key = "changed"  # type: ignore[misc]
+
+
+def test_register_returns_descriptor():
+    fn = AsyncMock(return_value=[])
+    desc = ScannerDescriptor(key="ret", display_name="R", description="d", run=fn)
+    returned = register(desc)
+    assert returned is desc

--- a/backend/tests/services/test_scanner_refactor.py
+++ b/backend/tests/services/test_scanner_refactor.py
@@ -325,3 +325,13 @@ def test_pre_market_scan_static_fallback_when_timesfm_score_below_threshold():
 
     mock_save.assert_not_called()
     assert results == []
+
+
+def test_save_event_importable_from_alert_service():
+    from app.services.alert_service import save_event
+    assert callable(save_event)
+
+
+def test_trigger_scanner_alert_importable_from_alert_service():
+    from app.services.alert_service import trigger_scanner_alert
+    assert callable(trigger_scanner_alert)


### PR DESCRIPTION
## Summary
Automated implementation for issue #60.

## Preview
- Frontend: http://localhost:16033
- Backend API: http://localhost:16080/docs

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #60"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #60"
```

---
*Generated by MarketHawk Dark Factory*