### PR TITLE
refactor: widen provider seam — honest sync interface + get_snapshots (#61)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,9 +77,9 @@ A full pre-market scan proceeds as follows:
 
 | File | Responsibility |
 |------|---------------|
-| `base.py` | `MarketDataProvider` abstract interface (fetch bars, tickers, news). |
-| `massive.py` | Polygon.io bulk operations: large-batch ticker sync, aggregate backfill. |
-| `ibkr.py` | `ib_insync`-based Interactive Brokers provider. Connects to the `ib-gateway` container on port 4002. |
+| `base.py` | `BaseDataProvider` sync abstract interface: `get_bars()`, `get_snapshots()`, `get_ticker_details()`. All providers must implement this contract. |
+| `massive.py` | Polygon.io provider: `get_bars()` (paginated OHLCV), `get_snapshots()` (normalised market snapshot dicts), large-batch ticker sync, aggregate backfill. |
+| `ibkr.py` | `ib_insync`-based Interactive Brokers provider. Futures-only (`get_bars`/`get_snapshots` return empty stubs). Connects to the `ib-gateway` container on port 4002. |
 
 ### Routers (`app/routers/`)
 

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -76,9 +76,9 @@ MarketHawk/
 │   │   │   ├── signal_ranker.py        # Phase 2c: compute_signal_quality_score() + load_ranker_config(); weights from SystemConfig
 │   │   │   └── __init__.py
 │   │   ├── providers/
-│   │   │   ├── base.py                 # MarketDataProvider abstract interface
-│   │   │   ├── massive.py              # Polygon.io bulk operations (large-batch sync, backfill)
-│   │   │   ├── ibkr.py                 # ib_insync Interactive Brokers provider
+│   │   │   ├── base.py                 # BaseDataProvider sync abstract interface: get_bars, get_snapshots, get_ticker_details
+│   │   │   ├── massive.py              # Polygon.io provider: get_bars (paginated), get_snapshots (normalised), bulk sync/backfill
+│   │   │   ├── ibkr.py                 # ib_insync Interactive Brokers provider (futures-only; get_bars/get_snapshots are no-op stubs)
 │   │   │   └── __init__.py
 │   │   ├── main.py                     # FastAPI app factory; global error handler; router mounts
 │   │   └── tasks.py                    # All Celery task definitions

--- a/backend/app/providers/base.py
+++ b/backend/app/providers/base.py
@@ -10,7 +10,7 @@ class BaseDataProvider(ABC):
     """
     Abstract base class for all data providers.
 
-    All providers expose a consistent async interface so the rest of the system
+    All providers expose a consistent sync interface so the rest of the system
     is completely decoupled from any specific vendor.  Adding a 3rd provider
     only requires implementing this class and registering it with the factory.
     """
@@ -44,7 +44,7 @@ class BaseDataProvider(ABC):
     # ------------------------------------------------------------------ #
 
     @abstractmethod
-    async def get_historical_bars(
+    def get_bars(
         self,
         symbol: str,
         timespan: str,
@@ -81,7 +81,27 @@ class BaseDataProvider(ABC):
         ...
 
     @abstractmethod
-    async def get_ticker_details(self, symbol: str) -> Dict[str, Any]:
+    def get_snapshots(self, symbols: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+        """
+        Fetch market snapshots, optionally filtered to a list of symbols.
+
+        Returns a list of dicts:
+            {
+                "ticker":       str,
+                "price":        float,
+                "change_pct":   float,   # % change from previous close
+                "change_value": float,   # absolute $ change from previous close
+                "volume":       int,
+                "prev_close":   float,
+            }
+
+        Providers that don't support snapshots (e.g. IBKR for futures) should
+        return an empty list rather than raising.
+        """
+        ...
+
+    @abstractmethod
+    def get_ticker_details(self, symbol: str) -> Dict[str, Any]:
         """
         Fetch reference/fundamental info for a symbol.
 

--- a/backend/app/providers/ibkr.py
+++ b/backend/app/providers/ibkr.py
@@ -156,42 +156,23 @@ class IBKRDataProvider(BaseDataProvider):
             return False, "Missing IBKR_HOST"
         return True, "Ready"
 
-    async def get_historical_bars(
+    def get_bars(
         self,
         symbol: str,
         timespan: str,
         multiplier: int,
         from_date: str,
         to_date: str,
-        what_to_show: str = "TRADES",
-        use_rth: bool = False,
         **kwargs,
     ) -> List[Dict[str, Any]]:
-        """
-        Fetch OHLCV bars from IBKR for a stock or generic contract.
+        """IBKR serves futures only; stock bars are not supported — return empty."""
+        return []
 
-        For futures, prefer get_futures_bars() which handles contract months.
-        """
-        if not IB_INSYNC_AVAILABLE:
-            return []
+    def get_snapshots(self, symbols: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+        """IBKR does not provide a snapshot feed; return empty."""
+        return []
 
-        ib = await self._get_connection()
-        if not ib:
-            return []
-
-        bar_size = self._resolve_bar_size(timespan, multiplier)
-        contract = Stock(symbol.upper(), "SMART", "USD")
-
-        return await self._fetch_bars_chunked(
-            contract=contract,
-            bar_size=bar_size,
-            from_date=from_date,
-            to_date=to_date,
-            what_to_show=what_to_show,
-            use_rth=use_rth,
-        )
-
-    async def get_ticker_details(self, symbol: str) -> Dict[str, Any]:
+    def get_ticker_details(self, symbol: str) -> Dict[str, Any]:
         """IBKR does not provide fundamental data in a convenient way; return empty."""
         return {}
 

--- a/backend/app/providers/massive.py
+++ b/backend/app/providers/massive.py
@@ -60,7 +60,7 @@ class MassiveDataProvider(BaseDataProvider):
             return False, "Polygon client failed to initialize"
         return True, "Ready"
 
-    def get_historical_bars(
+    def get_bars(
         self,
         symbol: str,
         timespan: str,
@@ -161,6 +161,58 @@ class MassiveDataProvider(BaseDataProvider):
         except Exception as e:
             logger.error(f"MassiveDataProvider: Error fetching details for {symbol}: {e}")
             return {}
+
+    def get_snapshots(self, symbols: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+        """
+        Fetch market snapshots from Polygon and return normalized dicts.
+
+        Normalization (volume extraction, change_pct, prev_close) lives here
+        so callers never need to inspect raw Polygon snapshot objects.
+        """
+        if not self._client:
+            return []
+        try:
+            raw = self._client.get_snapshot_all(market_type="stocks") or []
+        except Exception as e:
+            logger.error(f"MassiveDataProvider: Error fetching snapshots: {e}")
+            return []
+
+        # Build a lookup set for optional symbol filtering
+        filter_set = {s.upper() for s in symbols} if symbols else None
+
+        results: List[Dict[str, Any]] = []
+        for s in raw:
+            if not hasattr(s, "ticker") or not hasattr(s, "prev_day"):
+                continue
+            if filter_set and s.ticker not in filter_set:
+                continue
+
+            day_vol = getattr(s.day, "volume", 0) or 0
+            min_acc_vol = getattr(s.min, "accumulated_volume", 0) or 0
+            volume = max(day_vol, min_acc_vol)
+
+            prev_close = getattr(s.prev_day, "close", 0) or getattr(s.prev_day, "c", 0)
+            if prev_close == 0:
+                continue
+
+            current_price = (
+                getattr(s.min, "close", 0)
+                or getattr(s.last_trade, "price", 0)
+                or getattr(s.last_trade, "p", 0)
+            )
+            if current_price == 0:
+                continue
+
+            results.append({
+                "ticker": s.ticker,
+                "price": float(current_price),
+                "change_pct": float(getattr(s, "todays_change_percent", 0) or 0),
+                "change_value": float(getattr(s, "todays_change", 0) or 0),
+                "volume": int(volume),
+                "prev_close": float(prev_close),
+            })
+
+        return results
 
     # ------------------------------------------------------------------ #
     #  Polygon-specific extras (not part of the base interface)           #

--- a/backend/app/services/stock_data.py
+++ b/backend/app/services/stock_data.py
@@ -37,7 +37,7 @@ class StockDataService:
             end_date = datetime.now(timezone.utc)
             start_date = end_date - timedelta(days=days)
 
-            aggs = massive.get_historical_bars(
+            aggs = massive.get_bars(
                 symbol=ticker.upper(),
                 timespan="day",
                 multiplier=1,
@@ -85,7 +85,7 @@ class StockDataService:
             today_et = datetime.now(_ET)
 
             # Fetch minute-level data for extended hours
-            aggs = massive.get_historical_bars(
+            aggs = massive.get_bars(
                 symbol=ticker.upper(),
                 timespan="minute",
                 multiplier=1,
@@ -443,7 +443,7 @@ class StockDataService:
                 logging.error(f"Provider '{provider}' is not available.")
                 return []
 
-            return p.get_historical_bars(
+            return p.get_bars(
                 symbol=ticker.upper(),
                 timespan=timespan,
                 multiplier=multiplier,
@@ -473,15 +473,12 @@ class StockDataService:
         Filter by volume and return top movers by absolute percentage change.
         """
         try:
-            from app.providers.massive import MassiveDataProvider
             massive = DataProviderFactory.get("massive")
             if not massive.is_available():
                 logging.error("Massive (Polygon) provider not available")
                 return []
 
-            # get_snapshot_all is Polygon-specific — access via the concrete provider
-            assert isinstance(massive, MassiveDataProvider)
-            snapshots = massive.get_snapshot_all(market_type="stocks")
+            snapshots = massive.get_snapshots()
 
             if not snapshots:
                 logging.warning("No snapshots returned from Polygon")
@@ -489,42 +486,17 @@ class StockDataService:
 
             movers = []
             for s in snapshots:
-                # Basic validation
-                if not hasattr(s, 'ticker') or not hasattr(s, 'prev_day'):
-                    continue
-                
-                # Check volume (current day volume, which in pre-market includes pre-market trades)
-                # We check both day.volume and min.accumulated_volume because s.day.volume is often 0 in pre-market
-                day_vol = getattr(s.day, 'volume', 0) or 0
-                min_acc_vol = getattr(s.min, 'accumulated_volume', 0) or 0
-                volume = max(day_vol, min_acc_vol)
-                
-                if volume < min_volume:
-                    continue
-                
-                prev_close = getattr(s.prev_day, 'close', 0) or getattr(s.prev_day, 'c', 0)
-                if prev_close == 0:
-                    continue
-                
-                # Snapshot's todays_change_percent is the percentage change from previous close
-                change_percent = getattr(s, 'todays_change_percent', 0) or 0
-                
-                # If change is 0, we might still be in pre-market and it hasn't updated 
-                # but if there is volume, there should be a price.
-                # Use current minute close or last trade price
-                current_price = getattr(s.min, 'close', 0) or getattr(s.last_trade, 'price', 0) or getattr(s.last_trade, 'p', 0)
-                
-                if current_price == 0:
+                if s["volume"] < min_volume:
                     continue
 
                 movers.append({
-                    "ticker": s.ticker,
-                    "name": None,  # Snapshot doesn't include name, we'd need ticker details but that's a lot of calls
-                    "price": float(current_price),
-                    "change_percent": float(change_percent),
-                    "change_value": float(getattr(s, 'todays_change', 0)),
-                    "volume": int(volume),
-                    "prev_close": float(prev_close)
+                    "ticker": s["ticker"],
+                    "name": None,
+                    "price": s["price"],
+                    "change_percent": s["change_pct"],
+                    "change_value": s["change_value"],
+                    "volume": s["volume"],
+                    "prev_close": s["prev_close"],
                 })
 
             # Sort by absolute change percent descending

--- a/backend/tests/api/test_stocks.py
+++ b/backend/tests/api/test_stocks.py
@@ -184,5 +184,5 @@ def test_details_mock_provider_not_called_for_futures(db: Session, mock_polygon_
     app.dependency_overrides.clear()
 
     assert response.status_code == 200
-    mock_polygon_provider.get_historical_bars.assert_not_called()
+    mock_polygon_provider.get_bars.assert_not_called()
     mock_polygon_provider.get_ticker_details.assert_not_called()

--- a/backend/tests/fixtures/providers.py
+++ b/backend/tests/fixtures/providers.py
@@ -60,9 +60,9 @@ def mock_polygon_provider():
     mock.name = "massive"
     mock.supported_asset_classes = ["stocks"]
     mock.is_available.return_value = (True, "Ready (mock)")
-    mock.get_historical_bars.side_effect = lambda symbol, **kwargs: _make_canned_bars(symbol)
+    mock.get_bars.side_effect = lambda symbol, **kwargs: _make_canned_bars(symbol)
     mock.get_ticker_details.side_effect = lambda symbol: _make_canned_ticker_details(symbol)
-    mock.get_aggregates = mock.get_historical_bars  # alias used by some callers
+    mock.get_snapshots.return_value = []
 
     original = DataProviderFactory._providers.get("massive")
     DataProviderFactory._providers["massive"] = mock

--- a/backend/tests/providers/test_get_historical_bars_pagination.py
+++ b/backend/tests/providers/test_get_historical_bars_pagination.py
@@ -30,9 +30,9 @@ PAGE_LIMIT = 3  # use a small limit so tests don't need hundreds of fake bars
 
 class TestGetHistoricalBarsPagination:
     def _call(self, provider, pages):
-        """Set up get_aggs to return successive pages, then call get_historical_bars."""
+        """Set up get_aggs to return successive pages, then call get_bars."""
         provider._client.get_aggs.side_effect = pages
-        return provider.get_historical_bars(
+        return provider.get_bars(
             symbol="AAPL",
             timespan="minute",
             multiplier=1,

--- a/backend/tests/providers/test_ibkr_provider.py
+++ b/backend/tests/providers/test_ibkr_provider.py
@@ -1,0 +1,61 @@
+# backend/tests/providers/test_ibkr_provider.py
+"""
+Verify that IBKRDataProvider satisfies the sync BaseDataProvider interface.
+All futures-specific async methods are out of scope here.
+"""
+from app.providers.ibkr import IBKRDataProvider
+
+
+def _make_provider() -> IBKRDataProvider:
+    return IBKRDataProvider.__new__(IBKRDataProvider)
+
+
+class TestIBKRSyncInterface:
+    def test_get_bars_returns_empty_list(self):
+        p = _make_provider()
+        result = p.get_bars(
+            symbol="ES",
+            timespan="day",
+            multiplier=1,
+            from_date="2026-01-01",
+            to_date="2026-01-31",
+        )
+        assert result == []
+
+    def test_get_bars_is_not_a_coroutine(self):
+        import inspect
+        p = _make_provider()
+        result = p.get_bars(
+            symbol="ES", timespan="day", multiplier=1,
+            from_date="2026-01-01", to_date="2026-01-31",
+        )
+        assert not inspect.iscoroutine(result), "get_bars must be sync, not a coroutine"
+
+    def test_get_snapshots_returns_empty_list(self):
+        p = _make_provider()
+        assert p.get_snapshots() == []
+        assert p.get_snapshots(symbols=["ES", "NQ"]) == []
+
+    def test_get_snapshots_is_not_a_coroutine(self):
+        import inspect
+        p = _make_provider()
+        result = p.get_snapshots()
+        assert not inspect.iscoroutine(result), "get_snapshots must be sync, not a coroutine"
+
+    def test_get_ticker_details_returns_empty_dict(self):
+        p = _make_provider()
+        assert p.get_ticker_details("ES") == {}
+
+    def test_get_ticker_details_is_not_a_coroutine(self):
+        import inspect
+        p = _make_provider()
+        result = p.get_ticker_details("ES")
+        assert not inspect.iscoroutine(result), "get_ticker_details must be sync, not a coroutine"
+
+    def test_supported_asset_classes_is_futures(self):
+        p = _make_provider()
+        assert p.supported_asset_classes == ["futures"]
+
+    def test_name_is_ibkr(self):
+        p = _make_provider()
+        assert p.name == "ibkr"


### PR DESCRIPTION
## Summary

- Renamed `async get_historical_bars` → sync `get_bars` on `BaseDataProvider` — the interface now tells the truth: Polygon is synchronous, IBKR's async path is futures-specific and stays outside the base contract
- Added `get_snapshots(symbols=None)` as an abstract method on the base interface; `MassiveDataProvider` implements it with all normalization inline (volume extraction, change_pct, change_value, prev_close), eliminating the concrete-type cast in `StockDataService.get_pre_market_movers()`
- Dropped `async` from `get_ticker_details` on both the base and IBKR (was already sync in practice)
- Removed IBKR's dead `async get_historical_bars` override (IBKR is futures-only; no call site ever routed to it); added sync `get_bars` and `get_snapshots` no-op stubs
- Updated 3 `get_historical_bars` call sites in `stock_data.py` to `get_bars`
- Added 8 IBKR sync interface tests in `tests/providers/test_ibkr_provider.py`
- 307 tests pass, no migrations, no frontend changes

Closes #61

## Test plan

- [x] `python -m pytest tests/providers/ tests/api/test_stocks.py` — 31 tests pass
- [x] `python -m pytest` (full suite) — 307 tests pass, 0 failures
- [ ] Reviewer: verify `get_snapshot_all` is gone from `stock_data.py` (grep should return nothing)
- [ ] Reviewer: verify `isinstance(massive, MassiveDataProvider)` cast is gone from `stock_data.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)