### PR TITLE
feat(auth): Add JWT authentication and restrict CORS origins (#84)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,21 @@ DATABASE_URL=postgresql://postgres:change_me_db_password@postgres:5432/stockscan
 SECRET_KEY=your_secret_key_here
 
 # =============================================================================
+# REQUIRED: Authentication (JWT)
+# =============================================================================
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
+JWT_SECRET_KEY=
+ACCESS_TOKEN_EXPIRE_MINUTES=15
+REFRESH_TOKEN_EXPIRE_DAYS=7
+
+# =============================================================================
+# OPTIONAL: CORS Origins
+# =============================================================================
+# Comma-separated list of allowed frontend origins.
+# Default: http://localhost:3333
+# CORS_ORIGINS=http://localhost:3333,https://your-domain.com
+
+# =============================================================================
 # REQUIRED: pgAdmin Credentials
 # =============================================================================
 # Admin login for the pgAdmin web UI (http://localhost:5050).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,6 +109,7 @@ Domain-typed exceptions raised at service/provider public boundaries so callers 
 
 | File | Endpoints |
 |------|-----------|
+| `auth.py` | `GET /api/auth/status` (bootstrap check), `POST /api/auth/register` (first-user only), `POST /api/auth/login` (sets HttpOnly JWT cookies), `POST /api/auth/logout`, `POST /api/auth/refresh`, `GET /api/auth/me` |
 | `scanner.py` | `/api/scanner/run`, `/api/scanner/results` (eager-loads reviews, default sort: `signal_quality_score DESC`; supports `start_date`/`end_date` filters), `/api/scanner/history`, `/api/scanner/signal-quality-distribution`, `POST /api/scanner/events/{uuid}/review` (submit verdict), `GET /api/scanner/events/reviews?scanner_type=` (list with `liquidity_hunt` alias), `GET /api/scanner/reviews/stats` (coverage, acceptance rate, by-type breakdown) |
 | `universe.py` | `/api/universe/*` — CRUD for stock universes and memberships |
 | `stocks.py` | `/api/stocks/*` — historical data, ticker search, stock details |
@@ -150,6 +151,7 @@ Domain-typed exceptions raised at service/provider public boundaries so callers 
 | `SignalReview` | `signal_reviews` | User-submitted verdict (confirmed/rejected/enhanced/uncertain) on a `ScannerEvent`; FK → `scanner_events.id` CASCADE; supports `reject_reason` and `enhance_suggestion` JSONB. Written by `/validate-scanner` skill and frontend ReviewControls. Latest review exposed via `ScannerEvent.latest_review` @property. |
 | `MonitoredAccount` | `monitored_accounts` | X (Twitter) accounts tracked by the tweet-monitor service. Stores `handle`, `platform`, `poll_interval_seconds`, `last_tweet_id` for dedup, and per-account `classification_config` JSONB for keyword overrides. |
 | `TweetSignal` | `tweet_signals` | One row per scraped tweet. Records `classification` (CALLOUT/CELEBRATION/UPDATE/RETWEET/UNKNOWN), `confidence` score, extracted `tickers`/`price_levels` JSONB, `direction`, and `promoted` flag. FK to `scanner_events` when promoted. |
+| `User` | `users` | Operator account. Fields: `id` (UUID PK), `username` (unique), `password_hash` (bcrypt), `created_at`, `is_active`. First user created via bootstrap endpoint; additional users blocked at the application layer. |
 
 ## Frontend Architecture
 
@@ -175,6 +177,7 @@ Each page is a co-located directory (`pages/PageName/index.tsx` + panel files). 
 | `Alerts` | `/alerts` | `Alerts/` (index, AlertRulesPanel, AlertRuleModal, AlertLogsPanel, ChannelConfigPanel) | Alert configuration and delivery history |
 | `StockDetailPage` | `/stock/:ticker` | `StockDetailPage/` (index, ChartPanel, MetadataPanel, ScannerHistoryPanel) | Per-ticker chart, metrics, and news. Supports `?date=YYYY-MM-DD` |
 | `AutoTrading` | `/trading` | `AutoTrading/` (index, StrategyPanel, OrdersPanel, AccountPanel, ConfigPanel, components) | Strategy management, order approval, IBKR account |
+| `Login` | `/login` | `Login/index.tsx` | Bootstrap-aware login and first-user registration. On first launch shows "Create account" form; on subsequent launches shows login form. Redirects to `/` on success. |
 | `Settings` | `/settings` | `Settings.tsx` | System configuration |
 
 ### Charting Libraries

--- a/Docs/adr/0002-jwt-authentication-httponly-cookies.md
+++ b/Docs/adr/0002-jwt-authentication-httponly-cookies.md
@@ -1,0 +1,54 @@
+# ADR-002: JWT Authentication via HttpOnly Cookies
+
+**Date**: 2026-05-27  
+**Status**: Accepted  
+**Issue**: [#84 — Add authentication and restrict CORS origins](https://github.com/omniscient/markethawk/issues/84)
+
+## Context
+
+All 60+ API endpoints were publicly accessible with no authentication. Sensitive operations — auto-trade order submission, system configuration changes, scanner execution — were reachable by any HTTP client. The CORS configuration used a wildcard (`["*"]`), meaning any origin could call the API if it was network-accessible.
+
+### Options Considered
+
+**A. Static API key in `localStorage`** — Simple. One secret in `.env`, sent as `X-API-Key` header. Rejected: `localStorage` is readable by JavaScript; an XSS vulnerability exposes the key permanently.
+
+**B. JWT in HttpOnly cookies** — Access token (short-lived JWT) + refresh token (long-lived opaque, Redis-backed) both set as `HttpOnly; SameSite=Lax` cookies. Not accessible to JavaScript. Supports instant session revocation via Redis key deletion.
+
+**C. Session-based auth (Redis sessions)** — Same security properties as B, but adds stateful server-side session management without providing meaningful additional value over JWT + Redis refresh tokens.
+
+**D. OAuth2 / external provider** — Over-engineered for a self-hosted single-operator tool.
+
+## Decision
+
+Option **B**: JWT access tokens in HttpOnly cookies, backed by Redis-stored refresh tokens.
+
+### Parameters
+
+| Setting | Value |
+|---|---|
+| Access token | 15-minute JWT, HttpOnly cookie, path `/` |
+| Refresh token | 7-day opaque token (`secrets.token_hex(32)`), HttpOnly cookie, path `/api/auth/refresh`, key stored in Redis |
+| Cookie flags | `HttpOnly; SameSite=Lax; Secure` (Secure omitted on localhost) |
+| Signing | HS256, key from `JWT_SECRET_KEY` env var |
+| Auth enforcement | ASGI middleware — validates `jwt.decode()` only, no DB lookup in hot path |
+| Exempt paths | `/api/auth/`, `/api/health`, `/docs`, `/redoc`, `/openapi.json` |
+
+### Bootstrap flow
+
+`GET /api/auth/status` returns `{ bootstrapped: bool }`. When `false`, the login page shows a "Create account" form. `POST /api/auth/register` is only callable when the `users` table is empty; subsequent calls return 403. This eliminates the need for seed scripts or manual CLI setup.
+
+### Why `localStorage` was rejected
+
+`localStorage` is synchronously readable by any JavaScript running on the page. A single XSS vulnerability (injected script, malicious dependency, compromised CDN) exposes the secret permanently — the attacker can extract it and make authenticated API calls from any origin indefinitely. HttpOnly cookies are invisible to JavaScript by definition; even a full XSS compromise cannot extract the token.
+
+### Multi-user path
+
+The `User(id, username, password_hash, created_at, is_active)` model is the minimal schema needed for future multi-user support. Adding more users is additive (INSERT rows). Scoping data to users requires adding `user_id` foreign keys to the relevant tables — a mechanical migration, not an architectural rewrite.
+
+## Consequences
+
+- All API requests must include the `access_token` HttpOnly cookie (set automatically by the browser after login).
+- Frontend Axios client sets `withCredentials: true` and auto-refreshes on 401 before redirecting to `/login`.
+- `alerts.ts` and `trading.ts` were consolidated onto the shared `apiClient` (previously used standalone `axios.create()` instances that bypassed the auth interceptor).
+- CORS `allow_credentials=True` is required and already set; `CORS_ORIGINS` must list explicit origins (no wildcard) — now driven by the `CORS_ORIGINS` env var, defaulting to `http://localhost:3333`.
+- `JWT_SECRET_KEY` must be set in `.env` before first deployment. If unset, all non-exempt endpoints return 401 (fail-closed by empty-string key mismatch).

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -20,6 +20,7 @@ These must be set before starting the stack. The application will start without 
 | `POSTGRES_PASSWORD` | PostgreSQL superuser password | `change_me` |
 | `DATABASE_URL` | Full PostgreSQL connection string (must match `POSTGRES_*` vars) | `postgresql://postgres:change_me@postgres:5432/stockscanner` |
 | `SECRET_KEY` | JWT and session signing key. Generate with: `python -c "import secrets; print(secrets.token_hex(32))"` | `a3f8d2...` |
+| `JWT_SECRET_KEY` | Signing key for user access tokens. Fail-closed: empty value blocks all non-exempt endpoints. Generate same as `SECRET_KEY`. | `b9e1c4...` |
 | `PGADMIN_DEFAULT_EMAIL` | Login email for pgAdmin web UI | `admin@example.com` |
 | `PGADMIN_DEFAULT_PASSWORD` | Login password for pgAdmin web UI | `change_me` |
 | `SEQ_ADMIN_PASSWORD_HASH` | Bcrypt hash of the Seq admin password. Generate with: `echo 'YourPassword' \| docker run --rm -i datalust/seq config hash` | `$2a$11$...` |
@@ -37,6 +38,9 @@ These must be set before starting the stack. The application will start without 
 | `LOG_LEVEL` | `INFO` | Backend and Celery log verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
 | `SEQ_URL` | `http://seq:5341` | Seq ingestion endpoint. Set to `disabled` or leave empty to fall back to stdout-only logging. |
 | `POLYGON_DELAYED` | `true` | When `true`, treats Polygon data as potentially delayed. Set to `false` if your plan provides real-time data. |
+| `ACCESS_TOKEN_EXPIRE_MINUTES` | `15` | JWT access token lifetime in minutes. Short values improve security; longer values reduce refresh frequency. |
+| `REFRESH_TOKEN_EXPIRE_DAYS` | `7` | Refresh token lifetime in days. Stored in Redis; deleting the Redis key revokes the session. |
+| `CORS_ORIGINS` | `http://localhost:3333` | Comma-separated list of allowed frontend origins. Wildcard `*` is intentionally rejected; list explicit origins instead. |
 
 ---
 

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -44,8 +44,10 @@ MarketHawk/
 │   │   │   ├── signal_review.py        # SignalReview — user verdict (confirmed/rejected/enhanced/uncertain) on a ScannerEvent; latest_review @property exposed via ScannerEvent
 │   │   │   ├── monitored_account.py    # MonitoredAccount — X accounts tracked by tweet-monitor; handle, platform, poll_interval_seconds, last_tweet_id, classification_config JSONB
 │   │   │   ├── tweet_signal.py         # TweetSignal — one row per scraped tweet; classification, confidence, tickers/price_levels JSONB, promoted flag, FK → scanner_events
+│   │   │   ├── user.py                 # User — operator account; id (UUID PK), username (unique), password_hash (bcrypt), created_at, is_active
 │   │   │   └── __init__.py             # Re-exports all models (required for Alembic autogenerate)
 │   │   ├── routers/
+│   │   │   ├── auth.py                 # /api/auth/* — status, register (bootstrap), login (HttpOnly JWT cookies), logout, refresh, me
 │   │   │   ├── scanner.py              # /api/scanner/* — run, results (eager-loads reviews), history, signal-quality-distribution; review endpoints: POST /events/{uuid}/review, GET /events/reviews, GET /reviews/stats
 │   │   │   ├── universe.py             # /api/universe/* — CRUD for universes
 │   │   │   ├── stocks.py               # /api/stocks/* — historical data, ticker search

--- a/backend/app/alembic/versions/a1b2c3d4e5f7_add_users_table.py
+++ b/backend/app/alembic/versions/a1b2c3d4e5f7_add_users_table.py
@@ -1,0 +1,36 @@
+"""add_users_table
+
+Revision ID: a1b2c3d4e5f7
+Revises: 48f7ed85ea81
+Create Date: 2026-05-27 23:23:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f7'
+down_revision: Union[str, None] = '48f7ed85ea81'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'users',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('username', sa.String(length=64), nullable=False),
+        sa.Column('password_hash', sa.String(length=256), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_users_username'), 'users', ['username'], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_users_username'), table_name='users')
+    op.drop_table('users')

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -1,0 +1,55 @@
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import bcrypt
+from fastapi import Cookie, Depends, HTTPException, status
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+from sqlalchemy import select
+
+from app.core.config import get_settings
+from app.core.database import get_db
+from app.models.user import User
+
+
+def hash_password(plain: str) -> str:
+    return bcrypt.hashpw(plain.encode(), bcrypt.gensalt()).decode()
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return bcrypt.checkpw(plain.encode(), hashed.encode())
+
+
+def create_access_token(user_id: str) -> str:
+    settings = get_settings()
+    expire = datetime.now(timezone.utc) + timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    return jwt.encode(
+        {"sub": user_id, "exp": expire},
+        settings.JWT_SECRET_KEY,
+        algorithm=settings.JWT_ALGORITHM,
+    )
+
+
+def create_refresh_token() -> str:
+    return secrets.token_hex(32)
+
+
+def get_current_user(
+    access_token: str | None = Cookie(default=None),
+    db: Session = Depends(get_db),
+) -> User:
+    if not access_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    settings = get_settings()
+    try:
+        payload = jwt.decode(access_token, settings.JWT_SECRET_KEY, algorithms=[settings.JWT_ALGORITHM])
+        user_id: str = payload.get("sub")
+    except JWTError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    user = db.execute(
+        select(User).where(User.id == uuid.UUID(user_id), User.is_active == True)
+    ).scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+    return user

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -45,8 +45,18 @@ class Settings:
     # Set to an empty string or "disabled" to fall back to stdout-only logging.
     SEQ_URL: str = os.getenv("SEQ_URL", "http://seq:5341")
 
-    # CORS
-    CORS_ORIGINS: list = ["*"]
+    # CORS — comma-separated origins; defaults to frontend dev URL
+    CORS_ORIGINS: list = [
+        o.strip()
+        for o in os.getenv("CORS_ORIGINS", "http://localhost:3333").split(",")
+        if o.strip()
+    ]
+
+    # Auth
+    JWT_SECRET_KEY: str = os.getenv("JWT_SECRET_KEY", "")
+    JWT_ALGORITHM: str = "HS256"
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "15"))
+    REFRESH_TOKEN_EXPIRE_DAYS: int = int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", "7"))
 
     # ── Interactive Brokers (IBKR) ─────────────────────────────────────
     # Host/port for TWS or IB Gateway:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,8 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
-from app.core.config import settings
+from jose import JWTError, jwt
+from app.core.config import settings, get_settings
 from app.core.database import engine, Base
 from app.core.error_tracking import ErrorTrackerFactory
 from app.exceptions import MarketHawkError
@@ -156,6 +157,23 @@ def create_app() -> FastAPI:
         version=settings.APP_VERSION,
         lifespan=lifespan,
     )
+
+    EXEMPT_PREFIXES = ("/api/auth/", "/api/health", "/docs", "/redoc", "/openapi.json")
+
+    @app.middleware("http")
+    async def auth_middleware(request: Request, call_next):
+        path = request.url.path
+        if any(path.startswith(p) for p in EXEMPT_PREFIXES):
+            return await call_next(request)
+        token = request.cookies.get("access_token")
+        if not token:
+            return JSONResponse(status_code=401, content={"detail": "Not authenticated"})
+        _settings = get_settings()
+        try:
+            jwt.decode(token, _settings.JWT_SECRET_KEY, algorithms=[_settings.JWT_ALGORITHM])
+        except JWTError:
+            return JSONResponse(status_code=401, content={"detail": "Token expired or invalid"})
+        return await call_next(request)
 
     # CORS middleware
     app.add_middleware(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,7 +18,7 @@ from app.core.config import settings
 from app.core.database import engine, Base
 from app.core.error_tracking import ErrorTrackerFactory
 from app.exceptions import MarketHawkError
-from app.routers import health_router, scanner_router, universe_router, stocks_router, news_router, live_data_router, journal_router, system_router, futures_router, alerts_router, watchlist_router, auto_trading_router, outcomes_router
+from app.routers import health_router, scanner_router, universe_router, stocks_router, news_router, live_data_router, journal_router, system_router, futures_router, alerts_router, watchlist_router, auto_trading_router, outcomes_router, auth_router
 from app.routers.tweets import router as tweets_router
 from app.core.celery_app import celery_app as celery
 from app.services.websocket_manager import websocket_manager
@@ -170,6 +170,7 @@ def create_app() -> FastAPI:
     app.add_middleware(GZipMiddleware, minimum_size=1000)
 
     # Include routers
+    app.include_router(auth_router)
     app.include_router(health_router)
     app.include_router(scanner_router)
     app.include_router(universe_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -34,6 +34,7 @@ from app.models.signal_cluster import SignalCluster
 from app.models.signal_review import SignalReview
 from app.models.monitored_account import MonitoredAccount
 from app.models.tweet_signal import TweetSignal
+from app.models.user import User
 
 __all__ = [
     "StockUniverse",
@@ -70,4 +71,5 @@ __all__ = [
     "SignalReview",
     "MonitoredAccount",
     "TweetSignal",
+    "User",
 ]

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,17 @@
+import uuid
+from datetime import datetime, timezone
+from sqlalchemy import Boolean, DateTime, String
+from sqlalchemy.orm import Mapped, mapped_column
+from app.core.database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    username: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
+    password_hash: Mapped[str] = mapped_column(String(256), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -15,6 +15,7 @@ from app.routers.alerts import router as alerts_router
 from app.routers.watchlist import router as watchlist_router
 from app.routers.auto_trading import router as auto_trading_router
 from app.routers.outcomes import router as outcomes_router
+from app.routers.auth import router as auth_router
 __all__ = [
     "health_router",
     "scanner_router",
@@ -29,4 +30,5 @@ __all__ = [
     "watchlist_router",
     "auto_trading_router",
     "outcomes_router",
+    "auth_router",
 ]

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,158 @@
+import uuid
+from datetime import datetime, timezone
+
+import redis
+from fastapi import APIRouter, Cookie, Depends, HTTPException, Response, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.core.auth import (
+    create_access_token,
+    create_refresh_token,
+    get_current_user,
+    hash_password,
+    verify_password,
+)
+from app.core.config import get_settings
+from app.core.database import get_db
+from app.models.user import User
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+def _get_redis():
+    settings = get_settings()
+    return redis.from_url(settings.REDIS_URL, decode_responses=True)
+
+
+def _set_auth_cookies(response: Response, access_token: str, refresh_token: str) -> None:
+    settings = get_settings()
+    is_prod = settings.ENVIRONMENT == "production"
+    response.set_cookie(
+        key="access_token",
+        value=access_token,
+        httponly=True,
+        samesite="lax",
+        secure=is_prod,
+        max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+        path="/",
+    )
+    response.set_cookie(
+        key="refresh_token",
+        value=refresh_token,
+        httponly=True,
+        samesite="lax",
+        secure=is_prod,
+        max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 86400,
+        path="/api/auth/refresh",
+    )
+
+
+class RegisterRequest(BaseModel):
+    username: str
+    password: str
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class UserResponse(BaseModel):
+    id: uuid.UUID
+    username: str
+    created_at: datetime
+
+
+@router.get("/status")
+def auth_status(db: Session = Depends(get_db)):
+    count = db.execute(select(func.count()).select_from(User)).scalar_one()
+    return {"bootstrapped": count > 0}
+
+
+@router.post("/register", response_model=UserResponse)
+def register(body: RegisterRequest, db: Session = Depends(get_db)):
+    count = db.execute(select(func.count()).select_from(User)).scalar_one()
+    if count > 0:
+        raise HTTPException(status_code=403, detail="Registration is closed — a user already exists")
+    user = User(username=body.username, password_hash=hash_password(body.password))
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return UserResponse(id=user.id, username=user.username, created_at=user.created_at)
+
+
+@router.post("/login")
+def login(body: LoginRequest, db: Session = Depends(get_db)):
+    user = db.execute(
+        select(User).where(User.username == body.username, User.is_active == True)
+    ).scalar_one_or_none()
+    if not user or not verify_password(body.password, user.password_hash):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+    access_token = create_access_token(str(user.id))
+    refresh_token = create_refresh_token()
+
+    settings = get_settings()
+    r = _get_redis()
+    r.setex(
+        f"auth:refresh:{refresh_token}",
+        settings.REFRESH_TOKEN_EXPIRE_DAYS * 86400,
+        str(user.id),
+    )
+
+    response = JSONResponse(content={"message": "Logged in"})
+    _set_auth_cookies(response, access_token, refresh_token)
+    return response
+
+
+@router.post("/logout")
+def logout(
+    refresh_token: str | None = Cookie(default=None),
+    _current_user: User = Depends(get_current_user),
+):
+    if refresh_token:
+        r = _get_redis()
+        r.delete(f"auth:refresh:{refresh_token}")
+
+    response = JSONResponse(content={"message": "Logged out"})
+    response.delete_cookie("access_token", path="/")
+    response.delete_cookie("refresh_token", path="/api/auth/refresh")
+    return response
+
+
+@router.post("/refresh")
+def refresh(refresh_token: str | None = Cookie(default=None)):
+    if not refresh_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
+    r = _get_redis()
+    user_id = r.get(f"auth:refresh:{refresh_token}")
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired refresh token")
+
+    settings = get_settings()
+    new_access_token = create_access_token(user_id)
+    new_refresh_token = create_refresh_token()
+
+    r.delete(f"auth:refresh:{refresh_token}")
+    r.setex(
+        f"auth:refresh:{new_refresh_token}",
+        settings.REFRESH_TOKEN_EXPIRE_DAYS * 86400,
+        user_id,
+    )
+
+    response = JSONResponse(content={"message": "Token refreshed"})
+    _set_auth_cookies(response, new_access_token, new_refresh_token)
+    return response
+
+
+@router.get("/me", response_model=UserResponse)
+def me(current_user: User = Depends(get_current_user)):
+    return UserResponse(
+        id=current_user.id,
+        username=current_user.username,
+        created_at=current_user.created_at,
+    )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -45,3 +45,7 @@ email-validator==2.3.0
 
 # Browser Push Notifications (VAPID Web Push)
 pywebpush==2.0.0
+
+# Authentication
+python-jose[cryptography]==3.3.0
+passlib[bcrypt]==1.7.4

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -48,4 +48,4 @@ pywebpush==2.0.0
 
 # Authentication
 python-jose[cryptography]==3.3.0
-passlib[bcrypt]==1.7.4
+bcrypt==5.0.0

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -1,4 +1,13 @@
+import os
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-unit-tests-only-32chars!")
+
+from app.core.config import get_settings
+get_settings.cache_clear()
+
 import pytest
+import fakeredis
+from unittest.mock import patch
+from fastapi.testclient import TestClient
 from app.main import app
 from app.core.database import get_db
 
@@ -8,3 +17,26 @@ def override_get_db(db):
     app.dependency_overrides[get_db] = lambda: db
     yield
     app.dependency_overrides.clear()
+
+
+@pytest.fixture(autouse=True)
+def fake_redis():
+    """Patch redis.from_url in auth router to use fakeredis for all tests."""
+    fake = fakeredis.FakeRedis(decode_responses=True)
+    with patch("app.routers.auth._get_redis", return_value=fake):
+        yield fake
+
+
+@pytest.fixture(autouse=True)
+def inject_auth_into_module_client(request):
+    """Inject a valid JWT cookie into any module-level TestClient.
+
+    Existing test files define `client = TestClient(app)` at module level.
+    The auth middleware only validates jwt.decode() — no DB lookup — so any
+    token signed with the test secret passes, regardless of subject UUID.
+    """
+    from app.core.auth import create_access_token
+    module = request.module
+    if hasattr(module, "client") and isinstance(module.client, TestClient):
+        token = create_access_token("00000000-0000-0000-0000-000000000001")
+        module.client.cookies.set("access_token", token)

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -1,0 +1,79 @@
+import os
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-unit-tests-only-32chars!")
+
+from app.core.config import get_settings
+get_settings.cache_clear()
+
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_auth_status_returns_bootstrapped_false_when_no_users(db):
+    response = client.get("/api/auth/status")
+    assert response.status_code == 200
+    assert response.json() == {"bootstrapped": False}
+
+
+def test_register_creates_first_user(db):
+    response = client.post(
+        "/api/auth/register",
+        json={"username": "admin", "password": "hunter2"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["username"] == "admin"
+    assert "id" in data
+
+
+def test_register_blocked_when_user_exists(db):
+    client.post("/api/auth/register", json={"username": "admin", "password": "hunter2"})
+    response = client.post(
+        "/api/auth/register",
+        json={"username": "admin2", "password": "hunter2"},
+    )
+    assert response.status_code == 403
+
+
+def test_login_sets_cookies(db):
+    client.post("/api/auth/register", json={"username": "admin", "password": "hunter2"})
+    response = client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "hunter2"},
+    )
+    assert response.status_code == 200
+    assert "access_token" in response.cookies
+
+
+def test_login_wrong_password_returns_401(db):
+    client.post("/api/auth/register", json={"username": "admin", "password": "hunter2"})
+    response = client.post(
+        "/api/auth/login",
+        json={"username": "admin", "password": "wrongpassword"},
+    )
+    assert response.status_code == 401
+
+
+def test_me_returns_current_user(db):
+    from app.core.auth import create_access_token
+    # Register and get the real user ID to create an authenticated token
+    reg = client.post("/api/auth/register", json={"username": "admin", "password": "hunter2"})
+    user_id = reg.json()["id"]
+    token = create_access_token(user_id)
+    client.cookies.set("access_token", token)
+    response = client.get("/api/auth/me")
+    assert response.status_code == 200
+    assert response.json()["username"] == "admin"
+
+
+def test_logout_clears_cookies(db):
+    from app.core.auth import create_access_token
+    # Register and set a valid token for the registered user
+    reg = client.post("/api/auth/register", json={"username": "admin", "password": "hunter2"})
+    user_id = reg.json()["id"]
+    token = create_access_token(user_id)
+    client.cookies.set("access_token", token)
+    response = client.post("/api/auth/logout")
+    assert response.status_code == 200

--- a/backend/tests/api/test_health.py
+++ b/backend/tests/api/test_health.py
@@ -11,3 +11,13 @@ def test_health_check():
     assert data["status"] == "healthy"
     assert "timestamp" in data
     assert "version" in data
+
+def test_health_is_exempt_from_auth():
+    c = TestClient(app)
+    response = c.get("/api/health")
+    assert response.status_code == 200
+
+def test_protected_endpoint_returns_401_without_cookie():
+    c = TestClient(app, raise_server_exceptions=False)
+    response = c.get("/api/scanner/runs")
+    assert response.status_code == 401

--- a/backend/tests/test_auth_core.py
+++ b/backend/tests/test_auth_core.py
@@ -1,0 +1,30 @@
+import os
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-unit-tests-only-32chars!")
+
+# Clear cached settings so the env var above is picked up
+from app.core.config import get_settings
+get_settings.cache_clear()
+
+from app.core.auth import hash_password, verify_password, create_access_token, create_refresh_token
+from jose import jwt
+
+
+def test_hash_and_verify():
+    hashed = hash_password("mysecret")
+    assert hashed != "mysecret"
+    assert verify_password("mysecret", hashed)
+    assert not verify_password("wrong", hashed)
+
+
+def test_create_access_token_is_valid_jwt():
+    settings = get_settings()
+    token = create_access_token("user-123")
+    payload = jwt.decode(token, settings.JWT_SECRET_KEY, algorithms=["HS256"])
+    assert payload["sub"] == "user-123"
+    assert "exp" in payload
+
+
+def test_create_refresh_token_is_hex():
+    token = create_refresh_token()
+    assert len(token) == 64
+    int(token, 16)  # raises ValueError if not hex

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,29 @@
+import os
+import importlib
+
+
+def test_cors_origins_default():
+    os.environ.pop("CORS_ORIGINS", None)
+    import app.core.config as cfg
+    importlib.reload(cfg)
+    settings = cfg.Settings()
+    assert settings.CORS_ORIGINS == ["http://localhost:3333"]
+
+
+def test_cors_origins_from_env():
+    os.environ["CORS_ORIGINS"] = "http://localhost:3333,https://myapp.example.com"
+    import app.core.config as cfg
+    importlib.reload(cfg)
+    settings = cfg.Settings()
+    assert "https://myapp.example.com" in settings.CORS_ORIGINS
+    os.environ.pop("CORS_ORIGINS", None)
+
+
+def test_jwt_secret_key_field_exists():
+    import app.core.config as cfg
+    importlib.reload(cfg)
+    settings = cfg.Settings()
+    assert hasattr(settings, "JWT_SECRET_KEY")
+    assert hasattr(settings, "JWT_ALGORITHM")
+    assert hasattr(settings, "ACCESS_TOKEN_EXPIRE_MINUTES")
+    assert hasattr(settings, "REFRESH_TOKEN_EXPIRE_DAYS")

--- a/backend/tests/test_user_model.py
+++ b/backend/tests/test_user_model.py
@@ -1,0 +1,10 @@
+from app.models.user import User
+
+
+def test_user_model_has_required_columns():
+    cols = {c.key for c in User.__table__.columns}
+    assert {"id", "username", "password_hash", "created_at", "is_active"} <= cols
+
+
+def test_user_tablename():
+    assert User.__tablename__ == "users"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React, { ReactNode } from 'react';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
-// Components
 import Layout from './components/Layout';
 import Dashboard from './pages/Dashboard';
 import Scanner from './pages/Scanner';
@@ -18,40 +17,62 @@ import ActiveWatchlist from './pages/ActiveWatchlist';
 import AutoTrading from './pages/AutoTrading';
 import ScorecardOverview from './pages/ScorecardOverview';
 import ScorecardDetail from './pages/ScorecardDetail';
+import Login from './pages/Login';
 import { GlobalErrorToast } from './components/ui/GlobalErrorToast';
+import { apiClient } from './api/client';
 
-// Create a client
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 1000 * 60 * 5, // 5 minutes
+      staleTime: 1000 * 60 * 5,
       retry: 1,
     },
   },
 });
+
+function ProtectedRoute({ children }: { children: ReactNode }) {
+  const { isLoading, isError } = useQuery({
+    queryKey: ['auth', 'me'],
+    queryFn: () => apiClient.get('/auth/me').then((r) => r.data),
+    retry: false,
+  });
+  if (isLoading) return <div className="min-h-screen bg-financial-dark" />;
+  if (isError) return <Navigate to="/login" replace />;
+  return <>{children}</>;
+}
 
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <Router>
         <div className="min-h-screen bg-financial-dark text-financial-light relative">
-          <Layout>
-            <Routes>
-              <Route path="/" element={<Dashboard />} />
-              <Route path="/scanner" element={<Scanner />} />
-              <Route path="/universes" element={<Universes />} />
-              <Route path="/alerts" element={<Alerts />} />
-              <Route path="/settings" element={<Settings />} />
-              <Route path="/journal" element={<Journal />} />
-              <Route path="/edge-explorer" element={<EdgeExplorer />} />
-              <Route path="/scorecard" element={<ScorecardOverview />} />
-              <Route path="/scorecard/:scannerType" element={<ScorecardDetail />} />
-              <Route path="/movers/pre-market" element={<PreMarketMovers />} />
-              <Route path="/watchlist" element={<ActiveWatchlist />} />
-              <Route path="/trading" element={<AutoTrading />} />
-              <Route path="/stock/:ticker" element={<StockDetailPage />} />
-            </Routes>
-          </Layout>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route
+              path="/*"
+              element={
+                <ProtectedRoute>
+                  <Layout>
+                    <Routes>
+                      <Route path="/" element={<Dashboard />} />
+                      <Route path="/scanner" element={<Scanner />} />
+                      <Route path="/universes" element={<Universes />} />
+                      <Route path="/alerts" element={<Alerts />} />
+                      <Route path="/settings" element={<Settings />} />
+                      <Route path="/journal" element={<Journal />} />
+                      <Route path="/edge-explorer" element={<EdgeExplorer />} />
+                      <Route path="/scorecard" element={<ScorecardOverview />} />
+                      <Route path="/scorecard/:scannerType" element={<ScorecardDetail />} />
+                      <Route path="/movers/pre-market" element={<PreMarketMovers />} />
+                      <Route path="/watchlist" element={<ActiveWatchlist />} />
+                      <Route path="/trading" element={<AutoTrading />} />
+                      <Route path="/stock/:ticker" element={<StockDetailPage />} />
+                    </Routes>
+                  </Layout>
+                </ProtectedRoute>
+              }
+            />
+          </Routes>
           <GlobalErrorToast />
         </div>
       </Router>

--- a/frontend/src/api/alerts.ts
+++ b/frontend/src/api/alerts.ts
@@ -1,9 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
-
-const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || '',
-});
+import { apiClient as api } from './client';
 
 export interface AlertRule {
   id: number;
@@ -49,7 +45,7 @@ export const useAlertStats = () => {
   return useQuery<AlertStats>({
     queryKey: ['alerts', 'stats'],
     queryFn: async () => {
-      const { data } = await api.get('/api/alerts/stats');
+      const { data } = await api.get('/alerts/stats');
       return data;
     },
     refetchInterval: 30000, // Refresh every 30s
@@ -62,7 +58,7 @@ export const useAlertRules = () => {
   return useQuery<AlertRule[]>({
     queryKey: ['alerts', 'rules'],
     queryFn: async () => {
-      const { data } = await api.get('/api/alerts/rules');
+      const { data } = await api.get('/alerts/rules');
       return data;
     },
   });
@@ -72,7 +68,7 @@ export const useCreateAlertRule = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (newRule: Partial<AlertRule>) => {
-      const { data } = await api.post('/api/alerts/rules', newRule);
+      const { data } = await api.post('/alerts/rules', newRule);
       return data;
     },
     onSuccess: () => {
@@ -86,7 +82,7 @@ export const useUpdateAlertRule = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async ({ id, ...updates }: Partial<AlertRule> & { id: number }) => {
-      const { data } = await api.patch(`/api/alerts/rules/${id}`, updates);
+      const { data } = await api.patch(`/alerts/rules/${id}`, updates);
       return data;
     },
     onSuccess: () => {
@@ -100,7 +96,7 @@ export const useDeleteAlertRule = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (id: number) => {
-      await api.delete(`/api/alerts/rules/${id}`);
+      await api.delete(`/alerts/rules/${id}`);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['alerts', 'rules'] });
@@ -112,7 +108,7 @@ export const useDeleteAlertRule = () => {
 export const useTestAlertRule = () => {
   return useMutation({
     mutationFn: async (id: number) => {
-      const { data } = await api.post(`/api/alerts/rules/${id}/test`);
+      const { data } = await api.post(`/alerts/rules/${id}/test`);
       return data;
     },
   });
@@ -124,7 +120,7 @@ export const useAlertLogs = (limit = 20) => {
   return useQuery<AlertLog[]>({
     queryKey: ['alerts', 'logs', limit],
     queryFn: async () => {
-      const { data } = await api.get(`/api/alerts/logs?limit=${limit}`);
+      const { data } = await api.get(`/alerts/logs?limit=${limit}`);
       return data;
     },
     refetchInterval: 10000, // Refresh every 10s
@@ -150,7 +146,7 @@ export const usePushSubscription = () => {
   const subscribeMutation = useMutation({
     mutationFn: async () => {
       // 1. Get VAPID public key
-      const { data: { public_key } } = await api.get('/api/alerts/push/vapid-key');
+      const { data: { public_key } } = await api.get('/alerts/push/vapid-key');
 
       // 2. Ensure service worker is registered and active before subscribing
       await navigator.serviceWorker.register('/sw.js');
@@ -172,7 +168,7 @@ export const usePushSubscription = () => {
       });
 
       // 5. Save to backend
-      await api.post('/api/alerts/push/subscribe', subscription);
+      await api.post('/alerts/push/subscribe', subscription);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['alerts', 'stats'] });
@@ -184,7 +180,7 @@ export const usePushSubscription = () => {
       const registration = await navigator.serviceWorker.ready;
       const subscription = await registration.pushManager.getSubscription();
       if (subscription) {
-        await api.delete('/api/alerts/push/unsubscribe', { data: { endpoint: subscription.endpoint } });
+        await api.delete('/alerts/push/unsubscribe', { data: { endpoint: subscription.endpoint } });
         await subscription.unsubscribe();
       }
     },

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,34 @@
+import { apiClient } from './client';
+
+export interface AuthStatus {
+  bootstrapped: boolean;
+}
+
+export interface UserInfo {
+  id: string;
+  username: string;
+  created_at: string;
+}
+
+export async function getAuthStatus(): Promise<AuthStatus> {
+  const response = await apiClient.get<AuthStatus>('/auth/status');
+  return response.data;
+}
+
+export async function register(username: string, password: string): Promise<UserInfo> {
+  const response = await apiClient.post<UserInfo>('/auth/register', { username, password });
+  return response.data;
+}
+
+export async function login(username: string, password: string): Promise<void> {
+  await apiClient.post('/auth/login', { username, password });
+}
+
+export async function logout(): Promise<void> {
+  await apiClient.post('/auth/logout');
+}
+
+export async function getMe(): Promise<UserInfo> {
+  const response = await apiClient.get<UserInfo>('/auth/me');
+  return response.data;
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -16,7 +16,7 @@ apiClient.interceptors.response.use(
     const status = error.response?.status;
     const isNetworkError = !error.response;
 
-    if (status === 401 && !error.config._retried && !error.config.url?.includes('/auth/refresh')) {
+    if (status === 401 && !error.config._retried && !error.config.url?.includes('/auth/')) {
       error.config._retried = true;
       try {
         await apiClient.post('/auth/refresh');

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,60 +1,52 @@
-/**
- * Centralized API Client
- *
- * All HTTP calls to the backend must go through this module.
- * It provides:
- *  - A single, configurable Axios instance (baseURL driven by env var)
- *  - Global response interceptor that catches 5xx errors and fires a
- *    window 'server-error' event so the GlobalErrorToast can surface them
- *
- * Usage:
- *   import { apiClient } from '@/api/client';
- *   const data = await apiClient.get('/scanner/results');
- *
- * To swap the error-tracking backend: update the toast URL generation
- * in GlobalErrorToast.tsx – the API contract (error_id) stays the same.
- */
 import axios from 'axios';
 
-// Base is "/api" which the Vite dev proxy (vite.config.ts → /api → backend:8000) handles at runtime.
-// In production builds, VITE_API_BASE_URL should point at the full origin if needed.
 const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '/api';
 
 export const apiClient = axios.create({
   baseURL: API_BASE,
+  withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
   },
 });
 
-// ----- Global Error Interceptor ------------------------------------------ //
 apiClient.interceptors.response.use(
   (response) => response,
-  (error) => {
-    // 5xx errors or network errors with no response
+  async (error) => {
     const status = error.response?.status;
     const isNetworkError = !error.response;
+
+    if (status === 401 && !error.config._retried && !error.config.url?.includes('/auth/refresh')) {
+      error.config._retried = true;
+      try {
+        await apiClient.post('/auth/refresh');
+        return apiClient(error.config);
+      } catch {
+        window.location.href = '/login';
+      }
+    }
 
     if (status >= 500 || isNetworkError || status === undefined) {
       const data = error.response?.data;
       const isJson = error.response?.headers?.['content-type']?.includes('application/json');
 
-      // Fire global event that GlobalErrorToast listens to
       window.dispatchEvent(
         new CustomEvent('server-error', {
           detail: {
             message:
-              (isJson && data?.message) ? data.message : 
-              isNetworkError ? 'Network error or server timeout. Please check your connection or dashboard status.' :
-              'An unexpected server error occurred.',
-            error_id: (isJson && data?.error_id) ? data.error_id : null,
-            // In dev mode the backend also returns stack_trace + detail
-            detail: (isJson && data?.detail) ? data.detail : null,
-            stack_trace: (isJson && data?.stack_trace) ? data.stack_trace : null,
+              isJson && data?.message
+                ? data.message
+                : isNetworkError
+                  ? 'Network error or server timeout. Please check your connection or dashboard status.'
+                  : 'An unexpected server error occurred.',
+            error_id: isJson && data?.error_id ? data.error_id : null,
+            detail: isJson && data?.detail ? data.detail : null,
+            stack_trace: isJson && data?.stack_trace ? data.stack_trace : null,
           },
         }),
       );
     }
+
     return Promise.reject(error);
   },
 );

--- a/frontend/src/api/trading.ts
+++ b/frontend/src/api/trading.ts
@@ -1,9 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
-
-const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || '',
-});
+import { apiClient as api } from './client';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -110,7 +106,7 @@ export const useStrategies = (activeOnly = false) =>
   useQuery<TradingStrategy[]>({
     queryKey: ['trading', 'strategies', activeOnly],
     queryFn: async () => {
-      const { data } = await api.get('/api/trading/strategies', {
+      const { data } = await api.get('/trading/strategies', {
         params: activeOnly ? { active_only: true } : {},
       });
       return data;
@@ -121,7 +117,7 @@ export const useCreateStrategy = () => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (payload: Partial<TradingStrategy>) => {
-      const { data } = await api.post('/api/trading/strategies', payload);
+      const { data } = await api.post('/trading/strategies', payload);
       return data as TradingStrategy;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['trading', 'strategies'] }),
@@ -132,7 +128,7 @@ export const useUpdateStrategy = () => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async ({ id, ...rest }: Partial<TradingStrategy> & { id: number }) => {
-      const { data } = await api.patch(`/api/trading/strategies/${id}`, rest);
+      const { data } = await api.patch(`/trading/strategies/${id}`, rest);
       return data as TradingStrategy;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['trading', 'strategies'] }),
@@ -143,7 +139,7 @@ export const useDeleteStrategy = () => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (id: number) => {
-      await api.delete(`/api/trading/strategies/${id}`);
+      await api.delete(`/trading/strategies/${id}`);
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['trading', 'strategies'] }),
   });
@@ -161,7 +157,7 @@ export const useAutoTradeOrders = (params?: {
   useQuery<AutoTradeOrder[]>({
     queryKey: ['trading', 'orders', params],
     queryFn: async () => {
-      const { data } = await api.get('/api/trading/orders', { params });
+      const { data } = await api.get('/trading/orders', { params });
       return data;
     },
     refetchInterval: 30000,
@@ -171,7 +167,7 @@ export const useApproveOrder = () => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (id: number) => {
-      const { data } = await api.post(`/api/trading/orders/${id}/approve`);
+      const { data } = await api.post(`/trading/orders/${id}/approve`);
       return data as AutoTradeOrder;
     },
     onSuccess: () => {
@@ -185,7 +181,7 @@ export const useRejectOrder = () => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async ({ id, reason }: { id: number; reason?: string }) => {
-      const { data } = await api.post(`/api/trading/orders/${id}/reject`, { reason });
+      const { data } = await api.post(`/trading/orders/${id}/reject`, { reason });
       return data as AutoTradeOrder;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['trading', 'orders'] }),
@@ -196,7 +192,7 @@ export const useCancelOrder = () => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (id: number) => {
-      const { data } = await api.post(`/api/trading/orders/${id}/cancel`);
+      const { data } = await api.post(`/trading/orders/${id}/cancel`);
       return data as AutoTradeOrder;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['trading', 'orders'] }),
@@ -209,7 +205,7 @@ export const useTradingStats = (days = 30) =>
   useQuery<TradingStats>({
     queryKey: ['trading', 'stats', days],
     queryFn: async () => {
-      const { data } = await api.get('/api/trading/stats', { params: { days } });
+      const { data } = await api.get('/trading/stats', { params: { days } });
       return data;
     },
     refetchInterval: 60000,
@@ -219,7 +215,7 @@ export const useTradingConfig = () =>
   useQuery<TradingConfig>({
     queryKey: ['trading', 'config'],
     queryFn: async () => {
-      const { data } = await api.get('/api/trading/config');
+      const { data } = await api.get('/trading/config');
       return data;
     },
   });
@@ -228,7 +224,7 @@ export const useUpdateTradingConfig = () => {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (payload: Partial<TradingConfig>) => {
-      const { data } = await api.patch('/api/trading/config', payload);
+      const { data } = await api.patch('/trading/config', payload);
       return data as TradingConfig;
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['trading', 'config'] }),
@@ -239,7 +235,7 @@ export const useAccountSummary = () =>
   useQuery<AccountSummary>({
     queryKey: ['trading', 'account'],
     queryFn: async () => {
-      const { data } = await api.get('/api/trading/account');
+      const { data } = await api.get('/trading/account');
       return data;
     },
     refetchInterval: 30000,

--- a/frontend/src/pages/Login/index.tsx
+++ b/frontend/src/pages/Login/index.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getAuthStatus, getMe, login, register } from '../../api/auth';
+
+type Mode = 'loading' | 'login' | 'register' | 'redirecting';
+
+export default function Login() {
+  const navigate = useNavigate();
+  const [mode, setMode] = useState<Mode>('loading');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getMe()
+      .then(() => { if (!cancelled) navigate('/', { replace: true }); })
+      .catch(() =>
+        getAuthStatus().then((s) => {
+          if (!cancelled) setMode(s.bootstrapped ? 'login' : 'register');
+        })
+      );
+    return () => { cancelled = true; };
+  }, [navigate]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    if (mode === 'register' && password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      if (mode === 'register') {
+        await register(username, password);
+        await login(username, password);
+      } else {
+        await login(username, password);
+      }
+      navigate('/', { replace: true });
+    } catch {
+      setError(mode === 'register' ? 'Registration failed' : 'Invalid username or password');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (mode === 'loading' || mode === 'redirecting') {
+    return (
+      <div className="min-h-screen bg-financial-dark flex items-center justify-center">
+        <div className="text-financial-light">Loading...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-financial-dark flex items-center justify-center">
+      <div className="w-full max-w-sm bg-financial-surface border border-financial-border rounded-lg p-8 shadow-xl">
+        <h1 className="text-2xl font-bold text-financial-light mb-2">MarketHawk</h1>
+        <p className="text-financial-muted text-sm mb-6">
+          {mode === 'register' ? 'Create your account to get started' : 'Sign in to continue'}
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm text-financial-light mb-1">Username</label>
+            <input
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+              autoFocus
+              className="w-full bg-financial-dark border border-financial-border rounded px-3 py-2 text-financial-light focus:outline-none focus:border-blue-500"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-financial-light mb-1">Password</label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full bg-financial-dark border border-financial-border rounded px-3 py-2 text-financial-light focus:outline-none focus:border-blue-500"
+            />
+          </div>
+          {mode === 'register' && (
+            <div>
+              <label className="block text-sm text-financial-light mb-1">Confirm Password</label>
+              <input
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                className="w-full bg-financial-dark border border-financial-border rounded px-3 py-2 text-financial-light focus:outline-none focus:border-blue-500"
+              />
+            </div>
+          )}
+          {error && <p className="text-red-400 text-sm">{error}</p>}
+          <button
+            type="submit"
+            disabled={submitting}
+            className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white rounded py-2 font-medium transition-colors"
+          >
+            {submitting ? 'Please wait...' : mode === 'register' ? 'Create Account' : 'Sign In'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **JWT in HttpOnly cookies**: 15-minute access token + 7-day Redis-backed refresh token. Cookies set with `HttpOnly; SameSite=Lax; Secure` (Secure omitted on localhost). Not readable by JavaScript — XSS-safe by design.
- **ASGI auth middleware**: validates `jwt.decode()` on every non-exempt path (fail-closed if `JWT_SECRET_KEY` is empty). Exempt: `/api/auth/`, `/api/health`, `/docs`, `/redoc`, `/openapi.json`.
- **CORS restricted**: wildcard `["*"]` replaced with `CORS_ORIGINS` env var (default `http://localhost:3333`).
- **Bootstrap endpoint**: `POST /api/auth/register` succeeds only when `users` table is empty; `GET /api/auth/status` tells the frontend whether to show login or register.
- **Frontend**: `apiClient` gains `withCredentials: true` + 401 auto-refresh interceptor; `Login` page + `ProtectedRoute` added to `App.tsx`; `alerts.ts` and `trading.ts` consolidated onto shared `apiClient`.

## New files

| File | Purpose |
|------|---------|
| `backend/app/models/user.py` | `User` model (id, username, password_hash, created_at, is_active) |
| `backend/app/core/auth.py` | bcrypt hashing, JWT creation/validation, `get_current_user` dependency |
| `backend/app/routers/auth.py` | `GET /status`, `POST /register`, `POST /login`, `POST /logout`, `POST /refresh`, `GET /me` |
| `backend/app/alembic/versions/a1b2c3d4e5f7_add_users_table.py` | Migration: `users` table |
| `frontend/src/api/auth.ts` | Auth API module |
| `frontend/src/pages/Login/index.tsx` | Login / register page |
| `Docs/adr/0002-jwt-authentication-httponly-cookies.md` | ADR-002 documenting the JWT decision |

## Test plan

- [x] `python -m pytest` — 549 pass, 1 skipped (up from ~537; 15 new auth tests)
- [x] `node_modules/.bin/tsc --noEmit` — no TypeScript errors
- [x] `GET /api/health` returns 200 without a cookie (exempt path)
- [x] Any other endpoint returns 401 without a valid `access_token` cookie
- [x] `POST /api/auth/register` creates first user; subsequent calls return 403
- [x] `POST /api/auth/login` sets `access_token` + `refresh_token` HttpOnly cookies
- [x] `POST /api/auth/logout` clears both cookies and deletes Redis refresh key
- [x] `POST /api/auth/refresh` issues new access token from valid refresh token
- [x] `GET /api/auth/me` returns current user JSON
- [x] Frontend redirects to `/login` when unauthenticated; redirects to `/` when already logged in

## Key decisions

- **bcrypt direct** (not passlib): `passlib[bcrypt]==1.7.4` is incompatible with `bcrypt==5.0.0`. Using `bcrypt.hashpw`/`checkpw` directly — same security, no wrapper.
- **Test fixtures**: `inject_auth_into_module_client` autouse fixture injects a dummy UUID token into all existing module-level `TestClient` instances so existing 17 test files work without modification. Auth middleware does only `jwt.decode()` — no DB lookup in hot path.
- **Migration applied via SQL**: Running backend mounts from Windows path (`C:\git\trading\MarketHawk\backend`), not from the WSL2 workspace. Migration file is committed for `alembic upgrade head`; schema was applied directly via `docker compose exec postgres psql`.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)