### PR TITLE
Bind management service ports to localhost only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,14 @@ PGADMIN_DEFAULT_PASSWORD=change_me_pgadmin_password
 SEQ_ADMIN_PASSWORD_HASH=
 
 # =============================================================================
+# REQUIRED: Flower Basic Auth
+# =============================================================================
+# Basic auth credentials for the Flower Celery monitoring UI (http://localhost:5555).
+# Flower reads FLOWER_BASIC_AUTH automatically from the environment.
+# Format: user:password
+FLOWER_BASIC_AUTH=admin:change_me_flower_password
+
+# =============================================================================
 # OPTIONAL: Logging
 # =============================================================================
 # Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -23,6 +23,7 @@ These must be set before starting the stack. The application will start without 
 | `PGADMIN_DEFAULT_EMAIL` | Login email for pgAdmin web UI | `admin@example.com` |
 | `PGADMIN_DEFAULT_PASSWORD` | Login password for pgAdmin web UI | `change_me` |
 | `SEQ_ADMIN_PASSWORD_HASH` | Bcrypt hash of the Seq admin password. Generate with: `echo 'YourPassword' \| docker run --rm -i datalust/seq config hash` | `$2a$11$...` |
+| `FLOWER_BASIC_AUTH` | Basic auth credentials for the Flower Celery UI (http://localhost:5555). Flower reads this automatically. Format: `user:password` | `admin:change_me_flower_password` |
 
 ---
 

--- a/deployment-guide.md
+++ b/deployment-guide.md
@@ -23,15 +23,15 @@ Before exposing this stack outside your local machine, address the following:
 
 ### Network Exposure
 
-- [ ] Bind management service ports to `127.0.0.1` in `docker-compose.yml` to prevent external access:
+- [x] Bind management service ports to `127.0.0.1` in `docker-compose.yml` to prevent external access:
   ```yaml
   ports:
     - "127.0.0.1:5050:80"    # pgAdmin — localhost only
     - "127.0.0.1:5555:5555"  # Flower — localhost only
     - "127.0.0.1:5380:80"    # Seq — localhost only
   ```
-- [ ] Only expose port 3000 (frontend) and 8000 (backend API) to the network or a reverse proxy.
-- [ ] Add authentication to Flower: set `FLOWER_BASIC_AUTH=user:password` and add it to the Flower command in `docker-compose.yml`.
+- [ ] Only expose port 3333 (frontend) and 8000 (backend API) to the network or a reverse proxy.
+- [x] Add authentication to Flower: set `FLOWER_BASIC_AUTH=user:password` in `.env` — Flower reads it automatically from the environment.
 
 ### IB Gateway
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./database-schema.sql:/docker-entrypoint-initdb.d/01-schema.sql
@@ -27,7 +27,7 @@ services:
     image: redis:7-alpine
     container_name: stockscanner-redis
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis_data:/data
     networks:
@@ -237,8 +237,9 @@ services:
     environment:
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
+      FLOWER_BASIC_AUTH: ${FLOWER_BASIC_AUTH}
     ports:
-      - "5555:5555"
+      - "127.0.0.1:5555:5555"
     depends_on:
       redis:
         condition: service_healthy
@@ -256,7 +257,7 @@ services:
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
       PGADMIN_CONFIG_SERVER_MODE: 'False'
     ports:
-      - "5050:80"
+      - "127.0.0.1:5050:80"
     volumes:
       - pgadmin_data:/var/lib/pgadmin
     depends_on:
@@ -273,8 +274,8 @@ services:
       ACCEPT_EULA: Y
       SEQ_FIRSTRUN_ADMINPASSWORDHASH: ${SEQ_ADMIN_PASSWORD_HASH}
     ports:
-      - "5380:80"        # UI Port (Web Interface)
-      - "5341:5341"      # Ingestion Port (API)
+      - "127.0.0.1:5380:80"        # UI Port (Web Interface)
+      - "127.0.0.1:5341:5341"      # Ingestion Port (API)
     volumes:
       - seq_data:/data
     networks:
@@ -349,7 +350,7 @@ services:
     container_name: markethawk-tweet-monitor
     restart: unless-stopped
     ports:
-      - "8001:8000"
+      - "127.0.0.1:8001:8000"
     environment:
       DATABASE_URL: ${DATABASE_URL}
       REDIS_URL: redis://redis:6379/0


### PR DESCRIPTION
## Summary
Automated implementation for issue #86.

## Preview
- Frontend: http://localhost:18633
- Backend API: http://localhost:18680/docs

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #86"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #86"
```

---
*Generated by MarketHawk Dark Factory*