### PR TITLE
feat(rate-limiting): add SlowAPI middleware with Redis-backed rate limiting (#87)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,13 @@ SEQ_ADMIN_PASSWORD_HASH=
 FLOWER_BASIC_AUTH=admin:change_me_flower_password
 
 # =============================================================================
+# OPTIONAL: Rate Limiting
+# =============================================================================
+# Set to false to disable API rate limiting (useful during local development).
+# Default: true
+RATE_LIMITING_ENABLED=true
+
+# =============================================================================
 # OPTIONAL: Logging
 # =============================================================================
 # Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,6 +58,7 @@ A full pre-market scan proceeds as follows:
 | `database.py` | Async SQLAlchemy engine and session factory (`AsyncSession`). `get_db()` dependency. |
 | `celery_app.py` | Celery instance; beat schedule definitions (scan times, sync intervals). |
 | `error_tracking.py` | `ErrorTracker` protocol; `SeqErrorTracker` and `StdoutErrorTracker` implementations; MD5-based `ErrorId` generation. |
+| `rate_limits.py` | SlowAPI `limiter` instance + three tier constants: `GLOBAL_LIMIT` (100/min), `SCANNER_LIMIT` (5/min), `TRADING_LIMIT` (10/min). Lives in `core/` (not `main.py`) to break the circular import from routers importing `limiter`. Redis db 1 storage when `RATE_LIMITING_ENABLED=true`. |
 
 ### Exception Hierarchy (`app/exceptions.py`)
 

--- a/Docs/adr/0003-slowapi-middleware-for-rate-limiting.md
+++ b/Docs/adr/0003-slowapi-middleware-for-rate-limiting.md
@@ -1,0 +1,56 @@
+# ADR-003: SlowAPI Middleware for Rate Limiting
+
+**Date**: 2026-05-28  
+**Status**: Accepted  
+**Issue**: [#87 — Add API rate limiting (slowapi)](https://github.com/omniscient/markethawk/issues/87)
+
+## Context
+
+No API rate limiting existed on the backend. Any client could send unlimited requests, risking Polygon.io quota exhaustion (external API with monthly call caps), DB connection pool saturation under request floods, and Celery queue flooding via unlimited scan submissions.
+
+The threat model is self-inflicted: automation scripts gone wrong, not adversarial DDoS. Every risk named in the issue originates from developer tooling misbehaving, not an external attacker.
+
+### Options Considered
+
+**A. SlowAPI ASGI middleware** — Python decorator-based rate limiting on the FastAPI app. Redis-backed counters. Per-endpoint granularity via `@limiter.limit()` decorators. No new infrastructure service.
+
+**B. Reverse proxy gateway (Nginx/Traefik)** — Rate limiting at the socket layer. Rejects connections before Python processes them. Lower CPU cost per rejected request under high load.
+
+| Factor | SlowAPI middleware | Gateway (Nginx/Traefik) |
+|---|---|---|
+| Protects Polygon quota | ✓ | ✓ |
+| Sheds load before Python | ✗ | ✓ |
+| Per-endpoint granularity | ✓ | Limited |
+| Throttles Celery-indirect calls | ✓ | ✗ |
+| New infrastructure service | None | Required |
+
+The gateway's key advantage — socket-layer rejection — only matters for adversarial floods where the attacker has motivation to bypass or overwhelm the rate limiter. Self-inflicted accidents back off on a 429 response. The gateway's key blind spot: Polygon API calls originate from Celery workers, which bypass any reverse proxy entirely. The scan submission endpoints (`POST /api/scanner/run`) are the only lever that controls Polygon quota consumption — and only middleware-level limiting can throttle those.
+
+## Decision
+
+**Option A**: SlowAPI ASGI middleware with Redis db 1 storage.
+
+### Parameters
+
+| Parameter | Value |
+|---|---|
+| Storage backend | Redis db 1 (`REDIS_URL` with `/0` swapped to `/1`, isolated from Celery) |
+| Global default | 100 req/min per IP |
+| Scanner tier | 5/min — `POST /api/scanner/run`, `POST /api/scanner/run-range`, 6 universe sync POSTs |
+| Trading tier | 10/min — `POST /api/trading/orders/{id}/approve|reject|cancel` |
+| Exempt | `GET /api/health` (Docker liveness probe), all 7 WebSocket upgrade routes |
+| Disabled mode | `RATE_LIMITING_ENABLED=false` uses `enabled=False` — no-op at both middleware and decorator level |
+| Response | `429 {"message": "Rate limit exceeded", "error_id": null, "retry_after": N}` + `Retry-After` header |
+| Rate limit headers | None emitted on non-429 responses (`headers_enabled=False`) |
+
+### Architecture note
+
+The `limiter` instance lives in `app/core/rate_limits.py`, not `main.py`. `main.py` imports all routers, and routers need to import `limiter` for `@limiter.limit()` decorators — keeping `limiter` in `core/` breaks the circular import.
+
+## Consequences
+
+- All POST endpoints not listed as exempt receive the global 100/min default.
+- Expensive scan and sync POSTs are capped at 5/min; order state-change POSTs at 10/min.
+- When Redis is unavailable, SlowAPI falls back to in-memory storage (single-process accuracy only).
+- If MarketHawk becomes multi-tenant or internet-facing, a reverse proxy should be added in front of the backend in addition to this middleware (defense in depth — complementary roles, not substitutes).
+- `RATE_LIMITING_ENABLED=false` disables enforcement entirely for local development without removing the middleware from the app.

--- a/Docs/superpowers/specs/2026-05-27-api-rate-limiting-design.md
+++ b/Docs/superpowers/specs/2026-05-27-api-rate-limiting-design.md
@@ -1,0 +1,36 @@
+# API Rate Limiting Design Spec
+
+**Issue**: #87 — Add API rate limiting (SlowAPI)  
+**Date**: 2026-05-27  
+**ADR**: [ADR-003](../../adr/0003-slowapi-middleware-for-rate-limiting.md)
+
+## Summary
+
+SlowAPI middleware wired into `main.py` with Redis db 1 as storage backend. Three rate-limit tiers defined in `app/core/rate_limits.py`. WebSocket upgrade endpoints and `GET /api/health` exempt.
+
+## Requirements
+
+- `slowapi==0.1.9` in `backend/requirements.txt`
+- Redis db 1 storage, derived from `REDIS_URL` setting (db 0 reserved for Celery)
+- `app/core/rate_limits.py` with `GLOBAL_LIMIT = "100/minute"`, `SCANNER_LIMIT = "5/minute"`, `TRADING_LIMIT = "10/minute"`
+- `RATE_LIMITING_ENABLED: bool = True` in `Settings`
+- Exempt: `GET /api/health`, all 7 WebSocket routes
+- 5/min: `POST /api/scanner/run`, `POST /api/scanner/run-range`, and 6 universe bulk-sync/quality POSTs
+- 10/min: `POST /api/trading/orders/{id}/approve|reject|cancel`
+- 100/min global default: everything else
+- Custom `RateLimitExceeded` handler returning `{"message": "Rate limit exceeded", "error_id": null, "retry_after": N}` + `Retry-After` header
+- No `X-RateLimit-*` headers on any response (`headers_enabled=False`)
+
+## Architecture
+
+**Circular import avoidance**: `limiter` lives in `app/core/rate_limits.py`. `main.py` imports all routers; routers import `limiter`. Putting `limiter` in `main.py` would create a circular dependency.
+
+**Redis isolation**: Rate limit counters use Redis db 1. Celery broker uses db 0. Keys never collide.
+
+**Disabled mode**: `RATE_LIMITING_ENABLED=false` uses `enabled=False` — SlowAPI's purpose-built no-op flag. Disables enforcement at both middleware and decorator level simultaneously. Middleware is still added to the stack (avoids a conditional `add_middleware` call that would change app structure).
+
+**Naming conflict pattern**: Routes decorated with `@limiter.limit()` require `request: Request` as first positional parameter. Existing Pydantic body params named `request` are renamed to `body`.
+
+## Alternatives Considered
+
+See [ADR-003](../../adr/0003-slowapi-middleware-for-rate-limiting.md) for the gateway vs. middleware trade-off analysis and upgrade path documentation.

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -35,6 +35,7 @@ These must be set before starting the stack. The application will start without 
 | `POSTGRES_DB` | `stockscanner` | PostgreSQL database name |
 | `POSTGRES_USER` | `postgres` | PostgreSQL superuser name |
 | `REDIS_URL` | `redis://redis:6379/0` | Redis connection string. Overriding is only needed for external Redis. |
+| `RATE_LIMITING_ENABLED` | `true` | When `false`, disables all API rate limiting (SlowAPI `enabled=False` — no-op at both middleware and decorator level). Useful during local development to avoid 429s while iterating on scanner endpoints. |
 | `ENVIRONMENT` | `production` | Set to `development` to include stack traces in API error responses. Defaults to `production` so unset envs never leak internals. |
 | `LOG_LEVEL` | `INFO` | Backend and Celery log verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
 | `SEQ_URL` | `http://seq:5341` | Seq ingestion endpoint. Set to `disabled` or leave empty to fall back to stdout-only logging. |

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -29,7 +29,8 @@ class Settings:
     
     # Redis / Celery
     REDIS_URL: str = os.getenv("REDIS_URL", "redis://redis:6379/0")
-    
+    RATE_LIMITING_ENABLED: bool = os.getenv("RATE_LIMITING_ENABLED", "true").lower() == "true"
+
     # Application
     APP_NAME: str = "Stock Scanner API"
     APP_VERSION: str = "1.0.0"

--- a/backend/app/core/rate_limits.py
+++ b/backend/app/core/rate_limits.py
@@ -1,0 +1,32 @@
+"""Rate limiting constants and limiter instance (SlowAPI, issue #87).
+
+The limiter lives here (not main.py) to avoid circular imports: main.py
+imports all routers, and routers need to import limiter.
+"""
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from app.core.config import settings
+
+GLOBAL_LIMIT = "100/minute"
+SCANNER_LIMIT = "5/minute"
+TRADING_LIMIT = "10/minute"
+
+
+def _build_limiter() -> Limiter:
+    # headers_enabled=False: suppresses X-RateLimit-* headers on every response.
+    if not settings.RATE_LIMITING_ENABLED:
+        # enabled=False is SlowAPI's purpose-built no-op — neither middleware nor
+        # decorator auto_check will enforce limits.
+        return Limiter(key_func=get_remote_address, headers_enabled=False, enabled=False)
+    # rsplit('/', 1) safely strips the trailing /0 db segment.
+    rate_redis_url = settings.REDIS_URL.rsplit("/", 1)[0] + "/1"
+    return Limiter(
+        key_func=get_remote_address,
+        default_limits=[GLOBAL_LIMIT],
+        storage_uri=rate_redis_url,
+        headers_enabled=False,
+    )
+
+
+limiter = _build_limiter()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,8 +14,11 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
+from slowapi.middleware import SlowAPIASGIMiddleware
+from slowapi.errors import RateLimitExceeded
 from jose import JWTError, jwt
 from app.core.config import settings, get_settings
+from app.core.rate_limits import limiter
 from app.core.database import engine, Base
 from app.core.error_tracking import ErrorTrackerFactory
 from app.exceptions import MarketHawkError
@@ -186,6 +189,21 @@ def create_app() -> FastAPI:
     
     # Gzip middleware for large payloads
     app.add_middleware(GZipMiddleware, minimum_size=1000)
+
+    # Rate limiting — added last = outermost middleware (LIFO stacking = first to process
+    # inbound requests). When RATE_LIMITING_ENABLED=False, limiter.enabled=False means
+    # neither middleware nor @limiter.limit() decorators enforce any limits.
+    app.state.limiter = limiter
+    app.add_middleware(SlowAPIASGIMiddleware)
+
+    @app.exception_handler(RateLimitExceeded)
+    async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded):
+        retry_after = exc.limit.limit.get_expiry() if exc.limit else 60
+        return JSONResponse(
+            status_code=429,
+            headers={"Retry-After": str(retry_after)},
+            content={"message": "Rate limit exceeded", "error_id": None, "retry_after": retry_after},
+        )
 
     # Include routers
     app.include_router(auth_router)

--- a/backend/app/routers/auto_trading.py
+++ b/backend/app/routers/auto_trading.py
@@ -28,7 +28,8 @@ from datetime import datetime, timezone, date as date_type, timedelta
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
+from app.core.rate_limits import limiter, TRADING_LIMIT
 from sqlalchemy.orm import Session
 from sqlalchemy import func
 
@@ -270,7 +271,9 @@ def get_order(
 
 
 @router.post("/orders/{order_id}/approve")
+@limiter.limit(TRADING_LIMIT)
 def approve_order(
+    request: Request,
     order_id: int,
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
@@ -323,7 +326,9 @@ def approve_order(
 
 
 @router.post("/orders/{order_id}/reject")
+@limiter.limit(TRADING_LIMIT)
 def reject_order(
+    request: Request,
     order_id: int,
     payload: Dict[str, Any] = {},
     db: Session = Depends(get_db),
@@ -348,7 +353,9 @@ def reject_order(
 
 
 @router.post("/orders/{order_id}/cancel")
+@limiter.limit(TRADING_LIMIT)
 def cancel_order(
+    request: Request,
     order_id: int,
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -6,11 +6,13 @@ from datetime import datetime, timezone
 from fastapi import APIRouter
 
 from app.core.config import settings
+from app.core.rate_limits import limiter
 
 router = APIRouter(prefix="/api", tags=["health"])
 
 
 @router.get("/health")
+@limiter.exempt
 def health_check():
     """Health check endpoint."""
     return {

--- a/backend/app/routers/live_data.py
+++ b/backend/app/routers/live_data.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from app.core.rate_limits import limiter
 import asyncio
 import json
 import logging
@@ -11,6 +12,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/live", tags=["live"])
 
 @router.websocket("/ws/{ticker}/{resolution}")
+@limiter.exempt
 async def stock_live_websocket(websocket: WebSocket, ticker: str, resolution: str):
     """
     WebSocket endpoint for live stock updates with specific resolution (minute/second).
@@ -57,6 +59,7 @@ async def stock_live_websocket(websocket: WebSocket, ticker: str, resolution: st
 
 
 @router.websocket("/ws/watchlist")
+@limiter.exempt
 async def watchlist_live_websocket(websocket: WebSocket):
     """
     WebSocket endpoint that streams live tick data and alerts for all
@@ -90,6 +93,7 @@ async def watchlist_live_websocket(websocket: WebSocket):
 
 
 @router.websocket("/ws/scan-task/{task_id}")
+@limiter.exempt
 async def scan_task_websocket(websocket: WebSocket, task_id: str):
     """
     WebSocket endpoint that streams Celery task progress for a range scan.

--- a/backend/app/routers/news.py
+++ b/backend/app/routers/news.py
@@ -69,6 +69,7 @@ def get_recent_news(
     return articles
 
 from fastapi import WebSocket, WebSocketDisconnect
+from app.core.rate_limits import limiter
 import asyncio
 import redis.asyncio as aioredis
 from app.core.config import settings
@@ -81,6 +82,7 @@ def trigger_news_refresh():
     return {"status": "ok", "task_id": str(result.id)}
 
 @router.websocket("/ws")
+@limiter.exempt
 async def news_websocket(websocket: WebSocket):
     await websocket.accept()
     # Connect to redis using async redis client

--- a/backend/app/routers/scanner.py
+++ b/backend/app/routers/scanner.py
@@ -6,7 +6,8 @@ from datetime import date, datetime, timedelta, timezone
 from typing import List, Optional
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, WebSocket, WebSocketDisconnect
+from app.core.rate_limits import limiter, SCANNER_LIMIT
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import cast
 from sqlalchemy.dialects.postgresql import JSONB
@@ -64,8 +65,10 @@ def list_scanner_types():
 
 
 @router.post("/run", response_model=ScannerRunAsyncResponse, status_code=202)
+@limiter.limit(SCANNER_LIMIT)
 def run_scanner(
-    request: ScannerRunRequest,
+    request: Request,
+    body: ScannerRunRequest,
     db: Session = Depends(get_db),
 ):
     """Enqueue a scan and return immediately.
@@ -81,14 +84,14 @@ def run_scanner(
     from app.core.config import settings as _settings
     from app.tasks import run_universe_scan
 
-    if not request.universe_id:
+    if not body.universe_id:
         raise HTTPException(
             status_code=400,
             detail="universe_id is required (per-ticker scans go through /run-range)",
         )
 
     in_flight = ScannerService.check_concurrency(
-        _settings.REDIS_URL, request.universe_id, request.scanner_type
+        _settings.REDIS_URL, body.universe_id, body.scanner_type
     )
     if in_flight:
         raise HTTPException(
@@ -103,12 +106,12 @@ def run_scanner(
 
     try:
         start_date, end_date = ScannerService.resolve_date_range(
-            request.start_date, request.end_date
+            body.start_date, body.end_date
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
-    ticker_count = ScannerService.count_active_tickers(db, request.universe_id)
+    ticker_count = ScannerService.count_active_tickers(db, body.universe_id)
     if ticker_count == 0:
         raise HTTPException(
             status_code=400, detail="No tickers found in the selected universe"
@@ -117,8 +120,8 @@ def run_scanner(
     scan_id = str(uuid.uuid4())
     scanner_run = ScannerRun(
         uuid=uuid.UUID(scan_id),
-        scanner_type=request.scanner_type,
-        universe_id=request.universe_id,
+        scanner_type=body.scanner_type,
+        universe_id=body.universe_id,
         status="queued",
         stocks_scanned=ticker_count,
         scan_start_date=start_date,
@@ -130,8 +133,8 @@ def run_scanner(
 
     async_result = run_universe_scan.delay(
         scan_id=scan_id,
-        scanner_type=request.scanner_type,
-        universe_id=request.universe_id,
+        scanner_type=body.scanner_type,
+        universe_id=body.universe_id,
         start_date_iso=start_date.isoformat(),
         end_date_iso=end_date.isoformat(),
     )
@@ -147,8 +150,8 @@ def run_scanner(
         scan_id=scan_id,
         task_id=async_result.id,
         started_at=started_at,
-        scanner_type=request.scanner_type,
-        universe_id=request.universe_id,
+        scanner_type=body.scanner_type,
+        universe_id=body.universe_id,
         scan_start_date=start_date,
         scan_end_date=end_date,
         status="queued",
@@ -235,6 +238,7 @@ def cancel_scan(scan_id: str, db: Session = Depends(get_db)):
 
 
 @router.websocket("/ws/runs/{task_id}")
+@limiter.exempt
 async def scan_run_websocket(websocket: WebSocket, task_id: str):
     """Stream progress messages for one running scan.
 
@@ -679,18 +683,20 @@ def get_pre_market_movers(
 
 
 @router.post("/run-range")
+@limiter.limit(SCANNER_LIMIT)
 def run_scanner_range(
-    request: ScannerRangeRequest,
+    request: Request,
+    body: ScannerRangeRequest,
     db: Session = Depends(get_db),
 ):
     """Enqueue a date-range scan for a single ticker as a background Celery task."""
     from app.tasks import run_range_scan
     task = run_range_scan.delay(
-        ticker=request.ticker.upper(),
-        scanner_types=request.scanner_types,
-        start_date_str=request.start_date.isoformat(),
-        end_date_str=request.end_date.isoformat(),
-        fetch_missing_data=request.fetch_missing_data,
+        ticker=body.ticker.upper(),
+        scanner_types=body.scanner_types,
+        start_date_str=body.start_date.isoformat(),
+        end_date_str=body.end_date.isoformat(),
+        fetch_missing_data=body.fetch_missing_data,
     )
     return {"task_id": task.id, "status": "queued"}
 

--- a/backend/app/routers/system.py
+++ b/backend/app/routers/system.py
@@ -4,6 +4,7 @@ System-level information and status router.
 
 from typing import Dict, Any, Optional
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
+from app.core.rate_limits import limiter
 from sqlalchemy.orm import Session
 from sqlalchemy import text
 import logging
@@ -213,6 +214,7 @@ def apply_split_adjustments(db: Session = Depends(get_db)):
 
 
 @router.websocket("/ws/tasks")
+@limiter.exempt
 async def system_tasks_websocket(websocket: WebSocket):
     """
     WebSocket endpoint that aggregates and pushes active system tasks 

--- a/backend/app/routers/tweets.py
+++ b/backend/app/routers/tweets.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 import redis.asyncio as aioredis
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
+from app.core.rate_limits import limiter
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
@@ -24,6 +25,7 @@ router = APIRouter(prefix="/api/tweets", tags=["tweets"])
 
 
 @router.websocket("/feed")
+@limiter.exempt
 async def tweet_feed_websocket(websocket: WebSocket):
     """WebSocket: streams real-time tweet signals from Redis channel tweet_signals:all."""
     await websocket.accept()

--- a/backend/app/routers/universe.py
+++ b/backend/app/routers/universe.py
@@ -5,7 +5,8 @@ Universe router - CRUD operations for stock universes.
 from datetime import datetime, timezone
 from typing import List, Optional
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from app.core.rate_limits import limiter, SCANNER_LIMIT
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -180,7 +181,9 @@ def refresh_universe_stats(
 
 
 @router.post("/sync/fundamentals")
+@limiter.limit(SCANNER_LIMIT)
 def sync_fundamental_data(
+    request: Request,
     background_tasks: BackgroundTasks,
     delay: float = 15.0,
     db: Session = Depends(get_db),
@@ -192,7 +195,9 @@ def sync_fundamental_data(
 
 
 @router.post("/sync/details")
+@limiter.limit(SCANNER_LIMIT)
 def sync_ticker_details(
+    request: Request,
     background_tasks: BackgroundTasks,
     delay: float = 15.0,
     resync: bool = False,
@@ -224,7 +229,9 @@ def stop_sync(
 
 
 @router.post("/sync/metrics")
+@limiter.limit(SCANNER_LIMIT)
 def sync_daily_metrics(
+    request: Request,
     background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
 ):
@@ -292,7 +299,9 @@ def get_universe_stocks(
 
 
 @router.post("/{universe_id}/sync-aggregates")
+@limiter.limit(SCANNER_LIMIT)
 def sync_universe_aggregates(
+    request: Request,
     universe_id: int,
     from_date: str,
     to_date: str,
@@ -310,7 +319,9 @@ def sync_universe_aggregates(
 
 
 @router.post("/{universe_id}/analyze-quality")
+@limiter.limit(SCANNER_LIMIT)
 def trigger_quality_analysis(
+    request: Request,
     universe_id: int,
     db: Session = Depends(get_db),
 ):
@@ -383,13 +394,15 @@ def get_quality_report(
 
 
 @router.post("/{universe_id}/normalize")
+@limiter.limit(SCANNER_LIMIT)
 def trigger_normalization(
+    request: Request,
     universe_id: int,
-    request: Optional[NormalizeRequest] = None,
+    body: Optional[NormalizeRequest] = None,
     db: Session = Depends(get_db),
 ):
     """Start (or resume) a normalization run. Poll GET .../quality-report for status."""
-    target_tickers = request.target_tickers if request else None
+    target_tickers = body.target_tickers if body else None
     try:
         return universe_orchestrator.queue_normalization(universe_id, target_tickers, db)
     except UniverseNotFoundError:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,6 +27,7 @@ httpx==0.28.1
 # Background Tasks
 celery==5.6.3
 redis==7.4.0
+slowapi==0.1.9
 flower==2.0.1
 
 # Environment Variables

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -1,5 +1,8 @@
 import os
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-unit-tests-only-32chars!")
+# Disable rate limiting in tests: Redis is not available in the test environment,
+# and SlowAPIASGIMiddleware would raise ConnectionError on every request.
+os.environ.setdefault("RATE_LIMITING_ENABLED", "false")
 
 from app.core.config import get_settings
 get_settings.cache_clear()

--- a/backend/tests/api/test_rate_limiting.py
+++ b/backend/tests/api/test_rate_limiting.py
@@ -1,0 +1,148 @@
+"""Tests for API rate limiting (SlowAPI, issue #87)."""
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIASGIMiddleware
+from slowapi.util import get_remote_address
+
+from app.core.rate_limits import GLOBAL_LIMIT, SCANNER_LIMIT, TRADING_LIMIT, limiter
+from app.core.config import settings
+from app.main import app as main_app
+
+
+# ── Task 1: constants and limiter instance ────────────────────────────────────
+
+def test_rate_limit_constants():
+    assert GLOBAL_LIMIT == "100/minute"
+    assert SCANNER_LIMIT == "5/minute"
+    assert TRADING_LIMIT == "10/minute"
+
+
+def test_limiter_is_limiter_instance():
+    assert isinstance(limiter, Limiter)
+
+
+def test_rate_limiting_enabled_setting_is_bool():
+    assert isinstance(settings.RATE_LIMITING_ENABLED, bool)
+
+
+# ── Task 2: middleware wiring ─────────────────────────────────────────────────
+
+def _make_test_app() -> FastAPI:
+    """Minimal FastAPI app with rate limiting wired identically to main.py."""
+    test_limiter = Limiter(
+        key_func=get_remote_address,
+        default_limits=["100/minute"],
+        storage_uri="memory://",
+        headers_enabled=False,
+    )
+    test_app = FastAPI()
+    test_app.state.limiter = test_limiter
+    test_app.add_middleware(SlowAPIASGIMiddleware)
+
+    @test_app.exception_handler(RateLimitExceeded)
+    async def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded):
+        retry_after = exc.limit.limit.get_expiry() if exc.limit else 60
+        return JSONResponse(
+            status_code=429,
+            headers={"Retry-After": str(retry_after)},
+            content={"message": "Rate limit exceeded", "error_id": None, "retry_after": retry_after},
+        )
+
+    @test_app.get("/test-limited")
+    @test_limiter.limit("1/minute")
+    async def limited_route(request: Request):
+        return {"ok": True}
+
+    return test_app
+
+
+def test_429_response_format():
+    test_app = _make_test_app()
+    client = TestClient(test_app, raise_server_exceptions=False)
+    first = client.get("/test-limited")
+    assert first.status_code == 200
+    assert "X-RateLimit-Limit" not in first.headers
+    second = client.get("/test-limited")
+    assert second.status_code == 429
+    body = second.json()
+    assert body["message"] == "Rate limit exceeded"
+    assert "error_id" in body
+    assert body["error_id"] is None
+    assert "retry_after" in body
+    assert isinstance(body["retry_after"], int)
+    assert "Retry-After" in second.headers
+    assert "X-RateLimit-Limit" not in second.headers
+
+
+def test_main_app_has_limiter_state():
+    assert hasattr(main_app.state, "limiter")
+    assert isinstance(main_app.state.limiter, Limiter)
+
+
+def test_rate_limiting_disabled_is_noop():
+    """When enabled=False, limiter is a true no-op."""
+    disabled_limiter = Limiter(
+        key_func=get_remote_address,
+        headers_enabled=False,
+        enabled=False,
+    )
+    test_app = FastAPI()
+    test_app.state.limiter = disabled_limiter
+    test_app.add_middleware(SlowAPIASGIMiddleware)
+
+    @test_app.get("/test-disabled-limited")
+    @disabled_limiter.limit("1/minute")
+    async def limited_route(request: Request):
+        return {"ok": True}
+
+    client = TestClient(test_app, raise_server_exceptions=False)
+    for _ in range(5):
+        response = client.get("/test-disabled-limited")
+        assert response.status_code == 200
+
+
+# ── Task 6: exemption structural checks ──────────────────────────────────────
+
+def test_health_check_is_exempt():
+    from app.routers.health import health_check
+    fn = health_check
+    assert f"{fn.__module__}.{fn.__name__}" in limiter._exempt_routes
+
+
+def test_scanner_websocket_is_exempt():
+    from app.routers.scanner import scan_run_websocket
+    fn = scan_run_websocket
+    assert f"{fn.__module__}.{fn.__name__}" in limiter._exempt_routes
+
+
+def test_live_data_websockets_are_exempt():
+    from app.routers.live_data import (
+        stock_live_websocket,
+        watchlist_live_websocket,
+        scan_task_websocket,
+    )
+    for fn in (stock_live_websocket, watchlist_live_websocket, scan_task_websocket):
+        assert f"{fn.__module__}.{fn.__name__}" in limiter._exempt_routes
+
+
+def test_system_websocket_is_exempt():
+    from app.routers.system import system_tasks_websocket
+    fn = system_tasks_websocket
+    assert f"{fn.__module__}.{fn.__name__}" in limiter._exempt_routes
+
+
+def test_tweets_websocket_is_exempt():
+    from app.routers.tweets import tweet_feed_websocket
+    fn = tweet_feed_websocket
+    assert f"{fn.__module__}.{fn.__name__}" in limiter._exempt_routes
+
+
+def test_news_websocket_is_exempt():
+    from app.routers.news import news_websocket
+    fn = news_websocket
+    assert f"{fn.__module__}.{fn.__name__}" in limiter._exempt_routes

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,9 @@
 import os
+# Must be set before any app import so SlowAPI limiter builds as a no-op.
+# Redis (db 1) is not available in the test environment; without this the
+# SlowAPIASGIMiddleware raises ConnectionError on every request.
+os.environ.setdefault("RATE_LIMITING_ENABLED", "false")
+
 import pytest
 import logging as _logging
 from typing import Generator


### PR DESCRIPTION
## Summary

- Adds `slowapi==0.1.9` with Redis db 1 as storage backend (isolated from Celery on db 0)
- Three rate-limit tiers: GLOBAL=100/min, SCANNER=5/min (scan/sync triggers), TRADING=10/min (order state changes)
- Custom 429 handler returning existing `{"message": ..., "error_id": null, "retry_after": N}` envelope
- `RATE_LIMITING_ENABLED=false` setting for local dev; `GET /api/health` and all 7 WebSocket routes exempt
- ADR-003 documents the middleware-over-gateway decision

## Changes

**New files:**
- `backend/app/core/rate_limits.py` — limiter instance + tier constants (in `core/` to avoid circular imports)
- `backend/tests/api/test_rate_limiting.py` — 12 tests (all pass)
- `Docs/adr/0003-slowapi-middleware-for-rate-limiting.md`
- `Docs/superpowers/specs/2026-05-27-api-rate-limiting-design.md`

**Modified:**
- `backend/requirements.txt` — `slowapi==0.1.9`
- `backend/app/main.py` — `SlowAPIASGIMiddleware` + `RateLimitExceeded` handler
- `backend/app/core/config.py` / `.env.example` — `RATE_LIMITING_ENABLED`
- `backend/app/routers/scanner.py` — SCANNER_LIMIT on `/run`, `/run-range`; exempt WS
- `backend/app/routers/universe.py` — SCANNER_LIMIT on 6 bulk-sync POSTs
- `backend/app/routers/auto_trading.py` — TRADING_LIMIT on approve/reject/cancel
- `backend/app/routers/health.py`, `live_data.py`, `system.py`, `tweets.py`, `news.py` — exempt WebSockets and health
- `ARCHITECTURE.md`, `ENV_VARIABLES.md` — documentation updates

## Test plan

- [ ] `python -m pytest tests/api/test_rate_limiting.py` — 12/12 pass
- [ ] Backend starts without errors: `docker compose logs backend --tail=20`
- [ ] `curl http://localhost:8000/api/health` returns 200 (exempt route, no rate limit)
- [ ] Rapid `POST /api/scanner/run` (>5 in 1 min) returns 429 with `{"message": "Rate limit exceeded", "error_id": null, "retry_after": N}`
- [ ] WebSocket connections not affected by rate limits (exempt)
- [ ] Set `RATE_LIMITING_ENABLED=false` → all endpoints return 200 regardless of request count

Closes #87

🤖 Generated with [Claude Code](https://claude.ai/claude-code)