### PR TITLE
feat(ts): Enable TypeScript strict mode incrementally (#92)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';

--- a/frontend/src/api/journal.ts
+++ b/frontend/src/api/journal.ts
@@ -58,6 +58,32 @@ export interface JournalEntry {
   updated_at: string;
 }
 
+export interface CreateTradeRequest {
+  symbol: string;
+  side?: string;
+  open_date?: string;
+  quantity?: number;
+  avg_entry_price?: number;
+  notes?: string;
+}
+
+export interface CreateJournalEntryRequest {
+  entry_date: string;
+  content: string;
+  sentiment?: string;
+}
+
+export interface CreateTagRequest {
+  name: string;
+  color?: string;
+}
+
+export interface ImportTradesResponse {
+  imported: number;
+  skipped: number;
+  errors: string[];
+}
+
 // ---- API calls ------------------------------------------------------------ //
 
 export const journalApi = {
@@ -73,12 +99,12 @@ export const journalApi = {
     return response.data;
   },
 
-  createTrade: async (trade: any): Promise<Trade> => {
+  createTrade: async (trade: CreateTradeRequest): Promise<Trade> => {
     const response = await apiClient.post<Trade>('/journal/trades', trade);
     return response.data;
   },
 
-  updateTrade: async (tradeId: number, data: any): Promise<Trade> => {
+  updateTrade: async (tradeId: number, data: Partial<CreateTradeRequest>): Promise<Trade> => {
     const response = await apiClient.patch<Trade>(`/journal/trades/${tradeId}`, data);
     return response.data;
   },
@@ -88,7 +114,7 @@ export const journalApi = {
     return response.data;
   },
 
-  importTrades: async (file: File, broker: string): Promise<any> => {
+  importTrades: async (file: File, broker: string): Promise<ImportTradesResponse> => {
     const formData = new FormData();
     formData.append('file', file);
     const response = await apiClient.post(`/journal/import`, formData, {
@@ -103,7 +129,7 @@ export const journalApi = {
     return response.data;
   },
 
-  createEntry: async (data: any): Promise<JournalEntry> => {
+  createEntry: async (data: CreateJournalEntryRequest): Promise<JournalEntry> => {
     const response = await apiClient.post<JournalEntry>('/journal/entries', data);
     return response.data;
   },
@@ -113,7 +139,7 @@ export const journalApi = {
     return response.data;
   },
 
-  createTag: async (data: any): Promise<Tag> => {
+  createTag: async (data: CreateTagRequest): Promise<Tag> => {
     const response = await apiClient.post<Tag>('/journal/tags', data);
     return response.data;
   },

--- a/frontend/src/api/scanner.ts
+++ b/frontend/src/api/scanner.ts
@@ -18,9 +18,9 @@ export interface ScannerEvent {
 
   signal_quality_score?: number | null;
 
-  indicators: Record<string, any>;
-  criteria_met: Record<string, any>;
-  metadata: Record<string, any>;
+  indicators: Record<string, unknown>;
+  criteria_met: Record<string, unknown>;
+  metadata: Record<string, unknown>;
   
   created_at: string;
   updated_at: string;
@@ -64,8 +64,8 @@ export interface ScannerConfig {
   name: string;
   description: string;
   scanner_type: string;
-  parameters: Record<string, any>;
-  criteria: Record<string, any>[];
+  parameters: Record<string, unknown>;
+  criteria: Record<string, unknown>[];
   is_active: boolean;
   run_frequency: string;
   last_run: string | null;
@@ -77,7 +77,7 @@ export interface StockUniverse {
   uuid: string;
   name: string;
   description: string;
-  criteria: Record<string, any>;
+  criteria: Record<string, unknown>;
   created_at: string;
   is_active: boolean;
   ticker_count?: number;
@@ -243,7 +243,7 @@ export interface ScannerRunStatus {
     total_days?: number;
     tickers?: number;
     events_detected?: number;
-    [k: string]: any;
+    [k: string]: unknown;
   } | null;
 }
 
@@ -393,7 +393,7 @@ export const refreshUniverseStats = async (id: number): Promise<StockUniverse> =
 export const createStockUniverse = async (universe: {
   name: string;
   description?: string;
-  criteria: Record<string, any>;
+  criteria: Record<string, unknown>;
 }): Promise<StockUniverse> => {
   const response = await apiClient.post('/universe/create', universe);
   return response.data;
@@ -408,7 +408,7 @@ export const updateStockUniverse = async (
   universe: {
     name?: string;
     description?: string;
-    criteria?: Record<string, any>;
+    criteria?: Record<string, unknown>;
     is_active?: boolean;
   },
 ): Promise<StockUniverse> => {
@@ -416,22 +416,28 @@ export const updateStockUniverse = async (
   return response.data;
 };
 
-export const syncFundamentals = async (delay: number = 15.0): Promise<any> => {
+export interface TaskEnqueueResponse {
+  status: string;
+  message?: string;
+  task_id?: string;
+}
+
+export const syncFundamentals = async (delay: number = 15.0): Promise<TaskEnqueueResponse> => {
   const response = await apiClient.post('/universe/sync/fundamentals', null, { params: { delay } });
   return response.data;
 };
 
-export const syncMetrics = async (): Promise<any> => {
+export const syncMetrics = async (): Promise<TaskEnqueueResponse> => {
   const response = await apiClient.post('/universe/sync/metrics');
   return response.data;
 };
 
-export const syncTickerDetails = async (delay: number = 15.0): Promise<any> => {
+export const syncTickerDetails = async (delay: number = 15.0): Promise<TaskEnqueueResponse> => {
   const response = await apiClient.post('/universe/sync/details', null, { params: { delay } });
   return response.data;
 };
 
-export const stopSync = async (): Promise<any> => {
+export const stopSync = async (): Promise<TaskEnqueueResponse> => {
   const response = await apiClient.post('/universe/sync/stop');
   return response.data;
 };

--- a/frontend/src/api/scanner.ts
+++ b/frontend/src/api/scanner.ts
@@ -755,12 +755,16 @@ export const getSignalQualityDistribution = async (params: {
   return response.data;
 };
 
-export const handleApiError = (error: any): string => {
-  if (error.response) {
-    return error.response.data?.detail ?? error.response.statusText;
+export const handleApiError = (error: unknown): string => {
+  if (error && typeof error === 'object' && 'response' in error) {
+    const e = error as { response: { data?: { detail?: string }; statusText: string } };
+    return e.response.data?.detail ?? e.response.statusText;
   }
-  if (error.request) {
+  if (error && typeof error === 'object' && 'request' in error) {
     return 'Unable to connect to server';
   }
-  return error.message ?? 'An unexpected error occurred';
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return 'An unexpected error occurred';
 };

--- a/frontend/src/api/scanner.ts
+++ b/frontend/src/api/scanner.ts
@@ -600,6 +600,20 @@ export const syncUniverseAggregates = async (
 
 // ---- Stocks --------------------------------------------------------------- //
 
+export interface OHLCVRow {
+  Date: string;
+  Open: number;
+  High: number;
+  Low: number;
+  Close: number;
+  Volume?: number;
+  vwap?: number;
+  vwap_intraday?: number;
+  marker_type?: string;
+  contract_month?: string;
+  transactions?: number;
+}
+
 export const fetchHistoricalData = async (
   ticker: string,
   period: string = '30d',
@@ -611,7 +625,7 @@ export const fetchHistoricalData = async (
   timespan: string;
   multiplier: number;
   data_points: number;
-  data: any[];
+  data: OHLCVRow[];
   format?: 'row' | 'columnar';
 }> => {
   const response = await apiClient.get(`/stocks/historical/${ticker}`, {
@@ -634,7 +648,7 @@ export const fetchHistoricalData = async (
     const records = new Array(rowCount);
 
     for (let i = 0; i < rowCount; i++) {
-      const row: any = {};
+      const row: Record<string, string | number | null> = {};
       for (const key of keys) {
         const fullKey = mapping[key] || key;
         let value = data[key][i];
@@ -659,7 +673,7 @@ export const fetchHistoricalData = async (
     const records = new Array(rowCount);
     
     for (let i = 0; i < rowCount; i++) {
-       const row: any = {};
+       const row: Record<string, string | number | null> = {};
        for (const key of keys) {
          row[key] = data[key][i];
        }

--- a/frontend/src/api/stocks.ts
+++ b/frontend/src/api/stocks.ts
@@ -29,6 +29,12 @@ export interface StockDetailConsolidated {
   split_adjustment_pending?: boolean;
 }
 
+export interface StockDataTaskResponse {
+  status: string;
+  message?: string;
+  task_id?: string;
+}
+
 // ---- API calls ------------------------------------------------------------ //
 
 export const fetchStockDetails = async (ticker: string): Promise<StockDetailConsolidated> => {
@@ -40,19 +46,19 @@ export const refreshStockData = async (
   ticker: string,
   timespan: string = 'day',
   period?: string,
-): Promise<any> => {
+): Promise<StockDataTaskResponse> => {
   const response = await apiClient.post(`/stocks/refresh/${ticker}`, null, {
     params: { timespan, period },
   });
-  
+
   if (response.data?.status === 'error') {
     throw new Error(response.data.message || 'Error refreshing stock data');
   }
-  
+
   return response.data;
 };
 
-export const syncMissingStockAggregates = async (ticker: string): Promise<any> => {
+export const syncMissingStockAggregates = async (ticker: string): Promise<StockDataTaskResponse> => {
   const response = await apiClient.post(`/stocks/${ticker}/sync-missing`);
   return response.data;
 };

--- a/frontend/src/api/watchlist.ts
+++ b/frontend/src/api/watchlist.ts
@@ -26,7 +26,7 @@ const addToWatchlist = (payload: AddToWatchlistPayload): Promise<WatchlistItem> 
   apiClient.post('/watchlist/', payload).then((r) => r.data);
 
 const removeFromWatchlist = (symbol: string): Promise<void> =>
-  apiClient.delete(`/watchlist/${symbol}`).then(() => undefined);
+  apiClient.delete(`/watchlist/${symbol}`).then((): void => undefined);
 
 const updateWatchlistNotes = (symbol: string, notes: string | null): Promise<WatchlistItem> =>
   apiClient.patch(`/watchlist/${symbol}`, { notes }).then((r) => r.data);

--- a/frontend/src/components/ScannerResults.tsx
+++ b/frontend/src/components/ScannerResults.tsx
@@ -237,15 +237,15 @@ const ScannerResults: React.FC<ScannerResultsProps> = ({
                       <span className="text-[10px] font-bold text-gray-500 uppercase border border-gray-700 px-1.5 py-0.5 rounded-md bg-gray-900/50">
                         {event.scanner_type.replace(/_/g, ' ')}
                       </span>
-                      {event.scanner_type === 'social_callout' && event.metadata?.tweet_url && (
+                      {event.scanner_type === 'social_callout' && Boolean(event.metadata?.tweet_url) && (
                         <a
-                          href={event.metadata?.tweet_url}
+                          href={event.metadata.tweet_url as string}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="text-[10px] text-financial-blue hover:underline truncate max-w-[120px]"
-                          title={`@${event.metadata?.source_account ?? ''}`}
+                          title={`@${(event.metadata?.source_account as string) ?? ''}`}
                         >
-                          @{event.metadata?.source_account ?? 'unknown'}
+                          @{(event.metadata?.source_account as string) ?? 'unknown'}
                         </a>
                       )}
                     </div>
@@ -260,7 +260,7 @@ const ScannerResults: React.FC<ScannerResultsProps> = ({
                       {getImportantIndicators(event).map(key => (
                         <div key={key} className="flex flex-col">
                           <span className="text-gray-500 uppercase tracking-tighter text-[8px]">{key.replace(/_/g, ' ')}</span>
-                          <span className={event.indicators[key] > 0 || key.includes('rsi') ? 'text-financial-light' : 'text-gray-400'}>
+                          <span className={(event.indicators[key] as number) > 0 || key.includes('rsi') ? 'text-financial-light' : 'text-gray-400'}>
                              {renderIndicator(key, event.indicators[key])}
                           </span>
                         </div>

--- a/frontend/src/components/scorecard/DistributionChart.tsx
+++ b/frontend/src/components/scorecard/DistributionChart.tsx
@@ -9,6 +9,11 @@ import {
   ResponsiveContainer,
   Cell,
 } from 'recharts';
+
+// Per spec Req 7: library cast, does not count against @ts-expect-error budget.
+// strictFunctionTypes: (value: number) not assignable to (value: ValueType | undefined) because
+// ValueType includes string and array; runtime behavior is correct — this chart only passes numbers.
+type TooltipFormatterFn = NonNullable<React.ComponentProps<typeof Tooltip>['formatter']>;
 import { DistributionPoint } from '../../api/outcomes';
 
 interface DistributionChartProps {
@@ -100,7 +105,7 @@ const DistributionChart: React.FC<DistributionChartProps> = ({ data, isLoading }
               }}
               itemStyle={{ color: '#F9FAFB', fontSize: '12px' }}
               labelStyle={{ color: '#9CA3AF', fontSize: '10px', fontWeight: 'bold' }}
-              formatter={(value: number) => [`${value} events`, 'Count']}
+              formatter={((value: number) => [`${value} events`, 'Count']) as unknown as TooltipFormatterFn}
             />
             <Bar dataKey="count" radius={[4, 4, 0, 0]}>
               {bins.map((bin, i) => (

--- a/frontend/src/components/ui/GlobalErrorToast.tsx
+++ b/frontend/src/components/ui/GlobalErrorToast.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { AlertCircle, ChevronDown, ChevronUp, ExternalLink, X } from 'lucide-react';
 
 interface ServerErrorDetail {

--- a/frontend/src/components/ui/StockChart.tsx
+++ b/frontend/src/components/ui/StockChart.tsx
@@ -1,27 +1,46 @@
 import React, { useEffect, useRef } from 'react';
-import { 
-  createChart, 
-  ColorType, 
-  IChartApi, 
-  ISeriesApi, 
-  CandlestickData, 
-  LineData, 
+import {
+  createChart,
+  ColorType,
+  IChartApi,
+  ISeriesApi,
+  CandlestickData,
+  LineData,
   AreaData,
   Time,
   CandlestickSeries,
   AreaSeries,
   LineSeries,
   HistogramSeries,
-  createSeriesMarkers
+  createSeriesMarkers,
+  SeriesMarker,
 } from 'lightweight-charts';
-import { calculateDoubleSuperTrend } from '../../utils/indicators';
+import { calculateDoubleSuperTrend, OHLCVInput } from '../../utils/indicators';
+import { ScannerEvent } from '../../api/scanner';
+
+export interface StockBarRow {
+  Date?: string;
+  Open?: number;
+  High?: number;
+  Low?: number;
+  Close?: number;
+  Volume?: number | null;
+  vwap?: number | null;
+  vwap_intraday?: number | null;
+  marker_type?: string | null;
+  contract_month?: string | null;
+  transactions?: number | null;
+  // Used in line/area mode for relative volume charts
+  event_date?: string;
+  relative_volume?: number;
+}
 
 interface StockChartProps {
-  data: any[];
+  data: StockBarRow[];
   type: 'candlestick' | 'area' | 'line';
   timespan?: string;
   height?: number;
-  events?: any[];
+  events?: ScannerEvent[];
   highlightDate?: string;
   symbol?: string; // Ticker symbol for live data filtering
   liveData?: {
@@ -76,13 +95,15 @@ const StockChart: React.FC<StockChartProps> = ({
 
   const chartContainerRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<IChartApi | null>(null);
+  // lightweight-charts has no base series interface; ISeriesApi<SeriesType> makes setData
+  // unsatisfiable at call sites — keep ISeriesApi<any> per spec Req 7 (library limitation).
   const seriesRef = useRef<ISeriesApi<any> | null>(null);
   const volumeSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
   const vwapSeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
   const stLine1SeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
   const stLine2SeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
   const stCloudSeriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
-  const markersPluginRef = useRef<any | null>(null);
+  const markersPluginRef = useRef<ReturnType<typeof createSeriesMarkers> | null>(null);
   const prevDataLengthRef = useRef<number>(0);
   const currentBarRef = useRef<{
     time: Time;
@@ -268,7 +289,7 @@ const StockChart: React.FC<StockChartProps> = ({
       const seenTimes = new Set<number | string>();
 
       for (const d of data) {
-        if (!d.Date || d.Open == null) continue;
+        if (!d.Date || d.Open == null || d.High == null || d.Low == null || d.Close == null) continue;
 
         let timeValue: Time;
         if (timespan === 'day') {
@@ -318,8 +339,8 @@ const StockChart: React.FC<StockChartProps> = ({
 
         const stData = calculateDoubleSuperTrend(stInputData, 3, 12);
         
-        const line1Data = stData.map(d => ({ time: d.time, value: d.tsl1 }));
-        const line2Data = stData.map(d => ({ time: d.time, value: d.tsl2 }));
+        const line1Data = stData.map(d => ({ time: d.time as Time, value: d.tsl1 }));
+        const line2Data = stData.map(d => ({ time: d.time as Time, value: d.tsl2 }));
         const cloudData = stData.map(d => ({
           time: d.time,
           open: d.tsl1,
@@ -345,7 +366,7 @@ const StockChart: React.FC<StockChartProps> = ({
       }
 
       // Markers — events + inline indicators
-      let allMarkers: any[] = [];
+      let allMarkers: SeriesMarker<Time>[] = [];
 
       if (events && events.length > 0) {
         for (const e of events) {
@@ -393,7 +414,7 @@ const StockChart: React.FC<StockChartProps> = ({
               ? a.time - b.time
               : String(a.time).localeCompare(String(b.time))
           );
-          const validMarkers = allMarkers.filter(m => seenTimes.has(m.time as any));
+          const validMarkers = allMarkers.filter(m => seenTimes.has(m.time as number | string));
           markersPluginRef.current.setMarkers(validMarkers);
         } else {
           markersPluginRef.current.setMarkers([]);
@@ -406,13 +427,14 @@ const StockChart: React.FC<StockChartProps> = ({
       const formattedData: (LineData | AreaData)[] = data
         .filter(d => d[xKey] && d[yKey] != null)
         .map(d => {
-          const timeValue = String(d[xKey]).includes('T') || String(d[xKey]).includes(':') 
-            ? toLocalTime(new Date(d[xKey]).getTime() / 1000) as Time
-            : d[xKey].split('T')[0] as Time;
-          
+          const rawTime = d[xKey] as string;
+          const timeValue = rawTime.includes('T') || rawTime.includes(':')
+            ? toLocalTime(new Date(rawTime).getTime() / 1000) as Time
+            : rawTime.split('T')[0] as Time;
+
           return {
             time: timeValue,
-            value: d[yKey],
+            value: d[yKey] as number,
           };
         })
         .sort((a, b) => {
@@ -538,8 +560,8 @@ const StockChart: React.FC<StockChartProps> = ({
       // For intraday or other numeric time scales
       const targetTime = toLocalTime(new Date(highlightDate).getTime() / 1000) as Time;
       
-      const dataFreqSeconds = data.length > 1 
-        ? (new Date(data[1].Date || data[1].event_date).getTime() - new Date(data[0].Date || data[0].event_date).getTime()) / 1000
+      const dataFreqSeconds = data.length > 1
+        ? (new Date((data[1].Date || data[1].event_date) as string).getTime() - new Date((data[0].Date || data[0].event_date) as string).getTime()) / 1000
         : 86400; // default 1 day
 
       const bufferBars = 30;

--- a/frontend/src/components/ui/StockChart.tsx
+++ b/frontend/src/components/ui/StockChart.tsx
@@ -16,7 +16,7 @@ import {
   createSeriesMarkers,
   SeriesMarker,
 } from 'lightweight-charts';
-import { calculateDoubleSuperTrend, OHLCVInput } from '../../utils/indicators';
+import { calculateDoubleSuperTrend } from '../../utils/indicators';
 import { ScannerEvent } from '../../api/scanner';
 
 export interface StockBarRow {
@@ -397,7 +397,6 @@ const StockChart: React.FC<StockChartProps> = ({
           timeValue = toLocalTime(ts) as Time;
         }
         const isSwipe = d.marker_type === 'swipe';
-        const _isFlush = d.marker_type === 'flush';
         allMarkers.push({
           time: timeValue,
           position: isSwipe ? 'aboveBar' : 'belowBar' as const,

--- a/frontend/src/components/ui/StockChart.tsx
+++ b/frontend/src/components/ui/StockChart.tsx
@@ -4,6 +4,7 @@ import {
   ColorType,
   IChartApi,
   ISeriesApi,
+  ISeriesMarkersPluginApi,
   CandlestickData,
   LineData,
   AreaData,
@@ -103,7 +104,7 @@ const StockChart: React.FC<StockChartProps> = ({
   const stLine1SeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
   const stLine2SeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
   const stCloudSeriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
-  const markersPluginRef = useRef<ReturnType<typeof createSeriesMarkers> | null>(null);
+  const markersPluginRef = useRef<ISeriesMarkersPluginApi<Time> | null>(null);
   const prevDataLengthRef = useRef<number>(0);
   const currentBarRef = useRef<{
     time: Time;

--- a/frontend/src/hooks/useScannerWs.ts
+++ b/frontend/src/hooks/useScannerWs.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import type { MutableRefObject } from 'react';
 import type { QueryClient } from '@tanstack/react-query';
 import { createScanRunWebSocket } from '../api/scanner';
-import { ACTIVE_SCAN_LS_KEY, EMPTY_PROGRESS, type LiveProgress } from './useScannerState';
+import { ACTIVE_SCAN_LS_KEY, type LiveProgress } from './useScannerState';
 
 interface WsStateSlice {
   wsRef: MutableRefObject<WebSocket | null>;

--- a/frontend/src/pages/ActiveWatchlist/AlertBadges.tsx
+++ b/frontend/src/pages/ActiveWatchlist/AlertBadges.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import type { LiveAlert } from '../../hooks/useWatchlistLive';
 
 export function AlertBadge({ alert }: { alert: LiveAlert | null }) {

--- a/frontend/src/pages/ActiveWatchlist/WatchlistTable.tsx
+++ b/frontend/src/pages/ActiveWatchlist/WatchlistTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Edit2, Check, X, ExternalLink, Loader2, Trash2 } from 'lucide-react';
 import { useRemoveFromWatchlist, useUpdateWatchlistNotes, WatchlistItem } from '../../api/watchlist';

--- a/frontend/src/pages/Alerts/AlertLogsPanel.tsx
+++ b/frontend/src/pages/Alerts/AlertLogsPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import {
   Activity, RefreshCw, CheckCircle, AlertCircle,
   Smartphone, Mail, MessageSquare, Webhook,

--- a/frontend/src/pages/Alerts/AlertRuleModal.tsx
+++ b/frontend/src/pages/Alerts/AlertRuleModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import {
   ToggleLeft, ToggleRight, Mail, Smartphone, Webhook, MessageSquare,
   Bot, ChevronRight, AlertCircle,

--- a/frontend/src/pages/Alerts/AlertRulesPanel.tsx
+++ b/frontend/src/pages/Alerts/AlertRulesPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import {
   Bell, ToggleLeft, ToggleRight, Mail, Smartphone, Webhook,
   MessageSquare, Clock, ShieldCheck, Edit2, Trash2, Send, Bot, Loader2,

--- a/frontend/src/pages/Alerts/ChannelConfigPanel.tsx
+++ b/frontend/src/pages/Alerts/ChannelConfigPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import { Smartphone, ShieldCheck, ShieldAlert } from 'lucide-react';
 import Card from '../../components/ui/Card';
 import Button from '../../components/ui/Button';

--- a/frontend/src/pages/AutoTrading/ConfigPanel.tsx
+++ b/frontend/src/pages/AutoTrading/ConfigPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import { AlertTriangle, Zap } from 'lucide-react';
 import Button from '../../components/ui/Button';
 import Modal from '../../components/ui/Modal';

--- a/frontend/src/pages/AutoTrading/OrdersPanel.tsx
+++ b/frontend/src/pages/AutoTrading/OrdersPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import { Activity, Loader2 } from 'lucide-react';
 import Card from '../../components/ui/Card';
 import { OrderRow } from './components';
@@ -17,7 +17,7 @@ export interface OrdersPanelProps {
 
 export function OrdersPanel({
   orders, loadingOrders, orderFilter, onOrderFilter,
-  strategies, onApprove, onReject, onCancel,
+  strategies: _strategies, onApprove, onReject, onCancel,
 }: OrdersPanelProps) {
   return (
     <div className="space-y-4">

--- a/frontend/src/pages/AutoTrading/StrategyPanel.tsx
+++ b/frontend/src/pages/AutoTrading/StrategyPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import { Bot, Plus, Loader2 } from 'lucide-react';
 import Card from '../../components/ui/Card';
 import Button from '../../components/ui/Button';

--- a/frontend/src/pages/EdgeExplorer.tsx
+++ b/frontend/src/pages/EdgeExplorer.tsx
@@ -9,6 +9,11 @@ import {
   Target
 } from 'lucide-react';
 
+// Per spec Req 7: library cast, does not count against @ts-expect-error budget.
+// strictFunctionTypes: (value: number, name: string) not assignable to Formatter<ValueType, NameType>
+// because ValueType includes string and array; runtime behavior is correct.
+type TooltipFormatterFn = NonNullable<React.ComponentProps<typeof Tooltip>['formatter']>;
+
 // Components
 import Card from '../components/ui/Card';
 import MetricCard from '../components/ui/MetricCard';
@@ -378,11 +383,11 @@ const EdgeExplorer: React.FC = () => {
                     />
                     <Tooltip
                       contentStyle={{ backgroundColor: '#1F2937', border: '1px solid #374151' }}
-                      formatter={(value: number, name: string) => {
+                      formatter={((value: number, name: string) => {
                         if (name === 'avg_eod_pct') return [`${value?.toFixed(2)}%`, 'Avg EOD %'];
                         if (name === 'follow_through_rate') return [`${(value * 100).toFixed(1)}%`, 'Follow-through'];
                         return [value, name];
-                      }}
+                      }) as unknown as TooltipFormatterFn}
                     />
                     <Legend />
                     <Bar yAxisId="left" dataKey="avg_eod_pct" fill="#3B82F6" name="avg_eod_pct" radius={[2, 2, 0, 0]} />

--- a/frontend/src/pages/Scanner/ResultsPanel.tsx
+++ b/frontend/src/pages/Scanner/ResultsPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import ScannerResults from '../../components/ScannerResults';
 import SignalReviewStats from '../../components/SignalReviewStats';
 

--- a/frontend/src/pages/Scanner/ScanConfigPanel.tsx
+++ b/frontend/src/pages/Scanner/ScanConfigPanel.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { format, formatDistanceToNow } from 'date-fns';
+import { format } from 'date-fns';
 import { Play, X, Settings, Download, Clock, Zap } from 'lucide-react';
 import Card from '../../components/ui/Card';
 import Button from '../../components/ui/Button';

--- a/frontend/src/pages/Scanner/ScanStatusCard.tsx
+++ b/frontend/src/pages/Scanner/ScanStatusCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import { formatDistanceToNow } from 'date-fns';
 import { Eye } from 'lucide-react';
 import Card from '../../components/ui/Card';

--- a/frontend/src/pages/StockDetailPage/ChartPanel.tsx
+++ b/frontend/src/pages/StockDetailPage/ChartPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import { RefreshCw, Eye, EyeOff, BarChart2 } from 'lucide-react';
 import Card from '../../components/ui/Card';
 import Chart from '../../components/ui/Chart';

--- a/frontend/src/pages/StockDetailPage/MetadataPanel.tsx
+++ b/frontend/src/pages/StockDetailPage/MetadataPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import { Globe, Newspaper } from 'lucide-react';
 import Card from '../../components/ui/Card';
 import NewsFeed from '../../components/NewsFeed';

--- a/frontend/src/pages/StockDetailPage/ScannerHistoryPanel.tsx
+++ b/frontend/src/pages/StockDetailPage/ScannerHistoryPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+
 import { Zap } from 'lucide-react';
 import Card from '../../components/ui/Card';
 import RecentEvents from '../../components/RecentEvents';

--- a/frontend/src/utils/indicators.ts
+++ b/frontend/src/utils/indicators.ts
@@ -1,4 +1,19 @@
 
+export interface OHLCVInput {
+  High: number;
+  Low: number;
+  Open: number;
+  Close: number;
+  time: unknown;
+}
+
+export interface DoubleSuperTrendPoint {
+  time: unknown;
+  tsl1: number;
+  tsl2: number;
+  trend: number;
+}
+
 /**
  * Calculates the Double SuperTrend ATR indicator.
  * Translated from Pine Script:
@@ -9,13 +24,13 @@
  * Trend = close > TDown[1] ? 1: close< TUp[1]? -1: nz(Trend[1],1)
  */
 export function calculateDoubleSuperTrend(
-  data: any[],
+  data: OHLCVInput[],
   factor: number = 3,
   atrPeriod: number = 12
-) {
+): DoubleSuperTrendPoint[] {
   if (data.length < atrPeriod) return [];
 
-  const results = [];
+  const results: DoubleSuperTrendPoint[] = [];
   let prevATR = 0;
   let prevTUp = 0;
   let prevTDown = 0;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -20,6 +20,12 @@
         "strict": false,
         "noImplicitAny": true,
         "strictNullChecks": true,
+        "strictFunctionTypes": true,
+        "strictBindCallApply": true,
+        "strictPropertyInitialization": true,
+        "noImplicitThis": true,
+        "alwaysStrict": true,
+        "useUnknownInCatchVariables": true,
         "noUnusedLocals": false,
         "noUnusedParameters": false,
         "noFallthroughCasesInSwitch": true

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,6 +19,7 @@
         /* Linting - Relaxed for existing code */
         "strict": false,
         "noImplicitAny": true,
+        "strictNullChecks": true,
         "noUnusedLocals": false,
         "noUnusedParameters": false,
         "noFallthroughCasesInSwitch": true

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -18,6 +18,7 @@
         "jsx": "react-jsx",
         /* Linting - Relaxed for existing code */
         "strict": false,
+        "noImplicitAny": true,
         "noUnusedLocals": false,
         "noUnusedParameters": false,
         "noFallthroughCasesInSwitch": true

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,18 +16,10 @@
         "isolatedModules": true,
         "noEmit": true,
         "jsx": "react-jsx",
-        /* Linting - Relaxed for existing code */
-        "strict": false,
-        "noImplicitAny": true,
-        "strictNullChecks": true,
-        "strictFunctionTypes": true,
-        "strictBindCallApply": true,
-        "strictPropertyInitialization": true,
-        "noImplicitThis": true,
-        "alwaysStrict": true,
-        "useUnknownInCatchVariables": true,
-        "noUnusedLocals": false,
-        "noUnusedParameters": false,
+        /* Linting */
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
         "noFallthroughCasesInSwitch": true
     },
     "include": [


### PR DESCRIPTION
## Summary

Enables TypeScript `strict: true` (plus `noUnusedLocals` and `noUnusedParameters`) in the frontend in four sequential commits, each adding flags and fixing what they surface.

- **Phase 1** — `noImplicitAny`: typed `api/journal.ts` (5 interfaces), `handleApiError` → `error: unknown`, watchlist `.then()` callback
- **Phase 2** — `strictNullChecks`: typed `indicators.ts` (OHLCVInput/DoubleSuperTrendPoint), `StockChart.tsx` (StockBarRow, SeriesMarker<Time>[], ISeriesMarkersPluginApi<Time>), `scanner.ts` (OHLCVRow)
- **Phase 3** — remaining strict flags: replaced all `Record<string,any>` in api/ layer with `Record<string,unknown>`; added TaskEnqueueResponse, StockDataTaskResponse; fixed Recharts formatter casts (strictFunctionTypes library limitation)
- **Phase 4** — `strict: true` + `noUnusedLocals` + `noUnusedParameters`: removed ~14 unused `import React` declarations, 3 other unused imports/variables

**Final state**: `npx tsc --noEmit` passes with zero errors. `@ts-expect-error` count: **0** (Recharts casts use `as unknown as` per spec Req 7 — exempt from budget).

Closes #92

## Test plan

- [ ] `cd frontend && npx tsc --noEmit` — must produce no output (zero errors)
- [ ] Verify `"strict": true, "noUnusedLocals": true, "noUnusedParameters": true` in `frontend/tsconfig.json`
- [ ] Spot-check `api/scanner.ts`, `api/journal.ts`, `api/stocks.ts` — no `: any` in function signatures
- [ ] Confirm `ScannerResults.tsx` renders correctly (metadata casts)
- [ ] Confirm StockChart renders candlestick and line/area modes (null-guard change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)