### PR TITLE
feat(metrics): Add Prometheus metrics and Grafana dashboards (#95)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,3 +149,10 @@ PROMOTION_THRESHOLD=0.7
 BROWSER_MAX_AGE_MINUTES=30
 BROWSER_MAX_MEMORY_MB=512
 POLL_TIMEOUT_SECONDS=25
+
+# =============================================================================
+# Monitoring (Grafana)
+# =============================================================================
+# Admin password for the Grafana UI (http://localhost:3001, login: admin).
+# If not set, defaults to "admin" (change this in production).
+GRAFANA_ADMIN_PASSWORD=changeme

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,6 +31,9 @@ All services run as Docker containers on the `stockscanner-network` bridge netwo
                          │                    ──> redis:6379        │
                          │  (Playwright Chromium, triggered by      │
                          │   celery-beat every 45s via HTTP POST)   │
+                         │                                          │
+                         │ prometheus:9090 ──scrape──> backend:8000/metrics
+                         │ grafana:3001 ──> prometheus:9090         │
                          └─────────────────────────────────────────┘
 ```
 
@@ -387,6 +390,38 @@ sequenceDiagram
     UI->>API: POST /universe/{id}/refresh-stats  (per completed universe)
     UI->>UI: Invalidate React Query cache → reload universe list
 ```
+
+## Metrics and Observability
+
+### Prometheus metrics (`backend/app/core/metrics.py`)
+
+All custom metrics are registered in `app/core/metrics.py` and exported at `GET /metrics` (excluded from OpenAPI). The backend and `celery-worker` share a tmpfs volume (`prometheus_multiproc`) for `prometheus-client` multiprocess mode so Celery worker metrics aggregate correctly.
+
+| Metric | Type | Labels | Source |
+|--------|------|--------|--------|
+| `http_requests_total` | Counter | `method`, `handler`, `status_code` | `main.py` middleware |
+| `http_request_duration_seconds` | Histogram | `method`, `handler` | `main.py` middleware |
+| `scanner_events_total` | Counter | `scanner_type` | `scanner.py`, `liquidity_hunt.py` |
+| `scan_duration_seconds` | Histogram | `scanner_type` | `scanner.py`, `liquidity_hunt.py` |
+| `polygon_api_calls_total` | Counter | `endpoint` | `providers/massive.py` |
+| `ibkr_connection_status` | Gauge | — | `providers/ibkr.py` |
+| `celery_tasks_total` | Counter | `task_name`, `status` | all task files |
+| `celery_task_duration_seconds` | Histogram | `task_name` | all task files |
+| `active_websocket_connections` | Gauge | — | `routers/live_data.py` |
+| `db_pool_size` | Gauge | — | `main.py` lifespan |
+| `db_pool_checked_out` | Gauge | — | `main.py` lifespan |
+| `db_pool_overflow` | Gauge | — | `main.py` lifespan |
+
+### Grafana dashboards (`grafana/provisioning/dashboards/`)
+
+Four pre-provisioned dashboards load automatically from the `grafana/provisioning/` directory:
+
+- **API Overview** — request rate, error rate, P95 latency, WebSocket connections, DB pool
+- **Scanner Performance** — events/min per scanner type, scan durations, Polygon API call rate, IBKR status
+- **Celery Tasks** — success/failure rates and P95 duration per task
+- **Infrastructure** — IBKR status, DB pool utilization, WebSocket count
+
+Alerting rules (`grafana/provisioning/alerting/rules.yaml`) fire when IBKR disconnects for >2 min, Celery failure rate exceeds 10%, DB pool overflows, or HTTP 5xx rate spikes. Alerts POST to `backend:8000/api/alerts/infrastructure`.
 
 ## Test Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,9 +53,12 @@ npm run lint      # ESLint
 | Frontend    | http://localhost:3333         |
 | Backend API | http://localhost:8000         |
 | API Docs    | http://localhost:8000/docs    |
+| Metrics     | http://localhost:8000/metrics |
 | pgAdmin     | http://localhost:5050         |
 | Flower      | http://localhost:5555         |
 | Seq Logs    | http://localhost:5380         |
+| Prometheus  | http://localhost:9090         |
+| Grafana     | http://localhost:3001         |
 
 ## Architecture
 

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -94,6 +94,15 @@ Set in the `frontend` service's environment block in `docker-compose.yml`, or in
 
 ---
 
+## Monitoring
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `GRAFANA_ADMIN_PASSWORD` | `admin` | Password for the Grafana admin user (UI at http://localhost:3001) |
+| `PROMETHEUS_MULTIPROC_DIR` | `/tmp/prometheus_multiproc` | Shared tmpfs directory for prometheus-client multiprocess mode; set on both `backend` and `celery-worker` |
+
+---
+
 ## Verification
 
 ```bash

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -188,6 +188,23 @@ MarketHawk/
 │       │   ├── SKILL.md
 │       │   └── scripts/query_api.py    # CLI for ad-hoc Polygon API calls
 │       └── bash/SKILL.md               # Shell patterns for this environment
+├── monitoring/
+│   └── prometheus/
+│       └── prometheus.yml              # Prometheus scrape config (targets backend:8000/metrics every 15s)
+├── grafana/
+│   └── provisioning/
+│       ├── datasources/
+│       │   └── prometheus.yaml         # Auto-provision Prometheus datasource
+│       ├── dashboards/
+│       │   ├── dashboards.yaml         # Dashboard provider config (loads JSON files from this dir)
+│       │   ├── api-overview.json       # HTTP request rate, latency, DB pool, WebSocket connections
+│       │   ├── scanner-performance.json # Scanner events/duration, Polygon calls, IBKR status
+│       │   ├── celery-tasks.json       # Celery success/failure rates, P95 durations
+│       │   └── infrastructure.json     # IBKR status, DB pool, WebSocket, Polygon calls
+│       └── alerting/
+│           ├── contact-points.yaml     # Webhook receiver → backend /api/alerts/infrastructure
+│           ├── notification-policies.yaml # Default routing policy
+│           └── rules.yaml              # Alert rules: IBKR disconnect, high failure rate, DB overflow
 ├── database-schema.sql                 # Legacy SQL reference schema — do not use directly; use Alembic
 ├── docker-compose.yml                  # Full stack orchestration (all services)
 ├── .env.example                        # Environment variable template — copy to .env

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,6 +2,7 @@
 Application configuration using pydantic-settings.
 """
 
+import os
 from functools import lru_cache
 from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -1,0 +1,60 @@
+from prometheus_client import Counter, Gauge, Histogram
+
+http_requests_total = Counter(
+    "http_requests_total",
+    "Total HTTP requests received",
+    ["method", "handler", "status_code"],
+)
+
+http_request_duration_seconds = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request duration in seconds",
+    ["method", "handler"],
+    buckets=[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+)
+
+scanner_events_total = Counter(
+    "scanner_events_total",
+    "Total scanner events emitted",
+    ["scanner_type"],
+)
+
+scan_duration_seconds = Histogram(
+    "scan_duration_seconds",
+    "Duration of a scanner run in seconds",
+    ["scanner_type"],
+    buckets=[0.5, 1, 2, 5, 10, 30, 60, 120, 300],
+)
+
+polygon_api_calls_total = Counter(
+    "polygon_api_calls_total",
+    "Total calls made to the Polygon.io API",
+    ["endpoint"],
+)
+
+ibkr_connection_status = Gauge(
+    "ibkr_connection_status",
+    "IBKR connection status (1=connected, 0=disconnected)",
+)
+
+celery_tasks_total = Counter(
+    "celery_tasks_total",
+    "Total Celery tasks executed",
+    ["task_name", "status"],
+)
+
+celery_task_duration_seconds = Histogram(
+    "celery_task_duration_seconds",
+    "Celery task execution duration in seconds",
+    ["task_name"],
+    buckets=[0.1, 0.5, 1, 5, 10, 30, 60, 300],
+)
+
+active_websocket_connections = Gauge(
+    "active_websocket_connections",
+    "Number of active WebSocket connections from frontend clients",
+)
+
+db_pool_size = Gauge("db_pool_size", "SQLAlchemy connection pool configured size")
+db_pool_checked_out = Gauge("db_pool_checked_out", "Connections currently checked out from pool")
+db_pool_overflow = Gauge("db_pool_overflow", "Overflow connections beyond pool_size")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,17 +3,20 @@ Stock Scanner Backend API
 FastAPI-based REST API for stock scanning and alert system
 """
 
+import asyncio
 import logging
 import os
+import time as _time
 import traceback
 import hashlib
 
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
+from prometheus_client import generate_latest, CollectorRegistry, REGISTRY
 from slowapi.middleware import SlowAPIASGIMiddleware
 from slowapi.errors import RateLimitExceeded
 from jose import JWTError, jwt
@@ -83,9 +86,26 @@ async def lifespan(app: FastAPI):
     websocket_manager.start()
     logging.info("Stock WebSocket Manager started")
 
+    from app.core.metrics import db_pool_size, db_pool_checked_out, db_pool_overflow
+
+    async def _update_pool_metrics():
+        while True:
+            try:
+                pool = engine.pool
+                db_pool_size.set(pool.size())
+                db_pool_checked_out.set(pool.checkedout())
+                db_pool_overflow.set(pool.overflow())
+            except Exception:
+                pass
+            await asyncio.sleep(15)
+
+    _pool_task = asyncio.create_task(_update_pool_metrics())
+    logging.info("DB pool metrics background task started")
+
     yield
 
     # --- Shutdown ---
+    _pool_task.cancel()
     engine.dispose()
     logging.info("Database connection closed")
 
@@ -203,6 +223,41 @@ def create_app() -> FastAPI:
             status_code=429,
             headers={"Retry-After": str(retry_after)},
             content={"message": "Rate limit exceeded", "error_id": None, "retry_after": retry_after},
+        )
+
+    # Prometheus HTTP metrics middleware
+    from app.core.metrics import http_requests_total, http_request_duration_seconds
+
+    @app.middleware("http")
+    async def prometheus_middleware(request: Request, call_next):
+        if request.url.path == "/metrics":
+            return await call_next(request)
+        start = _time.monotonic()
+        response = await call_next(request)
+        duration = _time.monotonic() - start
+        handler = request.url.path
+        http_requests_total.labels(
+            method=request.method,
+            handler=handler,
+            status_code=str(response.status_code),
+        ).inc()
+        http_request_duration_seconds.labels(
+            method=request.method,
+            handler=handler,
+        ).observe(duration)
+        return response
+
+    @app.get("/metrics", include_in_schema=False)
+    def prometheus_metrics():
+        if os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+            from prometheus_client.multiprocess import MultiProcessCollector
+            reg = CollectorRegistry()
+            MultiProcessCollector(reg)
+        else:
+            reg = REGISTRY
+        return Response(
+            content=generate_latest(reg),
+            media_type="text/plain; version=0.0.4; charset=utf-8",
         )
 
     # Include routers

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -181,7 +181,7 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
-    EXEMPT_PREFIXES = ("/api/auth/", "/api/health", "/docs", "/redoc", "/openapi.json")
+    EXEMPT_PREFIXES = ("/api/auth/", "/api/health", "/metrics", "/api/alerts/infrastructure", "/docs", "/redoc", "/openapi.json")
 
     @app.middleware("http")
     async def auth_middleware(request: Request, call_next):

--- a/backend/app/providers/ibkr.py
+++ b/backend/app/providers/ibkr.py
@@ -20,6 +20,7 @@ from typing import Dict, Any, List, Optional, Tuple
 from app.core.config import settings
 from app.exceptions import ProviderError
 from app.providers.base import BaseDataProvider
+from app.core.metrics import ibkr_connection_status
 
 logger = logging.getLogger(__name__)
 
@@ -410,6 +411,7 @@ class IBKRDataProvider(BaseDataProvider):
                     )
 
                 self._connected = True
+                ibkr_connection_status.set(1)
                 logger.info(
                     f"IBKRDataProvider: Connected to IB Gateway at "
                     f"{settings.IBKR_HOST}:{settings.IBKR_PORT} "
@@ -422,6 +424,7 @@ class IBKRDataProvider(BaseDataProvider):
             except Exception as e:
                 self._ib = None
                 self._connected = False
+                ibkr_connection_status.set(0)
                 delay = min(5 * (2 ** attempt), 60)   # 5 10 20 40 60 60 …
                 if attempt < max_retries - 1:
                     logger.warning(
@@ -444,6 +447,7 @@ class IBKRDataProvider(BaseDataProvider):
             logger.info("IBKRDataProvider: Disconnected from TWS.")
         self._ib = None
         self._connected = False
+        ibkr_connection_status.set(0)
 
     async def _get_connection(self) -> Optional["IB"]:
         """Return a live IB connection, connecting if necessary."""

--- a/backend/app/providers/massive.py
+++ b/backend/app/providers/massive.py
@@ -15,6 +15,7 @@ from polygon import RESTClient
 from app.core.config import settings
 from app.exceptions import ProviderError
 from app.providers.base import BaseDataProvider
+from app.core.metrics import polygon_api_calls_total
 
 logger = logging.getLogger(__name__)
 
@@ -103,6 +104,7 @@ class MassiveDataProvider(BaseDataProvider):
             current_from: Any = from_date  # str on first call, int (ms) on subsequent calls
 
             while True:
+                polygon_api_calls_total.labels(endpoint="aggs").inc()
                 page = self._client.get_aggs(
                     ticker=symbol.upper(),
                     multiplier=multiplier,
@@ -150,6 +152,7 @@ class MassiveDataProvider(BaseDataProvider):
             return {}
 
         try:
+            polygon_api_calls_total.labels(endpoint="ticker_details").inc()
             details = self._client.get_ticker_details(symbol.upper())
             if not details:
                 return {}
@@ -176,6 +179,7 @@ class MassiveDataProvider(BaseDataProvider):
         if not self._client:
             return []
         try:
+            polygon_api_calls_total.labels(endpoint="snapshot_all").inc()
             raw = self._client.get_snapshot_all(market_type="stocks") or []
         except Exception as e:
             logger.error(f"MassiveDataProvider: Error fetching snapshots: {e}")
@@ -231,6 +235,7 @@ class MassiveDataProvider(BaseDataProvider):
         if not self._client:
             return []
         try:
+            polygon_api_calls_total.labels(endpoint="snapshot_all").inc()
             return self._client.get_snapshot_all(market_type=market_type) or []
         except Exception as e:
             logger.error(f"MassiveDataProvider: Error fetching snapshot: {e}")
@@ -240,6 +245,7 @@ class MassiveDataProvider(BaseDataProvider):
         if not self._client:
             return None
         try:
+            polygon_api_calls_total.labels(endpoint="snapshot_ticker").inc()
             snap = self._client.get_snapshot_ticker("stocks", symbol)
             if snap and snap.last_trade and snap.last_trade.price is not None:
                 return float(snap.last_trade.price)

--- a/backend/app/routers/alerts.py
+++ b/backend/app/routers/alerts.py
@@ -335,3 +335,17 @@ def unsubscribe_push(payload: Dict[str, Any], db: Session = Depends(get_db)) -> 
         db.commit()
         return {"status": "unsubscribed"}
     return {"status": "not_found"}
+
+
+@router.post("/infrastructure", status_code=200)
+def receive_infrastructure_alert(payload: Dict[str, Any]) -> Dict[str, str]:
+    """Receive Grafana alerting webhook payloads and log them."""
+    title = payload.get("title") or payload.get("message") or "unknown"
+    state = payload.get("state") or payload.get("status") or "unknown"
+    logger.warning(
+        "Grafana infrastructure alert received: title=%s state=%s payload=%s",
+        title,
+        state,
+        json.dumps(payload),
+    )
+    return {"status": "received"}

--- a/backend/app/routers/live_data.py
+++ b/backend/app/routers/live_data.py
@@ -6,6 +6,7 @@ import logging
 import redis.asyncio as aioredis
 from app.core.config import settings
 from app.services.websocket_manager import websocket_manager
+from app.core.metrics import active_websocket_connections
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +25,8 @@ async def stock_live_websocket(websocket: WebSocket, ticker: str, resolution: st
         resolution = "minute"
         
     await websocket.accept()
-    
+    active_websocket_connections.inc()
+
     # Ensure backend is connected to Polygon and subscribed to this ticker
     websocket_manager.subscribe(ticker)
     
@@ -52,6 +54,7 @@ async def stock_live_websocket(websocket: WebSocket, ticker: str, resolution: st
     except Exception as e:
         logger.error(f"WebSocket error for {ticker}: {e}")
     finally:
+        active_websocket_connections.dec()
         await pubsub.unsubscribe(channel)
         await redis_client.close()
         # Optionally tell manager to check if anyone else is watching this ticker
@@ -70,6 +73,7 @@ async def watchlist_live_websocket(websocket: WebSocket):
       - alert              (from live_scanner via 'watchlist:alerts' channel)
     """
     await websocket.accept()
+    active_websocket_connections.inc()
 
     redis_client = aioredis.from_url(settings.REDIS_URL, decode_responses=True)
     pubsub = redis_client.pubsub()
@@ -88,6 +92,7 @@ async def watchlist_live_websocket(websocket: WebSocket):
     except Exception as e:
         logger.error(f"Watchlist WebSocket error: {e}")
     finally:
+        active_websocket_connections.dec()
         await pubsub.unsubscribe("watchlist:live_data", "watchlist:alerts")
         await redis_client.close()
 
@@ -100,6 +105,7 @@ async def scan_task_websocket(websocket: WebSocket, task_id: str):
     Subscribes to Redis channel scan_task:{task_id} and forwards messages to the client.
     """
     await websocket.accept()
+    active_websocket_connections.inc()
 
     redis_client = aioredis.from_url(settings.REDIS_URL, decode_responses=True)
     pubsub = redis_client.pubsub()
@@ -126,5 +132,6 @@ async def scan_task_websocket(websocket: WebSocket, task_id: str):
     except Exception as e:
         logger.error(f"Scan task WebSocket error for {task_id}: {e}")
     finally:
+        active_websocket_connections.dec()
         await pubsub.unsubscribe(channel)
         await redis_client.aclose()

--- a/backend/app/services/liquidity_hunt.py
+++ b/backend/app/services/liquidity_hunt.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import math
+import time as _time
 from collections import defaultdict
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
@@ -28,6 +29,7 @@ from app.models.stock_split import StockSplit
 from app.services.catalyst_parser import CatalystParser
 from app.services.alert_service import save_event as _save_event
 from app.utils.session import get_market_today
+from app.core.metrics import scanner_events_total, scan_duration_seconds
 
 _ET = ZoneInfo("America/New_York")
 _LOG = logging.getLogger(__name__)
@@ -440,6 +442,7 @@ async def run_liquidity_hunt_scan(
     (no_data / no_prior_close / no_baseline / evaluated / fired_pre / fired_post /
     errors) plus the resolved start/end dates and ticker count.
     """
+    _start = _time.monotonic()
     # The pre/post variants need a *completed* regular session as a baseline,
     # so the no-args default rolls back to the previous trading day. This makes
     # the "Run Scanner" button always produce something pre-open instead of
@@ -542,6 +545,7 @@ async def run_liquidity_hunt_scan(
                     )
                     results.append(event_dict)
                     counts["fired_pre"] += 1
+                    scanner_events_total.labels(scanner_type="liquidity_hunt_pre").inc()
 
                 # Post-market variant (skip if no event_date regular close)
                 if event_date_regular_close is not None:
@@ -579,6 +583,7 @@ async def run_liquidity_hunt_scan(
                         )
                         results.append(event_dict)
                         counts["fired_post"] += 1
+                        scanner_events_total.labels(scanner_type="liquidity_hunt_post").inc()
 
             except Exception:
                 counts["errors"] += 1
@@ -608,6 +613,7 @@ async def run_liquidity_hunt_scan(
             "errors": counts["errors"],
         })
 
+    scan_duration_seconds.labels(scanner_type="liquidity_hunt").observe(_time.monotonic() - _start)
     return results
 
 

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -3,6 +3,7 @@ Scanner Service - Pre-market volume scanning logic.
 """
 
 import logging
+import time as _time
 import asyncio
 from datetime import datetime, date, time, timedelta, timezone
 from zoneinfo import ZoneInfo
@@ -25,6 +26,7 @@ from app.services.catalyst_parser import CatalystParser
 from app.services.event_helpers import generate_event_summary, compute_event_severity
 from app.services.timeseries_forecast import get_volume_forecast, compute_anomaly_score
 from app.services.signal_ranker import compute_signal_quality_score, load_ranker_config
+from app.core.metrics import scanner_events_total, scan_duration_seconds
 
 if TYPE_CHECKING:
     from app.models.scanner_run import ScannerRun
@@ -394,6 +396,7 @@ class ScannerService:
         scanner_run: Optional["ScannerRun"] = None,
     ) -> List[Dict[str, Any]]:
         """Run extended hours volume spike scanner using DB aggregates."""
+        _start = _time.monotonic()
         if event_date is None:
             event_date = get_market_today()
 
@@ -622,6 +625,7 @@ class ScannerService:
                         ranker_config=ranker_config,
                     )
                     results.append(event_dict)
+                    scanner_events_total.labels(scanner_type="pre_market_volume_spike").inc()
             except (ScanError, DataFetchError, ProviderError) as e:
                 logging.error(
                     "pre_market_scan: domain error for %s: %s",
@@ -640,6 +644,7 @@ class ScannerService:
             db.add(scanner_run)
 
         db.commit()
+        scan_duration_seconds.labels(scanner_type="pre_market_volume_spike").observe(_time.monotonic() - _start)
         return results
 
     @staticmethod
@@ -650,6 +655,7 @@ class ScannerService:
         scanner_run: Optional["ScannerRun"] = None,
     ) -> List[Dict[str, Any]]:
         """Run the Oversold Bounce (Dual RSI) scan using DB daily aggregates."""
+        _start = _time.monotonic()
         if event_date is None:
             event_date = get_market_today()
 
@@ -770,6 +776,7 @@ class ScannerService:
                         ranker_config=ranker_config,
                     )
                     results.append(event_dict)
+                    scanner_events_total.labels(scanner_type="oversold_bounce").inc()
             except (ScanError, DataFetchError, ProviderError) as e:
                 logging.error(
                     "oversold_bounce_scan: domain error for %s: %s",
@@ -788,6 +795,7 @@ class ScannerService:
             db.add(scanner_run)
 
         db.commit()
+        scan_duration_seconds.labels(scanner_type="oversold_bounce").observe(_time.monotonic() - _start)
         return results
 
     @staticmethod

--- a/backend/app/tasks/quality.py
+++ b/backend/app/tasks/quality.py
@@ -1,9 +1,11 @@
 import logging
+import time as _time
 from datetime import datetime, timezone
 from sqlalchemy.orm import Session
 
 from app.core.celery_app import celery_app
 from app.core.database import SessionLocal
+from app.core.metrics import celery_tasks_total, celery_task_duration_seconds
 
 logger = logging.getLogger(__name__)
 
@@ -16,6 +18,8 @@ def analyze_universe_quality(self, universe_id: int):
     from app.models.universe_quality_report import UniverseQualityReport
     from app.services.data_quality import DataQualityService
 
+    _task_name = "analyze_universe_quality"
+    _start = _time.monotonic()
     db: Session = SessionLocal()
     try:
         logger.info(f"🔍 Starting quality analysis for universe {universe_id}")
@@ -46,9 +50,11 @@ def analyze_universe_quality(self, universe_id: int):
             f"✅ Quality analysis complete for universe {universe_id}: "
             f"grade={result['overall_grade']} score={result['overall_score']}"
         )
+        celery_tasks_total.labels(task_name=_task_name, status="success").inc()
 
     except Exception as e:
         logger.error(f"❌ Quality analysis failed for universe {universe_id}: {e}")
+        celery_tasks_total.labels(task_name=_task_name, status="failure").inc()
         try:
             report = db.query(UniverseQualityReport).filter(
                 UniverseQualityReport.universe_id == universe_id
@@ -62,6 +68,7 @@ def analyze_universe_quality(self, universe_id: int):
         db.rollback()
         raise
     finally:
+        celery_task_duration_seconds.labels(task_name=_task_name).observe(_time.monotonic() - _start)
         db.close()
 
 

--- a/backend/app/tasks/scanning.py
+++ b/backend/app/tasks/scanning.py
@@ -2,12 +2,14 @@ import logging
 import asyncio
 import redis
 import json
+import time as _time
 from datetime import datetime, timezone
 from sqlalchemy.orm import Session
 
 from app.core.celery_app import celery_app
 from app.core.database import SessionLocal
 from app.core.config import settings
+from app.core.metrics import celery_tasks_total, celery_task_duration_seconds
 from app.models.monitored_stock import MonitoredStock
 
 logger = logging.getLogger(__name__)
@@ -24,6 +26,8 @@ def evaluate_scanner_alerts(self, scanner_event_id: int):
     from app.models.scanner_event import ScannerEvent
     from app.services.alert_service import AlertRuleService, NotificationDispatcher
 
+    _task_name = "evaluate_scanner_alerts"
+    _start = _time.monotonic()
     db: Session = SessionLocal()
     try:
         event = db.query(ScannerEvent).filter(ScannerEvent.id == scanner_event_id).first()
@@ -60,11 +64,16 @@ def evaluate_scanner_alerts(self, scanner_event_id: int):
                     f"strategy={rule.trading_strategy_id} ticker={event.ticker}"
                 )
 
+        celery_tasks_total.labels(task_name=_task_name, status="success").inc()
     except Exception as e:
+        celery_tasks_total.labels(task_name=_task_name, status="failure").inc()
         logger.error(f"❌ evaluate_scanner_alerts failed for event {scanner_event_id}: {e}")
         db.rollback()
         raise self.retry(exc=e, countdown=30)
     finally:
+        celery_task_duration_seconds.labels(task_name=_task_name).observe(
+            _time.monotonic() - _start
+        )
         db.close()
 
 
@@ -84,6 +93,8 @@ def run_range_scan(
     from app.exceptions import DataFetchError, ProviderError
     from app.services.stock_data import StockDataService
 
+    _task_name = "run_range_scan"
+    _start = _time.monotonic()
     task_id = run_range_scan.request.id
     r = redis.Redis.from_url(settings.REDIS_URL, decode_responses=True)
     channel = f"scan_task:{task_id}"
@@ -160,14 +171,19 @@ def run_range_scan(
             "events_detected": events_detected,
         }))
         logger.info(f"run_range_scan {task_id}: completed, {events_detected} events")
+        celery_tasks_total.labels(task_name=_task_name, status="success").inc()
 
     except Exception as e:
+        celery_tasks_total.labels(task_name=_task_name, status="failure").inc()
         logger.error(f"run_range_scan {task_id} failed: {e}")
         r.publish(channel, json.dumps({
             "status": "failed",
             "error": str(e),
         }))
     finally:
+        celery_task_duration_seconds.labels(task_name=_task_name).observe(
+            _time.monotonic() - _start
+        )
         r.delete(f"scan:{ticker}:range")
         db.close()
 
@@ -182,6 +198,8 @@ def run_liquidity_hunt_scheduled(self):
     from app.services.liquidity_hunt import run_liquidity_hunt_scan
     from app.models.scanner_config import ScannerConfig
 
+    _task_name = "run_liquidity_hunt_scheduled"
+    _start = _time.monotonic()
     db: Session = SessionLocal()
     try:
         event_date = get_market_today()
@@ -217,10 +235,15 @@ def run_liquidity_hunt_scheduled(self):
                 "liquidity_hunt scheduled scan for universe %s on %s: %d events",
                 universe_id, event_date, len(results),
             )
+        celery_tasks_total.labels(task_name=_task_name, status="success").inc()
     except Exception as exc:
+        celery_tasks_total.labels(task_name=_task_name, status="failure").inc()
         logger.exception("run_liquidity_hunt_scheduled failed: %s", exc)
         raise self.retry(exc=exc)
     finally:
+        celery_task_duration_seconds.labels(task_name=_task_name).observe(
+            _time.monotonic() - _start
+        )
         db.close()
 
 
@@ -254,6 +277,8 @@ def run_universe_scan(
     import app.services.liquidity_hunt  # noqa: F401
     import app.services.scan_orchestrator as _orchestrator
 
+    _task_name = "run_universe_scan"
+    _perf_start = _time.monotonic()
     task_id = self.request.id
     r = redis.Redis.from_url(settings.REDIS_URL, decode_responses=True)
     channel = f"scan_task:{task_id}"
@@ -410,8 +435,10 @@ def run_universe_scan(
             "run_universe_scan %s completed: type=%s universe=%s days=%d events=%d",
             scan_id, scanner_type, universe_id, len(trading_days), events_total,
         )
+        celery_tasks_total.labels(task_name=_task_name, status="success").inc()
 
     except Exception as exc:
+        celery_tasks_total.labels(task_name=_task_name, status="failure").inc()
         logger.exception("run_universe_scan %s failed", scan_id)
         try:
             run = db.query(ScannerRun).filter(ScannerRun.uuid == scan_id).first()
@@ -426,6 +453,9 @@ def run_universe_scan(
             db.rollback()
         _publish({"type": "failed", "error": str(exc)})
     finally:
+        celery_task_duration_seconds.labels(task_name=_task_name).observe(
+            _time.monotonic() - _perf_start
+        )
         try:
             r.delete(state_key)
             r.delete(cancel_key)

--- a/backend/app/tasks/sync.py
+++ b/backend/app/tasks/sync.py
@@ -1,4 +1,5 @@
 import logging
+import time as _time
 import httpx
 import redis
 import asyncio
@@ -17,6 +18,7 @@ from app.models.news_article import NewsArticle
 from app.models.monitored_stock import MonitoredStock
 from app.models.stock_split import StockSplit
 import json
+from app.core.metrics import celery_tasks_total, celery_task_duration_seconds
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +29,8 @@ def sync_tickers_batch(self, next_url: str = None, delay_seconds: float = 15.0):
     Celery task to sync tickers in batches using strict rate limiting (recursive chaining).
     Each execution processes one page and schedules the next page 15 seconds later.
     """
+    _task_name = "sync_tickers_batch"
+    _start = _time.monotonic()
     db: Session = SessionLocal()
     try:
         # 1. Prepare URL
@@ -106,12 +110,15 @@ def sync_tickers_batch(self, next_url: str = None, delay_seconds: float = 15.0):
             )
         else:
             logger.info("🎉 Sync Complete! No more pages.")
+        celery_tasks_total.labels(task_name=_task_name, status="success").inc()
 
     except Exception as e:
         logger.error(f"❌ Error in sync_tickers_batch: {str(e)}")
+        celery_tasks_total.labels(task_name=_task_name, status="failure").inc()
         db.rollback()
         raise e
     finally:
+        celery_task_duration_seconds.labels(task_name=_task_name).observe(_time.monotonic() - _start)
         db.close()
 
 

--- a/backend/app/tasks/trading.py
+++ b/backend/app/tasks/trading.py
@@ -1,10 +1,12 @@
 import logging
+import time as _time
 import asyncio
 from datetime import datetime, timezone
 from sqlalchemy.orm import Session
 
 from app.core.celery_app import celery_app
 from app.core.database import SessionLocal
+from app.core.metrics import celery_tasks_total, celery_task_duration_seconds
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +27,8 @@ def execute_auto_trade(self, rule_id: int, scanner_event_id: int):
     from app.models.scanner_event import ScannerEvent
     from app.services.auto_trade_service import auto_trade_executor
 
+    _task_name = "execute_auto_trade"
+    _start = _time.monotonic()
     db: Session = SessionLocal()
     try:
         rule = db.query(AlertRule).filter(AlertRule.id == rule_id).first()
@@ -48,12 +52,15 @@ def execute_auto_trade(self, rule_id: int, scanner_event_id: int):
                 f"execute_auto_trade: no order created for rule={rule_id} "
                 f"event={scanner_event_id}"
             )
+        celery_tasks_total.labels(task_name=_task_name, status="success").inc()
 
     except Exception as exc:
         logger.error(f"❌ execute_auto_trade failed rule={rule_id} event={scanner_event_id}: {exc}")
+        celery_tasks_total.labels(task_name=_task_name, status="failure").inc()
         db.rollback()
         raise self.retry(exc=exc, countdown=15)
     finally:
+        celery_task_duration_seconds.labels(task_name=_task_name).observe(_time.monotonic() - _start)
         db.close()
 
 
@@ -69,6 +76,8 @@ def submit_approved_order(self, order_id: int):
     from app.models.auto_trade_order import AutoTradeOrder
     from app.services.auto_trade_service import auto_trade_executor
 
+    _task_name = "submit_approved_order"
+    _start = _time.monotonic()
     db: Session = SessionLocal()
     try:
         order = db.query(AutoTradeOrder).filter(AutoTradeOrder.id == order_id).first()
@@ -86,11 +95,15 @@ def submit_approved_order(self, order_id: int):
         logger.info(
             f"✅ submit_approved_order: order {order_id} submitted, status={order.status}"
         )
+        celery_tasks_total.labels(task_name=_task_name, status="success").inc()
+
     except Exception as exc:
         logger.error(f"❌ submit_approved_order failed order={order_id}: {exc}")
+        celery_tasks_total.labels(task_name=_task_name, status="failure").inc()
         db.rollback()
         raise self.retry(exc=exc, countdown=15)
     finally:
+        celery_task_duration_seconds.labels(task_name=_task_name).observe(_time.monotonic() - _start)
         db.close()
 
 
@@ -110,6 +123,8 @@ def poll_auto_trade_fills(self):
     from app.models.auto_trade_order import AutoTradeOrder
     from app.models.trade import Trade, TradeExecution
 
+    _task_name = "poll_auto_trade_fills"
+    _start = _time.monotonic()
     db: Session = SessionLocal()
     try:
         pending_orders = (
@@ -118,6 +133,7 @@ def poll_auto_trade_fills(self):
             .all()
         )
         if not pending_orders:
+            celery_tasks_total.labels(task_name=_task_name, status="success").inc()
             return
 
         logger.info(f"poll_auto_trade_fills: checking {len(pending_orders)} open order(s)")
@@ -139,10 +155,14 @@ def poll_auto_trade_fills(self):
         if live_orders:
             _poll_live_orders(live_orders, db, now)
 
+        celery_tasks_total.labels(task_name=_task_name, status="success").inc()
+
     except Exception as exc:
         logger.error(f"❌ poll_auto_trade_fills error: {exc}")
+        celery_tasks_total.labels(task_name=_task_name, status="failure").inc()
         db.rollback()
     finally:
+        celery_task_duration_seconds.labels(task_name=_task_name).observe(_time.monotonic() - _start)
         db.close()
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -54,4 +54,3 @@ bcrypt==5.0.0
 
 # Metrics
 prometheus-client==0.21.1
-prometheus-fastapi-instrumentator==7.1.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -51,3 +51,7 @@ pywebpush==2.0.0
 # Authentication
 python-jose[cryptography]==3.3.0
 bcrypt==5.0.0
+
+# Metrics
+prometheus-client==0.21.1
+prometheus-fastapi-instrumentator==7.1.0

--- a/backend/tests/api/test_metrics.py
+++ b/backend/tests/api/test_metrics.py
@@ -1,0 +1,21 @@
+"""Integration tests for the /metrics endpoint."""
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_metrics_endpoint_returns_200():
+    response = client.get("/metrics")
+    assert response.status_code == 200
+
+
+def test_metrics_endpoint_returns_prometheus_format():
+    response = client.get("/metrics")
+    assert "text/plain" in response.headers["content-type"]
+    assert b"# TYPE" in response.content
+
+
+def test_metrics_endpoint_not_in_openapi_schema():
+    response = client.get("/openapi.json")
+    assert "/metrics" not in response.json().get("paths", {})

--- a/backend/tests/core/test_metrics_module.py
+++ b/backend/tests/core/test_metrics_module.py
@@ -7,13 +7,10 @@ def test_prometheus_client_importable():
     assert prometheus_client is not None
 
 
-def test_instrumentator_importable():
-    from prometheus_fastapi_instrumentator import Instrumentator
-    assert Instrumentator is not None
-
-
 def test_all_metric_names_registered():
     from app.core.metrics import (
+        http_requests_total,
+        http_request_duration_seconds,
         scanner_events_total,
         scan_duration_seconds,
         polygon_api_calls_total,
@@ -25,11 +22,14 @@ def test_all_metric_names_registered():
         db_pool_checked_out,
         db_pool_overflow,
     )
-    assert scanner_events_total._name == "scanner_events_total"
+    # prometheus_client strips the _total suffix from Counter internal _name
+    assert http_requests_total._name == "http_requests"
+    assert http_request_duration_seconds._name == "http_request_duration_seconds"
+    assert scanner_events_total._name == "scanner_events"
     assert scan_duration_seconds._name == "scan_duration_seconds"
-    assert polygon_api_calls_total._name == "polygon_api_calls_total"
+    assert polygon_api_calls_total._name == "polygon_api_calls"
     assert ibkr_connection_status._name == "ibkr_connection_status"
-    assert celery_tasks_total._name == "celery_tasks_total"
+    assert celery_tasks_total._name == "celery_tasks"
     assert celery_task_duration_seconds._name == "celery_task_duration_seconds"
     assert active_websocket_connections._name == "active_websocket_connections"
     assert db_pool_size._name == "db_pool_size"
@@ -40,9 +40,9 @@ def test_all_metric_names_registered():
 def test_scanner_events_counter_incrementable():
     from app.core.metrics import scanner_events_total
     label_vals = {"scanner_type": "pre_market_volume_spike"}
-    before = REGISTRY.get_sample_value("scanner_events_total_total", label_vals) or 0.0
+    before = REGISTRY.get_sample_value("scanner_events_total", label_vals) or 0.0
     scanner_events_total.labels(scanner_type="pre_market_volume_spike").inc()
-    after = REGISTRY.get_sample_value("scanner_events_total_total", label_vals) or 0.0
+    after = REGISTRY.get_sample_value("scanner_events_total", label_vals) or 0.0
     assert after == before + 1
 
 

--- a/backend/tests/core/test_metrics_module.py
+++ b/backend/tests/core/test_metrics_module.py
@@ -1,0 +1,54 @@
+"""Unit tests for the metrics registry module."""
+from prometheus_client import REGISTRY
+
+
+def test_prometheus_client_importable():
+    import prometheus_client
+    assert prometheus_client is not None
+
+
+def test_instrumentator_importable():
+    from prometheus_fastapi_instrumentator import Instrumentator
+    assert Instrumentator is not None
+
+
+def test_all_metric_names_registered():
+    from app.core.metrics import (
+        scanner_events_total,
+        scan_duration_seconds,
+        polygon_api_calls_total,
+        ibkr_connection_status,
+        celery_tasks_total,
+        celery_task_duration_seconds,
+        active_websocket_connections,
+        db_pool_size,
+        db_pool_checked_out,
+        db_pool_overflow,
+    )
+    assert scanner_events_total._name == "scanner_events_total"
+    assert scan_duration_seconds._name == "scan_duration_seconds"
+    assert polygon_api_calls_total._name == "polygon_api_calls_total"
+    assert ibkr_connection_status._name == "ibkr_connection_status"
+    assert celery_tasks_total._name == "celery_tasks_total"
+    assert celery_task_duration_seconds._name == "celery_task_duration_seconds"
+    assert active_websocket_connections._name == "active_websocket_connections"
+    assert db_pool_size._name == "db_pool_size"
+    assert db_pool_checked_out._name == "db_pool_checked_out"
+    assert db_pool_overflow._name == "db_pool_overflow"
+
+
+def test_scanner_events_counter_incrementable():
+    from app.core.metrics import scanner_events_total
+    label_vals = {"scanner_type": "pre_market_volume_spike"}
+    before = REGISTRY.get_sample_value("scanner_events_total_total", label_vals) or 0.0
+    scanner_events_total.labels(scanner_type="pre_market_volume_spike").inc()
+    after = REGISTRY.get_sample_value("scanner_events_total_total", label_vals) or 0.0
+    assert after == before + 1
+
+
+def test_ibkr_connection_status_settable():
+    from app.core.metrics import ibkr_connection_status
+    ibkr_connection_status.set(1)
+    assert REGISTRY.get_sample_value("ibkr_connection_status") == 1.0
+    ibkr_connection_status.set(0)
+    assert REGISTRY.get_sample_value("ibkr_connection_status") == 0.0

--- a/backend/tests/tasks/test_metrics_instrumentation.py
+++ b/backend/tests/tasks/test_metrics_instrumentation.py
@@ -1,0 +1,27 @@
+"""Verify that Celery tasks can be called with metrics instrumentation present."""
+
+
+def test_scanning_imports_metrics_without_error():
+    """Ensure scanning.py imports metrics module without raising."""
+    import app.tasks.scanning  # noqa: F401
+    from app.core.metrics import celery_tasks_total, celery_task_duration_seconds
+    assert celery_tasks_total is not None
+    assert celery_task_duration_seconds is not None
+
+
+def test_sync_imports_metrics_without_error():
+    import app.tasks.sync  # noqa: F401
+    from app.core.metrics import celery_tasks_total, celery_task_duration_seconds
+    assert celery_tasks_total is not None
+
+
+def test_quality_imports_metrics_without_error():
+    import app.tasks.quality  # noqa: F401
+    from app.core.metrics import celery_tasks_total
+    assert celery_tasks_total is not None
+
+
+def test_trading_imports_metrics_without_error():
+    import app.tasks.trading  # noqa: F401
+    from app.core.metrics import celery_tasks_total
+    assert celery_tasks_total is not None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -287,10 +287,11 @@ services:
 
   # Prometheus — metrics scraper
   prometheus:
-    image: prom/prometheus:v2.53.0
+    build:
+      context: ./monitoring/prometheus
+      dockerfile: Dockerfile
     container_name: stockscanner-prometheus
     volumes:
-      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
@@ -304,7 +305,9 @@ services:
 
   # Grafana — metrics visualization
   grafana:
-    image: grafana/grafana:11.1.0
+    build:
+      context: ./grafana
+      dockerfile: Dockerfile
     container_name: stockscanner-grafana
     ports:
       - "3001:3000"
@@ -313,7 +316,6 @@ services:
       GF_USERS_ALLOW_SIGN_UP: "false"
     volumes:
       - grafana_data:/var/lib/grafana
-      - ./grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:
       - prometheus
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
       SMTP_USER: ${SMTP_USER}
       SMTP_PASSWORD: ${SMTP_PASSWORD}
       SMTP_FROM_EMAIL: ${SMTP_FROM_EMAIL}
+      PROMETHEUS_MULTIPROC_DIR: /tmp/prometheus_multiproc
     ports:
       - "8000:8000"
     depends_on:
@@ -108,6 +109,7 @@ services:
         condition: service_started
     volumes:
       - ./backend:/app:ro
+      - prometheus_multiproc:/tmp/prometheus_multiproc
     networks:
       - stockscanner-network
     restart: unless-stopped
@@ -158,6 +160,7 @@ services:
       SMTP_USER: ${SMTP_USER}
       SMTP_PASSWORD: ${SMTP_PASSWORD}
       SMTP_FROM_EMAIL: ${SMTP_FROM_EMAIL}
+      PROMETHEUS_MULTIPROC_DIR: /tmp/prometheus_multiproc
     depends_on:
       postgres:
         condition: service_healthy
@@ -167,6 +170,7 @@ services:
         condition: service_started
     volumes:
       - ./backend:/app:ro
+      - prometheus_multiproc:/tmp/prometheus_multiproc
     networks:
       - stockscanner-network
     restart: unless-stopped
@@ -281,6 +285,41 @@ services:
     networks:
       - stockscanner-network
 
+  # Prometheus — metrics scraper
+  prometheus:
+    image: prom/prometheus:v2.53.0
+    container_name: stockscanner-prometheus
+    volumes:
+      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=15d'
+    ports:
+      - "9090:9090"
+    networks:
+      - stockscanner-network
+    restart: unless-stopped
+
+  # Grafana — metrics visualization
+  grafana:
+    image: grafana/grafana:11.1.0
+    container_name: stockscanner-grafana
+    ports:
+      - "3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus
+    networks:
+      - stockscanner-network
+    restart: unless-stopped
+
   # Dark Factory — autonomous development agent (run on demand)
   dark-factory:
     build:
@@ -391,6 +430,14 @@ volumes:
     external: true
     name: markethawk_ib_gateway_settings
   timesfm_cache:
+  prometheus_multiproc:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: size=256m
+  prometheus_data:
+  grafana_data:
 
 
 networks:

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,0 +1,2 @@
+FROM grafana/grafana:11.1.0
+COPY provisioning/ /etc/grafana/provisioning/

--- a/grafana/provisioning/alerting/contact-points.yaml
+++ b/grafana/provisioning/alerting/contact-points.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: markethawk-webhook
+    receivers:
+      - uid: markethawk-infra-webhook
+        type: webhook
+        settings:
+          url: http://backend:8000/api/alerts/infrastructure
+          httpMethod: POST

--- a/grafana/provisioning/alerting/notification-policies.yaml
+++ b/grafana/provisioning/alerting/notification-policies.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: markethawk-webhook
+    group_by: ["alertname", "job"]
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h

--- a/grafana/provisioning/alerting/rules.yaml
+++ b/grafana/provisioning/alerting/rules.yaml
@@ -15,11 +15,6 @@ groups:
         labels:
           severity: critical
         data:
-          - refId: A
-            datasourceUid: "-- Grafana --"
-            model:
-              type: math
-              expression: $B
           - refId: B
             relativeTimeRange:
               from: 300
@@ -29,6 +24,9 @@ groups:
               expr: ibkr_connection_status
               refId: B
           - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
             datasourceUid: "-- Grafana --"
             model:
               type: math
@@ -55,6 +53,9 @@ groups:
                 sum(rate(celery_tasks_total[5m]))
               refId: B
           - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
             datasourceUid: "-- Grafana --"
             model:
               type: math
@@ -78,6 +79,9 @@ groups:
               expr: db_pool_overflow
               refId: B
           - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
             datasourceUid: "-- Grafana --"
             model:
               type: math
@@ -101,6 +105,9 @@ groups:
               expr: sum(rate(http_requests_total{status_code=~"5.."}[1m])) * 60
               refId: B
           - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
             datasourceUid: "-- Grafana --"
             model:
               type: math

--- a/grafana/provisioning/alerting/rules.yaml
+++ b/grafana/provisioning/alerting/rules.yaml
@@ -1,0 +1,107 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: markethawk-infrastructure
+    folder: MarketHawk
+    interval: 1m
+    rules:
+      - uid: ibkr-disconnected
+        title: IBKR Disconnected
+        condition: C
+        for: 2m
+        annotations:
+          summary: IBKR Gateway has been disconnected for more than 2 minutes
+        labels:
+          severity: critical
+        data:
+          - refId: A
+            datasourceUid: "-- Grafana --"
+            model:
+              type: math
+              expression: $B
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: ibkr_connection_status
+              refId: B
+          - refId: C
+            datasourceUid: "-- Grafana --"
+            model:
+              type: math
+              expression: $B < 1
+
+      - uid: high-celery-failure-rate
+        title: High Celery Task Failure Rate
+        condition: C
+        for: 5m
+        annotations:
+          summary: Celery task failure rate exceeds 10% over the last 5 minutes
+        labels:
+          severity: warning
+        data:
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: >
+                sum(rate(celery_tasks_total{status="failure"}[5m]))
+                /
+                sum(rate(celery_tasks_total[5m]))
+              refId: B
+          - refId: C
+            datasourceUid: "-- Grafana --"
+            model:
+              type: math
+              expression: $B > 0.1
+
+      - uid: db-pool-overflow
+        title: DB Pool Overflow
+        condition: C
+        for: 5m
+        annotations:
+          summary: SQLAlchemy connection pool overflow is non-zero for more than 5 minutes
+        labels:
+          severity: warning
+        data:
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: db_pool_overflow
+              refId: B
+          - refId: C
+            datasourceUid: "-- Grafana --"
+            model:
+              type: math
+              expression: $B > 0
+
+      - uid: high-api-error-rate
+        title: High API Error Rate
+        condition: C
+        for: 5m
+        annotations:
+          summary: HTTP 5xx error rate exceeds 5 errors/min
+        labels:
+          severity: warning
+        data:
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: sum(rate(http_requests_total{status_code=~"5.."}[1m])) * 60
+              refId: B
+          - refId: C
+            datasourceUid: "-- Grafana --"
+            model:
+              type: math
+              expression: $B > 5

--- a/grafana/provisioning/dashboards/api-overview.json
+++ b/grafana/provisioning/dashboards/api-overview.json
@@ -1,0 +1,112 @@
+{
+  "title": "API Overview",
+  "uid": "markethawk-api",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Request Rate (req/s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(http_requests_total[1m])) by (handler)",
+          "legendFormat": "{{handler}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Error Rate (5xx)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(http_requests_total{status_code=~\"5..\"}[1m]))",
+          "legendFormat": "5xx errors/s"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "P95 Latency by Handler (ms)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, handler)) * 1000",
+          "legendFormat": "p95 {{handler}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Active WebSocket Connections",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "active_websocket_connections",
+          "legendFormat": "connections"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "DB Pool — Checked Out",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "db_pool_checked_out",
+          "legendFormat": "checked out"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "DB Pool — Size",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 16 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "db_pool_size",
+          "legendFormat": "pool size"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "DB Pool — Overflow",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 16 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "db_pool_overflow",
+          "legendFormat": "overflow"
+        }
+      ]
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "pluginId": "prometheus",
+        "hide": 0,
+        "label": "Datasource"
+      }
+    ]
+  }
+}

--- a/grafana/provisioning/dashboards/celery-tasks.json
+++ b/grafana/provisioning/dashboards/celery-tasks.json
@@ -1,0 +1,73 @@
+{
+  "title": "Celery Tasks",
+  "uid": "markethawk-celery",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-3h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Task Success Rate (rate/min)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(celery_tasks_total{status=\"success\"}[5m])) by (task_name) * 60",
+          "legendFormat": "{{task_name}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Task Failure Rate (rate/min)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(celery_tasks_total{status=\"failure\"}[5m])) by (task_name) * 60",
+          "legendFormat": "{{task_name}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Task Duration P95 (s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.95, sum(rate(celery_task_duration_seconds_bucket[5m])) by (le, task_name))",
+          "legendFormat": "p95 {{task_name}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Task Failure Ratio",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(celery_tasks_total{status=\"failure\"}[5m])) by (task_name) / sum(rate(celery_tasks_total[5m])) by (task_name)",
+          "legendFormat": "failure ratio {{task_name}}"
+        }
+      ]
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "pluginId": "prometheus",
+        "hide": 0,
+        "label": "Datasource"
+      }
+    ]
+  }
+}

--- a/grafana/provisioning/dashboards/dashboards.yaml
+++ b/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: markethawk
+    orgId: 1
+    folder: MarketHawk
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/grafana/provisioning/dashboards/infrastructure.json
+++ b/grafana/provisioning/dashboards/infrastructure.json
@@ -1,0 +1,158 @@
+{
+  "title": "Infrastructure",
+  "uid": "markethawk-infra",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "IBKR Connection Status",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "options": {
+        "colorMode": "background",
+        "thresholds": {
+          "mode": "absolute",
+          "steps": [
+            { "color": "red", "value": null },
+            { "color": "green", "value": 1 }
+          ]
+        },
+        "mappings": [
+          { "type": "value", "options": { "0": { "text": "Disconnected" }, "1": { "text": "Connected" } } }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "ibkr_connection_status",
+          "legendFormat": "IBKR"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Active WebSocket Connections",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "active_websocket_connections",
+          "legendFormat": "WebSocket connections"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "DB Pool — Checked Out",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "db_pool_checked_out",
+          "legendFormat": "checked out"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "DB Pool — Overflow",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
+      "options": {
+        "thresholds": {
+          "mode": "absolute",
+          "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 1 },
+            { "color": "red", "value": 5 }
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "db_pool_overflow",
+          "legendFormat": "overflow"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "DB Pool — Size",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "db_pool_size",
+          "legendFormat": "pool size"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "DB Pool Utilization Over Time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 4 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "db_pool_checked_out",
+          "legendFormat": "checked out"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "db_pool_overflow",
+          "legendFormat": "overflow"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "db_pool_size",
+          "legendFormat": "pool size"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Polygon API Call Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(polygon_api_calls_total[1m])) by (endpoint) * 60",
+          "legendFormat": "{{endpoint}}/min"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "WebSocket Connections Over Time",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "active_websocket_connections",
+          "legendFormat": "active connections"
+        }
+      ]
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "pluginId": "prometheus",
+        "hide": 0,
+        "label": "Datasource"
+      }
+    ]
+  }
+}

--- a/grafana/provisioning/dashboards/scanner-performance.json
+++ b/grafana/provisioning/dashboards/scanner-performance.json
@@ -1,0 +1,109 @@
+{
+  "title": "Scanner Performance",
+  "uid": "markethawk-scanner",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Scanner Events (rate/min)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(scanner_events_total[5m])) by (scanner_type) * 60",
+          "legendFormat": "{{scanner_type}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Total Scanner Events (24h)",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(increase(scanner_events_total[24h])) by (scanner_type)",
+          "legendFormat": "{{scanner_type}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Scan Duration — P50/P95/P99 (s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.50, sum(rate(scan_duration_seconds_bucket[5m])) by (le, scanner_type))",
+          "legendFormat": "p50 {{scanner_type}}"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.95, sum(rate(scan_duration_seconds_bucket[5m])) by (le, scanner_type))",
+          "legendFormat": "p95 {{scanner_type}}"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "histogram_quantile(0.99, sum(rate(scan_duration_seconds_bucket[5m])) by (le, scanner_type))",
+          "legendFormat": "p99 {{scanner_type}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Polygon API Calls (rate/min)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "sum(rate(polygon_api_calls_total[1m])) by (endpoint) * 60",
+          "legendFormat": "{{endpoint}}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "IBKR Connection Status",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "options": {
+        "colorMode": "background",
+        "thresholds": {
+          "mode": "absolute",
+          "steps": [
+            { "color": "red", "value": null },
+            { "color": "green", "value": 1 }
+          ]
+        },
+        "mappings": [
+          { "type": "value", "options": { "0": { "text": "Disconnected" }, "1": { "text": "Connected" } } }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "$datasource" },
+          "expr": "ibkr_connection_status",
+          "legendFormat": "IBKR"
+        }
+      ]
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "pluginId": "prometheus",
+        "hide": 0,
+        "label": "Datasource"
+      }
+    ]
+  }
+}

--- a/grafana/provisioning/datasources/prometheus.yaml
+++ b/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus/Dockerfile
+++ b/monitoring/prometheus/Dockerfile
@@ -1,0 +1,2 @@
+FROM prom/prometheus:v2.53.0
+COPY prometheus.yml /etc/prometheus/prometheus.yml

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: markethawk_backend
+    static_configs:
+      - targets: ["backend:8000"]
+    metrics_path: /metrics


### PR DESCRIPTION
## Summary

- **`GET /metrics`** endpoint exposes Prometheus-format metrics (excluded from OpenAPI schema); supports multiprocess mode via shared tmpfs volume between `backend` and `celery-worker`
- **12 custom metrics** in `app/core/metrics.py`: HTTP request counters/histograms, scanner event counters and duration histograms, Polygon API call counters, IBKR connection gauge, Celery task counters/histograms, WebSocket connection gauge, DB pool gauges
- **Full instrumentation** across all Celery tasks (scanning, sync, quality, trading), scanner services (scanner.py, liquidity_hunt.py), Polygon provider (massive.py), IBKR provider (ibkr.py), and WebSocket endpoints (live_data.py)
- **Prometheus + Grafana** services added to docker-compose.yml with 4 auto-provisioned dashboards: API Overview, Scanner Performance, Celery Tasks, Infrastructure
- **Grafana alerting** rules for IBKR disconnect, high Celery failure rate, DB pool overflow, and API error spikes; alerts POST to new `POST /api/alerts/infrastructure` webhook endpoint
- **`GRAFANA_ADMIN_PASSWORD`** added to `.env.example`; CLAUDE.md port table updated with Prometheus (:9090) and Grafana (:3001)

## Test plan

- [ ] All 11 new metrics tests pass (`tests/core/test_metrics_module.py`, `tests/api/test_metrics.py`, `tests/tasks/test_metrics_instrumentation.py`)
- [ ] Full test suite passes (584 tests, 62% coverage)
- [ ] `GET /metrics` returns 200 with `# TYPE` Prometheus text-format content
- [ ] `/metrics` is absent from `/openapi.json` paths
- [ ] Grafana at http://localhost:3001 auto-loads all 4 dashboards and Prometheus datasource after `docker compose up`
- [ ] Prometheus at http://localhost:9090 shows `markethawk_backend` scrape target as UP

🤖 Generated with [Claude Code](https://claude.com/claude-code)