### PR TITLE
feat: extract business logic from thick routers into services (#96)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,7 +77,9 @@ Domain-typed exceptions raised at service/provider public boundaries so callers 
 
 | File | Responsibility |
 |------|---------------|
-| `scan_orchestrator.py` | Scanner registry and orchestrator. `ScannerDescriptor` frozen dataclass; `_REGISTRY` populated via `register()` at import time. `run(scanner_type, tickers, db, event_date)` is the single dispatch entry point from `tasks/scanning.py`. `get_all()` enumerates entries for `GET /api/scanner/types`. |
+| `scan_orchestrator.py` | Scanner registry and orchestrator. `ScannerDescriptor` frozen dataclass; `_REGISTRY` populated via `register()` at import time. `run(scanner_type, tickers, db, event_date)` is the single dispatch entry point from `tasks/scanning.py`. `get_all()` enumerates entries for `GET /api/scanner/types`. `compute_next_run(scanner_type)` returns next scheduled fire time. `get_scan_progress(redis_url, universe_id, scanner_type)` reads Redis progress state. `request_scan_cancel(redis_url, scan_id)` sets Redis cancel flag. `enqueue_scan(db, request)` creates `ScannerRun` row and dispatches Celery task. |
+| `scanner_query_service.py` | `ScannerQueryService` — DB aggregation queries extracted from `routers/scanner.py`. `get_scan_status_block()` builds the Scan Status card payload. `get_signal_quality_distribution()` computes decile outcome stats. `get_review_stats()` aggregates signal review coverage, acceptance rate, and rejection reasons. |
+| `system_service.py` | `SystemService` — business logic extracted from `routers/system.py`. `get_market_status()` returns the current ET session. `check_ibkr_reachable()` socket probe. `format_bytes()` human-readable size. `get_storage_stats()` per-table PostgreSQL size queries. `get_active_tasks()` async Redis + DB poll for the `/ws/tasks` WebSocket. |
 | `pre_market_scan.py` | Self-registers `"pre_market_volume_spike"` in the orchestrator. Delegates to `ScannerService.run_pre_market_scan` (interim; body inlined in Task 8). |
 | `oversold_bounce_scan.py` | Self-registers `"oversold_bounce"` in the orchestrator. Delegates to `ScannerService.run_oversold_bounce_scan` (interim). |
 | `scanner.py` | `ScannerService` — `calculate_day_metrics()`, `_get_batch_enrichment_data()` (3-tuple with ES/NQ context and sector ETF changes), Phase 2a 19-key feature enrichment. `_save_event()` delegates to `alert_service.save_event`. `run_pre_market_scan`/`run_oversold_bounce_scan` accept optional `scanner_run` param; per-ticker domain failures accumulated into `scanner_run.failed_tickers`. |
@@ -94,6 +96,7 @@ Domain-typed exceptions raised at service/provider public boundaries so callers 
 | `websocket_manager.py` | WebSocket connection pool; `broadcast()` to all connected clients. |
 | `normalization.py` | Data normalization helpers (price/volume units, split adjustments). |
 | `data_quality.py` | Quality checks and `UniverseQualityReport` generation. |
+| `auto_trade_service.py` | `AutoTradeExecutor` — full auto-trade lifecycle (guard checks, sizing, IBKR submission). `approve_order(order, strategy, db)` handles paper vs. live approval. `cancel_order(order, db)` cancels via IBKR or marks paper cancelled. `get_account()` fetches IBKR account summary with graceful fallback. `get_stats(db, days)` computes P&L, win rate, and status breakdown. |
 | `stats.py` | Aggregate statistics helpers for dashboard metrics. |
 | `event_helpers.py` | Utility functions for `ScannerEvent` construction and querying. |
 | `statistical_discovery.py` | Pure-Python statistical analysis service: `build_feature_matrix`, `compute_correlations` (Pearson + Spearman), `compute_shap_weights` (LightGBM + SHAP), `run_kmeans`, `compute_conditional_stats`, `generate_label`. No DB dependencies; accepts DataFrames, returns typed dicts. |

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -67,11 +67,13 @@ MarketHawk/
 │   │   ├── services/
 │   │   │   ├── stock_data.py           # OHLCV fetch, gap calculation, session flags; is_futures_ticker(); get_historical_enriched() (coercion + indicators + guardrails)
 │   │   │   ├── universe_stats.py       # UniverseStatsService.compute() — universe aggregate stats (ticker count, bar count, date range, timespans)
-│   │   │   ├── scan_orchestrator.py    # Scanner registry (ScannerDescriptor, _REGISTRY, register, get_all, run); single dispatch entry point
+│   │   │   ├── scan_orchestrator.py    # Scanner registry (ScannerDescriptor, _REGISTRY, register, get_all, run); also compute_next_run, get_scan_progress, request_scan_cancel, enqueue_scan
+│   │   │   ├── scanner_query_service.py # ScannerQueryService: get_scan_status_block, get_signal_quality_distribution, get_review_stats
+│   │   │   ├── system_service.py       # SystemService: get_market_status, check_ibkr_reachable, format_bytes, get_storage_stats, get_active_tasks
+│   │   │   ├── auto_trade_service.py   # AutoTradeExecutor (lifecycle); approve_order, cancel_order, get_account, get_stats
 │   │   │   ├── pre_market_scan.py      # Self-registers "pre_market_volume_spike" in orchestrator
 │   │   │   ├── oversold_bounce_scan.py # Self-registers "oversold_bounce" in orchestrator
 │   │   │   ├── scanner.py              # ScannerService; calculate_day_metrics; _save_event delegates to alert_service.save_event
-│   │   │   ├── stock_data.py           # OHLCV fetch, gap calculation, session flags
 │   │   │   ├── discovery_service.py    # Bulk ticker sync from Polygon; rate-limit-aware paging
 │   │   │   ├── catalyst_parser.py      # Batch 72-hour news analysis; returns latest_article_utc for recency enrichment
 │   │   │   ├── futures_data.py         # 2-method public interface: get_continuous_series, sync_contracts; private write-path helpers

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -20,8 +20,8 @@ class Settings(BaseSettings):
     POLYGON_DELAYED: bool = True
 
     # Redis / Celery
-    REDIS_URL: str = os.getenv("REDIS_URL", "redis://redis:6379/0")
-    RATE_LIMITING_ENABLED: bool = os.getenv("RATE_LIMITING_ENABLED", "true").lower() == "true"
+    REDIS_URL: str = "redis://redis:6379/0"
+    RATE_LIMITING_ENABLED: bool = True
 
     # Application
     APP_NAME: str = "Stock Scanner API"

--- a/backend/app/routers/auto_trading.py
+++ b/backend/app/routers/auto_trading.py
@@ -22,84 +22,23 @@ Endpoints:
     PATCH  /api/trading/config
 """
 
-import asyncio
 import logging
-from datetime import datetime, timezone, date as date_type, timedelta
-from decimal import Decimal
+from datetime import datetime, timezone, date as date_type
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from app.core.rate_limits import limiter, TRADING_LIMIT
 from sqlalchemy.orm import Session
-from sqlalchemy import func
 
-from app.core.config import settings
 from app.core.database import get_db
 from app.models.auto_trade_order import AutoTradeOrder
 from app.models.system_config import SystemConfig
 from app.models.trading_strategy import TradingStrategy
-from app.models.trade import Trade
+from app.schemas.auto_trade import TradingStrategyResponse, AutoTradeOrderResponse
+from app.services.auto_trade_service import approve_order, cancel_order, get_account, get_stats
 
 router = APIRouter(prefix="/api/trading", tags=["auto-trading"])
 logger = logging.getLogger(__name__)
-
-
-# ── Serialisers ──────────────────────────────────────────────────────────────
-
-def _strategy_to_dict(s: TradingStrategy) -> Dict[str, Any]:
-    return {
-        "id": s.id,
-        "name": s.name,
-        "description": s.description,
-        "is_active": s.is_active,
-        "paper_mode": s.paper_mode,
-        "requires_approval": s.requires_approval,
-        "risk_per_trade_pct": float(s.risk_per_trade_pct) if s.risk_per_trade_pct is not None else None,
-        "max_position_usd": float(s.max_position_usd) if s.max_position_usd is not None else None,
-        "max_trades_per_day": s.max_trades_per_day,
-        "max_concurrent_positions": s.max_concurrent_positions,
-        "entry_type": s.entry_type,
-        "limit_offset_pct": float(s.limit_offset_pct) if s.limit_offset_pct is not None else 0.0,
-        "stop_pct": float(s.stop_pct) if s.stop_pct is not None else None,
-        "risk_reward_ratio": float(s.risk_reward_ratio) if s.risk_reward_ratio is not None else None,
-        "max_slippage_pct": float(s.max_slippage_pct) if s.max_slippage_pct is not None else None,
-        "allowed_sessions": s.allowed_sessions or ["regular"],
-        "direction": s.direction,
-        "created_at": s.created_at.isoformat() if s.created_at else None,
-        "updated_at": s.updated_at.isoformat() if s.updated_at else None,
-    }
-
-
-def _order_to_dict(o: AutoTradeOrder) -> Dict[str, Any]:
-    return {
-        "id": o.id,
-        "alert_rule_id": o.alert_rule_id,
-        "scanner_event_id": o.scanner_event_id,
-        "trading_strategy_id": o.trading_strategy_id,
-        "symbol": o.symbol,
-        "side": o.side,
-        "event_date": o.event_date.isoformat() if o.event_date else None,
-        "status": o.status,
-        "rejection_reason": o.rejection_reason,
-        "trigger_price": float(o.trigger_price) if o.trigger_price is not None else None,
-        "entry_price_target": float(o.entry_price_target) if o.entry_price_target is not None else None,
-        "calculated_stop": float(o.calculated_stop) if o.calculated_stop is not None else None,
-        "calculated_target": float(o.calculated_target) if o.calculated_target is not None else None,
-        "quantity": o.quantity,
-        "risk_amount_usd": float(o.risk_amount_usd) if o.risk_amount_usd is not None else None,
-        "is_paper": o.is_paper,
-        "broker_order_id": o.broker_order_id,
-        "broker_stop_id": o.broker_stop_id,
-        "broker_target_id": o.broker_target_id,
-        "fill_price": float(o.fill_price) if o.fill_price is not None else None,
-        "filled_at": o.filled_at.isoformat() if o.filled_at else None,
-        "exit_price": float(o.exit_price) if o.exit_price is not None else None,
-        "exited_at": o.exited_at.isoformat() if o.exited_at else None,
-        "exit_reason": o.exit_reason,
-        "trade_id": o.trade_id,
-        "created_at": o.created_at.isoformat() if o.created_at else None,
-        "updated_at": o.updated_at.isoformat() if o.updated_at else None,
-    }
 
 
 # ── Trading Strategies — CRUD ────────────────────────────────────────────────
@@ -123,7 +62,7 @@ def list_strategies(
     if active_only:
         q = q.filter(TradingStrategy.is_active == True)
     strategies = q.order_by(TradingStrategy.created_at.desc()).all()
-    return [_strategy_to_dict(s) for s in strategies]
+    return [TradingStrategyResponse.from_orm_dict(s).model_dump() for s in strategies]
 
 
 @router.post("/strategies", status_code=201)
@@ -154,7 +93,7 @@ def create_strategy(
     db.commit()
     db.refresh(strategy)
     logger.info(f"Created trading strategy id={strategy.id} name='{strategy.name}'")
-    return _strategy_to_dict(strategy)
+    return TradingStrategyResponse.from_orm_dict(strategy).model_dump()
 
 
 @router.get("/strategies/{strategy_id}")
@@ -165,7 +104,7 @@ def get_strategy(
     s = db.query(TradingStrategy).filter(TradingStrategy.id == strategy_id).first()
     if not s:
         raise HTTPException(status_code=404, detail="Strategy not found.")
-    return _strategy_to_dict(s)
+    return TradingStrategyResponse.from_orm_dict(s).model_dump()
 
 
 @router.patch("/strategies/{strategy_id}")
@@ -186,7 +125,7 @@ def update_strategy(
     s.updated_at = datetime.now(timezone.utc).replace(tzinfo=None)
     db.commit()
     db.refresh(s)
-    return _strategy_to_dict(s)
+    return TradingStrategyResponse.from_orm_dict(s).model_dump()
 
 
 @router.delete("/strategies/{strategy_id}", status_code=204)
@@ -204,7 +143,6 @@ def delete_strategy(
     if not s:
         raise HTTPException(status_code=404, detail="Strategy not found.")
 
-    # Refuse to delete if there are open orders on this strategy
     open_orders = (
         db.query(AutoTradeOrder)
         .filter(
@@ -256,7 +194,7 @@ def list_orders(
         .limit(min(limit, 500))
         .all()
     )
-    return [_order_to_dict(o) for o in orders]
+    return [AutoTradeOrderResponse.from_orm_dict(o).model_dump() for o in orders]
 
 
 @router.get("/orders/{order_id}")
@@ -267,22 +205,17 @@ def get_order(
     o = db.query(AutoTradeOrder).filter(AutoTradeOrder.id == order_id).first()
     if not o:
         raise HTTPException(status_code=404, detail="Order not found.")
-    return _order_to_dict(o)
+    return AutoTradeOrderResponse.from_orm_dict(o).model_dump()
 
 
 @router.post("/orders/{order_id}/approve")
 @limiter.limit(TRADING_LIMIT)
-def approve_order(
+def approve_order_endpoint(
     request: Request,
     order_id: int,
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
-    """
-    Approve a pending_approval order.
-
-    Moves the order to 'pending' then immediately submits it to IBKR
-    (or marks as submitted for paper orders).
-    """
+    """Approve a pending_approval order."""
     o = db.query(AutoTradeOrder).filter(AutoTradeOrder.id == order_id).first()
     if not o:
         raise HTTPException(status_code=404, detail="Order not found.")
@@ -292,37 +225,14 @@ def approve_order(
             detail=f"Order is not pending approval (current status: {o.status}).",
         )
 
-    # Fetch strategy to decide paper vs live
     strategy = db.query(TradingStrategy).filter(
         TradingStrategy.id == o.trading_strategy_id
     ).first()
     if not strategy:
         raise HTTPException(status_code=404, detail="Strategy not found.")
 
-    if strategy.paper_mode:
-        o.status = "submitted"
-        o.broker_order_id = f"PAPER-{o.id}"
-        o.broker_stop_id = f"PAPER-STOP-{o.id}"
-        o.broker_target_id = f"PAPER-TGT-{o.id}"
-        db.commit()
-        logger.info(f"Approved paper order id={o.id}")
-    else:
-        # Queue IBKR submission via Celery to avoid blocking the HTTP request.
-        # We submit the existing order directly — do NOT re-queue execute_auto_trade,
-        # which would hit the idempotency guard and silently skip.
-        from app.core.celery_app import celery_app as _celery
-
-        o.status = "pending"
-        db.commit()
-
-        _celery.send_task(
-            "app.tasks.submit_approved_order",
-            kwargs={"order_id": o.id},
-        )
-        logger.info(f"Approved live order id={o.id}, queued for IBKR submission")
-
-    db.refresh(o)
-    return _order_to_dict(o)
+    result = approve_order(o, strategy, db)
+    return AutoTradeOrderResponse.from_orm_dict(result).model_dump()
 
 
 @router.post("/orders/{order_id}/reject")
@@ -349,22 +259,17 @@ def reject_order(
     db.commit()
     db.refresh(o)
     logger.info(f"Rejected order id={o.id} reason='{o.rejection_reason}'")
-    return _order_to_dict(o)
+    return AutoTradeOrderResponse.from_orm_dict(o).model_dump()
 
 
 @router.post("/orders/{order_id}/cancel")
 @limiter.limit(TRADING_LIMIT)
-def cancel_order(
+def cancel_order_endpoint(
     request: Request,
     order_id: int,
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
-    """
-    Cancel an active order.
-
-    For paper orders: immediately sets status=cancelled.
-    For live orders: sends cancel to IBKR and sets status=cancelled.
-    """
+    """Cancel an active order."""
     o = db.query(AutoTradeOrder).filter(AutoTradeOrder.id == order_id).first()
     if not o:
         raise HTTPException(status_code=404, detail="Order not found.")
@@ -376,136 +281,30 @@ def cancel_order(
             detail=f"Order cannot be cancelled (current status: {o.status}).",
         )
 
-    if not o.is_paper and o.broker_order_id and o.status in ("submitted", "open"):
-        # Live cancel via IBKR
-        try:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            from app.providers.ibkr_orders import IBKROrderManager
-            manager = IBKROrderManager()
-            loop.run_until_complete(
-                manager.cancel_bracket(
-                    parent_order_id=int(o.broker_order_id),
-                    stop_order_id=int(o.broker_stop_id or 0),
-                    target_order_id=int(o.broker_target_id or 0),
-                )
-            )
-        except Exception as exc:
-            logger.error(f"IBKR cancel failed for order {o.id}: {exc}")
-            raise HTTPException(status_code=502, detail=f"IBKR cancel failed: {exc}")
-        finally:
-            loop.close()
-
-    o.status = "cancelled"
-    o.updated_at = datetime.now(timezone.utc).replace(tzinfo=None)
-    db.commit()
-    db.refresh(o)
-    logger.info(f"Cancelled order id={o.id}")
-    return _order_to_dict(o)
+    try:
+        result = cancel_order(o, db)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    return AutoTradeOrderResponse.from_orm_dict(result).model_dump()
 
 
 # ── Account Summary ──────────────────────────────────────────────────────────
 
 @router.get("/account")
-def get_account(db: Session = Depends(get_db)) -> Dict[str, Any]:
-    """
-    Fetch live account summary from IBKR.
-
-    Returns net_liquidation, available_funds, buying_power plus a list of
-    current open AutoTradeOrders that are in the 'open' state.
-    """
-    try:
-        from app.providers.ibkr_orders import IBKROrderManager
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            manager = IBKROrderManager()
-            account, open_broker_orders = loop.run_until_complete(
-                manager.get_account_and_orders()
-            )
-        finally:
-            loop.close()
-
-        return {
-            "net_liquidation": account.net_liquidation,
-            "available_funds": account.available_funds,
-            "buying_power": account.buying_power,
-            "currency": account.currency,
-            "connected": True,
-            "open_broker_orders": [
-                {
-                    "order_id": o.order_id,
-                    "symbol": o.symbol,
-                    "action": o.action,
-                    "order_type": o.order_type,
-                    "quantity": o.total_qty,
-                    "status": o.status,
-                    "filled": o.filled,
-                    "avg_fill_price": o.avg_fill_price,
-                }
-                for o in open_broker_orders
-            ],
-        }
-    except Exception as exc:
-        logger.warning(f"get_account: IBKR unavailable: {exc}")
-        return {
-            "net_liquidation": None,
-            "available_funds": None,
-            "buying_power": None,
-            "currency": "USD",
-            "connected": False,
-            "error": str(exc),
-            "open_broker_orders": [],
-        }
+def get_account_endpoint(db: Session = Depends(get_db)) -> Dict[str, Any]:
+    """Fetch live account summary from IBKR."""
+    return get_account()
 
 
 # ── Stats ────────────────────────────────────────────────────────────────────
 
 @router.get("/stats")
-def get_stats(
+def get_stats_endpoint(
     days: int = 30,
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
-    """
-    Return auto-trading statistics for the last N days.
-
-    Counts by status, total risk deployed, closed P&L, win rate.
-    """
-    since = date_type.today() - timedelta(days=days)
-    orders = (
-        db.query(AutoTradeOrder)
-        .filter(AutoTradeOrder.event_date >= since)
-        .all()
-    )
-
-    total = len(orders)
-    by_status: Dict[str, int] = {}
-    for o in orders:
-        by_status[o.status] = by_status.get(o.status, 0) + 1
-
-    closed = [o for o in orders if o.status == "closed"]
-    wins   = [o for o in closed if o.exit_price and o.fill_price and (
-        (o.side == "long"  and float(o.exit_price) > float(o.fill_price)) or
-        (o.side == "short" and float(o.exit_price) < float(o.fill_price))
-    )]
-
-    # P&L from linked Trade records
-    trade_ids = [o.trade_id for o in closed if o.trade_id]
-    total_pnl = 0.0
-    if trade_ids:
-        trades = db.query(Trade).filter(Trade.id.in_(trade_ids)).all()
-        total_pnl = sum(float(t.gross_pnl or 0) for t in trades)
-
-    return {
-        "period_days": days,
-        "total_orders": total,
-        "by_status": by_status,
-        "closed_count": len(closed),
-        "win_count": len(wins),
-        "win_rate": round(len(wins) / len(closed) * 100, 1) if closed else None,
-        "total_pnl": round(total_pnl, 2),
-        "avg_pnl_per_trade": round(total_pnl / len(closed), 2) if closed else None,
-    }
+    """Return auto-trading statistics for the last N days."""
+    return get_stats(db, days=days)
 
 
 # ── Config ───────────────────────────────────────────────────────────────────
@@ -532,13 +331,7 @@ def update_trading_config(
     payload: Dict[str, Any],
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
-    """
-    Update auto-trading system config.
-
-    Accepted keys:
-      - AUTO_TRADING_ENABLED (bool)
-      - PAPER_ACCOUNT_SIZE   (float)
-    """
+    """Update auto-trading system config (AUTO_TRADING_ENABLED, PAPER_ACCOUNT_SIZE)."""
     allowed = {"AUTO_TRADING_ENABLED", "PAPER_ACCOUNT_SIZE"}
     now = datetime.now(timezone.utc).replace(tzinfo=None)
 

--- a/backend/app/routers/scanner.py
+++ b/backend/app/routers/scanner.py
@@ -6,17 +6,14 @@ from datetime import date, datetime, timedelta, timezone
 from typing import List, Optional
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
 from app.core.rate_limits import limiter, SCANNER_LIMIT
 from sqlalchemy.orm import Session, joinedload
-from sqlalchemy import cast
-from sqlalchemy.dialects.postgresql import JSONB
 import sqlalchemy as sa
 
 from app.utils.session import get_market_today
 from app.core.database import get_db
 from app.models import MonitoredStock, ScannerEvent, ScannerConfig, ScannerRun
-from app.models.scanner_outcome_summary import ScannerOutcomeSummary
 from app.models.signal_review import SignalReview
 from app.schemas.signal_review import SignalReviewRequest, SignalReviewResponse, SignalReviewStatsResponse
 from app.models.system_config import SystemConfig
@@ -37,6 +34,8 @@ from app.schemas import (
 )
 from app.services import StockDataService
 from app.services.scanner import ScannerService
+from app.services.scan_orchestrator import get_scan_progress, request_scan_cancel
+from app.services.scanner_query_service import ScannerQueryService
 
 router = APIRouter(prefix="/api/scanner", tags=["scanner"])
 
@@ -166,8 +165,6 @@ def get_scan_status(scan_id: str, db: Session = Depends(get_db)):
     Celery worker after each day. Finished scans: progress is None and the row
     fields (status, events_detected, execution_time_ms) are authoritative.
     """
-    import json
-    import redis as _redis
     from app.core.config import settings as _settings
 
     try:
@@ -181,13 +178,7 @@ def get_scan_status(scan_id: str, db: Session = Depends(get_db)):
 
     progress = None
     if run.status in ("queued", "running"):
-        try:
-            r = _redis.Redis.from_url(_settings.REDIS_URL, decode_responses=True)
-            state = r.get(f"universe:{run.universe_id}:scan:{run.scanner_type}")
-            if state:
-                progress = json.loads(state)
-        except Exception:
-            progress = None
+        progress = get_scan_progress(_settings.REDIS_URL, run.universe_id, run.scanner_type)
 
     started_at = run.created_at
     if started_at and started_at.tzinfo is None:
@@ -218,7 +209,6 @@ def cancel_scan(scan_id: str, db: Session = Depends(get_db)):
     completes; the worker then writes status='cancelled' and emits a
     'cancelled' message on its progress channel.
     """
-    import redis as _redis
     from app.core.config import settings as _settings
 
     try:
@@ -232,8 +222,7 @@ def cancel_scan(scan_id: str, db: Session = Depends(get_db)):
     if run.status not in ("queued", "running"):
         raise HTTPException(status_code=409, detail=f"scan is {run.status}, not cancellable")
 
-    r = _redis.Redis.from_url(_settings.REDIS_URL, decode_responses=True)
-    r.set(f"scan_cancel:{scan_id}", "1", ex=3600)
+    request_scan_cancel(_settings.REDIS_URL, scan_id)
     return {"status": "cancel_requested", "scan_id": scan_id}
 
 
@@ -415,65 +404,10 @@ def get_signal_quality_distribution(
     end_date: Optional[str] = None,
     db: Session = Depends(get_db),
 ):
-    """
-    Returns avg eod_pct_change and follow_through rate per score decile for EdgeExplorer.
-    Deciles are bucketed as strings: '0.0-0.1', '0.1-0.2', ..., '0.9-1.0'.
-    Only events with both a signal_quality_score and a completed ScannerOutcomeSummary are included.
-    """
-    from sqlalchemy import func, case, cast as sa_cast
-    from sqlalchemy.types import Float as SAFloat
-
-    ranker_version = db.query(SystemConfig).filter(
-        SystemConfig.key == "signal_ranker_version"
-    ).first()
-    version = ranker_version.value if ranker_version else "unknown"
-
-    query = (
-        db.query(
-            ScannerEvent.signal_quality_score,
-            ScannerOutcomeSummary.eod_pct_change,
-            ScannerOutcomeSummary.follow_through,
-        )
-        .join(ScannerOutcomeSummary, ScannerOutcomeSummary.scanner_event_id == ScannerEvent.id)
-        .filter(ScannerEvent.signal_quality_score.isnot(None))
+    """Returns avg eod_pct_change and follow_through rate per score decile for EdgeExplorer."""
+    return ScannerQueryService.get_signal_quality_distribution(
+        db, scanner_type=scanner_type, start_date=start_date, end_date=end_date
     )
-    if scanner_type:
-        query = query.filter(ScannerEvent.scanner_type == scanner_type)
-    if start_date:
-        query = query.filter(ScannerEvent.event_date >= start_date)
-    if end_date:
-        query = query.filter(ScannerEvent.event_date <= end_date)
-
-    rows = query.all()
-
-    # Bucket into deciles
-    buckets: dict[str, dict] = {}
-    for label in [f"{i/10:.1f}-{(i+1)/10:.1f}" for i in range(10)]:
-        buckets[label] = {"count": 0, "eod_sum": 0.0, "ft_sum": 0, "eod_count": 0, "ft_count": 0}
-
-    for score, eod_pct, follow_through in rows:
-        idx = min(int(float(score) * 10), 9)
-        label = f"{idx/10:.1f}-{(idx+1)/10:.1f}"
-        b = buckets[label]
-        b["count"] += 1
-        if eod_pct is not None:
-            b["eod_sum"] += float(eod_pct)
-            b["eod_count"] += 1
-        if follow_through is not None:
-            b["ft_sum"] += int(follow_through)
-            b["ft_count"] += 1
-
-    deciles = [
-        {
-            "decile": label,
-            "count": b["count"],
-            "avg_eod_pct": round(b["eod_sum"] / b["eod_count"], 3) if b["eod_count"] > 0 else None,
-            "follow_through_rate": round(b["ft_sum"] / b["ft_count"], 3) if b["ft_count"] > 0 else None,
-        }
-        for label, b in buckets.items()
-    ]
-
-    return {"deciles": deciles, "signal_ranker_version": version}
 
 
 @router.get("/stats", response_model=ScannerStatsResponse)
@@ -549,22 +483,6 @@ def get_edge_distribution(
     return StatsService.get_distribution_data(db, ticker=ticker, scanner_type=scanner_type)
 
 
-def _compute_next_run(scanner_type: str) -> Optional[datetime]:
-    """Return next scheduled fire time for scanner_type, or None if not scheduled."""
-    from datetime import timedelta as _td
-
-    if scanner_type not in {"liquidity_hunt", "liquidity_hunt_pre", "liquidity_hunt_post"}:
-        return None
-
-    now = datetime.now(timezone.utc)
-    candidate = now.replace(minute=0, second=0, microsecond=0, hour=2)
-    if candidate <= now:
-        candidate += _td(days=1)
-    while candidate.weekday() >= 5:
-        candidate += _td(days=1)
-    return candidate
-
-
 @router.get("/scan-status-block", response_model=ScannerStatusBlockResponse)
 def get_scan_status_block(
     scanner_type: str,
@@ -572,85 +490,8 @@ def get_scan_status_block(
     db: Session = Depends(get_db),
 ):
     """Rich status data for the Scan Status card."""
-    from sqlalchemy import func
-
-    base_q = db.query(ScannerRun).filter(ScannerRun.scanner_type == scanner_type)
-    if universe_id is not None:
-        base_q = base_q.filter(ScannerRun.universe_id == universe_id)
-
-    last_run_record: Optional[ScannerRun] = (
-        base_q.order_by(ScannerRun.created_at.desc()).first()
-    )
-
-    last_run_info = None
-    if last_run_record is not None:
-        ts = last_run_record.created_at
-        if ts is not None and ts.tzinfo is None:
-            ts = ts.replace(tzinfo=timezone.utc)
-        last_run_info = {
-            "timestamp": ts,
-            "status": last_run_record.status,
-            "events_detected": last_run_record.events_detected or 0,
-            "duration_ms": last_run_record.execution_time_ms or 0,
-        }
-
-    recent_20 = (
-        base_q.order_by(ScannerRun.created_at.desc()).limit(20).all()
-    )
-    success_rate: Optional[float] = None
-    avg_events: Optional[float] = None
-    if recent_20:
-        completed = [r for r in recent_20 if r.status == "completed"]
-        success_rate = round(len(completed) / len(recent_20) * 100, 1)
-        if completed:
-            avg_events = round(
-                sum(r.events_detected or 0 for r in completed) / len(completed), 1
-            )
-
-    sparkline_rows = (
-        base_q.order_by(ScannerRun.created_at.desc()).limit(10).all()
-    )
-    sparkline = [
-        {
-            "created_at": (
-                r.created_at.replace(tzinfo=timezone.utc).isoformat()
-                if r.created_at and r.created_at.tzinfo is None
-                else r.created_at.isoformat() if r.created_at else None
-            ),
-            "events_detected": r.events_detected or 0,
-            "status": r.status,
-        }
-        for r in reversed(sparkline_rows)
-    ]
-
-    type_variants = [scanner_type]
-    if scanner_type == "liquidity_hunt":
-        type_variants = ["liquidity_hunt", "liquidity_hunt_pre", "liquidity_hunt_post"]
-
-    event_q = db.query(func.count(ScannerEvent.id)).filter(
-        ScannerEvent.scanner_type.in_(type_variants)
-    )
-    if universe_id is not None:
-        event_q = event_q.join(
-            MonitoredStock,
-            sa.and_(
-                ScannerEvent.ticker == MonitoredStock.ticker,
-                MonitoredStock.universe_id == universe_id,
-                MonitoredStock.is_active.is_(True),
-            ),
-        )
-    total_events: int = event_q.scalar() or 0
-
-    return ScannerStatusBlockResponse(
-        scanner_type=scanner_type,
-        universe_id=universe_id,
-        last_run=last_run_info,
-        next_run=_compute_next_run(scanner_type),
-        total_events=total_events,
-        success_rate=success_rate,
-        avg_events_per_scan=avg_events,
-        sparkline=sparkline,
-    )
+    data = ScannerQueryService.get_scan_status_block(db, scanner_type, universe_id=universe_id)
+    return ScannerStatusBlockResponse(**data)
 
 
 @router.get("/configs", response_model=List[ScannerConfigResponse])
@@ -798,66 +639,7 @@ def get_review_stats(
     db: Session = Depends(get_db),
 ):
     """Aggregate review stats: coverage, acceptance rate, by-type breakdown, top rejection reasons."""
-    from sqlalchemy import func, distinct
-
-    event_q = db.query(func.count(ScannerEvent.id))
-    review_q = db.query(SignalReview).join(ScannerEvent, SignalReview.scanner_event_id == ScannerEvent.id)
-
-    if scanner_type:
-        if scanner_type == "liquidity_hunt":
-            variants = ["liquidity_hunt", "liquidity_hunt_pre", "liquidity_hunt_post"]
-            event_q = event_q.filter(ScannerEvent.scanner_type.in_(variants))
-            review_q = review_q.filter(ScannerEvent.scanner_type.in_(variants))
-        else:
-            event_q = event_q.filter(ScannerEvent.scanner_type == scanner_type)
-            review_q = review_q.filter(ScannerEvent.scanner_type == scanner_type)
-    if start_date:
-        event_q = event_q.filter(ScannerEvent.event_date >= start_date)
-        review_q = review_q.filter(ScannerEvent.event_date >= start_date)
-    if end_date:
-        event_q = event_q.filter(ScannerEvent.event_date <= end_date)
-        review_q = review_q.filter(ScannerEvent.event_date <= end_date)
-
-    total_events = event_q.scalar() or 0
-    reviewed_count = (
-        review_q.with_entities(func.count(distinct(SignalReview.scanner_event_id))).scalar() or 0
+    data = ScannerQueryService.get_review_stats(
+        db, scanner_type=scanner_type, start_date=start_date, end_date=end_date
     )
-
-    confirmed_count = review_q.filter(SignalReview.verdict == "confirmed").count()
-    rejected_count = review_q.filter(SignalReview.verdict == "rejected").count()
-    denominator = confirmed_count + rejected_count
-    acceptance_rate = round(confirmed_count / denominator, 3) if denominator > 0 else 0.0
-
-    by_type_rows = (
-        review_q.with_entities(
-            ScannerEvent.scanner_type,
-            SignalReview.verdict,
-            func.count(SignalReview.id),
-        )
-        .group_by(ScannerEvent.scanner_type, SignalReview.verdict)
-        .all()
-    )
-    type_map: dict = {}
-    for stype, v, cnt in by_type_rows:
-        if stype not in type_map:
-            type_map[stype] = {"scanner_type": stype, "total": 0, "confirmed": 0, "rejected": 0, "uncertain": 0, "enhanced": 0}
-        type_map[stype]["total"] += cnt
-        if v in type_map[stype]:
-            type_map[stype][v] += cnt
-
-    reason_rows = (
-        review_q.filter(SignalReview.reject_reason.isnot(None))
-        .with_entities(SignalReview.reject_reason, func.count(SignalReview.id))
-        .group_by(SignalReview.reject_reason)
-        .order_by(func.count(SignalReview.id).desc())
-        .limit(5)
-        .all()
-    )
-
-    return SignalReviewStatsResponse(
-        total_events=total_events,
-        reviewed_count=reviewed_count,
-        acceptance_rate=acceptance_rate,
-        by_scanner_type=list(type_map.values()),
-        top_rejection_reasons=[{"reason": r, "count": c} for r, c in reason_rows],
-    )
+    return SignalReviewStatsResponse(**data)

--- a/backend/app/routers/system.py
+++ b/backend/app/routers/system.py
@@ -6,140 +6,24 @@ from typing import Dict, Any, Optional
 from fastapi import APIRouter, Depends, HTTPException, WebSocket, WebSocketDisconnect
 from app.core.rate_limits import limiter
 from sqlalchemy.orm import Session
-from sqlalchemy import text
 import logging
 import asyncio
-import json
-import socket
 import redis.asyncio as aioredis
 from datetime import datetime, timezone
-import zoneinfo
 
 from app.core.database import get_db, SessionLocal
-from app.models.universe_quality_report import UniverseQualityReport
-from app.models.stock_universe import StockUniverse
 from app.models.system_config import SystemConfig
+from app.services.system_service import SystemService
 
 router = APIRouter(prefix="/api/system", tags=["system"])
 logger = logging.getLogger(__name__)
 
-ET = zoneinfo.ZoneInfo("America/New_York")
-
-
-def _market_status() -> str:
-    """Return market session based on current ET time (weekday only)."""
-    now_et = datetime.now(ET)
-    if now_et.weekday() >= 5:
-        return "closed"
-    t = now_et.hour * 60 + now_et.minute
-    if 240 <= t < 570:   # 04:00–09:30
-        return "pre_market"
-    if 570 <= t < 960:   # 09:30–16:00
-        return "open"
-    if 960 <= t < 1200:  # 16:00–20:00
-        return "post_market"
-    return "closed"
-
-
-def _ibkr_reachable(host: str, port: int, timeout: float = 2.0) -> bool:
-    try:
-        sock = socket.create_connection((host, port), timeout=timeout)
-        sock.close()
-        return True
-    except OSError:
-        return False
-
-def format_bytes(size: int) -> str:
-    """Format bytes into a human-readable string."""
-    for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
-        if size < 1024:
-            return f"{size:.1f} {unit}"
-        size /= 1024
-    return f"{size:.1f} PB"
 
 @router.get("/storage")
 def get_storage_stats(db: Session = Depends(get_db)):
-    """
-    Get storage usage statistics for major database tables.
-    Returns sizes in bytes and formatted strings.
-    """
-    try:
-        # Define table groups as they appear in the UI
-        table_groups = {
-            "scanner": ["volume_events", "scanner_runs"],
-            "historical": ["stock_aggregates", "stock_metrics", "ticker_references", "news_articles"],
-            "settings": ["news_preferences", "scanner_configs"]
-        }
-        
-        results = {
-            "scanner": {"bytes": 0, "formatted": "0.0 B"},
-            "historical": {"bytes": 0, "formatted": "0.0 B"},
-            "settings": {"bytes": 0, "formatted": "0.0 B"},
-            "total": {"bytes": 0, "formatted": "0.0 B"}
-        }
+    """Get storage usage statistics for major database tables."""
+    return SystemService.get_storage_stats(db)
 
-        dialect = db.bind.dialect.name
-        
-        if dialect == "postgresql":
-            # For PostgreSQL, we can get per-table sizes
-            all_tables = []
-            for group in table_groups.values():
-                all_tables.extend(group)
-            
-            # Using a safer way to pass the list of tables for Postgres
-            query = text("""
-                SELECT 
-                    relname as table_name,
-                    pg_total_relation_size(relid) as total_size
-                FROM pg_catalog.pg_statio_user_tables
-                WHERE relname = ANY(:tables)
-            """)
-            
-            db_results = db.execute(query, {"tables": all_tables}).fetchall()
-            table_sizes = {row.table_name: row.total_size for row in db_results}
-            
-            for group_name, tables in table_groups.items():
-                group_size = sum(table_sizes.get(t, 0) for t in tables)
-                results[group_name]["bytes"] = group_size
-                results[group_name]["formatted"] = format_bytes(group_size)
-                results["total"]["bytes"] += group_size
-        
-        elif dialect == "sqlite":
-            # For SQLite, the entire database is usually one file.
-            # We'll get the total file size and label it as SQLITE
-            import os
-            db_url = str(db.bind.url)
-            # Handle sqlite:///test.db or absolute paths
-            db_path = db_url.replace("sqlite:///", "")
-            
-            total_size = 0
-            if os.path.exists(db_path):
-                total_size = os.path.getsize(db_path)
-            
-            # Since we can't easily break down SQLite by table group without 
-            # complex queries, we'll assign the total to total and historical
-            results["historical"]["bytes"] = total_size
-            results["historical"]["formatted"] = f"{format_bytes(total_size)} (SQLite)"
-            results["total"]["bytes"] = total_size
-            results["total"]["formatted"] = f"{format_bytes(total_size)} (Full DB)"
-        
-        else:
-            # Fallback for other dialects
-            results["total"]["formatted"] = f"Unknown DB ({dialect})"
-
-        results["total"]["formatted"] = format_bytes(results["total"]["bytes"])
-        
-        return results
-
-    except Exception as e:
-        logger.error(f"Error fetching storage stats: {e}", exc_info=True)
-        # Final fallback to avoid 500ing the page
-        return {
-            "scanner": {"bytes": 0, "formatted": "N/A"},
-            "historical": {"bytes": 0, "formatted": "N/A"},
-            "settings": {"bytes": 0, "formatted": "N/A"},
-            "total": {"bytes": 0, "formatted": "Service Error"}
-        }
 
 @router.get("/info", response_model=Dict[str, Any])
 def get_app_info():
@@ -152,13 +36,13 @@ def get_app_info():
         "log_level": settings.LOG_LEVEL
     }
 
+
 @router.get("/status")
 def get_system_status(db: Session = Depends(get_db)):
     """Lightweight status snapshot: market session, last scan, IBKR reachability."""
     from app.core.config import settings
     from app.models.scanner_run import ScannerRun
 
-    # Last scan
     last_run = db.query(ScannerRun).order_by(ScannerRun.created_at.desc()).first()
     last_scan_at: Optional[str] = None
     if last_run and last_run.created_at:
@@ -171,9 +55,9 @@ def get_system_status(db: Session = Depends(get_db)):
     ibkr_port = int(getattr(settings, "IBKR_PORT", 7497))
 
     return {
-        "market_status": _market_status(),
+        "market_status": SystemService.get_market_status(),
         "last_scan_at": last_scan_at,
-        "ibkr_reachable": _ibkr_reachable(ibkr_host, ibkr_port),
+        "ibkr_reachable": SystemService.check_ibkr_reachable(ibkr_host, ibkr_port),
         "ibkr_host": ibkr_host,
         "ibkr_port": ibkr_port,
     }
@@ -217,263 +101,22 @@ def apply_split_adjustments(db: Session = Depends(get_db)):
 @limiter.exempt
 async def system_tasks_websocket(websocket: WebSocket):
     """
-    WebSocket endpoint that aggregates and pushes active system tasks 
-    (data syncing, analysis, normalization) to clients every 2 seconds.
+    WebSocket endpoint that aggregates and pushes active system tasks to clients every 2.5 seconds.
     """
     from app.core.config import settings
     await websocket.accept()
-    
+
     redis_client = aioredis.from_url(settings.REDIS_URL, decode_responses=True)
-    
+
     try:
         while True:
-            active_tasks = []
-            
-            # 1. Check Redis for active syncs
-            sync_keys = []
-            cursor = '0'
-            while True:
-                cursor, keys = await redis_client.scan(cursor=cursor, match="universe:*:sync", count=100)
-                sync_keys.extend(keys)
-                if cursor == 0 or cursor == '0' or str(cursor) == '0':
-                    break
-                    
-            from datetime import datetime, timezone
-            from celery.result import AsyncResult
-            from app.core.celery_app import celery_app
-
             db = SessionLocal()
             try:
-                for key in sync_keys:
-                    parts = key.split(":")
-                    if len(parts) >= 2 and parts[1].isdigit():
-                        uid = int(parts[1])
-
-                        raw = await redis_client.get(key)
-                        if not raw:
-                            continue
-                        data = json.loads(raw)
-
-                        # Stale check: if started >4h ago, the key is a leftover — clean it up.
-                        # AsyncResult returns "PENDING" for expired results, making done tasks
-                        # look like they're still running. The 4h window covers all realistic syncs.
-                        started_at_str = data.get("started_at")
-                        if started_at_str:
-                            try:
-                                started_at = datetime.fromisoformat(started_at_str).replace(tzinfo=timezone.utc)
-                                age_hours = (datetime.now(timezone.utc) - started_at).total_seconds() / 3600
-                                if age_hours > 4:
-                                    await redis_client.delete(key)
-                                    continue
-                            except (ValueError, TypeError):
-                                pass
-
-                        # Check actual Celery task states.
-                        task_ids = data.get("task_ids", [])
-                        pending = sum(
-                            1 for tid in task_ids
-                            if AsyncResult(tid, app=celery_app).state in ("PENDING", "STARTED", "RETRY")
-                        )
-                        if pending == 0:
-                            # All tasks done — delete the key so it stops showing up.
-                            await redis_client.delete(key)
-                            continue
-
-                        universe = db.query(StockUniverse).filter(StockUniverse.id == uid).first()
-                        name = universe.name if universe else f"Universe {uid}"
-                        active_tasks.append({
-                            "id": f"sync_{uid}",
-                            "type": "sync",
-                            "title": f"Syncing Data: {name}",
-                            "status": "running"
-                        })
-                
-                # 1.5. Check Redis for active ticker syncs
-                ticker_sync_keys = []
-                cursor = '0'
-                while True:
-                    cursor, keys = await redis_client.scan(cursor=cursor, match="ticker:*:sync", count=100)
-                    ticker_sync_keys.extend(keys)
-                    if cursor == 0 or cursor == '0' or str(cursor) == '0':
-                        break
-                
-                for key in ticker_sync_keys:
-                    parts = key.split(":")
-                    if len(parts) >= 2:
-                        ticker = parts[1]
-                        raw = await redis_client.get(key)
-                        if not raw:
-                            continue
-                        try:
-                            tdata = json.loads(raw)
-                            ts_str = tdata.get("started_at")
-                            if ts_str:
-                                ts = datetime.fromisoformat(ts_str).replace(tzinfo=timezone.utc)
-                                if (datetime.now(timezone.utc) - ts).total_seconds() / 3600 > 4:
-                                    await redis_client.delete(key)
-                                    continue
-                            tids = tdata.get("task_ids", [])
-                            if tids:
-                                tpending = sum(
-                                    1 for tid in tids
-                                    if AsyncResult(tid, app=celery_app).state in ("PENDING", "STARTED", "RETRY")
-                                )
-                                if tpending == 0:
-                                    await redis_client.delete(key)
-                                    continue
-                        except (ValueError, TypeError, AttributeError):
-                            pass
-                        active_tasks.append({
-                            "id": f"sync_ticker_{ticker}",
-                            "type": "sync",
-                            "title": f"Syncing Data: {ticker}",
-                            "status": "running"
-                        })
-                
-                # 1.6. Check Redis for active range scans
-                scan_keys = []
-                cursor = '0'
-                while True:
-                    cursor, keys = await redis_client.scan(cursor=cursor, match="scan:*:range", count=100)
-                    scan_keys.extend(keys)
-                    if cursor == 0 or cursor == '0' or str(cursor) == '0':
-                        break
-
-                for key in scan_keys:
-                    parts = key.split(":")
-                    ticker_name = parts[1] if len(parts) >= 2 else "?"
-                    raw = await redis_client.get(key)
-                    if not raw:
-                        continue
-                    try:
-                        sdata = json.loads(raw)
-                        ts_str = sdata.get("started_at")
-                        if ts_str:
-                            ts = datetime.fromisoformat(ts_str).replace(tzinfo=timezone.utc)
-                            if (datetime.now(timezone.utc) - ts).total_seconds() / 3600 > 4:
-                                await redis_client.delete(key)
-                                continue
-                        tids = sdata.get("task_ids", [])
-                        if tids:
-                            tpending = sum(
-                                1 for tid in tids
-                                if AsyncResult(tid, app=celery_app).state in ("PENDING", "STARTED", "RETRY")
-                            )
-                            if tpending == 0:
-                                await redis_client.delete(key)
-                                continue
-                    except (ValueError, TypeError, AttributeError):
-                        pass
-                    active_tasks.append({
-                        "id": f"scan_{ticker_name}",
-                        "type": "scan",
-                        "title": f"Range Scan: {ticker_name}",
-                        "status": "running",
-                    })
-
-                # 1.7. Check Redis for active universe scans
-                #     Key shape: universe:{universe_id}:scan:{scanner_type}
-                uscan_keys = []
-                cursor = '0'
-                while True:
-                    cursor, keys = await redis_client.scan(cursor=cursor, match="universe:*:scan:*", count=100)
-                    uscan_keys.extend(keys)
-                    if cursor == 0 or cursor == '0' or str(cursor) == '0':
-                        break
-
-                for key in uscan_keys:
-                    parts = key.split(":")
-                    if len(parts) < 4 or not parts[1].isdigit():
-                        continue
-                    uid = int(parts[1])
-                    scanner_type = parts[3]
-                    raw = await redis_client.get(key)
-                    if not raw:
-                        continue
-                    try:
-                        udata = json.loads(raw)
-                        ts_str = udata.get("started_at")
-                        if ts_str:
-                            ts = datetime.fromisoformat(ts_str).replace(tzinfo=timezone.utc)
-                            if (datetime.now(timezone.utc) - ts).total_seconds() / 3600 > 4:
-                                await redis_client.delete(key)
-                                continue
-                        tids = udata.get("task_ids", [])
-                        if tids:
-                            tpending = sum(
-                                1 for tid in tids
-                                if AsyncResult(tid, app=celery_app).state in ("PENDING", "STARTED", "RETRY")
-                            )
-                            if tpending == 0:
-                                await redis_client.delete(key)
-                                continue
-                    except (ValueError, TypeError, AttributeError):
-                        pass
-                    universe = db.query(StockUniverse).filter(StockUniverse.id == uid).first()
-                    universe_name = universe.name if universe else f"Universe {uid}"
-                    day_idx = udata.get("day_index", 0) if isinstance(udata, dict) else 0
-                    total_days = udata.get("total_days", 0) if isinstance(udata, dict) else 0
-                    active_tasks.append({
-                        "id": f"scan_{uid}_{scanner_type}",
-                        "type": "scan",
-                        "title": (
-                            f"Scanning {universe_name}: {scanner_type.replace('_', ' ')}"
-                            + (f" — day {day_idx}/{total_days}" if total_days else "")
-                        ),
-                        "status": "running",
-                    })
-
-                # 2. Check DB for quality and normalization tasks.
-                # Auto-reset rows that have been stuck in pending/running for >4 hours
-                # (worker crash without updating status).
-                stale_cutoff = datetime.now(timezone.utc).replace(tzinfo=None) - __import__('datetime').timedelta(hours=4)
-                quality_reports = db.query(UniverseQualityReport).filter(
-                    (UniverseQualityReport.status.in_(["pending", "running"])) |
-                    (UniverseQualityReport.normalization_status.in_(["pending", "running"]))
-                ).all()
-
-                for report in quality_reports:
-                    is_stale = report.started_at and report.started_at < stale_cutoff
-
-                    if is_stale:
-                        # Reset stuck rows so they don't show up forever
-                        if report.status in ("pending", "running"):
-                            report.status = "failed"
-                        if report.normalization_status in ("pending", "running"):
-                            report.normalization_status = "failed"
-                        db.add(report)
-                        db.commit()
-                        continue
-
-                    universe = db.query(StockUniverse).filter(StockUniverse.id == report.universe_id).first()
-                    name = universe.name if universe else f"Universe {report.universe_id}"
-
-                    if report.status in ["pending", "running"]:
-                        active_tasks.append({
-                            "id": f"qa_{report.universe_id}",
-                            "type": "analysis",
-                            "title": f"Quality Analysis: {name}",
-                            "status": report.status
-                        })
-
-                    if report.normalization_status in ["pending", "running"]:
-                        active_tasks.append({
-                            "id": f"norm_{report.universe_id}",
-                            "type": "normalization",
-                            "title": f"Normalizing Data: {name}",
-                            "status": report.normalization_status
-                        })
-                        
-            except Exception as e:
-                logger.error(f"Error querying active tasks for WS: {e}")
+                tasks = await SystemService.get_active_tasks(redis_client, db)
             finally:
                 db.close()
-                
-            await websocket.send_json({"tasks": active_tasks})
-            
-            # Re-poll every 2.5 seconds
+            await websocket.send_json({"tasks": tasks})
             await asyncio.sleep(2.5)
-            
     except WebSocketDisconnect:
         pass
     except Exception as e:

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -23,8 +23,11 @@ from app.schemas.scanner import (
 )
 from app.schemas.event import ScannerEventResponse, ScannerEventSummary
 from app.schemas.stock import MonitoredStockResponse
+from app.schemas.auto_trade import TradingStrategyResponse, AutoTradeOrderResponse
 
 __all__ = [
+    "TradingStrategyResponse",
+    "AutoTradeOrderResponse",
     "StockUniverseCreate",
     "StockUniverseUpdate",
     "StockUniverseResponse",

--- a/backend/app/schemas/auto_trade.py
+++ b/backend/app/schemas/auto_trade.py
@@ -1,0 +1,119 @@
+"""Pydantic response models for auto-trading, replacing ad-hoc serialiser dicts."""
+
+from datetime import datetime, date
+from decimal import Decimal
+from typing import Any, List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class TradingStrategyResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    description: Optional[str] = None
+    is_active: bool
+    paper_mode: bool
+    requires_approval: bool
+    risk_per_trade_pct: Optional[float] = None
+    max_position_usd: Optional[float] = None
+    max_trades_per_day: int
+    max_concurrent_positions: int
+    entry_type: Optional[str] = None
+    limit_offset_pct: float = 0.0
+    stop_pct: Optional[float] = None
+    risk_reward_ratio: Optional[float] = None
+    max_slippage_pct: Optional[float] = None
+    allowed_sessions: List[str] = ["regular"]
+    direction: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    @classmethod
+    def from_orm_dict(cls, s: Any) -> "TradingStrategyResponse":
+        return cls(
+            id=s.id,
+            name=s.name,
+            description=s.description,
+            is_active=s.is_active,
+            paper_mode=s.paper_mode,
+            requires_approval=s.requires_approval,
+            risk_per_trade_pct=float(s.risk_per_trade_pct) if s.risk_per_trade_pct is not None else None,
+            max_position_usd=float(s.max_position_usd) if s.max_position_usd is not None else None,
+            max_trades_per_day=s.max_trades_per_day,
+            max_concurrent_positions=s.max_concurrent_positions,
+            entry_type=s.entry_type,
+            limit_offset_pct=float(s.limit_offset_pct) if s.limit_offset_pct is not None else 0.0,
+            stop_pct=float(s.stop_pct) if s.stop_pct is not None else None,
+            risk_reward_ratio=float(s.risk_reward_ratio) if s.risk_reward_ratio is not None else None,
+            max_slippage_pct=float(s.max_slippage_pct) if s.max_slippage_pct is not None else None,
+            allowed_sessions=s.allowed_sessions or ["regular"],
+            direction=s.direction,
+            created_at=s.created_at,
+            updated_at=s.updated_at,
+        )
+
+
+class AutoTradeOrderResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    alert_rule_id: Optional[int] = None
+    scanner_event_id: Optional[int] = None
+    trading_strategy_id: Optional[int] = None
+    symbol: str
+    side: str
+    event_date: Optional[date] = None
+    status: str
+    rejection_reason: Optional[str] = None
+    trigger_price: Optional[float] = None
+    entry_price_target: Optional[float] = None
+    calculated_stop: Optional[float] = None
+    calculated_target: Optional[float] = None
+    quantity: Optional[int] = None
+    risk_amount_usd: Optional[float] = None
+    is_paper: bool
+    broker_order_id: Optional[str] = None
+    broker_stop_id: Optional[str] = None
+    broker_target_id: Optional[str] = None
+    fill_price: Optional[float] = None
+    filled_at: Optional[datetime] = None
+    exit_price: Optional[float] = None
+    exited_at: Optional[datetime] = None
+    exit_reason: Optional[str] = None
+    trade_id: Optional[int] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    @classmethod
+    def from_orm_dict(cls, o: Any) -> "AutoTradeOrderResponse":
+        return cls(
+            id=o.id,
+            alert_rule_id=o.alert_rule_id,
+            scanner_event_id=o.scanner_event_id,
+            trading_strategy_id=o.trading_strategy_id,
+            symbol=o.symbol,
+            side=o.side,
+            event_date=o.event_date,
+            status=o.status,
+            rejection_reason=o.rejection_reason,
+            trigger_price=float(o.trigger_price) if o.trigger_price is not None else None,
+            entry_price_target=float(o.entry_price_target) if o.entry_price_target is not None else None,
+            calculated_stop=float(o.calculated_stop) if o.calculated_stop is not None else None,
+            calculated_target=float(o.calculated_target) if o.calculated_target is not None else None,
+            quantity=o.quantity,
+            risk_amount_usd=float(o.risk_amount_usd) if o.risk_amount_usd is not None else None,
+            is_paper=o.is_paper,
+            broker_order_id=o.broker_order_id,
+            broker_stop_id=o.broker_stop_id,
+            broker_target_id=o.broker_target_id,
+            fill_price=float(o.fill_price) if o.fill_price is not None else None,
+            filled_at=o.filled_at,
+            exit_price=float(o.exit_price) if o.exit_price is not None else None,
+            exited_at=o.exited_at,
+            exit_reason=o.exit_reason,
+            trade_id=o.trade_id,
+            created_at=o.created_at,
+            updated_at=o.updated_at,
+        )

--- a/backend/app/services/auto_trade_service.py
+++ b/backend/app/services/auto_trade_service.py
@@ -531,3 +531,181 @@ class AutoTradeExecutor:
 
 # Module-level singleton for import convenience
 auto_trade_executor = AutoTradeExecutor()
+
+
+# ── Service functions extracted from routers/auto_trading.py ─────────────────
+
+def approve_order(
+    order: "AutoTradeOrder",
+    strategy: "TradingStrategy",
+    db: Session,
+) -> "AutoTradeOrder":
+    """
+    Approve a pending_approval order.
+
+    Paper mode: immediately marks submitted.
+    Live mode: queues the order for IBKR submission via Celery.
+    """
+    import logging as _logging
+    _logger = _logging.getLogger(__name__)
+
+    if strategy.paper_mode:
+        order.status = "submitted"
+        order.broker_order_id = f"PAPER-{order.id}"
+        order.broker_stop_id = f"PAPER-STOP-{order.id}"
+        order.broker_target_id = f"PAPER-TGT-{order.id}"
+        db.commit()
+        _logger.info(f"Approved paper order id={order.id}")
+    else:
+        from app.core.celery_app import celery_app as _celery
+        order.status = "pending"
+        db.commit()
+        _celery.send_task(
+            "app.tasks.submit_approved_order",
+            kwargs={"order_id": order.id},
+        )
+        _logger.info(f"Approved live order id={order.id}, queued for IBKR submission")
+
+    db.refresh(order)
+    return order
+
+
+def cancel_order(
+    order: "AutoTradeOrder",
+    db: Session,
+) -> "AutoTradeOrder":
+    """
+    Cancel an active order.
+
+    Paper orders: immediately marks cancelled.
+    Live orders: sends cancel to IBKR then marks cancelled.
+    Raises RuntimeError if IBKR cancel fails.
+    """
+    import logging as _logging
+    _logger = _logging.getLogger(__name__)
+
+    if not order.is_paper and order.broker_order_id and order.status in ("submitted", "open"):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            from app.providers.ibkr_orders import IBKROrderManager
+            manager = IBKROrderManager()
+            loop.run_until_complete(
+                manager.cancel_bracket(
+                    parent_order_id=int(order.broker_order_id),
+                    stop_order_id=int(order.broker_stop_id or 0),
+                    target_order_id=int(order.broker_target_id or 0),
+                )
+            )
+        except Exception as exc:
+            _logger.error(f"IBKR cancel failed for order {order.id}: {exc}")
+            raise RuntimeError(f"IBKR cancel failed: {exc}") from exc
+        finally:
+            loop.close()
+
+    from datetime import datetime, timezone
+    order.status = "cancelled"
+    order.updated_at = datetime.now(timezone.utc).replace(tzinfo=None)
+    db.commit()
+    db.refresh(order)
+    _logger.info(f"Cancelled order id={order.id}")
+    return order
+
+
+def get_account() -> dict:
+    """
+    Fetch live account summary from IBKR.
+
+    Returns a dict with net_liquidation, available_funds, buying_power,
+    currency, connected, and open_broker_orders.
+    """
+    import logging as _logging
+    _logger = _logging.getLogger(__name__)
+
+    try:
+        from app.providers.ibkr_orders import IBKROrderManager
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            manager = IBKROrderManager()
+            account, open_broker_orders = loop.run_until_complete(
+                manager.get_account_and_orders()
+            )
+        finally:
+            loop.close()
+
+        return {
+            "net_liquidation": account.net_liquidation,
+            "available_funds": account.available_funds,
+            "buying_power": account.buying_power,
+            "currency": account.currency,
+            "connected": True,
+            "open_broker_orders": [
+                {
+                    "order_id": o.order_id,
+                    "symbol": o.symbol,
+                    "action": o.action,
+                    "order_type": o.order_type,
+                    "quantity": o.total_qty,
+                    "status": o.status,
+                    "filled": o.filled,
+                    "avg_fill_price": o.avg_fill_price,
+                }
+                for o in open_broker_orders
+            ],
+        }
+    except Exception as exc:
+        _logger.warning(f"get_account: IBKR unavailable: {exc}")
+        return {
+            "net_liquidation": None,
+            "available_funds": None,
+            "buying_power": None,
+            "currency": "USD",
+            "connected": False,
+            "error": str(exc),
+            "open_broker_orders": [],
+        }
+
+
+def get_stats(db: Session, days: int = 30) -> dict:
+    """Return auto-trading statistics for the last N days."""
+    from datetime import date as date_type, timedelta
+    from app.models.trade import Trade
+
+    since = date_type.today() - timedelta(days=days)
+    orders = (
+        db.query(AutoTradeOrder)
+        .filter(AutoTradeOrder.event_date >= since)
+        .all()
+    )
+
+    total = len(orders)
+    by_status: dict = {}
+    for o in orders:
+        by_status[o.status] = by_status.get(o.status, 0) + 1
+
+    closed = [o for o in orders if o.status == "closed"]
+    wins = [
+        o for o in closed
+        if o.exit_price and o.fill_price and (
+            (o.side == "long" and float(o.exit_price) > float(o.fill_price)) or
+            (o.side == "short" and float(o.exit_price) < float(o.fill_price))
+        )
+    ]
+
+    trade_ids = [o.trade_id for o in closed if o.trade_id]
+    total_pnl = 0.0
+    if trade_ids:
+        trades = db.query(Trade).filter(Trade.id.in_(trade_ids)).all()
+        total_pnl = sum(float(t.gross_pnl or 0) for t in trades)
+
+    return {
+        "period_days": days,
+        "total_orders": total,
+        "by_status": by_status,
+        "closed_count": len(closed),
+        "win_count": len(wins),
+        "win_rate": round(len(wins) / len(closed) * 100, 1) if closed else None,
+        "total_pnl": round(total_pnl, 2),
+        "avg_pnl_per_trade": round(total_pnl / len(closed), 2) if closed else None,
+    }

--- a/backend/app/services/scan_orchestrator.py
+++ b/backend/app/services/scan_orchestrator.py
@@ -1,6 +1,10 @@
+import json
+import uuid as _uuid
 from dataclasses import dataclass
-from datetime import date
-from typing import Any, Awaitable, Callable, Optional
+from datetime import date, datetime, timezone, timedelta
+from typing import Any, Awaitable, Callable, Optional, Tuple
+
+import redis as _redis
 
 ScannerFn = Callable[[list[str], Any, date], Awaitable[list[dict]]]
 
@@ -38,3 +42,82 @@ async def run(
             f"Unknown scanner type: {scanner_type!r}. Registered: {list(_REGISTRY)}"
         )
     return await descriptor.run(tickers, db, event_date, scanner_run=scanner_run)
+
+
+def compute_next_run(scanner_type: str) -> Optional[datetime]:
+    """Return next scheduled fire time, or None if scanner_type is not scheduled."""
+    if scanner_type not in {"liquidity_hunt", "liquidity_hunt_pre", "liquidity_hunt_post"}:
+        return None
+    now = datetime.now(timezone.utc)
+    candidate = now.replace(minute=0, second=0, microsecond=0, hour=2)
+    if candidate <= now:
+        candidate += timedelta(days=1)
+    while candidate.weekday() >= 5:
+        candidate += timedelta(days=1)
+    return candidate
+
+
+def get_scan_progress(
+    redis_url: str,
+    universe_id: int,
+    scanner_type: str,
+) -> Optional[dict]:
+    """Return the Redis progress payload for an in-flight scan, or None."""
+    try:
+        r = _redis.Redis.from_url(redis_url, decode_responses=True)
+        state = r.get(f"universe:{universe_id}:scan:{scanner_type}")
+        return json.loads(state) if state else None
+    except Exception:
+        return None
+
+
+def request_scan_cancel(redis_url: str, scan_id: str) -> None:
+    """Set the Redis cancel flag that the worker polls at each day boundary."""
+    r = _redis.Redis.from_url(redis_url, decode_responses=True)
+    r.set(f"scan_cancel:{scan_id}", "1", ex=3600)
+
+
+def enqueue_scan(db: Any, request: Any) -> Tuple[Any, Any]:
+    """Create a ScannerRun row and dispatch the Celery task.
+
+    Returns (scanner_run, async_result).
+    Raises ValueError if universe has no active tickers.
+    The concurrency guard (check_concurrency / 409) stays in the router because
+    it raises HTTPException — a FastAPI concern not appropriate in the service layer.
+    """
+    from app.tasks import run_universe_scan
+    from app.models.scanner_run import ScannerRun
+    from app.services.scanner import ScannerService
+
+    start_date, end_date = ScannerService.resolve_date_range(
+        request.start_date, request.end_date
+    )
+    ticker_count = ScannerService.count_active_tickers(db, request.universe_id)
+    if ticker_count == 0:
+        raise ValueError("No tickers found in the selected universe")
+
+    scan_id = str(_uuid.uuid4())
+    scanner_run = ScannerRun(
+        uuid=_uuid.UUID(scan_id),
+        scanner_type=request.scanner_type,
+        universe_id=request.universe_id,
+        status="queued",
+        stocks_scanned=ticker_count,
+        scan_start_date=start_date,
+        scan_end_date=end_date,
+    )
+    db.add(scanner_run)
+    db.commit()
+    db.refresh(scanner_run)
+
+    async_result = run_universe_scan.delay(
+        scan_id=scan_id,
+        scanner_type=request.scanner_type,
+        universe_id=request.universe_id,
+        start_date_iso=start_date.isoformat(),
+        end_date_iso=end_date.isoformat(),
+    )
+
+    scanner_run.celery_task_id = async_result.id
+    db.commit()
+    return scanner_run, async_result

--- a/backend/app/services/scanner_query_service.py
+++ b/backend/app/services/scanner_query_service.py
@@ -1,0 +1,228 @@
+"""ScannerQueryService — DB aggregation queries extracted from routers/scanner.py."""
+
+from datetime import timezone
+from typing import Any, Optional
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+from sqlalchemy import func, distinct
+
+from app.models import ScannerEvent, ScannerRun, MonitoredStock
+from app.models.scanner_outcome_summary import ScannerOutcomeSummary
+from app.models.signal_review import SignalReview
+from app.models.system_config import SystemConfig
+from app.services.scan_orchestrator import compute_next_run
+
+
+class ScannerQueryService:
+
+    @staticmethod
+    def get_scan_status_block(
+        db: Session,
+        scanner_type: str,
+        universe_id: Optional[int] = None,
+    ) -> dict[str, Any]:
+        base_q = db.query(ScannerRun).filter(ScannerRun.scanner_type == scanner_type)
+        if universe_id is not None:
+            base_q = base_q.filter(ScannerRun.universe_id == universe_id)
+
+        last_run_record: Optional[ScannerRun] = (
+            base_q.order_by(ScannerRun.created_at.desc()).first()
+        )
+        last_run_info = None
+        if last_run_record is not None:
+            ts = last_run_record.created_at
+            if ts is not None and ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            last_run_info = {
+                "timestamp": ts,
+                "status": last_run_record.status,
+                "events_detected": last_run_record.events_detected or 0,
+                "duration_ms": last_run_record.execution_time_ms or 0,
+            }
+
+        recent_20 = base_q.order_by(ScannerRun.created_at.desc()).limit(20).all()
+        success_rate: Optional[float] = None
+        avg_events: Optional[float] = None
+        if recent_20:
+            completed = [r for r in recent_20 if r.status == "completed"]
+            success_rate = round(len(completed) / len(recent_20) * 100, 1)
+            if completed:
+                avg_events = round(
+                    sum(r.events_detected or 0 for r in completed) / len(completed), 1
+                )
+
+        sparkline_rows = base_q.order_by(ScannerRun.created_at.desc()).limit(10).all()
+        sparkline = [
+            {
+                "created_at": (
+                    r.created_at.replace(tzinfo=timezone.utc).isoformat()
+                    if r.created_at and r.created_at.tzinfo is None
+                    else r.created_at.isoformat() if r.created_at else None
+                ),
+                "events_detected": r.events_detected or 0,
+                "status": r.status,
+            }
+            for r in reversed(sparkline_rows)
+        ]
+
+        type_variants = [scanner_type]
+        if scanner_type == "liquidity_hunt":
+            type_variants = ["liquidity_hunt", "liquidity_hunt_pre", "liquidity_hunt_post"]
+
+        event_q = db.query(func.count(ScannerEvent.id)).filter(
+            ScannerEvent.scanner_type.in_(type_variants)
+        )
+        if universe_id is not None:
+            event_q = event_q.join(
+                MonitoredStock,
+                sa.and_(
+                    ScannerEvent.ticker == MonitoredStock.ticker,
+                    MonitoredStock.universe_id == universe_id,
+                    MonitoredStock.is_active.is_(True),
+                ),
+            )
+        total_events: int = event_q.scalar() or 0
+
+        return {
+            "scanner_type": scanner_type,
+            "universe_id": universe_id,
+            "last_run": last_run_info,
+            "next_run": compute_next_run(scanner_type),
+            "total_events": total_events,
+            "success_rate": success_rate,
+            "avg_events_per_scan": avg_events,
+            "sparkline": sparkline,
+        }
+
+    @staticmethod
+    def get_signal_quality_distribution(
+        db: Session,
+        scanner_type: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> dict[str, Any]:
+        ranker_version_row = db.query(SystemConfig).filter(
+            SystemConfig.key == "signal_ranker_version"
+        ).first()
+        version = ranker_version_row.value if ranker_version_row else "unknown"
+
+        query = (
+            db.query(
+                ScannerEvent.signal_quality_score,
+                ScannerOutcomeSummary.eod_pct_change,
+                ScannerOutcomeSummary.follow_through,
+            )
+            .join(ScannerOutcomeSummary, ScannerOutcomeSummary.scanner_event_id == ScannerEvent.id)
+            .filter(ScannerEvent.signal_quality_score.isnot(None))
+        )
+        if scanner_type:
+            query = query.filter(ScannerEvent.scanner_type == scanner_type)
+        if start_date:
+            query = query.filter(ScannerEvent.event_date >= start_date)
+        if end_date:
+            query = query.filter(ScannerEvent.event_date <= end_date)
+
+        rows = query.all()
+        buckets: dict[str, dict] = {
+            f"{i/10:.1f}-{(i+1)/10:.1f}": {
+                "count": 0, "eod_sum": 0.0, "ft_sum": 0, "eod_count": 0, "ft_count": 0
+            }
+            for i in range(10)
+        }
+        for score, eod_pct, follow_through in rows:
+            idx = min(int(float(score) * 10), 9)
+            label = f"{idx/10:.1f}-{(idx+1)/10:.1f}"
+            b = buckets[label]
+            b["count"] += 1
+            if eod_pct is not None:
+                b["eod_sum"] += float(eod_pct)
+                b["eod_count"] += 1
+            if follow_through is not None:
+                b["ft_sum"] += int(follow_through)
+                b["ft_count"] += 1
+
+        deciles = [
+            {
+                "decile": label,
+                "count": b["count"],
+                "avg_eod_pct": round(b["eod_sum"] / b["eod_count"], 3) if b["eod_count"] > 0 else None,
+                "follow_through_rate": round(b["ft_sum"] / b["ft_count"], 3) if b["ft_count"] > 0 else None,
+            }
+            for label, b in buckets.items()
+        ]
+        return {"deciles": deciles, "signal_ranker_version": version}
+
+    @staticmethod
+    def get_review_stats(
+        db: Session,
+        scanner_type: Optional[str] = None,
+        start_date: Optional[Any] = None,
+        end_date: Optional[Any] = None,
+    ) -> dict[str, Any]:
+        event_q = db.query(func.count(ScannerEvent.id))
+        review_q = db.query(SignalReview).join(
+            ScannerEvent, SignalReview.scanner_event_id == ScannerEvent.id
+        )
+
+        if scanner_type:
+            if scanner_type == "liquidity_hunt":
+                variants = ["liquidity_hunt", "liquidity_hunt_pre", "liquidity_hunt_post"]
+                event_q = event_q.filter(ScannerEvent.scanner_type.in_(variants))
+                review_q = review_q.filter(ScannerEvent.scanner_type.in_(variants))
+            else:
+                event_q = event_q.filter(ScannerEvent.scanner_type == scanner_type)
+                review_q = review_q.filter(ScannerEvent.scanner_type == scanner_type)
+        if start_date:
+            event_q = event_q.filter(ScannerEvent.event_date >= start_date)
+            review_q = review_q.filter(ScannerEvent.event_date >= start_date)
+        if end_date:
+            event_q = event_q.filter(ScannerEvent.event_date <= end_date)
+            review_q = review_q.filter(ScannerEvent.event_date <= end_date)
+
+        total_events = event_q.scalar() or 0
+        reviewed_count = (
+            review_q.with_entities(func.count(distinct(SignalReview.scanner_event_id))).scalar() or 0
+        )
+
+        confirmed_count = review_q.filter(SignalReview.verdict == "confirmed").count()
+        rejected_count = review_q.filter(SignalReview.verdict == "rejected").count()
+        denominator = confirmed_count + rejected_count
+        acceptance_rate = round(confirmed_count / denominator, 3) if denominator > 0 else 0.0
+
+        by_type_rows = (
+            review_q.with_entities(
+                ScannerEvent.scanner_type,
+                SignalReview.verdict,
+                func.count(SignalReview.id),
+            )
+            .group_by(ScannerEvent.scanner_type, SignalReview.verdict)
+            .all()
+        )
+        type_map: dict = {}
+        for stype, v, cnt in by_type_rows:
+            if stype not in type_map:
+                type_map[stype] = {
+                    "scanner_type": stype, "total": 0,
+                    "confirmed": 0, "rejected": 0, "uncertain": 0, "enhanced": 0,
+                }
+            type_map[stype]["total"] += cnt
+            if v in type_map[stype]:
+                type_map[stype][v] += cnt
+
+        reason_rows = (
+            review_q.filter(SignalReview.reject_reason.isnot(None))
+            .with_entities(SignalReview.reject_reason, func.count(SignalReview.id))
+            .group_by(SignalReview.reject_reason)
+            .order_by(func.count(SignalReview.id).desc())
+            .limit(5)
+            .all()
+        )
+
+        return {
+            "total_events": total_events,
+            "reviewed_count": reviewed_count,
+            "acceptance_rate": acceptance_rate,
+            "by_scanner_type": list(type_map.values()),
+            "top_rejection_reasons": [{"reason": r, "count": c} for r, c in reason_rows],
+        }

--- a/backend/app/services/system_service.py
+++ b/backend/app/services/system_service.py
@@ -1,0 +1,286 @@
+"""SystemService — extracted business logic from routers/system.py."""
+
+import json
+import socket
+import zoneinfo
+from datetime import datetime, timezone, timedelta
+from typing import Any
+
+import redis.asyncio as aioredis
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+
+logger = __import__("logging").getLogger(__name__)
+
+ET = zoneinfo.ZoneInfo("America/New_York")
+
+
+def _now_et() -> datetime:
+    """Return current datetime in ET. Module-level so tests can monkeypatch it."""
+    return datetime.now(ET)
+
+
+class SystemService:
+
+    @staticmethod
+    def get_market_status() -> str:
+        now_et = _now_et()
+        if now_et.weekday() >= 5:
+            return "closed"
+        t = now_et.hour * 60 + now_et.minute
+        if 240 <= t < 570:    # 04:00–09:30
+            return "pre_market"
+        if 570 <= t < 960:    # 09:30–16:00
+            return "open"
+        if 960 <= t < 1200:   # 16:00–20:00
+            return "post_market"
+        return "closed"
+
+    @staticmethod
+    def check_ibkr_reachable(host: str, port: int, timeout: float = 2.0) -> bool:
+        try:
+            sock = socket.create_connection((host, port), timeout=timeout)
+            sock.close()
+            return True
+        except OSError:
+            return False
+
+    @staticmethod
+    def format_bytes(size: int) -> str:
+        for unit in ["B", "KB", "MB", "GB", "TB"]:
+            if size < 1024:
+                return f"{size:.1f} {unit}"
+            size /= 1024
+        return f"{size:.1f} PB"
+
+    @staticmethod
+    def get_storage_stats(db: Session) -> dict[str, Any]:
+        table_groups = {
+            "scanner": ["volume_events", "scanner_runs"],
+            "historical": ["stock_aggregates", "stock_metrics", "ticker_references", "news_articles"],
+            "settings": ["news_preferences", "scanner_configs"],
+        }
+        results: dict[str, Any] = {
+            "scanner": {"bytes": 0, "formatted": "0.0 B"},
+            "historical": {"bytes": 0, "formatted": "0.0 B"},
+            "settings": {"bytes": 0, "formatted": "0.0 B"},
+            "total": {"bytes": 0, "formatted": "0.0 B"},
+        }
+        try:
+            dialect = db.bind.dialect.name
+            if dialect == "postgresql":
+                all_tables: list[str] = []
+                for group in table_groups.values():
+                    all_tables.extend(group)
+                query = text("""
+                    SELECT relname as table_name,
+                           pg_total_relation_size(relid) as total_size
+                    FROM pg_catalog.pg_statio_user_tables
+                    WHERE relname = ANY(:tables)
+                """)
+                db_results = db.execute(query, {"tables": all_tables}).fetchall()
+                table_sizes = {row.table_name: row.total_size for row in db_results}
+                for group_name, tables in table_groups.items():
+                    group_size = sum(table_sizes.get(t, 0) for t in tables)
+                    results[group_name]["bytes"] = group_size
+                    results[group_name]["formatted"] = SystemService.format_bytes(group_size)
+                    results["total"]["bytes"] += group_size
+            elif dialect == "sqlite":
+                import os
+                db_url = str(db.bind.url)
+                db_path = db_url.replace("sqlite:///", "")
+                total_size = os.path.getsize(db_path) if os.path.exists(db_path) else 0
+                results["historical"]["bytes"] = total_size
+                results["historical"]["formatted"] = f"{SystemService.format_bytes(total_size)} (SQLite)"
+                results["total"]["bytes"] = total_size
+            else:
+                results["total"]["formatted"] = f"Unknown DB ({dialect})"
+            results["total"]["formatted"] = SystemService.format_bytes(results["total"]["bytes"])
+        except Exception as exc:
+            logger.error(f"Error fetching storage stats: {exc}", exc_info=True)
+            return {
+                "scanner": {"bytes": 0, "formatted": "N/A"},
+                "historical": {"bytes": 0, "formatted": "N/A"},
+                "settings": {"bytes": 0, "formatted": "N/A"},
+                "total": {"bytes": 0, "formatted": "Service Error"},
+            }
+        return results
+
+    @staticmethod
+    async def get_active_tasks(
+        redis_client: aioredis.Redis,
+        db: Session,
+    ) -> list[dict]:
+        from celery.result import AsyncResult
+        from app.core.celery_app import celery_app
+        from app.models.universe_quality_report import UniverseQualityReport
+        from app.models.stock_universe import StockUniverse
+
+        active_tasks: list[dict] = []
+
+        async def _scan_pattern(pattern: str) -> list[str]:
+            keys: list[str] = []
+            cursor = "0"
+            while True:
+                cursor, batch = await redis_client.scan(cursor=cursor, match=pattern, count=100)
+                keys.extend(batch)
+                if str(cursor) == "0":
+                    break
+            return keys
+
+        def _is_stale(data: dict) -> bool:
+            ts_str = data.get("started_at")
+            if not ts_str:
+                return False
+            try:
+                started = datetime.fromisoformat(ts_str).replace(tzinfo=timezone.utc)
+                return (datetime.now(timezone.utc) - started).total_seconds() / 3600 > 4
+            except (ValueError, TypeError):
+                return False
+
+        def _has_pending_tasks(data: dict) -> bool:
+            tids = data.get("task_ids") or []
+            return any(
+                AsyncResult(tid, app=celery_app).state in ("PENDING", "STARTED", "RETRY")
+                for tid in tids
+            )
+
+        # universe:*:sync
+        for key in await _scan_pattern("universe:*:sync"):
+            parts = key.split(":")
+            if len(parts) < 2 or not parts[1].isdigit():
+                continue
+            uid = int(parts[1])
+            raw = await redis_client.get(key)
+            if not raw:
+                continue
+            data = json.loads(raw)
+            if _is_stale(data):
+                await redis_client.delete(key)
+                continue
+            if not _has_pending_tasks(data):
+                await redis_client.delete(key)
+                continue
+            universe = db.query(StockUniverse).filter(StockUniverse.id == uid).first()
+            name = universe.name if universe else f"Universe {uid}"
+            active_tasks.append({
+                "id": f"sync_{uid}",
+                "type": "sync",
+                "title": f"Syncing Data: {name}",
+                "status": "running",
+            })
+
+        # ticker:*:sync
+        for key in await _scan_pattern("ticker:*:sync"):
+            parts = key.split(":")
+            if len(parts) < 2:
+                continue
+            ticker = parts[1]
+            raw = await redis_client.get(key)
+            if not raw:
+                continue
+            data = json.loads(raw)
+            if _is_stale(data):
+                await redis_client.delete(key)
+                continue
+            if not _has_pending_tasks(data):
+                await redis_client.delete(key)
+                continue
+            active_tasks.append({
+                "id": f"sync_ticker_{ticker}",
+                "type": "sync",
+                "title": f"Syncing Data: {ticker}",
+                "status": "running",
+            })
+
+        # scan:*:range
+        for key in await _scan_pattern("scan:*:range"):
+            parts = key.split(":")
+            ticker_name = parts[1] if len(parts) >= 2 else "?"
+            raw = await redis_client.get(key)
+            if not raw:
+                continue
+            data = json.loads(raw)
+            if _is_stale(data):
+                await redis_client.delete(key)
+                continue
+            if not _has_pending_tasks(data):
+                await redis_client.delete(key)
+                continue
+            active_tasks.append({
+                "id": f"scan_{ticker_name}",
+                "type": "scan",
+                "title": f"Range Scan: {ticker_name}",
+                "status": "running",
+            })
+
+        # universe:*:scan:*
+        for key in await _scan_pattern("universe:*:scan:*"):
+            parts = key.split(":")
+            if len(parts) < 4 or not parts[1].isdigit():
+                continue
+            uid = int(parts[1])
+            scanner_type = parts[3]
+            raw = await redis_client.get(key)
+            if not raw:
+                continue
+            data = json.loads(raw)
+            if _is_stale(data):
+                await redis_client.delete(key)
+                continue
+            if not _has_pending_tasks(data):
+                await redis_client.delete(key)
+                continue
+            universe = db.query(StockUniverse).filter(StockUniverse.id == uid).first()
+            universe_name = universe.name if universe else f"Universe {uid}"
+            day_idx = data.get("day_index", 0) if isinstance(data, dict) else 0
+            total_days = data.get("total_days", 0) if isinstance(data, dict) else 0
+            active_tasks.append({
+                "id": f"scan_{uid}_{scanner_type}",
+                "type": "scan",
+                "title": (
+                    f"Scanning {universe_name}: {scanner_type.replace('_', ' ')}"
+                    + (f" — day {day_idx}/{total_days}" if total_days else "")
+                ),
+                "status": "running",
+            })
+
+        # DB: quality + normalization tasks
+        stale_cutoff = (
+            datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=4)
+        )
+        quality_reports = db.query(UniverseQualityReport).filter(
+            (UniverseQualityReport.status.in_(["pending", "running"])) |
+            (UniverseQualityReport.normalization_status.in_(["pending", "running"]))
+        ).all()
+
+        for report in quality_reports:
+            is_stale = report.started_at and report.started_at < stale_cutoff
+            if is_stale:
+                if report.status in ("pending", "running"):
+                    report.status = "failed"
+                if report.normalization_status in ("pending", "running"):
+                    report.normalization_status = "failed"
+                db.add(report)
+                db.commit()
+                continue
+            universe = db.query(StockUniverse).filter(
+                StockUniverse.id == report.universe_id
+            ).first()
+            name = universe.name if universe else f"Universe {report.universe_id}"
+            if report.status in ("pending", "running"):
+                active_tasks.append({
+                    "id": f"qa_{report.universe_id}",
+                    "type": "analysis",
+                    "title": f"Quality Analysis: {name}",
+                    "status": report.status,
+                })
+            if report.normalization_status in ("pending", "running"):
+                active_tasks.append({
+                    "id": f"norm_{report.universe_id}",
+                    "type": "normalization",
+                    "title": f"Normalizing Data: {name}",
+                    "status": report.normalization_status,
+                })
+
+        return active_tasks

--- a/backend/tests/services/test_auto_trade_service.py
+++ b/backend/tests/services/test_auto_trade_service.py
@@ -14,7 +14,8 @@ from sqlalchemy.orm import Session
 from app.models.alert_rule import AlertRule
 from app.models.scanner_event import ScannerEvent
 from app.models.trading_strategy import TradingStrategy
-from app.services.auto_trade_service import AutoTradeExecutor, PositionCalc
+from app.models.auto_trade_order import AutoTradeOrder
+from app.services.auto_trade_service import AutoTradeExecutor, PositionCalc, approve_order, cancel_order, get_account, get_stats
 
 
 # ── helpers ────────────────────────────────────────────────────────────────
@@ -247,3 +248,97 @@ def test_maybe_execute_live_mode_isolates_ibkr(db: Session):
     assert order is not None
     assert order.status == "submitted"
     assert order.broker_order_id == "IB-PARENT-1"
+
+
+# ── New service functions ──────────────────────────────────────────────────
+
+
+def _make_order(db, strategy, paper=True, status="pending_approval"):
+    order = AutoTradeOrder(
+        trading_strategy_id=strategy.id,
+        symbol="AAPL",
+        side="long",
+        event_date=date.today(),
+        status=status,
+        is_paper=paper,
+        trigger_price=Decimal("50.00"),
+        calculated_stop=Decimal("49.00"),
+        calculated_target=Decimal("52.00"),
+        quantity=10,
+    )
+    db.add(order)
+    db.flush()
+    return order
+
+
+# ── approve_order ──────────────────────────────────────────────────────────
+
+def test_approve_order_paper_sets_submitted(db):
+    s = _strategy(db, paper_mode=True)
+    o = _make_order(db, s)
+    result = approve_order(o, s, db)
+    assert result.status == "submitted"
+    assert result.broker_order_id.startswith("PAPER-")
+
+
+def test_approve_order_live_queues_celery(db):
+    s = _strategy(db, paper_mode=False)
+    o = _make_order(db, s)
+    with patch("app.services.auto_trade_service.AutoTradeExecutor._get_account_equity"):
+        with patch("app.core.celery_app.celery_app.send_task") as mock_send:
+            result = approve_order(o, s, db)
+    assert result.status == "pending"
+    mock_send.assert_called_once_with(
+        "app.tasks.submit_approved_order",
+        kwargs={"order_id": o.id},
+    )
+
+
+# ── cancel_order ───────────────────────────────────────────────────────────
+
+def test_cancel_order_paper_sets_cancelled(db):
+    s = _strategy(db, paper_mode=True)
+    o = _make_order(db, s, paper=True, status="submitted")
+    result = cancel_order(o, db)
+    assert result.status == "cancelled"
+
+
+def test_cancel_order_live_calls_ibkr_cancel(db):
+    s = _strategy(db, paper_mode=False)
+    o = _make_order(db, s, paper=False, status="submitted")
+    o.broker_order_id = "12345"
+    o.broker_stop_id = "12346"
+    o.broker_target_id = "12347"
+    db.flush()
+
+    mock_mgr = MagicMock()
+    mock_mgr.cancel_bracket = AsyncMock()
+
+    with patch("app.providers.ibkr_orders.IBKROrderManager", return_value=mock_mgr):
+        result = cancel_order(o, db)
+
+    assert result.status == "cancelled"
+    mock_mgr.cancel_bracket.assert_awaited_once()
+
+
+# ── get_account ────────────────────────────────────────────────────────────
+
+def test_get_account_returns_disconnected_on_error():
+    result = get_account()
+    # In test env IBKR is not running — should return a graceful fallback
+    assert "connected" in result
+    # Either connected (if somehow IBKR is up) or not
+    if not result["connected"]:
+        assert result["net_liquidation"] is None
+        assert "error" in result
+
+
+# ── get_stats ──────────────────────────────────────────────────────────────
+
+def test_get_stats_returns_expected_shape(db):
+    result = get_stats(db, days=30)
+    assert "period_days" in result
+    assert "total_orders" in result
+    assert "by_status" in result
+    assert "win_rate" in result
+    assert result["period_days"] == 30

--- a/backend/tests/services/test_scan_orchestrator.py
+++ b/backend/tests/services/test_scan_orchestrator.py
@@ -79,3 +79,51 @@ def test_liquidity_hunt_variants_registered():
     import app.services.liquidity_hunt  # noqa: F401
     for key in ("liquidity_hunt", "liquidity_hunt_pre", "liquidity_hunt_post"):
         assert key in orchestrator._REGISTRY, f"Expected {key!r} in registry"
+
+
+# ── New orchestration functions ────────────────────────────────────────────
+
+import fakeredis
+from unittest.mock import patch
+
+from app.services.scan_orchestrator import (
+    compute_next_run,
+    get_scan_progress,
+    request_scan_cancel,
+)
+
+
+def test_compute_next_run_returns_none_for_non_scheduled():
+    assert compute_next_run("pre_market_volume_spike") is None
+
+
+def test_compute_next_run_returns_future_weekday_for_liquidity_hunt():
+    from datetime import datetime, timezone
+    result = compute_next_run("liquidity_hunt")
+    assert result is not None
+    assert result > datetime.now(timezone.utc)
+    assert result.weekday() < 5  # not a weekend
+
+
+def test_compute_next_run_returns_value_for_pre_variant():
+    result = compute_next_run("liquidity_hunt_pre")
+    assert result is not None
+
+
+def test_compute_next_run_returns_value_for_post_variant():
+    result = compute_next_run("liquidity_hunt_post")
+    assert result is not None
+
+
+def test_get_scan_progress_returns_none_when_no_key():
+    server = fakeredis.FakeRedis(decode_responses=True)
+    with patch("app.services.scan_orchestrator._redis.Redis.from_url", return_value=server):
+        result = get_scan_progress("redis://localhost", universe_id=1, scanner_type="liquidity_hunt")
+    assert result is None
+
+
+def test_request_scan_cancel_sets_redis_key():
+    server = fakeredis.FakeRedis(decode_responses=True)
+    with patch("app.services.scan_orchestrator._redis.Redis.from_url", return_value=server):
+        request_scan_cancel("redis://localhost", "test-scan-uuid")
+        assert server.get("scan_cancel:test-scan-uuid") == "1"

--- a/backend/tests/services/test_scanner_query_service.py
+++ b/backend/tests/services/test_scanner_query_service.py
@@ -1,0 +1,121 @@
+"""Tests for ScannerQueryService."""
+import pytest
+from datetime import date
+
+from app.models.scanner_run import ScannerRun
+from app.models.scanner_event import ScannerEvent
+from app.models.signal_review import SignalReview
+from app.models.scanner_outcome_summary import ScannerOutcomeSummary
+from app.models.stock_universe import StockUniverse
+from app.services.scanner_query_service import ScannerQueryService
+
+
+@pytest.fixture
+def universe(db):
+    u = StockUniverse(name="Test Universe", description="test", criteria={})
+    db.add(u)
+    db.flush()
+    return u
+
+
+@pytest.fixture
+def seeded_runs(db, universe):
+    runs = [
+        ScannerRun(
+            scanner_type="liquidity_hunt",
+            universe_id=universe.id,
+            status="completed",
+            stocks_scanned=10,
+            events_detected=5,
+            execution_time_ms=1000,
+        ),
+        ScannerRun(
+            scanner_type="liquidity_hunt",
+            universe_id=universe.id,
+            status="failed",
+            stocks_scanned=10,
+            events_detected=0,
+            execution_time_ms=500,
+        ),
+    ]
+    for r in runs:
+        db.add(r)
+    db.flush()
+    return runs
+
+
+@pytest.fixture
+def seeded_events(db):
+    events = []
+    for i in range(5):
+        e = ScannerEvent(
+            ticker=f"SYM{i}",
+            scanner_type="liquidity_hunt",
+            event_date=date(2026, 5, 1),
+            signal_quality_score=i * 0.2,
+        )
+        db.add(e)
+        db.flush()
+        summary = ScannerOutcomeSummary(
+            scanner_event_id=e.id,
+            reference_price=100.0,
+            eod_pct_change=float(i),
+            follow_through=bool(i % 2),
+        )
+        db.add(summary)
+        events.append(e)
+    db.flush()
+    return events
+
+
+# ── get_scan_status_block ──────────────────────────────────────────────────
+
+def test_get_scan_status_block_returns_expected_keys(db, universe, seeded_runs):
+    result = ScannerQueryService.get_scan_status_block(db, "liquidity_hunt", universe_id=universe.id)
+    assert "last_run" in result
+    assert "success_rate" in result
+    assert "sparkline" in result
+    assert "total_events" in result
+    assert "next_run" in result
+    assert result["success_rate"] == 50.0  # 1 completed out of 2
+
+
+def test_get_scan_status_block_no_runs_returns_nones(db):
+    result = ScannerQueryService.get_scan_status_block(db, "no_such_scanner")
+    assert result["last_run"] is None
+    assert result["success_rate"] is None
+    assert result["sparkline"] == []
+
+
+# ── get_signal_quality_distribution ────────────────────────────────────────
+
+def test_get_signal_quality_distribution_returns_10_deciles(db, seeded_events):
+    result = ScannerQueryService.get_signal_quality_distribution(db, scanner_type=None)
+    assert len(result["deciles"]) == 10
+    assert "signal_ranker_version" in result
+
+
+def test_get_signal_quality_distribution_filters_by_type(db, seeded_events):
+    result = ScannerQueryService.get_signal_quality_distribution(
+        db, scanner_type="liquidity_hunt"
+    )
+    populated = [d for d in result["deciles"] if d["count"] > 0]
+    assert len(populated) > 0
+
+
+# ── get_review_stats ───────────────────────────────────────────────────────
+
+def test_get_review_stats_returns_expected_shape(db, seeded_events):
+    event = seeded_events[0]
+    review = SignalReview(
+        scanner_event_id=event.id,
+        verdict="confirmed",
+    )
+    db.add(review)
+    db.flush()
+    result = ScannerQueryService.get_review_stats(db, scanner_type="liquidity_hunt")
+    assert "total_events" in result
+    assert "reviewed_count" in result
+    assert "acceptance_rate" in result
+    assert isinstance(result["by_scanner_type"], list)
+    assert isinstance(result["top_rejection_reasons"], list)

--- a/backend/tests/services/test_system_service.py
+++ b/backend/tests/services/test_system_service.py
@@ -1,0 +1,99 @@
+"""Tests for SystemService."""
+import socket
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import fakeredis.aioredis
+import pytest
+
+from app.services.system_service import SystemService
+
+
+# ── get_market_status ──────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("hour,minute,weekday,expected", [
+    (3, 59, 0, "closed"),       # before pre-market on Monday
+    (4, 0, 0, "pre_market"),    # 04:00 ET Monday
+    (9, 29, 1, "pre_market"),   # 09:29 ET Tuesday
+    (9, 30, 2, "open"),         # 09:30 ET Wednesday
+    (15, 59, 3, "open"),        # 15:59 ET Thursday
+    (16, 0, 4, "post_market"),  # 16:00 ET Friday
+    (19, 59, 4, "post_market"), # 19:59 ET Friday
+    (20, 0, 4, "closed"),       # 20:00 ET Friday
+    (12, 0, 5, "closed"),       # Saturday
+    (12, 0, 6, "closed"),       # Sunday
+])
+def test_get_market_status(hour, minute, weekday, expected):
+    fake_now = MagicMock()
+    fake_now.weekday.return_value = weekday
+    fake_now.hour = hour
+    fake_now.minute = minute
+    with patch("app.services.system_service._now_et", return_value=fake_now):
+        result = SystemService.get_market_status()
+    assert result == expected
+
+
+# ── check_ibkr_reachable ──────────────────────────────────────────────────
+
+def test_check_ibkr_reachable_returns_true_on_success():
+    mock_sock = MagicMock()
+    mock_sock.__enter__ = MagicMock(return_value=mock_sock)
+    mock_sock.__exit__ = MagicMock(return_value=False)
+    with patch("socket.create_connection", return_value=mock_sock):
+        assert SystemService.check_ibkr_reachable("127.0.0.1", 7497) is True
+
+
+def test_check_ibkr_reachable_returns_false_on_oserror():
+    with patch("socket.create_connection", side_effect=OSError("refused")):
+        assert SystemService.check_ibkr_reachable("127.0.0.1", 7497) is False
+
+
+# ── format_bytes ──────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("size,expected", [
+    (0, "0.0 B"),
+    (512, "512.0 B"),
+    (1024, "1.0 KB"),
+    (1024 * 1024, "1.0 MB"),
+    (1024 ** 3, "1.0 GB"),
+])
+def test_format_bytes(size, expected):
+    assert SystemService.format_bytes(size) == expected
+
+
+# ── get_storage_stats ─────────────────────────────────────────────────────
+
+def test_get_storage_stats_returns_dict(db):
+    result = SystemService.get_storage_stats(db)
+    assert "scanner" in result
+    assert "historical" in result
+    assert "settings" in result
+    assert "total" in result
+    assert "bytes" in result["total"]
+    assert "formatted" in result["total"]
+
+
+# ── get_active_tasks ──────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_get_active_tasks_empty_on_no_keys(db):
+    redis_client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    tasks = await SystemService.get_active_tasks(redis_client, db)
+    assert tasks == []
+
+
+@pytest.mark.asyncio
+async def test_get_active_tasks_skips_stale_sync_key(db):
+    import json
+    from datetime import timezone, timedelta
+
+    redis_client = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    old_ts = (datetime.now(timezone.utc) - timedelta(hours=5)).isoformat()
+    await redis_client.set("universe:1:sync", json.dumps({
+        "started_at": old_ts,
+        "task_ids": ["abc"],
+    }))
+    tasks = await SystemService.get_active_tasks(redis_client, db)
+    assert tasks == []
+    # Key must be deleted after stale detection
+    assert await redis_client.get("universe:1:sync") is None


### PR DESCRIPTION
## Summary

Extracts non-trivial business logic from three oversized FastAPI routers into service modules, following the `universe_orchestrator.py` thin-router pattern from PR #82. No API contract changes.

- **Phase 1** — `system.py` (482→108 lines): new `SystemService` with market status, IBKR probe, byte formatting, storage stats, active-task WebSocket polling
- **Phase 2** — `scanner.py` (863→~630 lines): new `ScannerQueryService` for aggregation endpoints; `scan_orchestrator.py` extended with `compute_next_run`, `get_scan_progress`, `request_scan_cancel`, `enqueue_scan`
- **Phase 3** — `auto_trading.py` (564→~280 lines): `approve_order`, `cancel_order`, `get_account`, `get_stats` moved to `auto_trade_service.py`; `_strategy_to_dict`/`_order_to_dict` replaced with Pydantic schemas

Also fixes a pre-existing `NameError` in `config.py` (`os.getenv` without `os` import).

## Test plan

- [x] 39 new tests added across 4 test files; full suite passes (621 passed, 1 skipped)
- [x] `npx tsc --noEmit` passes
- [x] All three routers import cleanly
- [x] No database migrations required

## Key decisions

- `check_concurrency` / 409 guard stays in the router (raises `HTTPException` — HTTP concern)
- `asyncio.new_event_loop()` pattern preserved for IBKR (established 5+ site convention)
- `_now_et()` is a module-level function to enable clean monkeypatching

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)