### PR TITLE
docs(adr): write ADRs 004-009 for key architectural decisions

### DIFF
--- a/Docs/adr/0004-synchronous-sqlalchemy.md
+++ b/Docs/adr/0004-synchronous-sqlalchemy.md
@@ -1,0 +1,37 @@
+# ADR-004: Synchronous SQLAlchemy ORM
+
+**Date**: 2026-05-28  
+**Status**: Accepted (short-term; async migration tracked in #103)
+
+## Context
+
+SQLAlchemy 2.0 ships both a synchronous and an async ORM. The project also has `asyncpg` installed (a pure-async PostgreSQL driver), which looks like async SQLAlchemy is in use — it is not. The actual synchronous driver is `psycopg2-binary`.
+
+At the time the project was bootstrapped, the REST API surface was small, the team was more familiar with synchronous SQLAlchemy patterns, and FastAPI's `Depends(get_db)` model works naturally with sync generators. Introducing async SQLAlchemy at that stage would have added complexity (all session access becomes `await session.execute(...)`, all relationships become `await session.run_sync(...)`) without a clear bottleneck to justify it.
+
+`asyncpg` was added for a future async migration and for Celery compatibility experiments; it is not currently wired into the ORM.
+
+### ARCHITECTURE.md note
+
+The architecture diagram currently shows `asyncpg ──> postgres:5432`. This is inaccurate — the backend uses `psycopg2`. The diagram correction is a separate follow-up change.
+
+### Options considered
+
+**A. Synchronous SQLAlchemy (psycopg2)** — Simple, well-understood, fits FastAPI sync route handlers. Known downside: each DB call blocks the event loop thread.
+
+**B. Async SQLAlchemy (asyncpg)** — Non-blocking I/O; route handlers must be `async def` throughout; relationship loading needs explicit `selectinload`/`joinedload` or `run_sync`. Correct choice at scale but requires an all-or-nothing migration.
+
+**C. Encode Databases / raw asyncpg** — Lightweight alternative for async DB access without the full SQLAlchemy ORM. Rejects the ORM entirely; would require rewriting all model queries.
+
+## Decision
+
+**Option A**: synchronous SQLAlchemy with `psycopg2-binary`. This is a deliberate short-term choice, not a permanent one.
+
+The consequence — that route handlers block the event loop when a DB query runs — is acceptable at the current scale (single-operator, low concurrency). The async migration is tracked as issue #103. ADR-004 should be superseded by that work.
+
+## Consequences
+
+- Route handlers that call `get_db()` block the event loop for the duration of the DB round-trip.
+- Under high concurrency (many simultaneous users or automated scan submissions) this becomes a throughput ceiling before connection pool exhaustion.
+- `asyncpg` in `requirements.txt` is not used by the ORM today; it is retained for the future migration.
+- Any new service or router added before #103 lands should follow the existing sync pattern to avoid a half-async, half-sync ORM setup.

--- a/Docs/adr/0005-jsonb-for-scanner-event-metadata.md
+++ b/Docs/adr/0005-jsonb-for-scanner-event-metadata.md
@@ -1,0 +1,40 @@
+# ADR-005: JSONB Columns for Scanner Event Metadata
+
+**Date**: 2026-05-28  
+**Status**: Accepted
+
+## Context
+
+`ScannerEvent` stores the output of each scanner type. Different scanner types produce different indicator sets — the pre-market volume scanner produces `volume_ratio`, `vwap_distance`, and `gap_pct`; the oversold bounce scanner produces `rsi_14`, `distance_from_52w_low`, and `bb_width`. Storing all possible indicator values as normalized columns would require either:
+
+- A wide table with many nullable columns (one per indicator per scanner type), growing with every new scanner, or
+- A scanner-specific table per scanner type, requiring schema changes and JOIN complexity each time a new scanner is added.
+
+Three columns on `scanner_events` use JSONB to avoid this:
+
+| Column | Purpose |
+|---|---|
+| `indicators` | Numeric signal values computed by the scanner (volume ratios, RSI, gap %, etc.) |
+| `criteria_met` | Boolean flags for each condition that triggered the alert |
+| `metadata_` | Enrichment data added after detection (catalysts, float, short interest, splits) |
+
+JSONB was chosen over JSON because PostgreSQL indexes JSONB as a binary document, enabling `@>` containment queries and GIN indexing — useful for queries like "all events where RSI < 30 was a criteria met flag."
+
+### Trade-offs accepted
+
+The primary cost of JSONB is queryability. Filtering on a specific indicator value requires a JSONB path expression (`indicators->>'volume_ratio'::numeric > 4`) rather than a simple column predicate. This is harder to write, harder for query planners to optimize without explicit GIN indexes, and harder to enforce as a schema.
+
+For ad-hoc signal analysis (the primary query pattern), this cost is acceptable. The alternative — a normalized schema — would make adding or changing scanner types a DDL operation requiring a migration for every iteration.
+
+## Decision
+
+Three JSONB columns on `scanner_events`: `indicators`, `criteria_met`, and `metadata_`. Schema flexibility over query ergonomics.
+
+New scanner types extend the payload by writing new keys into these columns. No migration is required to add a new scanner — only the service logic changes.
+
+## Consequences
+
+- No compile-time validation of indicator keys or value types. Errors in scanner logic produce silently wrong JSONB rather than a DB error.
+- Query filtering on JSONB values requires cast syntax and may need GIN indexes for performance as event volume grows.
+- The Pydantic schemas for `ScannerEvent` responses (`ScannerEventRead`) expose `indicators`, `criteria_met`, and `metadata_` as `dict[str, Any]` — callers cannot rely on a typed schema for scanner-specific fields without additional validation in the service layer.
+- Adding a new scanner type is a code-only change (no migration), which was the primary motivation.

--- a/Docs/adr/0006-celery-redis-for-background-tasks.md
+++ b/Docs/adr/0006-celery-redis-for-background-tasks.md
@@ -1,0 +1,33 @@
+# ADR-006: Celery + Redis for Background Tasks
+
+**Date**: 2026-05-28  
+**Status**: Accepted
+
+## Context
+
+Several operations in MarketHawk cannot run synchronously in an HTTP request: full scanner runs (tens of Polygon API calls, several seconds per ticker), nightly stock split syncs, news polling, and auto-trade fill polling. These need to be dispatched from route handlers and run in a separate process.
+
+### Options considered
+
+**A. FastAPI `BackgroundTasks`** — Built-in; no infrastructure. Tasks run in the same process as the ASGI server. Under load, long-running tasks compete with request handling for the event loop. No persistence: if the process restarts, queued tasks are lost. No visibility (no queue depth, no task status, no retry). Suitable for fire-and-forget notifications, not for multi-second compute.
+
+**B. Celery + Redis** — Battle-tested distributed task queue. Tasks persist in Redis across restarts. Workers run in a separate process (or container), fully isolated from the ASGI server. Built-in retry, rate limiting, and scheduled tasks (Celery Beat). Flower provides real-time monitoring. The cost is operational: Redis and a worker process/container must run alongside the backend.
+
+**C. Apache Airflow** — DAG-based workflow orchestrator. Excellent for data pipelines with complex dependencies. Requires a scheduler, web server, and metadata DB. Overkill for a set of independent periodic tasks with no inter-task DAG dependencies.
+
+**D. Prefect** — Modern alternative to Airflow. Cloud or self-hosted server required for the full feature set. Same over-engineering concern as Airflow for this use case.
+
+## Decision
+
+**Option B**: Celery with Redis as both broker and result backend.
+
+Redis is already required for other features (rate limiter storage, live scanner pub/sub, refresh token storage). Adding Celery uses an already-running service rather than introducing new infrastructure. The worker runs as a separate container (`celery-worker` in `docker-compose.yml`), keeping it isolated from the FastAPI ASGI process.
+
+Celery Beat handles the scheduled tasks (nightly splits, news polling, evening liquidity scan, signal analysis, tweet monitoring). A single Beat scheduler process avoids the overhead of cron-inside-container patterns.
+
+## Consequences
+
+- The `celery-worker` container must be running for any background task to execute. If it crashes, no tasks run until it restarts (observable via Flower at `:5555`).
+- Task results stored in Redis expire after the default TTL; tasks that need durable output write directly to PostgreSQL.
+- Redis is a single point of failure for both the broker and the backend. Restarting Redis loses any tasks that were queued but not yet acknowledged by a worker.
+- Airflow or Prefect would be appropriate if scan orchestration grows into a DAG with inter-task dependencies. Until then, Celery's simpler model is sufficient.

--- a/Docs/adr/0007-live-scanner-service-extraction.md
+++ b/Docs/adr/0007-live-scanner-service-extraction.md
@@ -1,0 +1,31 @@
+# ADR-007: Live Scanner as a Separate Container
+
+**Date**: 2026-05-28  
+**Status**: Accepted
+
+## Context
+
+The live scanner streams real-time 5-second IBKR bars for watchlist symbols and fires intraday alerts. It depends on `ib_insync`, which runs its own asyncio event loop via `IB.run()`. Two options were considered for where this code lives:
+
+**A. Inside the backend FastAPI process** — Reuse the existing container. Share the database session and Celery client directly. Downside: `ib_insync` runs a blocking event loop that conflicts with the FastAPI/uvicorn event loop. Threading workarounds are fragile; IBKR disconnects or reconnects can block the ASGI server.
+
+**B. Separate container (`live-scanner`)** — Runs as `python -m live_scanner.main`, fully isolated from the ASGI process. Has its own asyncio loop, dedicated IBKR `clientId` (5), and connects to the same PostgreSQL and Redis instances as the backend. Communicates outbound via Redis pub/sub channels.
+
+The IBKR API assigns work to `clientId` values. Sharing a `clientId` between two processes causes conflicts and dropped subscriptions. A dedicated clientId for the live scanner is required regardless of process topology; extracting it to a separate container makes this a natural boundary.
+
+## Decision
+
+**Option B**: `live-scanner` runs as a separate container with its own process and dedicated IBKR `clientId: 5`.
+
+Inbound data path: IBKR bars → `IBKRLiveAdapter` → `BarAggregator` (accumulates 5 s bars into 1 min bars) → `LivePublisher`.
+
+Outbound communication: `LivePublisher` writes to Redis pub/sub channels (`stock_updates:{symbol}:second`, `stock_updates:{symbol}:minute`, `watchlist:live_data`, `watchlist:alerts`). The FastAPI backend consumes these channels via its WebSocket endpoints. `LivePublisher` also writes `ScannerEvent` rows directly to PostgreSQL using the same `SessionLocal` as the backend (via `asyncio.to_thread`).
+
+Alert evaluation (notification rules, auto-trade rules) is handed off to Celery by queuing `evaluate_scanner_alerts` via `celery_app.send_task()` — same path as the historical scanner.
+
+## Consequences
+
+- `live-scanner` container must be running for real-time data to flow to the frontend. If it stops, the WebSocket endpoints return stale data until it reconnects.
+- `clientId: 5` is reserved by convention. Adding a third IBKR-connected service requires allocating a new clientId and documenting it.
+- DB writes from the live scanner go through `asyncio.to_thread` (sync SQLAlchemy in a thread pool) rather than async SQLAlchemy. This is consistent with ADR-004's short-term sync decision and inherits the same migration path.
+- Redis pub/sub is fire-and-forget; if the backend WebSocket consumer is not running, messages are lost. This is acceptable for real-time price data where staleness is the natural recovery.

--- a/Docs/adr/0008-dark-factory-autonomous-development.md
+++ b/Docs/adr/0008-dark-factory-autonomous-development.md
@@ -1,0 +1,34 @@
+# ADR-008: Dark Factory Autonomous Development Model
+
+**Date**: 2026-05-28  
+**Status**: Accepted
+
+## Context
+
+Implementing GitHub issues manually requires context-switching between the issue tracker, IDE, terminal, and browser for every feature. The Dark Factory automates the repetitive mechanics: clone, branch, implement, test, preview, PR — leaving the human to read the PR and give feedback.
+
+The core challenge is giving an AI agent enough access to build and run Docker containers (it needs to spin up a preview stack per issue) without giving it unrestricted access to the host Docker daemon. Unrestricted Docker socket access is equivalent to root on the host; any prompt injection or compromised dependency could destroy the live stack.
+
+### Trust model
+
+The Dark Factory uses `tecnativa/docker-socket-proxy` to restrict the Docker API surface. The proxy allows `CONTAINERS`, `IMAGES`, `NETWORKS`, `VOLUMES`, and `BUILD`, while blocking `SERVICES`, `EXEC`, and write access to `/info` endpoints. The factory container has no bind-mount to the host filesystem — it clones fresh from GitHub each run.
+
+### Known limitation accepted by convention
+
+`tecnativa/docker-socket-proxy` does not support label-based container filtering. The factory can technically enumerate all containers via the Docker API, not just its own `mh-preview-*` stacks. Stronger isolation (a custom proxy with namespace enforcement) would require writing and maintaining a custom API gateway. The risk is accepted: the factory is a trusted first-party tool, not an adversarial workload. The entrypoint script and Archon workflows only operate on `mh-preview-*` prefixed resources by convention.
+
+## Decision
+
+Dark Factory runs as an ephemeral `--rm` container (`dark-factory`) connected to Docker via a `docker-socket-proxy` sidecar. The factory has no persistent state on the host; all work goes through GitHub (branches, PRs). Preview stacks are named `mh-preview-{issue}` and run on deterministic ports (`1{NN}33` for frontend, `1{NN}80` for backend).
+
+Claude Code runs inside the factory as a non-root user (`factory`, UID 1000). `--dangerously-skip-permissions` is required and is a built-in safety check that fails if run as root.
+
+Credentials (`ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`) are injected from `.archon/.env`, mounted read-only. They are kept separate from `.env` to avoid mixing AI credentials with database passwords.
+
+## Consequences
+
+- The Docker socket proxy is the security boundary. If the proxy configuration is changed to grant additional permissions (e.g., `EXEC: 1`), the isolation guarantee weakens significantly.
+- The factory can see running containers outside the `mh-preview-*` namespace via the Docker API. This is a known, accepted risk for a trusted internal tool.
+- Preview stacks persist after the factory exits so the human can browse them. They must be torn down manually or via `docker compose --profile factory run --rm dark-factory "Close issue #N"`.
+- Port collisions are possible if two issues share the last two digits. The port scheme (`1{NN}33`) uses the issue number directly; issues > 99 use two-digit truncation of the last two digits.
+- The factory is stateless per run: if interrupted, it can be resumed with `"Continue issue #N"` — Archon reads the existing branch and open PR to reconstruct context.

--- a/Docs/adr/0009-naive-utc-timestamps.md
+++ b/Docs/adr/0009-naive-utc-timestamps.md
@@ -1,0 +1,35 @@
+# ADR-009: Naive UTC Timestamps in the Database
+
+**Date**: 2026-05-28  
+**Status**: Accepted
+
+## Context
+
+PostgreSQL's `TIMESTAMP WITHOUT TIME ZONE` column type stores a bare datetime with no timezone information. SQLAlchemy's `DateTime` column maps to this type by default. Python `datetime` objects can be either timezone-aware (with a `tzinfo`) or timezone-naive.
+
+If a timezone-aware datetime is passed to a `TIMESTAMP WITHOUT TIME ZONE` column, recent versions of SQLAlchemy/psycopg2 raise a warning or error. The historically common workaround was to store naive datetimes and document the convention that all stored values are UTC.
+
+Every `created_at` and `updated_at` column across the MarketHawk models uses this pattern:
+
+```python
+default=lambda: datetime.now(timezone.utc).replace(tzinfo=None)
+```
+
+This generates the correct UTC moment and then strips the timezone annotation before writing to the DB. Reading the value back produces a naive datetime that consumers must know is UTC.
+
+### Why not `TIMESTAMPTZ`?
+
+`TIMESTAMP WITH TIME ZONE` (`TIMESTAMPTZ`) stores an absolute moment in time and always normalises to UTC internally. It removes the ambiguity entirely. Migrating to `TIMESTAMPTZ` would be the correct long-term path and would eliminate the `.replace(tzinfo=None)` discipline requirement. The cost is a column-level migration across all models — mechanical but broad.
+
+At the time the models were written, the naive UTC pattern was the established codebase convention. Changing it mid-build would have required coordinating migrations with active feature work.
+
+## Decision
+
+All `DateTime` columns store naive UTC datetimes. The `.replace(tzinfo=None)` pattern is the project-wide convention for generating these values.
+
+## Consequences
+
+- Any code that reads a `created_at` or `updated_at` value and needs to do timezone-aware arithmetic must manually re-attach UTC: `value.replace(tzinfo=timezone.utc)`.
+- Passing a timezone-aware datetime directly to a model field will either silently strip the timezone (older psycopg2 behaviour) or raise a warning/error depending on SQLAlchemy version. Always strip before writing.
+- If the system is ever extended to support multiple timezones (e.g., per-user display preferences), the naive UTC pattern becomes a liability — all stored times must be re-interpreted as UTC at the application layer.
+- The migration to `TIMESTAMPTZ` columns is the clean long-term fix; it can be done as a targeted Alembic migration with `ALTER TABLE ... ALTER COLUMN ... TYPE TIMESTAMPTZ USING ... AT TIME ZONE 'UTC'`. Until then, the `.replace(tzinfo=None)` pattern must be followed in every new model.

--- a/Docs/adr/template.md
+++ b/Docs/adr/template.md
@@ -1,0 +1,20 @@
+# ADR-NNN: [Title]
+
+**Date**: YYYY-MM-DD  
+**Status**: [Proposed | Accepted | Deprecated | Superseded by ADR-NNN | Pending]  
+**Issue**: [#N — short description](link) _(optional)_
+
+## Context
+
+Why was this decision made? What forces were at play — constraints, options considered, trade-offs evaluated?
+
+## Decision
+
+What was decided, and the key parameters of that decision.
+
+## Consequences
+
+What changes as a result? What new constraints does this introduce? What risks are accepted?
+
+---
+_Note: ADR-001 predates this template and uses an informal prose style. Both formats are valid._


### PR DESCRIPTION
## Summary

- Adds `Docs/adr/template.md`: `Status:` field required; Context/Decision/Consequences sections are optional guidance for longer ADRs
- Writes ADR-004 through ADR-009 documenting the six largest implicit architectural decisions in the codebase
- ADRs 001-003 already existed in `main` (002 from #84, 003 from #87); this PR continues the sequence

| ADR | Decision |
|---|---|
| 004 | Synchronous SQLAlchemy as deliberate short-term choice (asyncpg installed but unused; forward pointer to #103) |
| 005 | JSONB for `indicators`, `criteria_met`, `metadata_` on `scanner_events` — flexibility over queryability |
| 006 | Celery + Redis for background tasks — rejects FastAPI BackgroundTasks (no persistence), Airflow, Prefect (over-engineered) |
| 007 | Live scanner as separate container — IBKR event loop isolation, dedicated clientId 5, Redis pub/sub |
| 008 | Dark Factory trust model — docker-socket-proxy, known container-visibility limitation accepted by convention |
| 009 | Naive UTC timestamps — `.replace(tzinfo=None)` pattern, discipline required, path to TIMESTAMPTZ migration noted |

## Test plan

- [ ] Review each ADR for accuracy against the actual codebase
- [ ] Confirm ADR-004 notes the ARCHITECTURE.md asyncpg/psycopg2 inaccuracy (prose note, not a diagram fix)
- [ ] Confirm ADR-002 (auth) and ADR-003 (rate limiting) are already present in `main` and not duplicated
- [ ] Confirm numbering is contiguous: 001 → 002 → 003 → 004 → 005 → 006 → 007 → 008 → 009

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)