### PR TITLE
feat(tracing): distributed tracing via OpenTelemetry + Jaeger (#103)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,6 +34,8 @@ All services run as Docker containers on the `stockscanner-network` bridge netwo
                          │                                          │
                          │ prometheus:9090 ──scrape──> backend:8000/metrics
                          │ grafana:3001 ──> prometheus:9090         │
+                         │ jaeger:16686/4317 ──OTLP──> backend,     │
+                         │                   celery-worker, beat    │
                          └─────────────────────────────────────────┘
 ```
 
@@ -85,7 +87,7 @@ Domain-typed exceptions raised at service/provider public boundaries so callers 
 | `system_service.py` | `SystemService` — business logic extracted from `routers/system.py`. `get_market_status()` returns the current ET session. `check_ibkr_reachable()` socket probe. `format_bytes()` human-readable size. `get_storage_stats()` per-table PostgreSQL size queries. `get_active_tasks()` async Redis + DB poll for the `/ws/tasks` WebSocket. |
 | `pre_market_scan.py` | Self-registers `"pre_market_volume_spike"` in the orchestrator. Delegates to `ScannerService.run_pre_market_scan` (interim; body inlined in Task 8). |
 | `oversold_bounce_scan.py` | Self-registers `"oversold_bounce"` in the orchestrator. Delegates to `ScannerService.run_oversold_bounce_scan` (interim). |
-| `scanner.py` | `ScannerService` — `calculate_day_metrics()`, `_get_batch_enrichment_data()` (3-tuple with ES/NQ context and sector ETF changes), Phase 2a 19-key feature enrichment. `_save_event()` delegates to `alert_service.save_event`. `run_pre_market_scan`/`run_oversold_bounce_scan` accept optional `scanner_run` param; per-ticker domain failures accumulated into `scanner_run.failed_tickers`. |
+| `scanner.py` | `ScannerService` — `calculate_day_metrics()`, `_get_batch_enrichment_data()` (3-tuple with ES/NQ context and sector ETF changes; emits `scanner.batch_enrichment` OTel span), Phase 2a 19-key feature enrichment. `_save_event()` delegates to `alert_service.save_event`. `run_pre_market_scan`/`run_oversold_bounce_scan` accept optional `scanner_run` param; per-ticker domain failures accumulated into `scanner_run.failed_tickers`. Per-ticker `scanner.evaluate_ticker` OTel spans in `run_pre_market_scan`. |
 | `signal_ranker.py` | Phase 2c signal quality scorer. `compute_signal_quality_score()` — weighted sum of normalized indicators (re-normalizes over present features). `load_ranker_config()` — reads `signal_ranker_enabled`, `signal_ranker_weights`, `signal_ranker_version` from `SystemConfig`. Weights updatable without redeploy. |
 | `stock_data.py` | Historical OHLCV fetch, gap calculation, session flags. `is_futures_ticker()` — asset-class lookup. `get_historical_enriched()` — fetch + Decimal coercion + MAX_DATAPOINTS guard + indicator gating. |
 | `universe_stats.py` | `UniverseStatsService.compute()` — aggregate stats for one universe (ticker count, bar count, date range, timespans) across both StockAggregate and FuturesAggregate. Callable outside HTTP context. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ npm run lint      # ESLint
 | Seq GELF    | udp://localhost:12201         |
 | Prometheus  | http://localhost:9090         |
 | Grafana     | http://localhost:3001         |
+| Jaeger UI   | http://localhost:16686        |
 
 ## Architecture
 

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -103,6 +103,17 @@ Set in the `frontend` service's environment block in `docker-compose.yml`, or in
 
 ---
 
+## Distributed Tracing (OpenTelemetry)
+
+Set on `backend`, `celery-worker`, and `celery-beat` services. When `OTEL_EXPORTER_OTLP_ENDPOINT` is empty the OTel SDK defaults to its built-in no-op tracer — no spans are created and no configuration is required to disable tracing.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `""` (no-op) | OTLP gRPC endpoint for the trace collector. In Docker Compose this is `http://jaeger:4317`. Leave empty in environments without Jaeger. |
+| `OTEL_SERVICE_NAME` | `markethawk` | Service name shown in the Jaeger UI to distinguish API spans (`markethawk-backend`) from worker spans (`markethawk-worker`, `markethawk-beat`). |
+
+---
+
 ## Verification
 
 ```bash

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -18,7 +18,8 @@ MarketHawk/
 │   │   │   ├── config.py               # Settings class; all env vars with typed defaults
 │   │   │   ├── database.py             # Async SQLAlchemy engine and session factory
 │   │   │   ├── celery_app.py           # Celery instance and beat schedule definitions
-│   │   │   └── error_tracking.py       # ErrorTracker protocol; Seq + stdout implementations
+│   │   │   ├── error_tracking.py       # ErrorTracker protocol; Seq + stdout implementations
+│   │   │   └── tracing.py              # OtelTraceIdFilter (log correlation); setup_otel() (TracerProvider init); instrument_fastapi()
 │   │   ├── models/
 │   │   │   ├── active_watchlist.py     # ActiveWatchlist — manually curated live-observation list (soft limit 50)
 │   │   │   ├── scanner_run.py          # ScannerRun — one row per scan execution; failed_tickers JSONB for per-ticker domain failures
@@ -73,7 +74,7 @@ MarketHawk/
 │   │   │   ├── auto_trade_service.py   # AutoTradeExecutor (lifecycle); approve_order, cancel_order, get_account, get_stats
 │   │   │   ├── pre_market_scan.py      # Self-registers "pre_market_volume_spike" in orchestrator
 │   │   │   ├── oversold_bounce_scan.py # Self-registers "oversold_bounce" in orchestrator
-│   │   │   ├── scanner.py              # ScannerService; calculate_day_metrics; _save_event delegates to alert_service.save_event
+│   │   │   ├── scanner.py              # ScannerService; calculate_day_metrics; _save_event delegates to alert_service.save_event; OTel spans: scanner.batch_enrichment, scanner.evaluate_ticker
 │   │   │   ├── discovery_service.py    # Bulk ticker sync from Polygon; rate-limit-aware paging
 │   │   │   ├── catalyst_parser.py      # Batch 72-hour news analysis; returns latest_article_utc for recency enrichment
 │   │   │   ├── futures_data.py         # 2-method public interface: get_continuous_series, sync_contracts; private write-path helpers

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -39,6 +39,13 @@ class Settings(BaseSettings):
     # Set to an empty string or "disabled" to fall back to stdout-only logging.
     SEQ_URL: str = "http://seq:5341"
 
+    # Distributed Tracing (OpenTelemetry)
+    # OTEL_EXPORTER_OTLP_ENDPOINT: OTLP gRPC endpoint (e.g. http://jaeger:4317).
+    # Leave empty to use the OTel no-op tracer (zero overhead, no Jaeger required).
+    OTEL_EXPORTER_OTLP_ENDPOINT: str = ""
+    # OTEL_SERVICE_NAME: identifies this process in Jaeger UI traces.
+    OTEL_SERVICE_NAME: str = "markethawk"
+
     # CORS — JSON array format in .env: CORS_ORIGINS=["http://localhost:3333","https://example.com"]
     CORS_ORIGINS: list[str] = ["http://localhost:3333"]
 

--- a/backend/app/core/tracing.py
+++ b/backend/app/core/tracing.py
@@ -1,0 +1,69 @@
+"""
+OpenTelemetry tracing utilities.
+
+Initialization is conditional on OTEL_EXPORTER_OTLP_ENDPOINT being set.
+When the endpoint is empty the OTel SDK's built-in no-op tracer is used —
+no spans are created, no imports fail, and there is zero overhead.
+"""
+
+import logging
+from typing import Optional
+
+from opentelemetry import trace
+
+
+class OtelTraceIdFilter(logging.Filter):
+    """Injects trace_id and span_id into every log record emitted during a traced operation."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        span = trace.get_current_span()
+        ctx = span.get_span_context()
+        if ctx.is_valid:
+            record.trace_id = format(ctx.trace_id, "032x")
+            record.span_id = format(ctx.span_id, "016x")
+        else:
+            record.trace_id = ""
+            record.span_id = ""
+        return True
+
+
+def setup_otel(endpoint: str, service_name: str, engine: Optional[object]) -> None:
+    """Configure the global OTel TracerProvider.
+
+    When *endpoint* is empty this function returns immediately, leaving the
+    default no-op tracer in place.  Auto-instrumentation for FastAPI,
+    SQLAlchemy, and Celery is applied inline; callers must pass the FastAPI
+    app via ``instrument_app`` after calling this function.
+    """
+    if not endpoint:
+        return
+
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+    from opentelemetry.instrumentation.celery import CeleryInstrumentor
+
+    resource = Resource.create({"service.name": service_name})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(
+        BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint, insecure=True))
+    )
+    trace.set_tracer_provider(provider)
+
+    if engine is not None:
+        SQLAlchemyInstrumentor().instrument(engine=engine)
+
+    CeleryInstrumentor().instrument()
+
+
+def instrument_fastapi(app: object) -> None:
+    """Apply FastAPI auto-instrumentation to *app* (only when OTel is active)."""
+    from opentelemetry.sdk.trace import TracerProvider
+
+    if not isinstance(trace.get_tracer_provider(), TracerProvider):
+        return
+
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+    FastAPIInstrumentor.instrument_app(app)  # type: ignore[arg-type]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,6 +42,7 @@ from app.routers import (
     watchlist_router,
 )
 from app.routers.tweets import router as tweets_router
+from app.core.tracing import OtelTraceIdFilter, instrument_fastapi, setup_otel
 from app.services.websocket_manager import websocket_manager
 
 # Celery Configuration
@@ -146,6 +147,7 @@ def create_app() -> FastAPI:
         level=getattr(logging, settings.LOG_LEVEL),
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
+    logging.getLogger().addFilter(OtelTraceIdFilter())
 
     # Centralized SQL Logging
     # Centralized SQL Logging
@@ -218,6 +220,13 @@ def create_app() -> FastAPI:
         version=settings.APP_VERSION,
         lifespan=lifespan,
     )
+
+    setup_otel(
+        endpoint=settings.OTEL_EXPORTER_OTLP_ENDPOINT,
+        service_name=settings.OTEL_SERVICE_NAME,
+        engine=engine,
+    )
+    instrument_fastapi(app)
 
     EXEMPT_PREFIXES = (
         "/api/auth/",

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -251,6 +251,16 @@ class ScannerService:
 
         Returns a 3-tuple: (ticker_batch_data, market_context_dict, sector_etf_pct_dict)
         """
+        from opentelemetry import trace as _otel_trace
+        _tracer = _otel_trace.get_tracer(__name__)
+        with _tracer.start_as_current_span("scanner.batch_enrichment") as _span:
+            _span.set_attribute("ticker_count", len(tickers))
+            return ScannerService._get_batch_enrichment_data_impl(tickers, event_date, db)
+
+    @staticmethod
+    def _get_batch_enrichment_data_impl(
+        tickers: List[str], event_date: date, db: Session
+    ) -> Tuple[Dict[str, Dict[str, Any]], Dict[str, Any], Dict[str, Optional[float]]]:
         day_start_et = datetime.combine(event_date, datetime.min.time(), tzinfo=_ET)
         day_start_utc = day_start_et.astimezone(timezone.utc).replace(tzinfo=None)
         day_end_utc = (
@@ -509,8 +519,17 @@ class ScannerService:
             ScannerService._get_batch_enrichment_data, tickers, event_date, db
         )
 
+        from opentelemetry import trace as _otel_trace, context as _otel_context
+        _tracer = _otel_trace.get_tracer(__name__)
+
         for ticker in tickers:
+            _ticker_span = _tracer.start_span("scanner.evaluate_ticker")
+            _ticker_token = _otel_context.attach(
+                _otel_trace.set_span_in_context(_ticker_span)
+            )
             try:
+                _ticker_span.set_attribute("ticker", ticker)
+                _ticker_span.set_attribute("scanner_type", "pre_market_volume_spike")
                 daily_bars = (
                     db.query(StockAggregate)
                     .filter(
@@ -782,6 +801,9 @@ class ScannerService:
                         "retryable": e.is_retryable,
                     }
                 )
+            finally:
+                _ticker_span.end()
+                _otel_context.detach(_ticker_token)
 
         if failed and scanner_run is not None:
             scanner_run.failed_tickers = failed

--- a/backend/app/tasks/scanning.py
+++ b/backend/app/tasks/scanning.py
@@ -24,9 +24,11 @@ def evaluate_scanner_alerts(self, scanner_event_id: int):
     For rules with auto_trade=True, queues execute_auto_trade as a follow-up task.
     Called automatically when a new ScannerEvent is created.
     """
+    from opentelemetry import trace as _otel_trace
     from app.models.scanner_event import ScannerEvent
     from app.services.alert_service import AlertRuleService, NotificationDispatcher
 
+    _tracer = _otel_trace.get_tracer(__name__)
     _task_name = "evaluate_scanner_alerts"
     _start = _time.monotonic()
     db: Session = SessionLocal()
@@ -40,7 +42,11 @@ def evaluate_scanner_alerts(self, scanner_event_id: int):
             )
             return
 
-        matching_rules = AlertRuleService.get_matching_rules(event, db)
+        with _tracer.start_as_current_span("alerts.evaluate") as _eval_span:
+            _eval_span.set_attribute("event_id", scanner_event_id)
+            matching_rules = AlertRuleService.get_matching_rules(event, db)
+            _eval_span.set_attribute("rules_matched", len(matching_rules))
+
         if not matching_rules:
             return
 
@@ -49,26 +55,29 @@ def evaluate_scanner_alerts(self, scanner_event_id: int):
             f"event={scanner_event_id} ticker={event.ticker} type={event.scanner_type}"
         )
 
-        for rule in matching_rules:
-            # Notification dispatch
-            try:
-                NotificationDispatcher.dispatch(rule, event, db)
-            except Exception as exc:
-                logger.error(f"❌ Dispatch failed for rule {rule.id}: {exc}")
+        with _tracer.start_as_current_span("alerts.dispatch") as _dispatch_span:
+            _dispatch_span.set_attribute("event_id", scanner_event_id)
+            _dispatch_span.set_attribute("rules_matched", len(matching_rules))
+            for rule in matching_rules:
+                # Notification dispatch
+                try:
+                    NotificationDispatcher.dispatch(rule, event, db)
+                except Exception as exc:
+                    logger.error(f"❌ Dispatch failed for rule {rule.id}: {exc}")
 
-            # Auto-trade: queue a separate task so notification failures
-            # never block order placement, and vice versa.
-            if rule.auto_trade and rule.trading_strategy_id:
-                from app.tasks.trading import execute_auto_trade
+                # Auto-trade: queue a separate task so notification failures
+                # never block order placement, and vice versa.
+                if rule.auto_trade and rule.trading_strategy_id:
+                    from app.tasks.trading import execute_auto_trade
 
-                execute_auto_trade.delay(
-                    rule_id=rule.id,
-                    scanner_event_id=scanner_event_id,
-                )
-                logger.info(
-                    f"🤖 Auto-trade queued for rule={rule.id} "
-                    f"strategy={rule.trading_strategy_id} ticker={event.ticker}"
-                )
+                    execute_auto_trade.delay(
+                        rule_id=rule.id,
+                        scanner_event_id=scanner_event_id,
+                    )
+                    logger.info(
+                        f"🤖 Auto-trade queued for rule={rule.id} "
+                        f"strategy={rule.trading_strategy_id} ticker={event.ticker}"
+                    )
 
         celery_tasks_total.labels(task_name=_task_name, status="success").inc()
     except Exception as e:
@@ -313,11 +322,21 @@ def run_universe_scan(
     from datetime import date as _date
     from datetime import timedelta as _td
 
+    from opentelemetry import context as _otel_context
+    from opentelemetry import trace as _otel_trace
+
     import app.services.liquidity_hunt  # noqa: F401
     import app.services.oversold_bounce_scan  # noqa: F401
     import app.services.pre_market_scan  # noqa: F401 — triggers self-registration
     import app.services.scan_orchestrator as _orchestrator
     from app.models.scanner_run import ScannerRun
+
+    _tracer = _otel_trace.get_tracer(__name__)
+    _root_span = _tracer.start_span("scanner.universe_scan")
+    _root_token = _otel_context.attach(_otel_trace.set_span_in_context(_root_span))
+    _root_span.set_attribute("scan_id", scan_id)
+    _root_span.set_attribute("universe_id", universe_id)
+    _root_span.set_attribute("scanner_type", scanner_type)
 
     _task_name = "run_universe_scan"
     _perf_start = _time.monotonic()
@@ -546,3 +565,5 @@ def run_universe_scan(
         except Exception:
             pass
         db.close()
+        _root_span.end()
+        _otel_context.detach(_root_token)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -54,3 +54,11 @@ bcrypt==5.0.0
 
 # Metrics
 prometheus-client==0.21.1
+
+# Distributed Tracing (OpenTelemetry)
+opentelemetry-api==1.42.1
+opentelemetry-sdk==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-instrumentation-fastapi==0.63b1
+opentelemetry-instrumentation-sqlalchemy==0.63b1
+opentelemetry-instrumentation-celery==0.63b1

--- a/backend/tests/core/test_tracing.py
+++ b/backend/tests/core/test_tracing.py
@@ -1,0 +1,76 @@
+"""Unit tests for OpenTelemetry tracing utilities."""
+import logging
+
+
+def test_otel_config_defaults():
+    from app.core.config import settings
+    assert settings.OTEL_EXPORTER_OTLP_ENDPOINT == ""
+    assert settings.OTEL_SERVICE_NAME == "markethawk"
+
+
+def test_otel_trace_id_filter_no_active_span():
+    """Filter produces empty trace_id/span_id when no OTel span is active."""
+    from app.core.tracing import OtelTraceIdFilter
+
+    f = OtelTraceIdFilter()
+    record = logging.LogRecord(
+        name="test", level=logging.INFO, pathname="", lineno=0,
+        msg="hello", args=(), exc_info=None,
+    )
+    result = f.filter(record)
+    assert result is True
+    assert record.trace_id == ""
+    assert record.span_id == ""
+
+
+def test_otel_trace_id_filter_with_active_span():
+    """Filter populates trace_id/span_id fields when a span is active."""
+    from app.core.tracing import OtelTraceIdFilter
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+
+    provider = TracerProvider()
+    tracer = provider.get_tracer("test")
+
+    f = OtelTraceIdFilter()
+    with tracer.start_as_current_span("test-span"):
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="hello", args=(), exc_info=None,
+        )
+        result = f.filter(record)
+
+    assert result is True
+    assert len(record.trace_id) == 32
+    assert len(record.span_id) == 16
+
+
+def test_setup_otel_noop_when_endpoint_empty(monkeypatch):
+    """_setup_otel() is a no-op when OTEL_EXPORTER_OTLP_ENDPOINT is empty."""
+    from opentelemetry import trace as otel_trace
+    from app.core.tracing import setup_otel
+
+    setup_otel(endpoint="", service_name="test", engine=None)
+    # The global tracer provider should remain the default (ProxyTracerProvider or NoOpTracerProvider)
+    provider = otel_trace.get_tracer_provider()
+    # Just verify we can get a tracer without error and it's not an SDK TracerProvider
+    from opentelemetry.sdk.trace import TracerProvider as SDKProvider
+    assert not isinstance(provider, SDKProvider)
+
+
+def test_setup_otel_registers_sdk_provider(monkeypatch):
+    """_setup_otel() registers an SDK TracerProvider when endpoint is set."""
+    from opentelemetry import trace as otel_trace
+    from opentelemetry.sdk.trace import TracerProvider as SDKProvider
+    from app.core.tracing import setup_otel
+
+    # Use a fake endpoint — we don't actually connect
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://fake-jaeger:4317")
+
+    setup_otel(endpoint="http://fake-jaeger:4317", service_name="test-svc", engine=None)
+    provider = otel_trace.get_tracer_provider()
+    assert isinstance(provider, SDKProvider)
+
+    # Restore default provider so other tests are not affected
+    from opentelemetry.trace import ProxyTracerProvider
+    otel_trace._TRACER_PROVIDER = None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,8 @@ services:
       SMTP_PASSWORD: ${SMTP_PASSWORD}
       SMTP_FROM_EMAIL: ${SMTP_FROM_EMAIL}
       PROMETHEUS_MULTIPROC_DIR: /tmp/prometheus_multiproc
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+      OTEL_SERVICE_NAME: markethawk-backend
     ports:
       - "8000:8000"
     depends_on:
@@ -178,6 +180,8 @@ services:
       SMTP_PASSWORD: ${SMTP_PASSWORD}
       SMTP_FROM_EMAIL: ${SMTP_FROM_EMAIL}
       PROMETHEUS_MULTIPROC_DIR: /tmp/prometheus_multiproc
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+      OTEL_SERVICE_NAME: markethawk-worker
     depends_on:
       postgres:
         condition: service_healthy
@@ -246,6 +250,8 @@ services:
       SEQ_URL: http://seq:5341
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       PYTHONDONTWRITEBYTECODE: "1"
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+      OTEL_SERVICE_NAME: markethawk-beat
     depends_on:
       postgres:
         condition: service_healthy
@@ -486,6 +492,19 @@ services:
       resources:
         limits:
           memory: 1G
+
+  # Distributed Tracing — Jaeger all-in-one
+  jaeger:
+    image: jaegertracing/all-in-one:1.57
+    container_name: markethawk-jaeger
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:16686:16686"   # Jaeger UI
+      - "4317:4317"                # OTLP gRPC receiver
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    networks:
+      - stockscanner-network
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary

- Adds OpenTelemetry distributed tracing to `backend`, `celery-worker`, and `celery-beat`
- Auto-instruments FastAPI routes, SQLAlchemy queries, and Celery task dispatch/execution
- Four targeted manual spans: `scanner.universe_scan`, `scanner.evaluate_ticker` (per-ticker), `scanner.batch_enrichment`, `alerts.evaluate` + `alerts.dispatch`
- Injects `trace_id`/`span_id` into every Seq log record via `OtelTraceIdFilter` for log↔trace correlation
- Adds Jaeger all-in-one container (UI at http://localhost:16686); tracing is a zero-cost no-op when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset

Closes #103

## Test plan

- [x] 5 new unit tests in `tests/core/test_tracing.py` (OtelTraceIdFilter, setup_otel no-op, setup_otel SDK registration)
- [x] Full test suite: 637 passed, 1 skipped, 0 failures
- [ ] Smoke-test Jaeger UI: `docker compose up -d jaeger && docker compose restart backend celery-worker celery-beat`, trigger a scan, open http://localhost:16686 and search for service `markethawk-backend`
- [ ] Verify log correlation: Seq log entries during a scan should carry `trace_id` field matching Jaeger span IDs
- [ ] Verify no-op: set `OTEL_EXPORTER_OTLP_ENDPOINT=""` in `.env`, restart — no errors, no Jaeger dependency

## Files changed

| File | Change |
|------|--------|
| `backend/app/core/tracing.py` | New — OtelTraceIdFilter, setup_otel(), instrument_fastapi() |
| `backend/requirements.txt` | +6 OTel packages |
| `backend/app/core/config.py` | +OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_SERVICE_NAME |
| `backend/app/main.py` | Wire tracing init into create_app() |
| `backend/app/services/scanner.py` | +batch_enrichment span, +per-ticker evaluate_ticker span |
| `backend/app/tasks/scanning.py` | +universe_scan root span, +alerts.evaluate/dispatch spans |
| `docker-compose.yml` | +Jaeger service; +OTel env vars on backend/worker/beat |
| `ENV_VARIABLES.md` | +Distributed Tracing section |
| `CLAUDE.md` | +Jaeger UI port |

🤖 Generated with [Claude Code](https://claude.com/claude-code)