### PR TITLE
feat(api): add URL prefix versioning — /api/v1/ for all application routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -151,6 +151,13 @@ BROWSER_MAX_MEMORY_MB=512
 POLL_TIMEOUT_SECONDS=25
 
 # =============================================================================
+# OPTIONAL: Frontend API Base URL
+# =============================================================================
+# Overrides the default versioned API base used by the React frontend.
+# Default: /api/v1 (versioned — leave unset unless you have a specific reason)
+# VITE_API_BASE_URL=/api/v1
+
+# =============================================================================
 # Monitoring (Grafana)
 # =============================================================================
 # Admin password for the Grafana UI (http://localhost:3001, login: admin).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,7 +9,7 @@ All services run as Docker containers on the `stockscanner-network` bridge netwo
                          │          stockscanner-network            │
                          │                                          │
   Browser ──HTTP:3000──> │ frontend ──HTTP──> backend:8000          │
-                         │   │ WS:3000/api/live/ws/*                │
+                         │   │ WS:3000/api/v1/live/ws/*             │
                          │                       │                  │
                          │                  asyncpg ──> postgres:5432
                          │                  aioredis ──> redis:6379  │
@@ -41,7 +41,7 @@ All services run as Docker containers on the `stockscanner-network` bridge netwo
 
 A full pre-market scan proceeds as follows:
 
-1. **Trigger** — Celery Beat fires `run_scanner` at a scheduled time, or a user POSTs to `/api/scanner/run`.
+1. **Trigger** — Celery Beat fires `run_scanner` at a scheduled time, or a user POSTs to `/api/v1/scanner/run`.
 2. **Session classification** — `ScannerService.calculate_day_metrics()` (`services/scanner.py`) determines the active market session (pre-market 04:00–09:30, regular, post-market) using `ZoneInfo("America/New_York")`, then maps session boundaries to UTC for database queries.
 3. **Ticker list** — The service resolves the universe's ticker list from `StockUniverseTicker` records.
 4. **Parallel data fetch** — Tickers are fetched from Polygon in batches. An `asyncio.Semaphore(10)` bounds concurrency to 10 in-flight requests; `asyncio.gather()` parallelises within that bound.
@@ -49,7 +49,7 @@ A full pre-market scan proceeds as follows:
 6. **News catalyst analysis** — `CatalystParser.analyze_batch()` (`services/catalyst_parser.py`) queries the `NewsArticle` table once for a 72-hour window covering all tickers, then matches articles to tickers in memory.
 7. **Criteria evaluation** — Each ticker is evaluated against the five scanner criteria (see README). Passing tickers produce `ScannerEvent` records.
 8. **Persistence** — A `ScannerRun` row is written with metadata; `ScannerEvent` rows are written for each hit.
-9. **Delivery** — The frontend polls `/api/scanner/results` via React Query. Live pushes are broadcast through `services/websocket_manager.py`.
+9. **Delivery** — The frontend polls `/api/v1/scanner/results` via React Query. Live pushes are broadcast through `services/websocket_manager.py`.
 
 ## Backend Module Map
 
@@ -80,7 +80,7 @@ Domain-typed exceptions raised at service/provider public boundaries so callers 
 
 | File | Responsibility |
 |------|---------------|
-| `scan_orchestrator.py` | Scanner registry and orchestrator. `ScannerDescriptor` frozen dataclass; `_REGISTRY` populated via `register()` at import time. `run(scanner_type, tickers, db, event_date)` is the single dispatch entry point from `tasks/scanning.py`. `get_all()` enumerates entries for `GET /api/scanner/types`. `compute_next_run(scanner_type)` returns next scheduled fire time. `get_scan_progress(redis_url, universe_id, scanner_type)` reads Redis progress state. `request_scan_cancel(redis_url, scan_id)` sets Redis cancel flag. `enqueue_scan(db, request)` creates `ScannerRun` row and dispatches Celery task. |
+| `scan_orchestrator.py` | Scanner registry and orchestrator. `ScannerDescriptor` frozen dataclass; `_REGISTRY` populated via `register()` at import time. `run(scanner_type, tickers, db, event_date)` is the single dispatch entry point from `tasks/scanning.py`. `get_all()` enumerates entries for `GET /api/v1/scanner/types`. `compute_next_run(scanner_type)` returns next scheduled fire time. `get_scan_progress(redis_url, universe_id, scanner_type)` reads Redis progress state. `request_scan_cancel(redis_url, scan_id)` sets Redis cancel flag. `enqueue_scan(db, request)` creates `ScannerRun` row and dispatches Celery task. |
 | `scanner_query_service.py` | `ScannerQueryService` — DB aggregation queries extracted from `routers/scanner.py`. `get_scan_status_block()` builds the Scan Status card payload. `get_signal_quality_distribution()` computes decile outcome stats. `get_review_stats()` aggregates signal review coverage, acceptance rate, and rejection reasons. |
 | `system_service.py` | `SystemService` — business logic extracted from `routers/system.py`. `get_market_status()` returns the current ET session. `check_ibkr_reachable()` socket probe. `format_bytes()` human-readable size. `get_storage_stats()` per-table PostgreSQL size queries. `get_active_tasks()` async Redis + DB poll for the `/ws/tasks` WebSocket. |
 | `pre_market_scan.py` | Self-registers `"pre_market_volume_spike"` in the orchestrator. Delegates to `ScannerService.run_pre_market_scan` (interim; body inlined in Task 8). |
@@ -117,18 +117,18 @@ Domain-typed exceptions raised at service/provider public boundaries so callers 
 | File | Endpoints |
 |------|-----------|
 | `auth.py` | `GET /api/auth/status` (bootstrap check), `POST /api/auth/register` (first-user only), `POST /api/auth/login` (sets HttpOnly JWT cookies), `POST /api/auth/logout`, `POST /api/auth/refresh`, `GET /api/auth/me` |
-| `scanner.py` | `/api/scanner/run`, `/api/scanner/results` (eager-loads reviews, default sort: `signal_quality_score DESC`; supports `start_date`/`end_date` filters), `/api/scanner/history`, `/api/scanner/signal-quality-distribution`, `POST /api/scanner/events/{uuid}/review` (submit verdict), `GET /api/scanner/events/reviews?scanner_type=` (list with `liquidity_hunt` alias), `GET /api/scanner/reviews/stats` (coverage, acceptance rate, by-type breakdown) |
-| `universe.py` | `/api/universe/*` — CRUD for stock universes and memberships |
-| `stocks.py` | `/api/stocks/*` — historical data, ticker search, stock details |
-| `news.py` | `/api/news/*` — news articles and preferences |
-| `live_data.py` | `/api/live/ws/{ticker}/{resolution}` — per-symbol WebSocket; `/api/live/ws/watchlist` — watchlist-wide WebSocket (all symbols + alerts) |
-| `futures.py` | `/api/futures/*` — `GET /history/{symbol}`, `GET /contracts/{symbol}`, `GET /rollovers/{symbol}`, `POST /download/{symbol}` (catalog refresh), `GET /providers` |
-| `journal.py` | `/api/journal/*` — trade journal entries |
-| `watchlist.py` | `/api/watchlist/*` — active watchlist CRUD (list, add, update notes, remove) |
-| `health.py` | `GET /health` — liveness probe |
-| `system.py` | `/api/system/*` — configuration, status |
-| `outcomes.py` | `/api/outcomes/*` — scorecard, intervals, distribution, edge decay, signals, event detail, backfill; `POST /analyze` (trigger analysis), `GET /correlations`, `GET /analysis/latest` |
-| `tweets.py` | `GET /api/tweets/recent` — recent TweetSignals (filter by classification/promoted); `WS /api/tweets/feed` — live WebSocket stream of all new tweet signals from Redis `tweet_signals:all` channel |
+| `scanner.py` | `/api/v1/scanner/run`, `/api/v1/scanner/results` (eager-loads reviews, default sort: `signal_quality_score DESC`; supports `start_date`/`end_date` filters), `/api/v1/scanner/history`, `/api/v1/scanner/signal-quality-distribution`, `POST /api/v1/scanner/events/{uuid}/review` (submit verdict), `GET /api/v1/scanner/events/reviews?scanner_type=` (list with `liquidity_hunt` alias), `GET /api/v1/scanner/reviews/stats` (coverage, acceptance rate, by-type breakdown) |
+| `universe.py` | `/api/v1/universe/*` — CRUD for stock universes and memberships |
+| `stocks.py` | `/api/v1/stocks/*` — historical data, ticker search, stock details |
+| `news.py` | `/api/v1/news/*` — news articles and preferences |
+| `live_data.py` | `/api/v1/live/ws/{ticker}/{resolution}` — per-symbol WebSocket; `/api/v1/live/ws/watchlist` — watchlist-wide WebSocket (all symbols + alerts) |
+| `futures.py` | `/api/v1/futures/*` — `GET /history/{symbol}`, `GET /contracts/{symbol}`, `GET /rollovers/{symbol}`, `POST /download/{symbol}` (catalog refresh), `GET /providers` |
+| `journal.py` | `/api/v1/journal/*` — trade journal entries |
+| `watchlist.py` | `/api/v1/watchlist/*` — active watchlist CRUD (list, add, update notes, remove) |
+| `health.py` | `GET /api/health` — liveness probe (unversioned; consumed by Docker and monitoring tools) |
+| `system.py` | `/api/v1/system/*` — configuration, status |
+| `outcomes.py` | `/api/v1/outcomes/*` — scorecard, intervals, distribution, edge decay, signals, event detail, backfill; `POST /analyze` (trigger analysis), `GET /correlations`, `GET /analysis/latest` |
+| `tweets.py` | `GET /api/v1/tweets/recent` — recent TweetSignals (filter by classification/promoted); `WS /api/v1/tweets/feed` — live WebSocket stream of all new tweet signals from Redis `tweet_signals:all` channel |
 
 ### Database Models (`app/models/`)
 
@@ -270,7 +270,7 @@ IB Gateway
                                       └── publish → Redis watchlist:alerts {"type":"alert"}
 
 Redis pub/sub
-  └── FastAPI /api/live/ws/watchlist (subscribes to watchlist:live_data + watchlist:alerts)
+  └── FastAPI /api/v1/live/ws/watchlist (subscribes to watchlist:live_data + watchlist:alerts)
         └── WebSocket → Browser (ActiveWatchlist page)
 ```
 
@@ -308,16 +308,16 @@ Defined in `app/tasks/` (package), scheduled via `app/core/celery_app.py`. All t
 | `sync.py` | `sync_stock_splits` | Beat (01:00 UTC daily) | Fetch 180-day splits from Polygon and apply adjustments |
 | `sync.py` | `poll_massive_news` | Beat (weekdays) | Poll Polygon news API per tracked tickers/universes |
 | `sync.py` | `trigger_tweet_monitor` | Beat (every 45s) | HTTP trigger for tweet-monitor microservice |
-| `scanning.py` | `run_universe_scan` | On-demand via `POST /api/scanner/runs` | Full universe scan over a date range with Redis progress |
-| `scanning.py` | `run_range_scan` | On-demand via `POST /api/scanner/scan` | Single-ticker scan over a date range |
+| `scanning.py` | `run_universe_scan` | On-demand via `POST /api/v1/scanner/runs` | Full universe scan over a date range with Redis progress |
+| `scanning.py` | `run_range_scan` | On-demand via `POST /api/v1/scanner/scan` | Single-ticker scan over a date range |
 | `scanning.py` | `run_liquidity_hunt_scheduled` | Beat (02:00 UTC weekdays) | Nightly liquidity-hunt scan over all active configs |
 | `scanning.py` | `evaluate_scanner_alerts` | On scanner event create | Match alert rules; dispatch notifications; queue auto-trade |
 | `trading.py` | `execute_auto_trade` | Queued by `evaluate_scanner_alerts` | Run AutoTradeExecutor for a matched rule/event pair |
-| `trading.py` | `submit_approved_order` | On-demand via `POST /api/auto-trading/orders/{id}/approve` | Submit a pending AutoTradeOrder to IBKR |
+| `trading.py` | `submit_approved_order` | On-demand via `POST /api/v1/trading/orders/{id}/approve` | Submit a pending AutoTradeOrder to IBKR |
 | `trading.py` | `poll_auto_trade_fills` | Beat (every minute, weekdays 09–23 UTC) | Poll IBKR fills; simulate paper exits; update Trade records |
-| `quality.py` | `analyze_universe_quality` | On-demand via `POST /api/universe/{id}/quality` | Run data-quality analysis and persist grade/score |
-| `quality.py` | `normalize_universe_quality` | On-demand via `POST /api/universe/{id}/normalize` | Fix data gaps/duplicates and re-run quality analysis |
-| `quality.py` | `analyze_signal_features` | Beat (11:00 UTC weekdays) / on-demand via `POST /api/outcomes/analyze` | Statistical discovery: correlation, SHAP, K-means clustering. Requires ≥500 complete events. |
+| `quality.py` | `analyze_universe_quality` | On-demand via `POST /api/v1/universe/{id}/quality` | Run data-quality analysis and persist grade/score |
+| `quality.py` | `normalize_universe_quality` | On-demand via `POST /api/v1/universe/{id}/normalize` | Fix data gaps/duplicates and re-run quality analysis |
+| `quality.py` | `analyze_signal_features` | Beat (11:00 UTC weekdays) / on-demand via `POST /api/v1/outcomes/analyze` | Statistical discovery: correlation, SHAP, K-means clustering. Requires ≥500 complete events. |
 
 Redis is used as both the Celery broker and result backend. Worker and beat run as separate containers so the scheduler doesn't compete with task execution.
 
@@ -424,7 +424,7 @@ Four pre-provisioned dashboards load automatically from the `grafana/provisionin
 - **Celery Tasks** — success/failure rates and P95 duration per task
 - **Infrastructure** — IBKR status, DB pool utilization, WebSocket count
 
-Alerting rules (`grafana/provisioning/alerting/rules.yaml`) fire when IBKR disconnects for >2 min, Celery failure rate exceeds 10%, DB pool overflows, or HTTP 5xx rate spikes. Alerts POST to `backend:8000/api/alerts/infrastructure`.
+Alerting rules (`grafana/provisioning/alerting/rules.yaml`) fire when IBKR disconnects for >2 min, Celery failure rate exceeds 10%, DB pool overflows, or HTTP 5xx rate spikes. Alerts POST to `backend:8000/api/v1/alerts/infrastructure`.
 
 ## Test Architecture
 

--- a/Docs/adr/0010-api-versioning-policy.md
+++ b/Docs/adr/0010-api-versioning-policy.md
@@ -1,0 +1,50 @@
+# ADR-010: API Versioning Policy
+
+**Date**: 2026-05-29  
+**Status**: Accepted  
+**Issue**: [#105 — Add API versioning](https://github.com/omniscient/markethawk/issues/105)
+
+## Context
+
+All API endpoints were served at `/api/{resource}` with no version prefix. Any breaking change — renamed fields, removed endpoints, changed response shapes — would affect all clients simultaneously with no migration path.
+
+The only current consumer is the React frontend. No external third-party clients exist.
+
+Three versioning strategies were considered:
+
+- **URL prefix** (`/api/v1/`) — visible, cache-friendly, works natively with FastAPI's router model
+- **Header-based** (`Accept-Version: v1`) — cleaner URLs but adds middleware complexity; worth it only when third-party clients need stable-looking URLs
+- **Query parameter** (`?version=1`) — least standard, poorest cache behaviour
+
+## Decision
+
+**URL prefix versioning** at `/api/v1/{resource}`.
+
+All 13 application routers move from `/api/{resource}` to `/api/v1/{resource}` in a single hard-cut change. Auth (`/api/auth`) and health (`/api/health`) are explicitly excluded from versioning:
+
+- **Auth** is infrastructure, not a versioned resource. Tokens must work across all API versions. A `/api/v1/auth` prefix would raise the question "do I need a v2 token for v2 endpoints?" Keeping auth unversioned avoids this permanently.
+- **Health** is a platform contract consumed by Docker, load-balancers, and monitoring tools. It must remain stable regardless of API version evolution.
+
+No backward-compatibility redirect layer is introduced. The only consumer (the React frontend) is updated in the same change. Dual routing would leave dead code with no runtime benefit.
+
+### Versioning policy
+
+| Trigger | Action |
+|---|---|
+| Additive change (new field, new endpoint) | No version bump — v1 stays current |
+| Breaking change (renamed/removed field, changed response shape, removed endpoint) | Introduce `/api/v2/` alongside v1 |
+| v1 sunset after v2 ships | 90-day deprecation window; `Sunset` response header on v1 endpoints during that period |
+
+A breaking change is defined as any change that would require a client code update to continue working correctly.
+
+### Sunset mechanism (deferred)
+
+The `Sunset` header middleware described in issue #105 is deferred to the PR that introduces `/api/v2/`. Shipping it now would deploy code with no runtime effect — no old routes exist to sunset.
+
+## Consequences
+
+- All versioned API calls go to `/api/v1/{resource}`. Frontend `VITE_API_BASE_URL` defaults to `/api/v1`.
+- Auth endpoints remain at `/api/auth/` and use a dedicated `unversionedClient` in the frontend.
+- WebSocket endpoints version together with their REST siblings (`/api/v1/live/ws/`, `/api/v1/scanner/ws/`, `/api/v1/system/ws/`).
+- Future breaking changes require introducing `/api/v2/` and running both versions in parallel for 90 days before removing v1.
+- The `EXEMPT_PREFIXES` list in `main.py` requires no changes — auth and health middleware exemptions remain at their current paths.

--- a/backend/app/routers/alerts.py
+++ b/backend/app/routers/alerts.py
@@ -16,7 +16,7 @@ from app.models.alert_rule import AlertRule
 from app.models.push_subscription import PushSubscription
 from app.models.scanner_event import ScannerEvent
 
-router = APIRouter(prefix="/api/alerts", tags=["alerts"])
+router = APIRouter(prefix="/api/v1/alerts", tags=["alerts"])
 logger = logging.getLogger(__name__)
 
 

--- a/backend/app/routers/auto_trading.py
+++ b/backend/app/routers/auto_trading.py
@@ -43,7 +43,7 @@ from app.services.auto_trade_service import (
     get_stats,
 )
 
-router = APIRouter(prefix="/api/trading", tags=["auto-trading"])
+router = APIRouter(prefix="/api/v1/trading", tags=["auto-trading"])
 logger = logging.getLogger(__name__)
 
 

--- a/backend/app/routers/futures.py
+++ b/backend/app/routers/futures.py
@@ -19,7 +19,7 @@ from app.providers import DataProviderFactory
 from app.services.futures_data import FuturesDataService
 
 logger = logging.getLogger(__name__)
-router = APIRouter(prefix="/api/futures", tags=["futures"])
+router = APIRouter(prefix="/api/v1/futures", tags=["futures"])
 
 
 @router.get("/history/{symbol}")

--- a/backend/app/routers/journal.py
+++ b/backend/app/routers/journal.py
@@ -16,7 +16,7 @@ from app.schemas.journal import (
 )
 from app.services import journal_service
 
-router = APIRouter(prefix="/api/journal", tags=["Journal"])
+router = APIRouter(prefix="/api/v1/journal", tags=["Journal"])
 
 
 @router.get("/trades", response_model=List[TradeSchema])

--- a/backend/app/routers/live_data.py
+++ b/backend/app/routers/live_data.py
@@ -12,7 +12,7 @@ from app.services.websocket_manager import websocket_manager
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/live", tags=["live"])
+router = APIRouter(prefix="/api/v1/live", tags=["live"])
 
 
 @router.websocket("/ws/{ticker}/{resolution}")

--- a/backend/app/routers/news.py
+++ b/backend/app/routers/news.py
@@ -16,7 +16,7 @@ from app.schemas.news_preference import (
     NewsPreferenceUpdate,
 )
 
-router = APIRouter(prefix="/api/news", tags=["news"])
+router = APIRouter(prefix="/api/v1/news", tags=["news"])
 
 
 @router.get("/preferences", response_model=NewsPreferenceResponse)

--- a/backend/app/routers/outcomes.py
+++ b/backend/app/routers/outcomes.py
@@ -33,7 +33,7 @@ from app.services.data_readiness import DataReadinessService
 from app.services.outcome_service import OutcomeService
 from app.services.stats import StatsService
 
-router = APIRouter(prefix="/api/outcomes", tags=["outcomes"])
+router = APIRouter(prefix="/api/v1/outcomes", tags=["outcomes"])
 
 
 @router.get("/scorecard")

--- a/backend/app/routers/scanner.py
+++ b/backend/app/routers/scanner.py
@@ -46,7 +46,7 @@ from app.services.scanner import ScannerService
 from app.services.scanner_query_service import ScannerQueryService
 from app.utils.session import get_market_today
 
-router = APIRouter(prefix="/api/scanner", tags=["scanner"])
+router = APIRouter(prefix="/api/v1/scanner", tags=["scanner"])
 
 
 def _last_completed_weekday() -> "date":

--- a/backend/app/routers/stocks.py
+++ b/backend/app/routers/stocks.py
@@ -15,7 +15,7 @@ from app.exceptions import DataFetchError
 from app.services import StockDataService
 from app.utils.session import get_market_today
 
-router = APIRouter(prefix="/api/stocks", tags=["stocks"])
+router = APIRouter(prefix="/api/v1/stocks", tags=["stocks"])
 
 
 @router.get("/historical/{ticker}")

--- a/backend/app/routers/system.py
+++ b/backend/app/routers/system.py
@@ -16,7 +16,7 @@ from app.core.rate_limits import limiter
 from app.models.system_config import SystemConfig
 from app.services.system_service import SystemService
 
-router = APIRouter(prefix="/api/system", tags=["system"])
+router = APIRouter(prefix="/api/v1/system", tags=["system"])
 logger = logging.getLogger(__name__)
 
 

--- a/backend/app/routers/tweets.py
+++ b/backend/app/routers/tweets.py
@@ -21,7 +21,7 @@ from app.models.tweet_signal import TweetSignal
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/tweets", tags=["tweets"])
+router = APIRouter(prefix="/api/v1/tweets", tags=["tweets"])
 
 
 @router.websocket("/feed")

--- a/backend/app/routers/universe.py
+++ b/backend/app/routers/universe.py
@@ -25,7 +25,7 @@ from app.services import universe_export, universe_orchestrator
 from app.services.discovery_service import DiscoveryService
 from app.services.universe_stats import UniverseStatsService
 
-router = APIRouter(prefix="/api/universe", tags=["universe"])
+router = APIRouter(prefix="/api/v1/universe", tags=["universe"])
 
 
 class ExportAggregatesRequest(BaseModel):

--- a/backend/app/routers/watchlist.py
+++ b/backend/app/routers/watchlist.py
@@ -17,7 +17,7 @@ from app.schemas.active_watchlist import (
 )
 
 logger = logging.getLogger(__name__)
-router = APIRouter(prefix="/api/watchlist", tags=["watchlist"])
+router = APIRouter(prefix="/api/v1/watchlist", tags=["watchlist"])
 
 
 @router.get("/", response_model=List[ActiveWatchlistItem])

--- a/backend/tests/api/test_alerts.py
+++ b/backend/tests/api/test_alerts.py
@@ -19,7 +19,7 @@ client = TestClient(app)
 
 
 def test_stats_returns_correct_shape(db: Session):
-    response = client.get("/api/alerts/stats")
+    response = client.get("/api/v1/alerts/stats")
 
     assert response.status_code == 200
     data = response.json()
@@ -36,7 +36,7 @@ def test_stats_returns_correct_shape(db: Session):
 def test_stats_counts_active_rules(db: Session):
     seed_alert_rules(db)  # 3 active, 1 inactive
 
-    response = client.get("/api/alerts/stats")
+    response = client.get("/api/v1/alerts/stats")
 
     data = response.json()
     assert data["active_rules"] == 3
@@ -47,7 +47,7 @@ def test_stats_delivery_rate_reflects_sent_vs_failed(db: Session):
     rules = seed_alert_rules(db)
     seed_alert_delivery_logs(db, rules)  # 4 sent, 2 failed out of 6 total
 
-    response = client.get("/api/alerts/stats")
+    response = client.get("/api/v1/alerts/stats")
 
     data = response.json()
     # 4 sent / 6 total = 66.7%
@@ -55,7 +55,7 @@ def test_stats_delivery_rate_reflects_sent_vs_failed(db: Session):
 
 
 def test_stats_empty_db_returns_100_delivery_rate(db: Session):
-    response = client.get("/api/alerts/stats")
+    response = client.get("/api/v1/alerts/stats")
 
     assert response.status_code == 200
     assert response.json()["delivery_rate"] == 100.0
@@ -69,7 +69,7 @@ def test_stats_empty_db_returns_100_delivery_rate(db: Session):
 def test_list_rules_returns_all_rules(db: Session):
     seed_alert_rules(db)
 
-    response = client.get("/api/alerts/rules")
+    response = client.get("/api/v1/alerts/rules")
 
     assert response.status_code == 200
     data = response.json()
@@ -80,7 +80,7 @@ def test_list_rules_returns_all_rules(db: Session):
 
 
 def test_list_rules_empty_returns_empty_list(db: Session):
-    response = client.get("/api/alerts/rules")
+    response = client.get("/api/v1/alerts/rules")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -89,7 +89,7 @@ def test_list_rules_empty_returns_empty_list(db: Session):
 def test_list_rules_response_shape(db: Session):
     seed_alert_rules(db)
 
-    response = client.get("/api/alerts/rules")
+    response = client.get("/api/v1/alerts/rules")
 
     assert response.status_code == 200
     rule = response.json()[0]
@@ -112,7 +112,7 @@ def test_list_rules_ordered_newest_first(db: Session):
     rules = seed_alert_rules(db)
     last_created_name = rules[-1].name  # last inserted = most recently created
 
-    response = client.get("/api/alerts/rules")
+    response = client.get("/api/v1/alerts/rules")
 
     assert response.status_code == 200
     assert response.json()[0]["name"] == last_created_name
@@ -133,7 +133,7 @@ def test_create_rule_returns_201_and_persists(db: Session):
         "channel_config": {},
     }
 
-    response = client.post("/api/alerts/rules", json=payload)
+    response = client.post("/api/v1/alerts/rules", json=payload)
 
     assert response.status_code == 201
     data = response.json()
@@ -146,7 +146,7 @@ def test_create_rule_returns_201_and_persists(db: Session):
 
 
 def test_create_rule_applies_defaults(db: Session):
-    response = client.post("/api/alerts/rules", json={})
+    response = client.post("/api/v1/alerts/rules", json={})
 
     assert response.status_code == 201
     data = response.json()
@@ -160,8 +160,8 @@ def test_create_rule_applies_defaults(db: Session):
 def test_create_rule_appears_in_list(db: Session):
     payload = {"name": "Discoverable Rule"}
 
-    client.post("/api/alerts/rules", json=payload)
-    list_response = client.get("/api/alerts/rules")
+    client.post("/api/v1/alerts/rules", json=payload)
+    list_response = client.get("/api/v1/alerts/rules")
 
     names = [r["name"] for r in list_response.json()]
     assert "Discoverable Rule" in names
@@ -177,7 +177,7 @@ def test_update_rule_name(db: Session):
     rule_id = rules[0].id
 
     response = client.patch(
-        f"/api/alerts/rules/{rule_id}", json={"name": "Renamed Rule"}
+        f"/api/v1/alerts/rules/{rule_id}", json={"name": "Renamed Rule"}
     )
 
     assert response.status_code == 200
@@ -189,7 +189,7 @@ def test_update_rule_toggle_active(db: Session):
     rules = seed_alert_rules(db)
     rule_id = rules[0].id  # starts active
 
-    response = client.patch(f"/api/alerts/rules/{rule_id}", json={"is_active": False})
+    response = client.patch(f"/api/v1/alerts/rules/{rule_id}", json={"is_active": False})
 
     assert response.status_code == 200
     assert response.json()["is_active"] is False
@@ -200,7 +200,7 @@ def test_update_rule_channels(db: Session):
     rule_id = rules[1].id
 
     response = client.patch(
-        f"/api/alerts/rules/{rule_id}",
+        f"/api/v1/alerts/rules/{rule_id}",
         json={
             "channels": ["webhook"],
             "channel_config": {"webhook_url": "https://example.com/hook"},
@@ -214,7 +214,7 @@ def test_update_rule_channels(db: Session):
 
 
 def test_update_rule_not_found(db: Session):
-    response = client.patch("/api/alerts/rules/99999", json={"name": "Ghost"})
+    response = client.patch("/api/v1/alerts/rules/99999", json={"name": "Ghost"})
 
     assert response.status_code == 404
 
@@ -228,7 +228,7 @@ def test_delete_rule_returns_204(db: Session):
     rules = seed_alert_rules(db)
     rule_id = rules[0].id
 
-    response = client.delete(f"/api/alerts/rules/{rule_id}")
+    response = client.delete(f"/api/v1/alerts/rules/{rule_id}")
 
     assert response.status_code == 204
 
@@ -237,15 +237,15 @@ def test_delete_rule_removes_from_list(db: Session):
     rules = seed_alert_rules(db)
     rule_id = rules[0].id
 
-    client.delete(f"/api/alerts/rules/{rule_id}")
-    list_response = client.get("/api/alerts/rules")
+    client.delete(f"/api/v1/alerts/rules/{rule_id}")
+    list_response = client.get("/api/v1/alerts/rules")
 
     ids = [r["id"] for r in list_response.json()]
     assert rule_id not in ids
 
 
 def test_delete_rule_not_found(db: Session):
-    response = client.delete("/api/alerts/rules/99999")
+    response = client.delete("/api/v1/alerts/rules/99999")
 
     assert response.status_code == 404
 
@@ -259,7 +259,7 @@ def test_list_logs_returns_seeded_entries(db: Session):
     rules = seed_alert_rules(db)
     seed_alert_delivery_logs(db, rules)
 
-    response = client.get("/api/alerts/logs")
+    response = client.get("/api/v1/alerts/logs")
 
     assert response.status_code == 200
     data = response.json()
@@ -267,7 +267,7 @@ def test_list_logs_returns_seeded_entries(db: Session):
 
 
 def test_list_logs_empty_returns_empty_list(db: Session):
-    response = client.get("/api/alerts/logs")
+    response = client.get("/api/v1/alerts/logs")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -277,7 +277,7 @@ def test_list_logs_response_shape(db: Session):
     rules = seed_alert_rules(db)
     seed_alert_delivery_logs(db, rules)
 
-    response = client.get("/api/alerts/logs")
+    response = client.get("/api/v1/alerts/logs")
 
     assert response.status_code == 200
     log = response.json()[0]
@@ -297,7 +297,7 @@ def test_list_logs_ordered_newest_first(db: Session):
     rules = seed_alert_rules(db)
     seed_alert_delivery_logs(db, rules)  # first entry has newest delivered_at
 
-    response = client.get("/api/alerts/logs")
+    response = client.get("/api/v1/alerts/logs")
 
     data = response.json()
     assert data[0]["ticker"] == "AAPL"  # most recently delivered
@@ -308,7 +308,7 @@ def test_list_logs_limit_param(db: Session):
     rules = seed_alert_rules(db)
     seed_alert_delivery_logs(db, rules)  # 6 entries
 
-    response = client.get("/api/alerts/logs?limit=3")
+    response = client.get("/api/v1/alerts/logs?limit=3")
 
     assert response.status_code == 200
     assert len(response.json()) == 3
@@ -318,7 +318,7 @@ def test_list_logs_includes_failed_entries(db: Session):
     rules = seed_alert_rules(db)
     seed_alert_delivery_logs(db, rules)
 
-    response = client.get("/api/alerts/logs")
+    response = client.get("/api/v1/alerts/logs")
 
     statuses = {log["status"] for log in response.json()}
     assert "sent" in statuses

--- a/backend/tests/api/test_analysis.py
+++ b/backend/tests/api/test_analysis.py
@@ -15,13 +15,13 @@ client = TestClient(app)
 
 
 def test_correlations_returns_404_when_no_run(db: Session):
-    response = client.get("/api/outcomes/correlations")
+    response = client.get("/api/v1/outcomes/correlations")
     assert response.status_code == 404
 
 
 def test_correlations_returns_correct_shape(db: Session):
     seed_completed_analysis_run(db)
-    response = client.get("/api/outcomes/correlations")
+    response = client.get("/api/v1/outcomes/correlations")
 
     assert response.status_code == 200
     data = response.json()
@@ -36,7 +36,7 @@ def test_correlations_returns_correct_shape(db: Session):
 
 def test_correlations_filters_by_scanner_type(db: Session):
     seed_completed_analysis_run(db)
-    response = client.get("/api/outcomes/correlations?scanner_type=nonexistent_type")
+    response = client.get("/api/v1/outcomes/correlations?scanner_type=nonexistent_type")
     assert response.status_code == 404
 
 
@@ -46,13 +46,13 @@ def test_correlations_filters_by_scanner_type(db: Session):
 
 
 def test_latest_returns_404_when_no_run(db: Session):
-    response = client.get("/api/outcomes/analysis/latest")
+    response = client.get("/api/v1/outcomes/analysis/latest")
     assert response.status_code == 404
 
 
 def test_latest_returns_feature_weights_and_clusters(db: Session):
     seed_completed_analysis_run(db)
-    response = client.get("/api/outcomes/analysis/latest")
+    response = client.get("/api/v1/outcomes/analysis/latest")
 
     assert response.status_code == 200
     data = response.json()
@@ -81,7 +81,7 @@ def test_trigger_analysis_returns_202(db: Session):
     mock_result = type("R", (), {"id": "test-task-123"})()
     with patch("app.tasks.analyze_signal_features") as mock_task:
         mock_task.delay.return_value = mock_result
-        response = client.post("/api/outcomes/analyze")
+        response = client.post("/api/v1/outcomes/analyze")
         assert response.status_code == 202
     data = response.json()
     assert "task_id" in data

--- a/backend/tests/api/test_auto_trading.py
+++ b/backend/tests/api/test_auto_trading.py
@@ -57,7 +57,7 @@ def _order(db, strategy, symbol="AAPL", status="submitted"):
 
 
 def test_list_strategies_returns_200(db: Session):
-    response = client.get("/api/trading/strategies")
+    response = client.get("/api/v1/trading/strategies")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
 
@@ -65,7 +65,7 @@ def test_list_strategies_returns_200(db: Session):
 def test_list_strategies_contains_created(db: Session):
     _strategy(db, name="Visible Strategy")
     db.flush()
-    response = client.get("/api/trading/strategies")
+    response = client.get("/api/v1/trading/strategies")
     names = [s["name"] for s in response.json()]
     assert "Visible Strategy" in names
 
@@ -75,7 +75,7 @@ def test_list_strategies_contains_created(db: Session):
 
 def test_create_strategy_returns_201(db: Session):
     payload = {"name": "New Strategy", "stop_pct": 2.5, "direction": "long_only"}
-    response = client.post("/api/trading/strategies", json=payload)
+    response = client.post("/api/v1/trading/strategies", json=payload)
     assert response.status_code == 201
     data = response.json()
     assert data["name"] == "New Strategy"
@@ -84,7 +84,7 @@ def test_create_strategy_returns_201(db: Session):
 
 
 def test_create_strategy_defaults_paper_mode(db: Session):
-    response = client.post("/api/trading/strategies", json={"name": "Safe"})
+    response = client.post("/api/v1/trading/strategies", json={"name": "Safe"})
     assert response.status_code == 201
     assert response.json()["paper_mode"] is True
 
@@ -94,13 +94,13 @@ def test_create_strategy_defaults_paper_mode(db: Session):
 
 def test_get_strategy_returns_200(db: Session):
     s = _strategy(db)
-    response = client.get(f"/api/trading/strategies/{s.id}")
+    response = client.get(f"/api/v1/trading/strategies/{s.id}")
     assert response.status_code == 200
     assert response.json()["id"] == s.id
 
 
 def test_get_strategy_not_found_returns_404(db: Session):
-    response = client.get("/api/trading/strategies/999999")
+    response = client.get("/api/v1/trading/strategies/999999")
     assert response.status_code == 404
 
 
@@ -110,7 +110,7 @@ def test_get_strategy_not_found_returns_404(db: Session):
 def test_patch_strategy_updates_field(db: Session):
     s = _strategy(db)
     response = client.patch(
-        f"/api/trading/strategies/{s.id}",
+        f"/api/v1/trading/strategies/{s.id}",
         json={"is_active": False},
     )
     assert response.status_code == 200
@@ -118,7 +118,7 @@ def test_patch_strategy_updates_field(db: Session):
 
 
 def test_patch_strategy_not_found_returns_404(db: Session):
-    response = client.patch("/api/trading/strategies/999999", json={"is_active": True})
+    response = client.patch("/api/v1/trading/strategies/999999", json={"is_active": True})
     assert response.status_code == 404
 
 
@@ -127,13 +127,13 @@ def test_patch_strategy_not_found_returns_404(db: Session):
 
 def test_delete_strategy_returns_204(db: Session):
     s = _strategy(db)
-    response = client.delete(f"/api/trading/strategies/{s.id}")
+    response = client.delete(f"/api/v1/trading/strategies/{s.id}")
     assert response.status_code == 204
 
 
 def test_delete_strategy_soft_deletes(db: Session):
     s = _strategy(db)
-    client.delete(f"/api/trading/strategies/{s.id}")
+    client.delete(f"/api/v1/trading/strategies/{s.id}")
     db.refresh(s)
     assert s.is_active is False
 
@@ -141,12 +141,12 @@ def test_delete_strategy_soft_deletes(db: Session):
 def test_delete_strategy_with_open_orders_returns_409(db: Session):
     s = _strategy(db)
     _order(db, s, status="submitted")
-    response = client.delete(f"/api/trading/strategies/{s.id}")
+    response = client.delete(f"/api/v1/trading/strategies/{s.id}")
     assert response.status_code == 409
 
 
 def test_delete_strategy_not_found_returns_404(db: Session):
-    response = client.delete("/api/trading/strategies/999999")
+    response = client.delete("/api/v1/trading/strategies/999999")
     assert response.status_code == 404
 
 
@@ -154,7 +154,7 @@ def test_delete_strategy_not_found_returns_404(db: Session):
 
 
 def test_list_orders_returns_200(db: Session):
-    response = client.get("/api/trading/orders")
+    response = client.get("/api/v1/trading/orders")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
 
@@ -162,7 +162,7 @@ def test_list_orders_returns_200(db: Session):
 def test_list_orders_contains_created(db: Session):
     s = _strategy(db)
     o = _order(db, s, symbol="TSLA")
-    response = client.get("/api/trading/orders")
+    response = client.get("/api/v1/trading/orders")
     ids = [r["id"] for r in response.json()]
     assert o.id in ids
 
@@ -173,13 +173,13 @@ def test_list_orders_contains_created(db: Session):
 def test_get_order_returns_200(db: Session):
     s = _strategy(db)
     o = _order(db, s)
-    response = client.get(f"/api/trading/orders/{o.id}")
+    response = client.get(f"/api/v1/trading/orders/{o.id}")
     assert response.status_code == 200
     assert response.json()["id"] == o.id
 
 
 def test_get_order_not_found_returns_404(db: Session):
-    response = client.get("/api/trading/orders/999999")
+    response = client.get("/api/v1/trading/orders/999999")
     assert response.status_code == 404
 
 
@@ -189,7 +189,7 @@ def test_get_order_not_found_returns_404(db: Session):
 def test_approve_pending_order_sets_submitted(db: Session):
     s = _strategy(db)
     o = _order(db, s, status="pending_approval")
-    response = client.post(f"/api/trading/orders/{o.id}/approve")
+    response = client.post(f"/api/v1/trading/orders/{o.id}/approve")
     assert response.status_code == 200
     assert response.json()["status"] == "submitted"
 
@@ -201,7 +201,7 @@ def test_reject_pending_order_sets_rejected(db: Session):
     s = _strategy(db)
     o = _order(db, s, status="pending_approval")
     response = client.post(
-        f"/api/trading/orders/{o.id}/reject",
+        f"/api/v1/trading/orders/{o.id}/reject",
         json={"reason": "Too risky"},
     )
     assert response.status_code == 200
@@ -214,7 +214,7 @@ def test_reject_pending_order_sets_rejected(db: Session):
 def test_cancel_submitted_order_sets_cancelled(db: Session):
     s = _strategy(db)
     o = _order(db, s, status="submitted")
-    response = client.post(f"/api/trading/orders/{o.id}/cancel")
+    response = client.post(f"/api/v1/trading/orders/{o.id}/cancel")
     assert response.status_code == 200
     assert response.json()["status"] == "cancelled"
 
@@ -222,7 +222,7 @@ def test_cancel_submitted_order_sets_cancelled(db: Session):
 def test_cancel_already_closed_order_returns_409(db: Session):
     s = _strategy(db)
     o = _order(db, s, status="closed")
-    response = client.post(f"/api/trading/orders/{o.id}/cancel")
+    response = client.post(f"/api/v1/trading/orders/{o.id}/cancel")
     assert response.status_code == 409
 
 
@@ -230,7 +230,7 @@ def test_cancel_already_closed_order_returns_409(db: Session):
 
 
 def test_stats_returns_expected_shape(db: Session):
-    response = client.get("/api/trading/stats")
+    response = client.get("/api/v1/trading/stats")
     assert response.status_code == 200
     data = response.json()
     assert "total_orders" in data
@@ -243,7 +243,7 @@ def test_stats_returns_expected_shape(db: Session):
 
 
 def test_get_config_returns_200(db: Session):
-    response = client.get("/api/trading/config")
+    response = client.get("/api/v1/trading/config")
     assert response.status_code == 200
     data = response.json()
     assert "AUTO_TRADING_ENABLED" in data
@@ -252,7 +252,7 @@ def test_get_config_returns_200(db: Session):
 
 def test_patch_config_updates_enabled_flag(db: Session):
     response = client.patch(
-        "/api/trading/config",
+        "/api/v1/trading/config",
         json={"AUTO_TRADING_ENABLED": True},
     )
     assert response.status_code == 200

--- a/backend/tests/api/test_futures.py
+++ b/backend/tests/api/test_futures.py
@@ -28,7 +28,7 @@ client = TestClient(app)
 def test_contracts_returns_correct_shape(db: Session):
     seed_futures_contracts(db, symbol="ES", exchange="CME", count=2)
 
-    response = client.get("/api/futures/contracts/ES")
+    response = client.get("/api/v1/futures/contracts/ES")
 
     assert response.status_code == 200
     data = response.json()
@@ -45,7 +45,7 @@ def test_contracts_returns_correct_shape(db: Session):
 def test_contracts_symbol_is_case_insensitive(db: Session):
     seed_futures_contracts(db, symbol="NQ", exchange="CME", count=1)
 
-    response = client.get("/api/futures/contracts/nq")
+    response = client.get("/api/v1/futures/contracts/nq")
 
     assert response.status_code == 200
     data = response.json()
@@ -54,7 +54,7 @@ def test_contracts_symbol_is_case_insensitive(db: Session):
 
 
 def test_contracts_empty_db_returns_zero(db: Session):
-    response = client.get("/api/futures/contracts/ZZ")
+    response = client.get("/api/v1/futures/contracts/ZZ")
 
     assert response.status_code == 200
     data = response.json()
@@ -77,7 +77,7 @@ def test_rollovers_returns_correct_shape(db: Session):
         to_contract="20250620",
     )
 
-    response = client.get("/api/futures/rollovers/ES")
+    response = client.get("/api/v1/futures/rollovers/ES")
 
     assert response.status_code == 200
     data = response.json()
@@ -92,7 +92,7 @@ def test_rollovers_returns_correct_shape(db: Session):
 
 
 def test_rollovers_empty_db_returns_zero(db: Session):
-    response = client.get("/api/futures/rollovers/ZZ")
+    response = client.get("/api/v1/futures/rollovers/ZZ")
 
     assert response.status_code == 200
     data = response.json()
@@ -111,7 +111,7 @@ def test_history_returns_correct_shape(db: Session):
     seed_futures_aggregates(db, symbol="ES", contract_month="20250321", count=5)
 
     with patch("app.services.futures_data.SessionLocal", return_value=db):
-        response = client.get("/api/futures/history/ES")
+        response = client.get("/api/v1/futures/history/ES")
 
     assert response.status_code == 200
     data = response.json()
@@ -129,7 +129,7 @@ def test_history_returns_correct_shape(db: Session):
 
 def test_history_empty_db_returns_zero_data_points(db: Session):
     with patch("app.services.futures_data.SessionLocal", return_value=db):
-        response = client.get("/api/futures/history/ZZ")
+        response = client.get("/api/v1/futures/history/ZZ")
 
     assert response.status_code == 200
     data = response.json()
@@ -143,7 +143,7 @@ def test_history_symbol_is_case_insensitive(db: Session):
     seed_futures_aggregates(db, symbol="NQ", contract_month="20250321", count=3)
 
     with patch("app.services.futures_data.SessionLocal", return_value=db):
-        response = client.get("/api/futures/history/nq")
+        response = client.get("/api/v1/futures/history/nq")
 
     assert response.status_code == 200
     data = response.json()
@@ -157,7 +157,7 @@ def test_history_symbol_is_case_insensitive(db: Session):
 
 
 def test_providers_lists_ibkr(mock_futures_provider):
-    response = client.get("/api/futures/providers")
+    response = client.get("/api/v1/futures/providers")
 
     assert response.status_code == 200
     data = response.json()
@@ -168,7 +168,7 @@ def test_providers_lists_ibkr(mock_futures_provider):
 
 
 def test_providers_response_shape(mock_futures_provider):
-    response = client.get("/api/futures/providers")
+    response = client.get("/api/v1/futures/providers")
 
     assert response.status_code == 200
     data = response.json()

--- a/backend/tests/api/test_health.py
+++ b/backend/tests/api/test_health.py
@@ -21,5 +21,5 @@ def test_health_is_exempt_from_auth():
 
 def test_protected_endpoint_returns_401_without_cookie():
     c = TestClient(app, raise_server_exceptions=False)
-    response = c.get("/api/scanner/runs")
+    response = c.get("/api/v1/scanner/runs")
     assert response.status_code == 401

--- a/backend/tests/api/test_journal.py
+++ b/backend/tests/api/test_journal.py
@@ -20,14 +20,14 @@ client = TestClient(app)
 def test_list_trades_returns_all_seeded(db: Session):
     seed_trades(db)
 
-    response = client.get("/api/journal/trades")
+    response = client.get("/api/v1/journal/trades")
 
     assert response.status_code == 200
     assert len(response.json()) == 6
 
 
 def test_list_trades_empty_when_none(db: Session):
-    response = client.get("/api/journal/trades")
+    response = client.get("/api/v1/journal/trades")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -36,7 +36,7 @@ def test_list_trades_empty_when_none(db: Session):
 def test_list_trades_filter_by_symbol(db: Session):
     seed_trades(db)
 
-    response = client.get("/api/journal/trades?symbol=AAPL")
+    response = client.get("/api/v1/journal/trades?symbol=AAPL")
 
     assert response.status_code == 200
     data = response.json()
@@ -47,7 +47,7 @@ def test_list_trades_filter_by_symbol(db: Session):
 def test_list_trades_filter_by_status_open(db: Session):
     seed_trades(db)
 
-    response = client.get("/api/journal/trades?status=open")
+    response = client.get("/api/v1/journal/trades?status=open")
 
     assert response.status_code == 200
     data = response.json()
@@ -58,7 +58,7 @@ def test_list_trades_filter_by_status_open(db: Session):
 def test_list_trades_filter_by_status_closed(db: Session):
     seed_trades(db)
 
-    response = client.get("/api/journal/trades?status=closed")
+    response = client.get("/api/v1/journal/trades?status=closed")
 
     assert response.status_code == 200
     data = response.json()
@@ -69,7 +69,7 @@ def test_list_trades_filter_by_status_closed(db: Session):
 def test_list_trades_response_shape(db: Session):
     seed_trades(db)
 
-    response = client.get("/api/journal/trades")
+    response = client.get("/api/v1/journal/trades")
 
     assert response.status_code == 200
     trade = response.json()[0]
@@ -102,7 +102,7 @@ def test_create_trade_returns_new_record(db: Session):
         "avg_entry_price": "175.50",
     }
 
-    response = client.post("/api/journal/trades", json=payload)
+    response = client.post("/api/v1/journal/trades", json=payload)
 
     assert response.status_code == 200
     data = response.json()
@@ -117,7 +117,7 @@ def test_create_trade_returns_new_record(db: Session):
 def test_create_trade_minimal_payload(db: Session):
     payload = {"symbol": "SPY", "status": "open"}
 
-    response = client.post("/api/journal/trades", json=payload)
+    response = client.post("/api/v1/journal/trades", json=payload)
 
     assert response.status_code == 200
     assert response.json()["symbol"] == "SPY"
@@ -132,7 +132,7 @@ def test_get_trade_by_id_happy_path(db: Session):
     trades = seed_trades(db)
     trade_id = trades[0].id
 
-    response = client.get(f"/api/journal/trades/{trade_id}")
+    response = client.get(f"/api/v1/journal/trades/{trade_id}")
 
     assert response.status_code == 200
     data = response.json()
@@ -141,7 +141,7 @@ def test_get_trade_by_id_happy_path(db: Session):
 
 
 def test_get_trade_by_id_not_found(db: Session):
-    response = client.get("/api/journal/trades/99999")
+    response = client.get("/api/v1/journal/trades/99999")
 
     assert response.status_code == 404
 
@@ -157,7 +157,7 @@ def test_update_trade_status(db: Session):
     trade_id = open_trade.id
 
     response = client.patch(
-        f"/api/journal/trades/{trade_id}", json={"status": "closed"}
+        f"/api/v1/journal/trades/{trade_id}", json={"status": "closed"}
     )
 
     assert response.status_code == 200
@@ -170,7 +170,7 @@ def test_update_trade_notes(db: Session):
     trade_id = trades[0].id
 
     response = client.patch(
-        f"/api/journal/trades/{trade_id}",
+        f"/api/v1/journal/trades/{trade_id}",
         json={"notes": "Strong breakout with volume confirmation."},
     )
 
@@ -179,7 +179,7 @@ def test_update_trade_notes(db: Session):
 
 
 def test_update_trade_not_found(db: Session):
-    response = client.patch("/api/journal/trades/99999", json={"status": "closed"})
+    response = client.patch("/api/v1/journal/trades/99999", json={"status": "closed"})
 
     assert response.status_code == 404
 
@@ -192,7 +192,7 @@ def test_update_trade_not_found(db: Session):
 def test_stats_returns_correct_shape(db: Session):
     seed_trades(db)
 
-    response = client.get("/api/journal/stats")
+    response = client.get("/api/v1/journal/stats")
 
     assert response.status_code == 200
     data = response.json()
@@ -211,7 +211,7 @@ def test_stats_returns_correct_shape(db: Session):
 def test_stats_counts_match_seeded_trades(db: Session):
     seed_trades(db)
 
-    response = client.get("/api/journal/stats")
+    response = client.get("/api/v1/journal/stats")
 
     assert response.status_code == 200
     data = response.json()
@@ -223,7 +223,7 @@ def test_stats_counts_match_seeded_trades(db: Session):
 
 
 def test_stats_empty_database(db: Session):
-    response = client.get("/api/journal/stats")
+    response = client.get("/api/v1/journal/stats")
 
     assert response.status_code == 200
     data = response.json()
@@ -239,14 +239,14 @@ def test_stats_empty_database(db: Session):
 def test_list_entries_returns_seeded(db: Session):
     seed_journal_entries(db)
 
-    response = client.get("/api/journal/entries")
+    response = client.get("/api/v1/journal/entries")
 
     assert response.status_code == 200
     assert len(response.json()) == 3
 
 
 def test_list_entries_empty(db: Session):
-    response = client.get("/api/journal/entries")
+    response = client.get("/api/v1/journal/entries")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -255,7 +255,7 @@ def test_list_entries_empty(db: Session):
 def test_list_entries_response_shape(db: Session):
     seed_journal_entries(db)
 
-    response = client.get("/api/journal/entries")
+    response = client.get("/api/v1/journal/entries")
 
     assert response.status_code == 200
     entry = response.json()[0]
@@ -282,7 +282,7 @@ def test_create_journal_entry(db: Session):
         "sentiment": "bullish",
     }
 
-    response = client.post("/api/journal/entries", json=payload)
+    response = client.post("/api/v1/journal/entries", json=payload)
 
     assert response.status_code == 200
     data = response.json()
@@ -297,7 +297,7 @@ def test_create_journal_entry_without_sentiment(db: Session):
         "content": "Quiet day, no trades taken.",
     }
 
-    response = client.post("/api/journal/entries", json=payload)
+    response = client.post("/api/v1/journal/entries", json=payload)
 
     assert response.status_code == 200
     assert response.json()["sentiment"] is None
@@ -311,7 +311,7 @@ def test_create_journal_entry_without_sentiment(db: Session):
 def test_list_tags_returns_seeded(db: Session):
     seed_tags(db)
 
-    response = client.get("/api/journal/tags")
+    response = client.get("/api/v1/journal/tags")
 
     assert response.status_code == 200
     names = {t["name"] for t in response.json()}
@@ -319,7 +319,7 @@ def test_list_tags_returns_seeded(db: Session):
 
 
 def test_list_tags_empty(db: Session):
-    response = client.get("/api/journal/tags")
+    response = client.get("/api/v1/journal/tags")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -333,7 +333,7 @@ def test_list_tags_empty(db: Session):
 def test_create_tag(db: Session):
     payload = {"name": "scalp", "color": "#FF5733"}
 
-    response = client.post("/api/journal/tags", json=payload)
+    response = client.post("/api/v1/journal/tags", json=payload)
 
     assert response.status_code == 200
     data = response.json()
@@ -345,7 +345,7 @@ def test_create_tag(db: Session):
 def test_create_tag_without_color(db: Session):
     payload = {"name": "swing"}
 
-    response = client.post("/api/journal/tags", json=payload)
+    response = client.post("/api/v1/journal/tags", json=payload)
 
     assert response.status_code == 200
     assert response.json()["name"] == "swing"

--- a/backend/tests/api/test_news.py
+++ b/backend/tests/api/test_news.py
@@ -25,7 +25,7 @@ client = TestClient(app)
 
 
 def test_recent_empty_db_returns_empty_list(db: Session):
-    response = client.get("/api/news/recent")
+    response = client.get("/api/v1/news/recent")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -34,7 +34,7 @@ def test_recent_empty_db_returns_empty_list(db: Session):
 def test_recent_returns_seeded_articles(db: Session):
     seed_news_articles(db, count=3)
 
-    response = client.get("/api/news/recent")
+    response = client.get("/api/v1/news/recent")
 
     assert response.status_code == 200
     data = response.json()
@@ -44,7 +44,7 @@ def test_recent_returns_seeded_articles(db: Session):
 def test_recent_response_shape(db: Session):
     seed_news_articles(db, count=1)
 
-    response = client.get("/api/news/recent")
+    response = client.get("/api/v1/news/recent")
 
     assert response.status_code == 200
     article = response.json()[0]
@@ -58,7 +58,7 @@ def test_recent_response_shape(db: Session):
 def test_recent_ordered_newest_first(db: Session):
     seed_news_articles(db, count=3)
 
-    response = client.get("/api/news/recent")
+    response = client.get("/api/v1/news/recent")
 
     assert response.status_code == 200
     articles = response.json()
@@ -69,7 +69,7 @@ def test_recent_ordered_newest_first(db: Session):
 def test_recent_capped_at_100_articles(db: Session):
     seed_news_articles(db, count=105)
 
-    response = client.get("/api/news/recent")
+    response = client.get("/api/v1/news/recent")
 
     assert response.status_code == 200
     assert len(response.json()) == 100
@@ -84,7 +84,7 @@ def test_recent_ticker_filter_returns_matching_articles(db: Session):
     seed_news_articles(db, count=2, tickers=["AAPL"])
     seed_news_articles(db, count=2, tickers=["MSFT"])
 
-    response = client.get("/api/news/recent?ticker=AAPL")
+    response = client.get("/api/v1/news/recent?ticker=AAPL")
 
     assert response.status_code == 200
     data = response.json()
@@ -96,7 +96,7 @@ def test_recent_ticker_filter_returns_matching_articles(db: Session):
 def test_recent_ticker_filter_no_match_returns_empty(db: Session):
     seed_news_articles(db, count=3, tickers=["NVDA"])
 
-    response = client.get("/api/news/recent?ticker=TSLA")
+    response = client.get("/api/v1/news/recent?ticker=TSLA")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -105,7 +105,7 @@ def test_recent_ticker_filter_no_match_returns_empty(db: Session):
 def test_recent_ticker_filter_is_case_insensitive(db: Session):
     seed_news_articles(db, count=2, tickers=["AAPL"])
 
-    response = client.get("/api/news/recent?ticker=aapl")
+    response = client.get("/api/v1/news/recent?ticker=aapl")
 
     assert response.status_code == 200
     assert len(response.json()) == 2
@@ -115,7 +115,7 @@ def test_recent_no_ticker_param_returns_all_articles(db: Session):
     seed_news_articles(db, count=2, tickers=["AAPL"])
     seed_news_articles(db, count=2, tickers=["MSFT"])
 
-    response = client.get("/api/news/recent")
+    response = client.get("/api/v1/news/recent")
 
     assert response.status_code == 200
     assert len(response.json()) == 4
@@ -127,7 +127,7 @@ def test_recent_no_ticker_param_returns_all_articles(db: Session):
 
 
 def test_get_preferences_creates_default_when_none(db: Session):
-    response = client.get("/api/news/preferences")
+    response = client.get("/api/v1/news/preferences")
 
     assert response.status_code == 200
     data = response.json()
@@ -136,7 +136,7 @@ def test_get_preferences_creates_default_when_none(db: Session):
 
 
 def test_get_preferences_response_shape(db: Session):
-    response = client.get("/api/news/preferences")
+    response = client.get("/api/v1/news/preferences")
 
     assert response.status_code == 200
     data = response.json()
@@ -149,8 +149,8 @@ def test_get_preferences_response_shape(db: Session):
 
 
 def test_get_preferences_idempotent(db: Session):
-    r1 = client.get("/api/news/preferences")
-    r2 = client.get("/api/news/preferences")
+    r1 = client.get("/api/v1/news/preferences")
+    r2 = client.get("/api/v1/news/preferences")
 
     assert r1.status_code == 200
     assert r2.status_code == 200
@@ -164,7 +164,7 @@ def test_get_preferences_idempotent(db: Session):
 
 def test_put_preferences_updates_tracked_tickers(db: Session):
     response = client.put(
-        "/api/news/preferences",
+        "/api/v1/news/preferences",
         json={"tracked_tickers": ["AAPL", "NVDA"], "tracked_universes": []},
     )
 
@@ -175,7 +175,7 @@ def test_put_preferences_updates_tracked_tickers(db: Session):
 
 def test_put_preferences_updates_refresh_interval(db: Session):
     response = client.put(
-        "/api/news/preferences",
+        "/api/v1/news/preferences",
         json={
             "tracked_tickers": [],
             "tracked_universes": [],
@@ -189,10 +189,10 @@ def test_put_preferences_updates_refresh_interval(db: Session):
 
 def test_put_preferences_persists_on_get(db: Session):
     client.put(
-        "/api/news/preferences",
+        "/api/v1/news/preferences",
         json={"tracked_tickers": ["TSLA"], "tracked_universes": []},
     )
-    response = client.get("/api/news/preferences")
+    response = client.get("/api/v1/news/preferences")
 
     assert response.status_code == 200
     assert "TSLA" in response.json()["tracked_tickers"]
@@ -200,7 +200,7 @@ def test_put_preferences_persists_on_get(db: Session):
 
 def test_put_preferences_creates_if_none_exist(db: Session):
     response = client.put(
-        "/api/news/preferences",
+        "/api/v1/news/preferences",
         json={"tracked_tickers": ["AMD"], "tracked_universes": []},
     )
 
@@ -218,7 +218,7 @@ def test_refresh_returns_ok_and_task_id(mock_news_provider):
     fake_result.id = "test-task-id-abc123"
 
     with patch("app.tasks.poll_massive_news.apply_async", return_value=fake_result):
-        response = client.post("/api/news/refresh")
+        response = client.post("/api/v1/news/refresh")
 
     assert response.status_code == 200
     data = response.json()
@@ -231,6 +231,6 @@ def test_refresh_polygon_not_called_directly(mock_news_provider):
     fake_result.id = "test-task-id-def456"
 
     with patch("app.tasks.poll_massive_news.apply_async", return_value=fake_result):
-        client.post("/api/news/refresh")
+        client.post("/api/v1/news/refresh")
 
     mock_news_provider.assert_not_called()

--- a/backend/tests/api/test_outcomes.py
+++ b/backend/tests/api/test_outcomes.py
@@ -19,7 +19,7 @@ client = TestClient(app)
 
 
 def test_scorecard_returns_correct_shape(db: Session):
-    response = client.get("/api/outcomes/scorecard/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/scorecard/pre_market_volume_spike")
 
     assert response.status_code == 200
     data = response.json()
@@ -43,7 +43,7 @@ def test_scorecard_returns_correct_shape(db: Session):
 
 
 def test_scorecard_empty_db_returns_zero_counts(db: Session):
-    response = client.get("/api/outcomes/scorecard/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/scorecard/pre_market_volume_spike")
 
     assert response.status_code == 200
     data = response.json()
@@ -55,7 +55,7 @@ def test_scorecard_empty_db_returns_zero_counts(db: Session):
 def test_scorecard_win_rate_reflects_complete_summaries(db: Session):
     seed_outcomes(db)  # 2 wins, 1 loss out of 3 complete signals
 
-    response = client.get("/api/outcomes/scorecard/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/scorecard/pre_market_volume_spike")
 
     data = response.json()
     assert data["complete_signals"] == 3
@@ -65,7 +65,7 @@ def test_scorecard_win_rate_reflects_complete_summaries(db: Session):
 def test_scorecard_filters_by_scanner_type(db: Session):
     seed_outcomes(db)  # includes 1 liquidity_hunt_pre event (no summary)
 
-    response = client.get("/api/outcomes/scorecard/liquidity_hunt_pre")
+    response = client.get("/api/v1/outcomes/scorecard/liquidity_hunt_pre")
 
     data = response.json()
     assert data["total_signals"] == 0  # no summaries for liquidity_hunt_pre
@@ -73,7 +73,7 @@ def test_scorecard_filters_by_scanner_type(db: Session):
 
 
 def test_scorecard_query_param_missing_returns_400(db: Session):
-    response = client.get("/api/outcomes/scorecard")
+    response = client.get("/api/v1/outcomes/scorecard")
 
     assert response.status_code == 400
 
@@ -81,7 +81,7 @@ def test_scorecard_query_param_missing_returns_400(db: Session):
 def test_scorecard_follow_through_rate(db: Session):
     seed_outcomes(db)  # 2 of 3 summaries have follow_through=True
 
-    response = client.get("/api/outcomes/scorecard/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/scorecard/pre_market_volume_spike")
 
     data = response.json()
     assert data["follow_through_rate_pct"] == pytest.approx(66.67, abs=0.1)
@@ -95,7 +95,7 @@ def test_scorecard_follow_through_rate(db: Session):
 def test_intervals_returns_dict_keyed_by_interval(db: Session):
     seed_outcomes(db)  # snapshots for 5m, 15m, 30m
 
-    response = client.get("/api/outcomes/intervals/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/intervals/pre_market_volume_spike")
 
     assert response.status_code == 200
     data = response.json()
@@ -107,7 +107,7 @@ def test_intervals_returns_dict_keyed_by_interval(db: Session):
 def test_intervals_response_shape(db: Session):
     seed_outcomes(db)
 
-    response = client.get("/api/outcomes/intervals/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/intervals/pre_market_volume_spike")
 
     data = response.json()
     interval = data["5m"]
@@ -116,7 +116,7 @@ def test_intervals_response_shape(db: Session):
 
 
 def test_intervals_empty_db_returns_empty_dict(db: Session):
-    response = client.get("/api/outcomes/intervals/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/intervals/pre_market_volume_spike")
 
     assert response.status_code == 200
     assert response.json() == {}
@@ -126,7 +126,7 @@ def test_intervals_filter_by_interval_key(db: Session):
     seed_outcomes(db)
 
     response = client.get(
-        "/api/outcomes/intervals/pre_market_volume_spike?interval_key=5m"
+        "/api/v1/outcomes/intervals/pre_market_volume_spike?interval_key=5m"
     )
 
     assert response.status_code == 200
@@ -143,7 +143,7 @@ def test_intervals_filter_by_interval_key(db: Session):
 def test_distribution_returns_list(db: Session):
     seed_outcomes(db)  # 3 complete summaries with mfe_pct
 
-    response = client.get("/api/outcomes/distribution/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/distribution/pre_market_volume_spike")
 
     assert response.status_code == 200
     data = response.json()
@@ -154,7 +154,7 @@ def test_distribution_returns_list(db: Session):
 def test_distribution_response_shape(db: Session):
     seed_outcomes(db)
 
-    response = client.get("/api/outcomes/distribution/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/distribution/pre_market_volume_spike")
 
     item = response.json()[0]
     for field in ("ticker", "event_date", "value", "scanner_type", "severity"):
@@ -163,7 +163,7 @@ def test_distribution_response_shape(db: Session):
 
 
 def test_distribution_empty_db_returns_empty_list(db: Session):
-    response = client.get("/api/outcomes/distribution/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/distribution/pre_market_volume_spike")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -173,7 +173,7 @@ def test_distribution_metric_param(db: Session):
     seed_outcomes(db)
 
     response = client.get(
-        "/api/outcomes/distribution/pre_market_volume_spike?metric=mae_pct"
+        "/api/v1/outcomes/distribution/pre_market_volume_spike?metric=mae_pct"
     )
 
     assert response.status_code == 200
@@ -188,14 +188,14 @@ def test_distribution_metric_param(db: Session):
 def test_edge_decay_returns_list(db: Session):
     seed_outcomes(db)
 
-    response = client.get("/api/outcomes/edge-decay/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/edge-decay/pre_market_volume_spike")
 
     assert response.status_code == 200
     assert isinstance(response.json(), list)
 
 
 def test_edge_decay_empty_db_returns_empty_list(db: Session):
-    response = client.get("/api/outcomes/edge-decay/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/edge-decay/pre_market_volume_spike")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -204,7 +204,7 @@ def test_edge_decay_empty_db_returns_empty_list(db: Session):
 def test_edge_decay_response_shape(db: Session):
     seed_outcomes(db)
 
-    response = client.get("/api/outcomes/edge-decay/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/edge-decay/pre_market_volume_spike")
 
     data = response.json()
     if data:
@@ -219,7 +219,7 @@ def test_edge_decay_response_shape(db: Session):
 
 
 def test_signals_returns_correct_shape(db: Session):
-    response = client.get("/api/outcomes/signals/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/signals/pre_market_volume_spike")
 
     assert response.status_code == 200
     data = response.json()
@@ -231,7 +231,7 @@ def test_signals_returns_correct_shape(db: Session):
 def test_signals_returns_seeded_events(db: Session):
     seed_outcomes(db)  # 3 pre_market_volume_spike events
 
-    response = client.get("/api/outcomes/signals/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/signals/pre_market_volume_spike")
 
     data = response.json()
     assert data["total"] == 3
@@ -240,7 +240,7 @@ def test_signals_returns_seeded_events(db: Session):
 def test_signals_item_shape(db: Session):
     seed_outcomes(db)
 
-    response = client.get("/api/outcomes/signals/pre_market_volume_spike")
+    response = client.get("/api/v1/outcomes/signals/pre_market_volume_spike")
 
     signal = response.json()["signals"][0]
     for field in (
@@ -261,7 +261,7 @@ def test_signals_item_shape(db: Session):
 def test_signals_limit_param(db: Session):
     seed_outcomes(db)
 
-    response = client.get("/api/outcomes/signals/pre_market_volume_spike?limit=2")
+    response = client.get("/api/v1/outcomes/signals/pre_market_volume_spike?limit=2")
 
     data = response.json()
     assert len(data["signals"]) == 2
@@ -271,7 +271,7 @@ def test_signals_limit_param(db: Session):
 def test_signals_offset_param(db: Session):
     seed_outcomes(db)
 
-    response = client.get("/api/outcomes/signals/pre_market_volume_spike?offset=2")
+    response = client.get("/api/v1/outcomes/signals/pre_market_volume_spike?offset=2")
 
     data = response.json()
     assert len(data["signals"]) == 1
@@ -280,7 +280,7 @@ def test_signals_offset_param(db: Session):
 def test_signals_filters_by_scanner_type(db: Session):
     seed_outcomes(db)  # 1 liquidity_hunt_pre event, no summaries
 
-    response = client.get("/api/outcomes/signals/liquidity_hunt_pre")
+    response = client.get("/api/v1/outcomes/signals/liquidity_hunt_pre")
 
     data = response.json()
     assert data["total"] == 1
@@ -296,7 +296,7 @@ def test_event_outcome_returns_summary_and_snapshots(db: Session):
     seeded = seed_outcomes(db)
     event_id = seeded["events"][0].id
 
-    response = client.get(f"/api/outcomes/event/{event_id}")
+    response = client.get(f"/api/v1/outcomes/event/{event_id}")
 
     assert response.status_code == 200
     data = response.json()
@@ -310,7 +310,7 @@ def test_event_outcome_no_summary_returns_null_summary(db: Session):
     seeded = seed_outcomes(db)
     event_id = seeded["events"][3].id  # MRNA — no summary or snapshots
 
-    response = client.get(f"/api/outcomes/event/{event_id}")
+    response = client.get(f"/api/v1/outcomes/event/{event_id}")
 
     assert response.status_code == 200
     data = response.json()
@@ -319,7 +319,7 @@ def test_event_outcome_no_summary_returns_null_summary(db: Session):
 
 
 def test_event_outcome_not_found_returns_404(db: Session):
-    response = client.get("/api/outcomes/event/99999")
+    response = client.get("/api/v1/outcomes/event/99999")
 
     assert response.status_code == 404
 
@@ -328,7 +328,7 @@ def test_event_outcome_summary_shape(db: Session):
     seeded = seed_outcomes(db)
     event_id = seeded["events"][0].id
 
-    response = client.get(f"/api/outcomes/event/{event_id}")
+    response = client.get(f"/api/v1/outcomes/event/{event_id}")
 
     summary = response.json()["summary"]
     for field in (
@@ -348,7 +348,7 @@ def test_event_outcome_snapshot_shape(db: Session):
     seeded = seed_outcomes(db)
     event_id = seeded["events"][0].id
 
-    response = client.get(f"/api/outcomes/event/{event_id}")
+    response = client.get(f"/api/v1/outcomes/event/{event_id}")
 
     snap = response.json()["snapshots"][0]
     for field in (
@@ -366,7 +366,7 @@ def test_event_outcome_snapshots_ordered_by_interval_key(db: Session):
     seeded = seed_outcomes(db)
     event_id = seeded["events"][0].id
 
-    response = client.get(f"/api/outcomes/event/{event_id}")
+    response = client.get(f"/api/v1/outcomes/event/{event_id}")
 
     keys = [s["interval_key"] for s in response.json()["snapshots"]]
     assert keys == sorted(keys)
@@ -378,14 +378,14 @@ def test_event_outcome_snapshots_ordered_by_interval_key(db: Session):
 
 
 def test_readiness_missing_scanner_type_returns_400(db: Session):
-    response = client.get("/api/outcomes/readiness/AAPL")
+    response = client.get("/api/v1/outcomes/readiness/AAPL")
 
     assert response.status_code == 400
 
 
 def test_readiness_returns_correct_shape(db: Session):
     response = client.get(
-        "/api/outcomes/readiness/AAPL?scanner_type=pre_market_volume_spike"
+        "/api/v1/outcomes/readiness/AAPL?scanner_type=pre_market_volume_spike"
     )
 
     assert response.status_code == 200

--- a/backend/tests/api/test_scanner.py
+++ b/backend/tests/api/test_scanner.py
@@ -28,7 +28,7 @@ client = TestClient(app)
 def test_results_returns_all_events(db: Session):
     seed_scanner_events(db)
 
-    response = client.get("/api/scanner/results")
+    response = client.get("/api/v1/scanner/results")
 
     assert response.status_code == 200
     data = response.json()
@@ -40,7 +40,7 @@ def test_results_returns_all_events(db: Session):
 def test_results_filter_by_ticker(db: Session):
     seed_scanner_events(db)
 
-    response = client.get("/api/scanner/results?ticker=AAPL")
+    response = client.get("/api/v1/scanner/results?ticker=AAPL")
 
     assert response.status_code == 200
     data = response.json()
@@ -51,7 +51,7 @@ def test_results_filter_by_ticker(db: Session):
 def test_results_filter_by_scanner_type(db: Session):
     seed_scanner_events(db)
 
-    response = client.get("/api/scanner/results?scanner_type=pre_market_volume_spike")
+    response = client.get("/api/v1/scanner/results?scanner_type=pre_market_volume_spike")
 
     assert response.status_code == 200
     data = response.json()
@@ -66,7 +66,7 @@ def test_results_filter_by_universe_id(db: Session):
 
     tech_universe_id = universes[0].id  # contains AAPL, MSFT, NVDA
 
-    response = client.get(f"/api/scanner/results?universe_id={tech_universe_id}")
+    response = client.get(f"/api/v1/scanner/results?universe_id={tech_universe_id}")
 
     assert response.status_code == 200
     data = response.json()
@@ -76,7 +76,7 @@ def test_results_filter_by_universe_id(db: Session):
 
 
 def test_results_empty_when_no_events(db: Session):
-    response = client.get("/api/scanner/results")
+    response = client.get("/api/v1/scanner/results")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -90,7 +90,7 @@ def test_results_empty_when_no_events(db: Session):
 def test_configs_returns_active_only(db: Session):
     seed_scanner_configs(db)
 
-    response = client.get("/api/scanner/configs")
+    response = client.get("/api/v1/scanner/configs")
 
     assert response.status_code == 200
     data = response.json()
@@ -101,7 +101,7 @@ def test_configs_returns_active_only(db: Session):
 
 
 def test_configs_returns_empty_when_none(db: Session):
-    response = client.get("/api/scanner/configs")
+    response = client.get("/api/v1/scanner/configs")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -110,7 +110,7 @@ def test_configs_returns_empty_when_none(db: Session):
 def test_configs_response_shape(db: Session):
     seed_scanner_configs(db)
 
-    response = client.get("/api/scanner/configs")
+    response = client.get("/api/v1/scanner/configs")
 
     cfg = response.json()[0]
     for field in (
@@ -133,7 +133,7 @@ def test_configs_response_shape(db: Session):
 def test_history_returns_runs_desc(db: Session):
     seed_scanner_runs(db)
 
-    response = client.get("/api/scanner/history")
+    response = client.get("/api/v1/scanner/history")
 
     assert response.status_code == 200
     data = response.json()
@@ -154,14 +154,14 @@ def test_history_returns_runs_desc(db: Session):
 def test_history_respects_limit(db: Session):
     seed_scanner_runs(db)
 
-    response = client.get("/api/scanner/history?limit=2")
+    response = client.get("/api/v1/scanner/history?limit=2")
 
     assert response.status_code == 200
     assert len(response.json()) == 2
 
 
 def test_history_empty_when_no_runs(db: Session):
-    response = client.get("/api/scanner/history")
+    response = client.get("/api/v1/scanner/history")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -176,7 +176,7 @@ def test_scan_status_block_without_universe(db: Session):
     seed_scanner_runs(db)
 
     response = client.get(
-        "/api/scanner/scan-status-block?scanner_type=pre_market_volume_spike"
+        "/api/v1/scanner/scan-status-block?scanner_type=pre_market_volume_spike"
     )
 
     assert response.status_code == 200
@@ -194,7 +194,7 @@ def test_scan_status_block_with_universe(db: Session):
     seed_scanner_runs(db, universe_id=universe_id)
 
     response = client.get(
-        f"/api/scanner/scan-status-block?scanner_type=pre_market_volume_spike&universe_id={universe_id}"
+        f"/api/v1/scanner/scan-status-block?scanner_type=pre_market_volume_spike&universe_id={universe_id}"
     )
 
     assert response.status_code == 200
@@ -205,7 +205,7 @@ def test_scan_status_block_with_universe(db: Session):
 
 def test_scan_status_block_no_runs(db: Session):
     response = client.get(
-        "/api/scanner/scan-status-block?scanner_type=pre_market_volume_spike"
+        "/api/v1/scanner/scan-status-block?scanner_type=pre_market_volume_spike"
     )
 
     assert response.status_code == 200
@@ -219,7 +219,7 @@ def test_scan_status_block_sparkline(db: Session):
     seed_scanner_runs(db)
 
     response = client.get(
-        "/api/scanner/scan-status-block?scanner_type=pre_market_volume_spike"
+        "/api/v1/scanner/scan-status-block?scanner_type=pre_market_volume_spike"
     )
 
     data = response.json()
@@ -237,7 +237,7 @@ def test_scan_status_block_sparkline(db: Session):
 def test_stats_returns_counts(db: Session):
     seed_scanner_events(db)
 
-    response = client.get("/api/scanner/stats")
+    response = client.get("/api/v1/scanner/stats")
 
     assert response.status_code == 200
     data = response.json()
@@ -247,7 +247,7 @@ def test_stats_returns_counts(db: Session):
 
 
 def test_stats_empty_db(db: Session):
-    response = client.get("/api/scanner/stats")
+    response = client.get("/api/v1/scanner/stats")
 
     assert response.status_code == 200
     data = response.json()
@@ -260,7 +260,7 @@ def test_stats_empty_db(db: Session):
 def test_stats_today_events(db: Session):
     seed_scanner_events(db)
 
-    response = client.get("/api/scanner/stats")
+    response = client.get("/api/v1/scanner/stats")
 
     data = response.json()
     # seed_scanner_events seeds events on today's date — at least 5 of them
@@ -277,7 +277,7 @@ def test_results_filter_by_start_date(db: Session):
     today = get_market_today()
     today_str = str(today)
 
-    response = client.get(f"/api/scanner/results?start_date={today_str}")
+    response = client.get(f"/api/v1/scanner/results?start_date={today_str}")
 
     assert response.status_code == 200
     data = response.json()
@@ -290,7 +290,7 @@ def test_results_filter_by_end_date(db: Session):
     today = get_market_today()
     two_days_ago = str(today - timedelta(days=2))
 
-    response = client.get(f"/api/scanner/results?end_date={two_days_ago}")
+    response = client.get(f"/api/v1/scanner/results?end_date={two_days_ago}")
 
     assert response.status_code == 200
     data = response.json()
@@ -304,7 +304,7 @@ def test_results_filter_by_date_range(db: Session):
     yesterday = str(today - timedelta(days=1))
 
     response = client.get(
-        f"/api/scanner/results?start_date={yesterday}&end_date={yesterday}"
+        f"/api/v1/scanner/results?start_date={yesterday}&end_date={yesterday}"
     )
 
     assert response.status_code == 200
@@ -323,7 +323,7 @@ def test_list_scanner_types():
     import app.services.oversold_bounce_scan  # noqa: F401
     import app.services.pre_market_scan  # noqa: F401
 
-    response = client.get("/api/scanner/types")
+    response = client.get("/api/v1/scanner/types")
     assert response.status_code == 200
     data = response.json()
     assert isinstance(data, list)

--- a/backend/tests/api/test_scanner_clear.py
+++ b/backend/tests/api/test_scanner_clear.py
@@ -24,7 +24,7 @@ def test_clear_events_returns_count(db: Session):
     db.add(_make_event("AAPL", "oversold_bounce"))
     db.flush()
 
-    response = client.delete("/api/scanner/events/AAPL")
+    response = client.delete("/api/v1/scanner/events/AAPL")
 
     assert response.status_code == 200
     body = response.json()
@@ -33,7 +33,7 @@ def test_clear_events_returns_count(db: Session):
 
 
 def test_clear_events_zero_when_none_exist(db: Session):
-    response = client.delete("/api/scanner/events/ZZZZ")
+    response = client.delete("/api/v1/scanner/events/ZZZZ")
 
     assert response.status_code == 200
     assert response.json()["deleted_count"] == 0
@@ -44,7 +44,7 @@ def test_clear_events_does_not_affect_other_tickers(db: Session):
     db.add(_make_event("MSFT"))
     db.flush()
 
-    response = client.delete("/api/scanner/events/TSLA")
+    response = client.delete("/api/v1/scanner/events/TSLA")
 
     assert response.status_code == 200
     assert response.json()["deleted_count"] == 1
@@ -56,7 +56,7 @@ def test_clear_events_normalises_ticker_case(db: Session):
     db.add(_make_event("AMZN"))
     db.flush()
 
-    response = client.delete("/api/scanner/events/amzn")
+    response = client.delete("/api/v1/scanner/events/amzn")
 
     assert response.status_code == 200
     body = response.json()

--- a/backend/tests/api/test_scanner_range.py
+++ b/backend/tests/api/test_scanner_range.py
@@ -12,7 +12,7 @@ def test_run_range_returns_task_id(db):
         mock_task.delay.return_value = type("R", (), {"id": "test-task-123"})()
 
         response = client.post(
-            "/api/scanner/run-range",
+            "/api/v1/scanner/run-range",
             json={
                 "ticker": "AAPL",
                 "scanner_types": ["pre_market_volume_spike"],
@@ -31,7 +31,7 @@ def test_run_range_returns_task_id(db):
 def test_run_range_rejects_empty_scanner_types(db):
 
     response = client.post(
-        "/api/scanner/run-range",
+        "/api/v1/scanner/run-range",
         json={
             "ticker": "AAPL",
             "scanner_types": [],

--- a/backend/tests/api/test_signal_reviews.py
+++ b/backend/tests/api/test_signal_reviews.py
@@ -23,7 +23,7 @@ def _get_first_event(db: Session) -> ScannerEvent:
 def test_create_confirmed_review(db: Session):
     event = _get_first_event(db)
     response = client.post(
-        f"/api/scanner/events/{event.uuid}/review",
+        f"/api/v1/scanner/events/{event.uuid}/review",
         json={
             "verdict": "confirmed",
         },
@@ -37,7 +37,7 @@ def test_create_confirmed_review(db: Session):
 def test_create_uncertain_review(db: Session):
     event = _get_first_event(db)
     response = client.post(
-        f"/api/scanner/events/{event.uuid}/review",
+        f"/api/v1/scanner/events/{event.uuid}/review",
         json={
             "verdict": "uncertain",
             "notes": "Need to check chart",
@@ -50,7 +50,7 @@ def test_create_uncertain_review(db: Session):
 def test_create_rejected_review_requires_reason(db: Session):
     event = _get_first_event(db)
     response = client.post(
-        f"/api/scanner/events/{event.uuid}/review",
+        f"/api/v1/scanner/events/{event.uuid}/review",
         json={
             "verdict": "rejected",
         },
@@ -61,7 +61,7 @@ def test_create_rejected_review_requires_reason(db: Session):
 def test_create_rejected_review_with_reason(db: Session):
     event = _get_first_event(db)
     response = client.post(
-        f"/api/scanner/events/{event.uuid}/review",
+        f"/api/v1/scanner/events/{event.uuid}/review",
         json={
             "verdict": "rejected",
             "reject_reason": "noise",
@@ -74,7 +74,7 @@ def test_create_rejected_review_with_reason(db: Session):
 
 def test_create_review_invalid_uuid(db: Session):
     response = client.post(
-        "/api/scanner/events/not-a-uuid/review",
+        "/api/v1/scanner/events/not-a-uuid/review",
         json={
             "verdict": "confirmed",
         },
@@ -85,7 +85,7 @@ def test_create_review_invalid_uuid(db: Session):
 def test_create_review_nonexistent_event(db: Session):
     fake_uuid = str(uuid_lib.uuid4())
     response = client.post(
-        f"/api/scanner/events/{fake_uuid}/review",
+        f"/api/v1/scanner/events/{fake_uuid}/review",
         json={
             "verdict": "confirmed",
         },
@@ -96,7 +96,7 @@ def test_create_review_nonexistent_event(db: Session):
 def test_create_review_invalid_verdict(db: Session):
     event = _get_first_event(db)
     response = client.post(
-        f"/api/scanner/events/{event.uuid}/review",
+        f"/api/v1/scanner/events/{event.uuid}/review",
         json={
             "verdict": "maybe",
         },
@@ -111,7 +111,7 @@ def test_list_reviews_by_scanner_type(db: Session):
     db.flush()
 
     response = client.get(
-        f"/api/scanner/events/reviews?scanner_type={event.scanner_type}"
+        f"/api/v1/scanner/events/reviews?scanner_type={event.scanner_type}"
     )
     assert response.status_code == 200
     data = response.json()
@@ -126,7 +126,7 @@ def test_list_reviews_liquidity_hunt_alias(db: Session):
     db.add(review)
     db.flush()
 
-    response = client.get("/api/scanner/events/reviews?scanner_type=liquidity_hunt")
+    response = client.get("/api/v1/scanner/events/reviews?scanner_type=liquidity_hunt")
     assert response.status_code == 200
     data = response.json()
     assert len(data) >= 1
@@ -143,7 +143,7 @@ def test_list_reviews_filter_by_verdict(db: Session):
     db.flush()
 
     response = client.get(
-        f"/api/scanner/events/reviews?scanner_type={event.scanner_type}&verdict=confirmed"
+        f"/api/v1/scanner/events/reviews?scanner_type={event.scanner_type}&verdict=confirmed"
     )
     assert response.status_code == 200
     data = response.json()
@@ -151,7 +151,7 @@ def test_list_reviews_filter_by_verdict(db: Session):
 
 
 def test_list_reviews_missing_scanner_type(db: Session):
-    response = client.get("/api/scanner/events/reviews")
+    response = client.get("/api/v1/scanner/events/reviews")
     assert response.status_code == 422
 
 
@@ -166,7 +166,7 @@ def test_review_stats(db: Session):
     db.add(SignalReview(scanner_event_id=events[2].id, verdict="uncertain"))
     db.flush()
 
-    response = client.get("/api/scanner/reviews/stats")
+    response = client.get("/api/v1/scanner/reviews/stats")
     assert response.status_code == 200
     data = response.json()
     assert data["total_events"] > 0
@@ -184,7 +184,7 @@ def test_review_stats_with_scanner_type_filter(db: Session):
     db.flush()
 
     response = client.get(
-        "/api/scanner/reviews/stats?scanner_type=pre_market_volume_spike"
+        "/api/v1/scanner/reviews/stats?scanner_type=pre_market_volume_spike"
     )
     assert response.status_code == 200
     data = response.json()
@@ -200,7 +200,7 @@ def test_scanner_results_include_latest_review(db: Session):
     db.add(SignalReview(scanner_event_id=event.id, verdict="confirmed"))
     db.flush()
 
-    response = client.get(f"/api/scanner/results?scanner_type={event.scanner_type}")
+    response = client.get(f"/api/v1/scanner/results?scanner_type={event.scanner_type}")
     assert response.status_code == 200
     data = response.json()
     reviewed = [e for e in data if e.get("latest_review") is not None]

--- a/backend/tests/api/test_stocks.py
+++ b/backend/tests/api/test_stocks.py
@@ -24,7 +24,7 @@ client = TestClient(app)
 def test_historical_returns_columnar_compact_format(db: Session):
     seed_stock_aggregates(db, ticker="AAPL", timespan="day", multiplier=1, count=5)
 
-    response = client.get("/api/stocks/historical/AAPL")
+    response = client.get("/api/v1/stocks/historical/AAPL")
 
     assert response.status_code == 200
     data = response.json()
@@ -36,7 +36,7 @@ def test_historical_returns_columnar_compact_format(db: Session):
 def test_historical_ticker_is_case_insensitive(db: Session):
     seed_stock_aggregates(db, ticker="MSFT", timespan="day", multiplier=1, count=3)
 
-    response = client.get("/api/stocks/historical/msft")
+    response = client.get("/api/v1/stocks/historical/msft")
 
     assert response.status_code == 200
     assert response.json()["ticker"] == "MSFT"
@@ -44,7 +44,7 @@ def test_historical_ticker_is_case_insensitive(db: Session):
 
 
 def test_historical_empty_db_returns_zero_data_points(db: Session):
-    response = client.get("/api/stocks/historical/NOOP")
+    response = client.get("/api/v1/stocks/historical/NOOP")
 
     assert response.status_code == 200
     data = response.json()
@@ -56,7 +56,7 @@ def test_historical_empty_db_returns_zero_data_points(db: Session):
 def test_historical_data_contains_required_columns(db: Session):
     seed_stock_aggregates(db, ticker="NVDA", timespan="day", multiplier=1, count=2)
 
-    response = client.get("/api/stocks/historical/NVDA")
+    response = client.get("/api/v1/stocks/historical/NVDA")
 
     assert response.status_code == 200
     compact = response.json()["data"]
@@ -75,7 +75,7 @@ def test_historical_respects_timespan_param(db: Session):
     # Day bars for same ticker — should NOT appear when requesting minute/5
     seed_stock_aggregates(db, ticker="TSLA", timespan="day", multiplier=1, count=10)
 
-    response = client.get("/api/stocks/historical/TSLA?timespan=minute&multiplier=5")
+    response = client.get("/api/v1/stocks/historical/TSLA?timespan=minute&multiplier=5")
 
     assert response.status_code == 200
     data = response.json()
@@ -88,7 +88,7 @@ def test_historical_respects_multiplier_param(db: Session):
     seed_stock_aggregates(db, ticker="AMD", timespan="hour", multiplier=1, count=3)
     seed_stock_aggregates(db, ticker="AMD", timespan="hour", multiplier=4, count=7)
 
-    response = client.get("/api/stocks/historical/AMD?timespan=hour&multiplier=4")
+    response = client.get("/api/v1/stocks/historical/AMD?timespan=hour&multiplier=4")
 
     assert response.status_code == 200
     assert response.json()["data_points"] == 7
@@ -99,7 +99,7 @@ def test_historical_period_filters_rows(db: Session):
     which is in the future relative to our test data anchor, so they appear outside the
     default 30d window only if we seed with a very old date. Here we verify that an
     absent ticker returns 0 data points when there's no data within the window."""
-    response = client.get("/api/stocks/historical/GHOST?period=1d")
+    response = client.get("/api/v1/stocks/historical/GHOST?period=1d")
 
     assert response.status_code == 200
     assert response.json()["data_points"] == 0
@@ -111,13 +111,13 @@ def test_historical_period_filters_rows(db: Session):
 
 
 def test_details_returns_200_with_mocked_provider(db: Session, mock_polygon_provider):
-    response = client.get("/api/stocks/details/AAPL")
+    response = client.get("/api/v1/stocks/details/AAPL")
 
     assert response.status_code == 200
 
 
 def test_details_response_shape(db: Session, mock_polygon_provider):
-    response = client.get("/api/stocks/details/AAPL")
+    response = client.get("/api/v1/stocks/details/AAPL")
 
     data = response.json()
     assert data["ticker"] == "AAPL"
@@ -129,14 +129,14 @@ def test_details_response_shape(db: Session, mock_polygon_provider):
 def test_details_polygon_never_called_without_mock(db: Session):
     """Without the mock fixture, the real provider is unavailable (no API key in test env).
     The endpoint should still return 200 with empty/null fields rather than 500."""
-    response = client.get("/api/stocks/details/FAKE")
+    response = client.get("/api/v1/stocks/details/FAKE")
 
     # Acceptable outcomes: 200 with partial data or a graceful non-500
     assert response.status_code in (200, 500)
 
 
 def test_details_ticker_is_case_insensitive(db: Session, mock_polygon_provider):
-    response = client.get("/api/stocks/details/msft")
+    response = client.get("/api/v1/stocks/details/msft")
 
     assert response.status_code == 200
     assert response.json()["ticker"] == "MSFT"
@@ -160,7 +160,7 @@ def test_details_mock_provider_not_called_for_futures(
     db.add(futures)
     db.flush()
 
-    response = client.get("/api/stocks/details/ES")
+    response = client.get("/api/v1/stocks/details/ES")
 
     assert response.status_code == 200
     mock_polygon_provider.get_bars.assert_not_called()

--- a/backend/tests/api/test_system.py
+++ b/backend/tests/api/test_system.py
@@ -18,7 +18,7 @@ client = TestClient(app)
 
 
 def test_get_config_empty_db_returns_empty_dict(db: Session):
-    response = client.get("/api/system/config")
+    response = client.get("/api/v1/system/config")
 
     assert response.status_code == 200
     assert response.json() == {}
@@ -27,7 +27,7 @@ def test_get_config_empty_db_returns_empty_dict(db: Session):
 def test_get_config_returns_seeded_keys(db: Session):
     seed_system_config(db)
 
-    response = client.get("/api/system/config")
+    response = client.get("/api/v1/system/config")
 
     assert response.status_code == 200
     data = response.json()
@@ -39,7 +39,7 @@ def test_get_config_returns_seeded_keys(db: Session):
 def test_get_config_returns_flat_dict(db: Session):
     seed_system_config(db)
 
-    response = client.get("/api/system/config")
+    response = client.get("/api/v1/system/config")
 
     data = response.json()
     assert isinstance(data, dict)
@@ -52,7 +52,7 @@ def test_get_config_returns_flat_dict(db: Session):
 
 
 def test_patch_config_inserts_new_key(db: Session):
-    response = client.patch("/api/system/config", json={"new_key": "new_value"})
+    response = client.patch("/api/v1/system/config", json={"new_key": "new_value"})
 
     assert response.status_code == 200
     data = response.json()
@@ -62,7 +62,7 @@ def test_patch_config_inserts_new_key(db: Session):
 def test_patch_config_updates_existing_key(db: Session):
     seed_system_config(db)
 
-    response = client.patch("/api/system/config", json={"scan_enabled": "false"})
+    response = client.patch("/api/v1/system/config", json={"scan_enabled": "false"})
 
     assert response.status_code == 200
     data = response.json()
@@ -71,7 +71,7 @@ def test_patch_config_updates_existing_key(db: Session):
 
 def test_patch_config_multiple_keys(db: Session):
     response = client.patch(
-        "/api/system/config",
+        "/api/v1/system/config",
         json={"key_a": "val_a", "key_b": "val_b", "key_c": "val_c"},
     )
 
@@ -85,7 +85,7 @@ def test_patch_config_multiple_keys(db: Session):
 def test_patch_config_returns_full_config(db: Session):
     seed_system_config(db)
 
-    response = client.patch("/api/system/config", json={"new_setting": "42"})
+    response = client.patch("/api/v1/system/config", json={"new_setting": "42"})
 
     data = response.json()
     # Original seeded keys still present
@@ -97,8 +97,8 @@ def test_patch_config_returns_full_config(db: Session):
 
 
 def test_patch_config_persists_across_get(db: Session):
-    client.patch("/api/system/config", json={"persisted_key": "persisted_value"})
-    response = client.get("/api/system/config")
+    client.patch("/api/v1/system/config", json={"persisted_key": "persisted_value"})
+    response = client.get("/api/v1/system/config")
 
     assert response.status_code == 200
     assert response.json()["persisted_key"] == "persisted_value"
@@ -107,7 +107,7 @@ def test_patch_config_persists_across_get(db: Session):
 def test_patch_config_empty_payload_returns_current_config(db: Session):
     seed_system_config(db)
 
-    response = client.patch("/api/system/config", json={})
+    response = client.patch("/api/v1/system/config", json={})
 
     assert response.status_code == 200
     data = response.json()
@@ -115,7 +115,7 @@ def test_patch_config_empty_payload_returns_current_config(db: Session):
 
 
 def test_patch_config_numeric_value_stored_as_string(db: Session):
-    response = client.patch("/api/system/config", json={"threshold": 5})
+    response = client.patch("/api/v1/system/config", json={"threshold": 5})
 
     assert response.status_code == 200
     data = response.json()

--- a/backend/tests/api/test_universe.py
+++ b/backend/tests/api/test_universe.py
@@ -20,7 +20,7 @@ client = TestClient(app)
 def test_list_returns_only_active_universes(db: Session):
     seed_universes(db)
 
-    response = client.get("/api/universe/list")
+    response = client.get("/api/v1/universe/list")
 
     assert response.status_code == 200
     data = response.json()
@@ -32,7 +32,7 @@ def test_list_returns_only_active_universes(db: Session):
 
 
 def test_list_returns_empty_when_no_universes(db: Session):
-    response = client.get("/api/universe/list")
+    response = client.get("/api/v1/universe/list")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -41,7 +41,7 @@ def test_list_returns_empty_when_no_universes(db: Session):
 def test_list_response_shape(db: Session):
     seed_universes(db)
 
-    response = client.get("/api/universe/list")
+    response = client.get("/api/v1/universe/list")
 
     assert response.status_code == 200
     universe = response.json()[0]
@@ -60,7 +60,7 @@ def test_list_response_shape(db: Session):
 def test_list_include_stats_false_returns_zero_counts(db: Session):
     seed_universes(db)
 
-    response = client.get("/api/universe/list?include_stats=false")
+    response = client.get("/api/v1/universe/list?include_stats=false")
 
     assert response.status_code == 200
     for u in response.json():
@@ -80,7 +80,7 @@ def test_create_universe_returns_new_record(db: Session):
         "criteria": {"sector": "tech"},
     }
 
-    response = client.post("/api/universe/create", json=payload)
+    response = client.post("/api/v1/universe/create", json=payload)
 
     assert response.status_code == 200
     data = response.json()
@@ -95,7 +95,7 @@ def test_create_universe_returns_new_record(db: Session):
 def test_create_universe_without_description(db: Session):
     payload = {"name": "Minimal Universe", "criteria": {}}
 
-    response = client.post("/api/universe/create", json=payload)
+    response = client.post("/api/v1/universe/create", json=payload)
 
     assert response.status_code == 200
     assert response.json()["name"] == "Minimal Universe"
@@ -111,7 +111,7 @@ def test_update_universe_name(db: Session):
     universes = seed_universes(db)
     uid = universes[0].id
 
-    response = client.put(f"/api/universe/{uid}", json={"name": "Updated Name"})
+    response = client.put(f"/api/v1/universe/{uid}", json={"name": "Updated Name"})
 
     assert response.status_code == 200
     assert response.json()["name"] == "Updated Name"
@@ -123,7 +123,7 @@ def test_update_universe_description_and_criteria(db: Session):
     uid = universes[1].id
 
     response = client.put(
-        f"/api/universe/{uid}",
+        f"/api/v1/universe/{uid}",
         json={"description": "New desc", "criteria": {"sector": "pharma"}},
     )
 
@@ -134,7 +134,7 @@ def test_update_universe_description_and_criteria(db: Session):
 
 
 def test_update_universe_not_found(db: Session):
-    response = client.put("/api/universe/99999", json={"name": "Ghost"})
+    response = client.put("/api/v1/universe/99999", json={"name": "Ghost"})
 
     assert response.status_code == 404
 
@@ -148,20 +148,20 @@ def test_delete_universe_soft_deletes(db: Session):
     universes = seed_universes(db)
     uid = universes[0].id
 
-    response = client.delete(f"/api/universe/{uid}")
+    response = client.delete(f"/api/v1/universe/{uid}")
 
     assert response.status_code == 200
     assert "deleted" in response.json()["message"].lower()
 
     # Confirm it no longer appears in list
-    list_response = client.get("/api/universe/list")
+    list_response = client.get("/api/v1/universe/list")
 
     ids = [u["id"] for u in list_response.json()]
     assert uid not in ids
 
 
 def test_delete_universe_not_found(db: Session):
-    response = client.delete("/api/universe/99999")
+    response = client.delete("/api/v1/universe/99999")
 
     assert response.status_code == 404
 
@@ -176,7 +176,7 @@ def test_get_universe_stocks_returns_seeded_stocks(db: Session):
     seed_monitored_stocks(db, universes)
     uid = universes[0].id  # Tech Stocks: AAPL, MSFT, NVDA
 
-    response = client.get(f"/api/universe/{uid}/stocks")
+    response = client.get(f"/api/v1/universe/{uid}/stocks")
 
     assert response.status_code == 200
     tickers = {s["ticker"] for s in response.json()}
@@ -187,7 +187,7 @@ def test_get_universe_stocks_empty_when_none(db: Session):
     universes = seed_universes(db)
     uid = universes[0].id
 
-    response = client.get(f"/api/universe/{uid}/stocks")
+    response = client.get(f"/api/v1/universe/{uid}/stocks")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -198,7 +198,7 @@ def test_get_universe_stocks_response_shape(db: Session):
     seed_monitored_stocks(db, universes)
     uid = universes[0].id
 
-    response = client.get(f"/api/universe/{uid}/stocks")
+    response = client.get(f"/api/v1/universe/{uid}/stocks")
 
     assert response.status_code == 200
     stock = response.json()[0]
@@ -212,7 +212,7 @@ def test_get_universe_stocks_response_shape(db: Session):
 
 
 def test_refresh_universe_not_found(db: Session):
-    response = client.post("/api/universe/99999/refresh")
+    response = client.post("/api/v1/universe/99999/refresh")
 
     assert response.status_code == 404
 
@@ -221,7 +221,7 @@ def test_refresh_universe_returns_completed_status(db: Session):
     universes = seed_universes(db)
     uid = universes[0].id
 
-    response = client.post(f"/api/universe/{uid}/refresh")
+    response = client.post(f"/api/v1/universe/{uid}/refresh")
 
     assert response.status_code == 200
     data = response.json()
@@ -239,7 +239,7 @@ def test_by_ticker_returns_universes_containing_ticker(db: Session):
     universes = seed_universes(db)
     seed_tickers(db, universes)
 
-    response = client.get("/api/universe/by-ticker/AAPL")
+    response = client.get("/api/v1/universe/by-ticker/AAPL")
 
     assert response.status_code == 200
     names = [u["name"] for u in response.json()]
@@ -251,7 +251,7 @@ def test_by_ticker_excludes_inactive_universes(db: Session):
     universes = seed_universes(db)
     seed_tickers(db, universes)
 
-    response = client.get("/api/universe/by-ticker/AAPL")
+    response = client.get("/api/v1/universe/by-ticker/AAPL")
 
     assert response.status_code == 200
     names = [u["name"] for u in response.json()]
@@ -261,7 +261,7 @@ def test_by_ticker_excludes_inactive_universes(db: Session):
 def test_by_ticker_returns_empty_for_unknown_ticker(db: Session):
     seed_universes(db)
 
-    response = client.get("/api/universe/by-ticker/ZZZZ")
+    response = client.get("/api/v1/universe/by-ticker/ZZZZ")
 
     assert response.status_code == 200
     assert response.json() == []

--- a/backend/tests/api/test_universe_by_ticker.py
+++ b/backend/tests/api/test_universe_by_ticker.py
@@ -26,7 +26,7 @@ def test_returns_universes_for_ticker(db: Session):
     _seed(db, "Momentum", "AAPL")
     _seed(db, "Tech Picks", "AAPL")
 
-    response = client.get("/api/universe/by-ticker/AAPL")
+    response = client.get("/api/v1/universe/by-ticker/AAPL")
 
     assert response.status_code == 200
     names = [u["name"] for u in response.json()]
@@ -35,7 +35,7 @@ def test_returns_universes_for_ticker(db: Session):
 
 
 def test_returns_empty_for_unknown_ticker(db: Session):
-    response = client.get("/api/universe/by-ticker/ZZZZ")
+    response = client.get("/api/v1/universe/by-ticker/ZZZZ")
 
     assert response.status_code == 200
     assert response.json() == []
@@ -45,7 +45,7 @@ def test_excludes_inactive_universes(db: Session):
     _seed(db, "Active Universe", "MSFT", is_active=True)
     _seed(db, "Inactive Universe", "MSFT", is_active=False)
 
-    response = client.get("/api/universe/by-ticker/MSFT")
+    response = client.get("/api/v1/universe/by-ticker/MSFT")
 
     assert response.status_code == 200
     names = [u["name"] for u in response.json()]
@@ -56,7 +56,7 @@ def test_excludes_inactive_universes(db: Session):
 def test_ticker_lookup_is_case_insensitive(db: Session):
     _seed(db, "Mixed Case", "NVDA")
 
-    response = client.get("/api/universe/by-ticker/nvda")
+    response = client.get("/api/v1/universe/by-ticker/nvda")
 
     assert response.status_code == 200
     assert len(response.json()) == 1

--- a/backend/tests/api/test_watchlist.py
+++ b/backend/tests/api/test_watchlist.py
@@ -22,7 +22,7 @@ def _sym(prefix="T"):
 
 def _post(symbol, security_type="STK"):
     return client.post(
-        "/api/watchlist/", json={"symbol": symbol, "security_type": security_type}
+        "/api/v1/watchlist/", json={"symbol": symbol, "security_type": security_type}
     )
 
 
@@ -30,7 +30,7 @@ def _post(symbol, security_type="STK"):
 
 
 def test_list_watchlist_returns_200(db: Session):
-    response = client.get("/api/watchlist/")
+    response = client.get("/api/v1/watchlist/")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
 
@@ -38,7 +38,7 @@ def test_list_watchlist_returns_200(db: Session):
 def test_list_watchlist_contains_added_entry(db: Session):
     sym = _sym("L")
     _post(sym)
-    response = client.get("/api/watchlist/")
+    response = client.get("/api/v1/watchlist/")
     symbols = [e["symbol"] for e in response.json()]
     assert sym in symbols
 
@@ -84,13 +84,13 @@ def test_add_beyond_soft_limit_returns_422(db: Session):
 def test_update_watchlist_notes(db: Session):
     sym = _sym("U")
     _post(sym)
-    response = client.patch(f"/api/watchlist/{sym}", json={"notes": "Watching closely"})
+    response = client.patch(f"/api/v1/watchlist/{sym}", json={"notes": "Watching closely"})
     assert response.status_code == 200
     assert response.json()["notes"] == "Watching closely"
 
 
 def test_update_watchlist_not_found_returns_404(db: Session):
-    response = client.patch("/api/watchlist/ZZZZ9", json={"notes": "nothing"})
+    response = client.patch("/api/v1/watchlist/ZZZZ9", json={"notes": "nothing"})
     assert response.status_code == 404
 
 
@@ -100,19 +100,19 @@ def test_update_watchlist_not_found_returns_404(db: Session):
 def test_delete_from_watchlist_returns_204(db: Session):
     sym = _sym("E")
     _post(sym)
-    response = client.delete(f"/api/watchlist/{sym}")
+    response = client.delete(f"/api/v1/watchlist/{sym}")
     assert response.status_code == 204
 
 
 def test_delete_removes_entry_from_list(db: Session):
     sym = _sym("R")
     _post(sym)
-    client.delete(f"/api/watchlist/{sym}")
-    response = client.get("/api/watchlist/")
+    client.delete(f"/api/v1/watchlist/{sym}")
+    response = client.get("/api/v1/watchlist/")
     symbols = [e["symbol"] for e in response.json()]
     assert sym not in symbols
 
 
 def test_delete_not_found_returns_404(db: Session):
-    response = client.delete("/api/watchlist/ZZZZ8")
+    response = client.delete("/api/v1/watchlist/ZZZZ8")
     assert response.status_code == 404

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,4 +1,4 @@
-import { apiClient } from './client';
+import { unversionedClient } from './client';
 
 export interface AuthStatus {
   bootstrapped: boolean;
@@ -11,24 +11,24 @@ export interface UserInfo {
 }
 
 export async function getAuthStatus(): Promise<AuthStatus> {
-  const response = await apiClient.get<AuthStatus>('/auth/status');
+  const response = await unversionedClient.get<AuthStatus>('/auth/status');
   return response.data;
 }
 
 export async function register(username: string, password: string): Promise<UserInfo> {
-  const response = await apiClient.post<UserInfo>('/auth/register', { username, password });
+  const response = await unversionedClient.post<UserInfo>('/auth/register', { username, password });
   return response.data;
 }
 
 export async function login(username: string, password: string): Promise<void> {
-  await apiClient.post('/auth/login', { username, password });
+  await unversionedClient.post('/auth/login', { username, password });
 }
 
 export async function logout(): Promise<void> {
-  await apiClient.post('/auth/logout');
+  await unversionedClient.post('/auth/logout');
 }
 
 export async function getMe(): Promise<UserInfo> {
-  const response = await apiClient.get<UserInfo>('/auth/me');
+  const response = await unversionedClient.get<UserInfo>('/auth/me');
   return response.data;
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,9 +1,19 @@
 import axios from 'axios';
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '/api';
+const API_BASE = import.meta.env.VITE_API_BASE_URL ?? '/api/v1';
 
 export const apiClient = axios.create({
   baseURL: API_BASE,
+  withCredentials: true,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// Separate client for unversioned endpoints (auth, health). Auth stays at /api/auth
+// regardless of API version so tokens work across all versions.
+export const unversionedClient = axios.create({
+  baseURL: '/api',
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
@@ -19,7 +29,7 @@ apiClient.interceptors.response.use(
     if (status === 401 && !error.config._retried && !error.config.url?.includes('/auth/')) {
       error.config._retried = true;
       try {
-        await apiClient.post('/auth/refresh');
+        await unversionedClient.post('/auth/refresh');
         return apiClient(error.config);
       } catch {
         window.location.href = '/login';

--- a/frontend/src/api/scanner.ts
+++ b/frontend/src/api/scanner.ts
@@ -267,7 +267,7 @@ export const cancelScan = async (scanId: string): Promise<{ status: string; scan
 export const createScanRunWebSocket = (taskId: string): WebSocket | null => {
   try {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    return new WebSocket(`${protocol}//${window.location.host}/api/scanner/ws/runs/${taskId}`);
+    return new WebSocket(`${protocol}//${window.location.host}/api/v1/scanner/ws/runs/${taskId}`);
   } catch (e) {
     console.error('[WS] Failed to open scanner run WS', e);
     return null;
@@ -719,7 +719,7 @@ export const fetchStorageStats = async (): Promise<StorageStats> => {
 export const createScannerWebSocket = (): WebSocket | null => {
   try {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const ws = new WebSocket(`${protocol}//${window.location.host}/api/ws/scanner`);
+    const ws = new WebSocket(`${protocol}//${window.location.host}/api/v1/ws/scanner`);
     ws.onopen = () => console.log('[WS] Scanner connected');
     ws.onclose = () => console.log('[WS] Scanner disconnected');
     ws.onerror = (e) => console.error('[WS] Scanner error', e);

--- a/frontend/src/components/SystemActivityMonitor.tsx
+++ b/frontend/src/components/SystemActivityMonitor.tsx
@@ -24,7 +24,7 @@ export const SystemActivityMonitor: React.FC = () => {
       const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
       const host = window.location.host;
       
-      ws = new WebSocket(`${protocol}//${host}/api/system/ws/tasks`);
+      ws = new WebSocket(`${protocol}//${host}/api/v1/system/ws/tasks`);
 
       ws.onopen = () => {
         if (!isMounted) {

--- a/frontend/src/hooks/useLiveStockData.ts
+++ b/frontend/src/hooks/useLiveStockData.ts
@@ -25,7 +25,7 @@ export const useLiveStockData = (symbol: string | undefined, resolution: 'minute
     const host = window.location.host;
     
     // Updated to include resolution in the path
-    const wsUrl = `${protocol}//${host}/api/live/ws/${symbol.toUpperCase()}/${resolution}`;
+    const wsUrl = `${protocol}//${host}/api/v1/live/ws/${symbol.toUpperCase()}/${resolution}`;
 
     console.log(`Connecting to live updates: ${wsUrl}`);
     

--- a/frontend/src/hooks/useScanTask.ts
+++ b/frontend/src/hooks/useScanTask.ts
@@ -39,7 +39,7 @@ export const useScanTask = (
     setState({ ...INITIAL_STATE, status: 'connecting' });
 
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsUrl = `${protocol}//${window.location.host}/api/live/ws/scan-task/${taskId}`;
+    const wsUrl = `${protocol}//${window.location.host}/api/v1/live/ws/scan-task/${taskId}`;
 
     let isMounted = true;
 

--- a/frontend/src/hooks/useWatchlistLive.ts
+++ b/frontend/src/hooks/useWatchlistLive.ts
@@ -72,7 +72,7 @@ export function useWatchlistLive() {
       if (destroyed) return;
 
       const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-      const ws = new WebSocket(`${protocol}://${window.location.host}/api/live/ws/watchlist`);
+      const ws = new WebSocket(`${protocol}://${window.location.host}/api/v1/live/ws/watchlist`);
       wsRef.current = ws;
 
       ws.onopen = () => {

--- a/frontend/src/pages/EdgeExplorer.tsx
+++ b/frontend/src/pages/EdgeExplorer.tsx
@@ -59,7 +59,7 @@ const EdgeExplorer: React.FC = () => {
       if (ticker) params.append('ticker', ticker);
       if (scannerType) params.append('scanner_type', scannerType);
       
-      const response = await fetch(`/api/scanner/edge-stats?${params.toString()}`);
+      const response = await fetch(`/api/v1/scanner/edge-stats?${params.toString()}`);
       if (!response.ok) return [];
       return response.json();
     }
@@ -73,7 +73,7 @@ const EdgeExplorer: React.FC = () => {
       if (ticker) params.append('ticker', ticker);
       if (scannerType) params.append('scanner_type', scannerType);
       
-      const response = await fetch(`/api/scanner/edge-distribution?${params.toString()}`);
+      const response = await fetch(`/api/v1/scanner/edge-distribution?${params.toString()}`);
       if (!response.ok) return { events: [] };
       return response.json();
     }


### PR DESCRIPTION
## Summary

- All 13 application routers moved from `/api/{resource}` to `/api/v1/{resource}` in a single hard cut
- Auth (`/api/auth`) and health (`/api/health`) stay unversioned — tokens must work across all API versions; infrastructure probes must stay stable
- Frontend `apiClient` baseURL updated to `/api/v1`; a new `unversionedClient` handles auth calls
- All 6 hardcoded WebSocket URLs and 2 raw `fetch()` calls updated in the frontend
- 259 backend tests pass; TypeScript type-check passes
- ADR-010 documents the versioning policy and 90-day deprecation window for future breaking changes
- Sunset header middleware deferred to the v2 PR (no old routes exist to sunset)

Closes #105

## Test plan

- [ ] `cd backend && python -m pytest tests/api/ -q` — all 259 tests pass
- [ ] `cd frontend && npx tsc --noEmit` — no type errors
- [ ] Docker stack: `curl http://localhost:8000/api/v1/scanner/results` returns 200 (with auth cookie)
- [ ] Docker stack: `curl http://localhost:8000/api/health` returns 200 (unversioned health probe still works)
- [ ] Docker stack: `curl http://localhost:8000/api/auth/status` returns 200 (auth stays unversioned)
- [ ] Frontend: log in, navigate to Scanner and Universes pages — data loads correctly
- [ ] Frontend: WebSocket connections on ActiveWatchlist and Scanner pages connect successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)