### PR TITLE
fix(dark-factory): stop issue >=100 sticking In Progress; repair cost report

### DIFF
--- a/.archon/workflows/archon-dark-factory.yaml
+++ b/.archon/workflows/archon-dark-factory.yaml
@@ -168,7 +168,7 @@ nodes:
     bash: |
       ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
       EPIC_NUM=$(echo $fetch-issue.output | jq -r '.epic_number // empty')
-      PADDED=$(printf "%02d" "$ISSUE")
+      PADDED=$(printf "%02d" $((ISSUE % 100)))  # slot 00-99 keeps preview ports <= 65535 (3-digit issues would overflow, e.g. #100 -> 110033)
 
       echo "Tearing down mh-preview-${ISSUE}..."
       docker compose -p "mh-preview-${ISSUE}" down -v 2>/dev/null || echo "No preview stack found"
@@ -290,7 +290,11 @@ nodes:
   - id: preview-up
     bash: |
       ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
-      PADDED=$(printf "%02d" "$ISSUE")
+      # Preview ports follow 1{SLOT}{suffix} (e.g. slot 03 -> frontend 10333, backend 10380).
+      # SLOT must stay 2 digits or the port exceeds 65535 (issue #100 produced 110033 -> "invalid hostPort").
+      # Map the issue number into a 2-digit slot via modulo. Caveat: two previews whose issue numbers are
+      # congruent mod 100 collide on ports; acceptable given the single-factory guard + teardown on close.
+      PADDED=$(printf "%02d" $((ISSUE % 100)))  # slot 00-99 keeps preview ports <= 65535 (3-digit issues would overflow, e.g. #100 -> 110033)
       export ISSUE_NUM_PADDED="$PADDED"
       export POLYGON_API_KEY="${POLYGON_API_KEY:-}"
 
@@ -358,7 +362,7 @@ nodes:
     bash: |
       ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
       EPIC_NUM=$(echo $fetch-issue.output | jq -r '.epic_number // empty')
-      PADDED=$(printf "%02d" "$ISSUE")
+      PADDED=$(printf "%02d" $((ISSUE % 100)))  # slot 00-99 keeps preview ports <= 65535 (3-digit issues would overflow, e.g. #100 -> 110033)
       BRANCH=$(git branch --show-current)
       echo "Pushing branch and creating/updating PR for issue #${ISSUE}..."
 
@@ -424,7 +428,7 @@ nodes:
     bash: |
       ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
       EPIC_NUM=$(echo $fetch-issue.output | jq -r '.epic_number // empty')
-      PADDED=$(printf "%02d" "$ISSUE")
+      PADDED=$(printf "%02d" $((ISSUE % 100)))  # slot 00-99 keeps preview ports <= 65535 (3-digit issues would overflow, e.g. #100 -> 110033)
       INTENT=$parse-intent.output.intent
       BRANCH=$(git branch --show-current)
       echo "Posting summary to issue #${ISSUE}..."

--- a/dark-factory/Dockerfile
+++ b/dark-factory/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
     wget \
     git \
     jq \
+    bc \
     bubblewrap \
     socat \
     ca-certificates \

--- a/dark-factory/entrypoint.sh
+++ b/dark-factory/entrypoint.sh
@@ -91,7 +91,7 @@ post_cost_report() {
   # Archon's pino logger writes to stdout; use --quiet to suppress, fall back to jq filtering
   local RAW_OUTPUT RUN_JSON
   RAW_OUTPUT=$(archon workflow cost --last --json --quiet 2>/dev/null || true)
-  RUN_JSON=$(echo "$RAW_OUTPUT" | jq -s 'map(select(.run_id?)) | .[0] // empty' 2>/dev/null || true)
+  RUN_JSON=$(echo "$RAW_OUTPUT" | jq -s 'map(select((.run_id // .runId) != null)) | .[0] // empty' 2>/dev/null || true)
   if [ -z "$RUN_JSON" ] || [ "$RUN_JSON" = "null" ]; then return; fi
 
   echo "Posting cost report to issue #${ISSUE_NUM}..."
@@ -105,9 +105,9 @@ post_cost_report() {
   local RUN_ROWS TOTAL_COST TOTAL_IN TOTAL_OUT RUN_STATUS TIMESTAMP
   TIMESTAMP=$(date -u +"%Y-%m-%d %H:%M UTC")
   RUN_STATUS=$(echo "$RUN_JSON" | jq -r '.status // "unknown"')
-  TOTAL_COST=$(echo "$RUN_JSON" | jq -r '.totals.cost_usd // 0')
-  TOTAL_IN=$(echo "$RUN_JSON" | jq -r '.totals.input_tokens // 0')
-  TOTAL_OUT=$(echo "$RUN_JSON" | jq -r '.totals.output_tokens // 0')
+  TOTAL_COST=$(echo "$RUN_JSON" | jq -r '.totals.cost_usd // .totals.costUsd // 0')
+  TOTAL_IN=$(echo "$RUN_JSON" | jq -r '.totals.input_tokens // .totals.inputTokens // 0')
+  TOTAL_OUT=$(echo "$RUN_JSON" | jq -r '.totals.output_tokens // .totals.outputTokens // 0')
 
   # jq helper functions for human-readable formatting
   RUN_ROWS=$(echo "$RUN_JSON" | jq -r '
@@ -118,10 +118,10 @@ post_cost_report() {
                  elif . < 60000 then "\(. / 100 | round / 10)s"
                  else "\(. / 60000 | floor)m \((. % 60000 / 1000) | round)s" end;
     def fmt_cost: "$\(. * 10000 | round / 10000)";
-    def fmt_model: ((.modelUsage // {}) | keys[0] // "") |
+    def fmt_model: (((.modelUsage // .model_usage) // {}) | keys[0] // "") |
                    gsub("^claude-"; "") | gsub("-2025.*$"; "");
-    .nodes[] |
-    "| \(.nodeId) | \(fmt_model) | \(.inputTokens | fmt_tokens) | \(.outputTokens | fmt_tokens) | \(.costUsd | fmt_cost) | \(.durationMs | fmt_dur) |"
+    (.nodes // [])[] |
+    "| \(.nodeId // .node_id) | \(fmt_model) | \((.inputTokens // .input_tokens // 0) | fmt_tokens) | \((.outputTokens // .output_tokens // 0) | fmt_tokens) | \((.costUsd // .cost_usd // 0) | fmt_cost) | \((.durationMs // .duration_ms // 0) | fmt_dur) |"
   ' 2>/dev/null || true)
 
   if [ -z "$RUN_ROWS" ]; then return; fi
@@ -198,7 +198,6 @@ ${RUN_ROWS}
 # --- Error handler: move ticket back to Ready and post comment ---
 on_failure() {
   local EXIT_CODE=$?
-  post_cost_report
   if [ -n "${ISSUE_NUM:-}" ] && [ "$INTENT" != "close" ]; then
     if [ "$INTENT" = "refine" ] || [ "$INTENT" = "plan" ]; then
       echo "Refinement pipeline failed (exit $EXIT_CODE) for issue #$ISSUE_NUM"
@@ -230,6 +229,10 @@ docker compose --profile factory run --rm dark-factory \"$ARGUMENTS\"
 *Posted by MarketHawk Dark Factory*" 2>/dev/null || true
     fi
   fi
+  # Cost report runs LAST and is non-fatal: a failure here (missing dependency,
+  # cost-JSON schema drift) must never abort the trap before the Blocked transition
+  # and failure comment above have run.
+  post_cost_report || true
 }
 trap on_failure ERR
 
@@ -260,5 +263,5 @@ export ARCHON_SUPPRESS_NESTED_CLAUDE_WARNING=1
 echo "Starting dark factory: $ARGUMENTS"
 archon workflow run archon-dark-factory "$ARGUMENTS"
 
-# --- Post cost report to GitHub issue (success path) ---
-post_cost_report
+# --- Post cost report to GitHub issue (success path) — non-fatal ---
+post_cost_report || true

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -140,6 +140,19 @@ dispatch() {
   docker compose -f /workspace/project/docker-compose.yml --profile factory run -d --rm dark-factory "$command"
 }
 
+# --- Move an issue to a board status (used by the orphaned-in-progress sweep) ---
+set_board_status() {
+  local issue_num="$1"
+  local option_id="$2"
+  local item_id
+  item_id=$(gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 200 2>/dev/null \
+    | jq -r ".items[] | select(.content.number == $issue_num and .content.type == \"Issue\") | .id")
+  if [ -n "$item_id" ]; then
+    gh project item-edit --project-id "$PROJECT_ID" --id "$item_id" \
+      --field-id "$STATUS_FIELD" --single-select-option-id "$option_id" >/dev/null 2>&1 || true
+  fi
+}
+
 # --- Board state ---
 fetch_board_items() {
   local raw
@@ -364,6 +377,27 @@ while true; do
   BACKLOG_COUNT=$(echo "$BACKLOG" | jq 'length')
   REFINED_COUNT=$(echo "$REFINED" | jq 'length')
   REFINE_RUNNING=$(count_refine_running)
+
+  # --- Sweep: recover orphaned "In progress" items ---
+  # We only reach here when no factory container is running (FACTORY_RUNNING guard
+  # above), so any issue still in "In progress" was abandoned mid-run. The usual
+  # failure path (entrypoint on_failure -> Blocked) cannot fire for untrappable
+  # deaths — host reboot, OOM/SIGKILL — so those issues would otherwise sit stuck
+  # forever and silently consume a WIP slot. Route them into the Blocked retry path,
+  # exactly what on_failure would have done. (Skip-labels let a human park an item.)
+  while IFS= read -r item; do
+    ISSUE=$(get_issue_number "$item")
+    if has_skip_label "$item"; then continue; fi
+    if is_issue_running "$ISSUE"; then continue; fi
+    echo "[$(date -u +%FT%TZ)] sweep=orphaned_in_progress issue=#${ISSUE} action=move_to_blocked"
+    set_board_status "$ISSUE" "$STATUS_BLOCKED"
+    gh issue comment "$ISSUE" --repo "${OWNER}/markethawk" --body "## Dark Factory — Orphaned Run Recovered
+
+This issue was left in **In progress** with no running factory container — the run died without its error handler executing (e.g. a host restart or OOM/SIGKILL). The scheduler has moved it to **Blocked** so it will be retried automatically.
+
+---
+*Posted by MarketHawk Backlog Scheduler*" 2>/dev/null || true
+  done < <(echo "$IN_PROGRESS" | jq -c '.[]')
 
   # --- Priority 1: In Review items with new comments (unblock existing work) ---
   while IFS= read -r item; do


### PR DESCRIPTION
## Summary

Fixes the dark-factory reliability bugs that left issue omniscient/markethawk#100 stuck in **In progress** and that
have prevented any cost report from ever posting. Full root-cause analysis in omniscient/dark-factory#64.

Closes omniscient/dark-factory#64

## Root cause

The `Fix issue omniscient/markethawk#100` run implemented the work and created its PR (#123) successfully, then the
pipeline failed at `preview-up` and could not recover:

- **Port overflow:** `1{printf "%02d" ISSUE}{suffix}` → issue omniscient/markethawk#100 produced host port `110033`
  (> 65535) → `invalid hostPort`. Deterministic for any issue ≥ 100.
- **Broken `on_failure`:** it ran `post_cost_report` first, which died on `bc: command not found`
  before the `set_board_status BLOCKED` line — so failed runs were never marked Blocked and
  posted no comment.
- **No recovery for untrappable deaths:** host reboot / OOM / SIGKILL skip the bash trap
  entirely, and the scheduler had no handler for the In-progress column.
- **Cost report never posts:** the same `bc` failure aborts `post_cost_report` on every run.

## Changes

| File | Change |
|------|--------|
| `.archon/workflows/archon-dark-factory.yaml` | Preview slot = `printf "%02d" $((ISSUE % 100))` (4 sites); keeps ports 10000–19999, backward-compatible for issues ≤ 99 |
| `dark-factory/Dockerfile` | Install `bc` |
| `dark-factory/entrypoint.sh` | `on_failure`: Blocked transition first, cost report last + `\|\| true`; success-path cost report `\|\| true`; cost-JSON tolerant of snake/camel + null-guarded |
| `dark-factory/scheduler.sh` | `set_board_status` helper + sweep that moves orphaned In-Progress items to Blocked |

## Validation

- `bash -n` passes on `entrypoint.sh` and `scheduler.sh`
- tolerant jq verified on both camelCase and snake_case input (identical correct rows)
- workflow YAML parses
- port math confirmed valid + backward-compatible for issues 3 / 12 / 88 / 93 / 99 / 100 / 105 / 123 / 200

## Rollout

The workflow YAML is cloned from `main` at runtime; `entrypoint.sh` / `scheduler.sh` / `bc` are
baked into the image. After merge:

```bash
docker compose --profile factory build dark-factory
docker compose --profile scheduler up -d --build backlog-scheduler
```

## Follow-up

The `ISSUE % 100` slot is a workaround with a residual collision risk (two previews congruent
mod 100). Collision-free dynamic port allocation is tracked in omniscient/dark-factory#63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
