### PR TITLE
fix(dark-factory): cost report no longer triggers a duplicate spec

### DIFF
--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -115,22 +115,22 @@ has_new_comment_after_report() {
   local comments
   comments=$(gh issue view "$issue_num" --repo "${OWNER}/markethawk" --json comments -q '.comments' 2>/dev/null) || { echo "no"; return; }
 
-  local report_idx
-  report_idx=$(echo "$comments" | jq "map(.body) | to_entries | map(select(.value | test(\"$report_marker\"))) | last | .key // -1")
+  # A comment counts as reviewer feedback only if it appears AFTER the last spec report
+  # AND is not one of our own automated comments. The dark factory posts its cost report
+  # after the spec on the success path (entrypoint.sh post_cost_report), and the scheduler
+  # posts pipeline-status comments — none are feedback, so re-running the spec on them
+  # loops the pipeline (issue #124: cost report -> spurious second spec). Match on
+  # footer/marker, NOT author: every comment is authored by the same PAT account.
+  local bot_re="Posted by MarketHawk Refinement Pipeline|Posted by MarketHawk Backlog Scheduler|Posted by MarketHawk Dark Factory|Updated by MarketHawk Dark Factory|dark-factory-cost-report"
 
-  if [ "$report_idx" = "-1" ]; then
-    echo "no"
-    return
-  fi
+  local has_human
+  has_human=$(echo "$comments" | jq --arg marker "$report_marker" --arg bot "$bot_re" '
+    (to_entries | map(select(.value.body | test($marker))) | last | .key // -1) as $ridx
+    | if $ridx == -1 then false
+      else (to_entries | any(.key > $ridx and (.value.body | test($bot) | not)))
+      end')
 
-  local total
-  total=$(echo "$comments" | jq 'length')
-  local next_idx=$((report_idx + 1))
-  if [ "$next_idx" -lt "$total" ]; then
-    echo "yes"
-  else
-    echo "no"
-  fi
+  if [ "$has_human" = "true" ]; then echo "yes"; else echo "no"; fi
 }
 
 # --- Dispatch ---
@@ -363,6 +363,13 @@ ${comment_text}"
       ;;
   esac
 }
+
+# When sourced for testing (SCHEDULER_SOURCE_ONLY=1) stop here: the helper functions
+# and constants above are now defined, but the startup probes and poll loop below must
+# not run (they would call gh and block forever in `while true`).
+if [ "${SCHEDULER_SOURCE_ONLY:-0}" = "1" ]; then
+  return 0
+fi
 
 # --- Fetch WIP limits once at startup (cached until restart) ---
 WIP_DATA=$(fetch_wip_limits)

--- a/dark-factory/tests/test_has_new_comment_after_report.sh
+++ b/dark-factory/tests/test_has_new_comment_after_report.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Regression test for has_new_comment_after_report() in scheduler.sh.
+#
+# Bug (issue #124): the dark factory posts its cost-report comment AFTER the spec on the
+# success path. has_new_comment_after_report() found the last "Posted by MarketHawk
+# Refinement Pipeline" comment (the spec) and returned "yes" if ANY comment followed it —
+# so the bot-authored cost report was mistaken for human feedback and a duplicate spec run
+# was dispatched. Only genuine human comments after the spec should return "yes".
+#
+# Run: bash dark-factory/tests/test_has_new_comment_after_report.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCHEDULER="${SCRIPT_DIR}/../scheduler.sh"
+
+# scheduler.sh validates these at top level; provide dummies so sourcing succeeds.
+export GH_TOKEN="test-token"
+export CLAUDE_CODE_OAUTH_TOKEN="test-oauth"
+export SCHEDULER_SOURCE_ONLY=1
+
+# shellcheck source=/dev/null
+source "$SCHEDULER"
+set +e  # scheduler.sh sets -e; don't let an assertion failure abort the run
+
+# --- gh stub: return the JSON in $MOCK_COMMENTS for `gh issue view ... --json comments` ---
+MOCK_COMMENTS='[]'
+gh() {
+  case "$*" in
+    *"issue view"*) printf '%s' "$MOCK_COMMENTS" ;;
+    *) return 0 ;;
+  esac
+}
+
+REPORT_MARKER="Posted by MarketHawk Refinement Pipeline"
+PASS=0
+FAIL=0
+
+# Footers used by the comment factories, kept verbatim so the test breaks if they drift.
+SCHED_FOOTER="*Posted by MarketHawk Backlog Scheduler*"
+SPEC_FOOTER="*Posted by MarketHawk Refinement Pipeline*"
+COST_FOOTER="*Updated by MarketHawk Dark Factory*"
+
+# Build a GitHub-shaped comments array from the body strings passed as arguments.
+# Uses jq --args (NOT process substitution, which is broken under MSYS bash).
+mock_comments() {
+  jq -n '$ARGS.positional | map({body: ., author: {login: "omniscient"}})' --args "$@"
+}
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected '$expected', got '$actual')"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Scenario A — issue #124 exactly: spec, then cost report. No human feedback => "no".
+MOCK_COMMENTS=$(mock_comments \
+  "🧠 Starting brainstorming and spec generation.
+---
+${SCHED_FOOTER}" \
+  "## Refinement Pipeline — Spec Generated
+The spec body.
+---
+${SPEC_FOOTER}" \
+  "<!-- dark-factory-cost-report -->
+## Dark Factory — Cost Report
+---
+${COST_FOOTER}")
+assert_eq "cost report after spec is NOT human feedback" "no" "$(has_new_comment_after_report 124 "$REPORT_MARKER")"
+
+# Scenario B — a genuine human comment after the spec => "yes".
+MOCK_COMMENTS=$(mock_comments \
+  "## Refinement Pipeline — Spec Generated
+---
+${SPEC_FOOTER}" \
+  "Please use a port range starting at 20000 instead.")
+assert_eq "human comment after spec IS feedback" "yes" "$(has_new_comment_after_report 124 "$REPORT_MARKER")"
+
+# Scenario C — cost report AND a later human comment => "yes" (human still counts).
+MOCK_COMMENTS=$(mock_comments \
+  "## Refinement Pipeline — Spec Generated
+---
+${SPEC_FOOTER}" \
+  "<!-- dark-factory-cost-report -->
+---
+${COST_FOOTER}" \
+  "Looks good but rename the helper.")
+assert_eq "human comment after cost report IS feedback" "yes" "$(has_new_comment_after_report 124 "$REPORT_MARKER")"
+
+# Scenario D — spec only, nothing after => "no".
+MOCK_COMMENTS=$(mock_comments \
+  "## Refinement Pipeline — Spec Generated
+---
+${SPEC_FOOTER}")
+assert_eq "spec with no following comment" "no" "$(has_new_comment_after_report 124 "$REPORT_MARKER")"
+
+# Scenario E — no spec marker present at all => "no".
+MOCK_COMMENTS=$(mock_comments "Just a stray comment, no spec yet.")
+assert_eq "no spec marker" "no" "$(has_new_comment_after_report 124 "$REPORT_MARKER")"
+
+echo ""
+echo "Passed: $PASS  Failed: $FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Problem

When the refinement pipeline posts a spec (issue labeled `spec-pending-review`), the dark factory then posts its **cost report as a separate comment** on the success path (`entrypoint.sh` → `post_cost_report`). The scheduler's `has_new_comment_after_report()` counted *any* comment after the spec as reviewer feedback, so the cost report tripped a spurious re-run: the `spec-pending-review` label was stripped, _"Re-running with new feedback"_ was posted, and a **second `Refine`** was dispatched — a duplicate spec.

Observed on omniscient/dark-factory#63:

| Time | Comment |
|------|---------|
| 17:27 | Spec generated (`Posted by MarketHawk Refinement Pipeline`) |
| 17:28 | Cost report (`<!-- dark-factory-cost-report -->`, posted *after* the spec) |
| 17:29 | "🔄 Re-running with new feedback" |
| 17:34 | Duplicate spec |

It's bounded to **one** extra spec, not a loop — the cost report is edited in place (matched by its marker), so it stays before the new spec and the next cycle finds nothing after the latest spec marker. Also: every comment is authored by the same PAT account (`omniscient`), so author-based filtering won't work — the footer/marker is the only reliable discriminator.

## Fix

`has_new_comment_after_report()` now counts a post-spec comment as reviewer feedback only if its body is **not** one of our own automated comments (refinement pipeline / backlog scheduler / dark factory / cost-report markers). Implemented as a single jq pass.

## Tests

- Adds `dark-factory/tests/test_has_new_comment_after_report.sh` (5 scenarios). Against the **unfixed** code it failed exactly on the omniscient/dark-factory#63 case (`got 'yes', expected 'no'`) and passed the rest — proving it reproduces the bug. Against the fix, **5/5 pass**.
- Verified the fixed function against live omniscient/dark-factory#63 JSON → returns `no`.
- Added a `SCHEDULER_SOURCE_ONLY=1` guard so the helper functions can be sourced for testing without running the poll loop (only ever set by the test harness).

Surfaced via omniscient/dark-factory#63 (that ticket — preview port allocation — is unrelated and stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
