### PR TITLE
fix(dark-factory): cost report comment never updated (wrong REST endpoint)

### DIFF
--- a/dark-factory/entrypoint.sh
+++ b/dark-factory/entrypoint.sh
@@ -130,7 +130,10 @@ post_cost_report() {
   local PRIOR_RUNS="" PREV_COST="0" PREV_IN="0" PREV_OUT="0"
   if [ -n "$COMMENT_ID" ]; then
     local EXISTING_BODY
-    EXISTING_BODY=$(gh api "repos/omniscient/markethawk/issues/${ISSUE_NUM}/comments/${COMMENT_ID}" \
+    # Single-comment endpoint omits the issue number: /issues/comments/{id}, NOT
+    # /issues/{n}/comments/{id} (the latter 404s — it silently lost all prior-run
+    # history and left the report frozen on its first run).
+    EXISTING_BODY=$(gh api "repos/omniscient/markethawk/issues/comments/${COMMENT_ID}" \
       --jq '.body' 2>/dev/null || true)
     PRIOR_RUNS=$(echo "$EXISTING_BODY" | sed -n '/^### Run:/,/^---$/p' | head -n -1 || true)
     # Extract previous grand total from hidden data marker
@@ -187,9 +190,12 @@ ${RUN_ROWS}
   echo "$BODY" > "$TMPFILE"
 
   if [ -n "$COMMENT_ID" ]; then
-    gh api "repos/omniscient/markethawk/issues/${ISSUE_NUM}/comments/${COMMENT_ID}" \
-      --method PATCH -F "body=@${TMPFILE}" > /dev/null 2>&1 \
-      || echo "WARNING: Could not update cost report comment"
+    # Same canonical single-comment endpoint (no issue number). Let gh's stderr through
+    # on failure — swallowing it with 2>&1 is what hid the 404 path bug for so long.
+    if ! gh api "repos/omniscient/markethawk/issues/comments/${COMMENT_ID}" \
+        --method PATCH -F "body=@${TMPFILE}" >/dev/null; then
+      echo "WARNING: Could not update cost report comment ${COMMENT_ID}"
+    fi
   else
     gh issue comment "$ISSUE_NUM" --body-file "$TMPFILE" 2>/dev/null \
       || echo "WARNING: Could not post cost report"

--- a/dark-factory/tests/test_cost_report_endpoint.sh
+++ b/dark-factory/tests/test_cost_report_endpoint.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Regression guard for the cost-report comment endpoint in entrypoint.sh.
+#
+# Bug: post_cost_report() read and PATCHed the cost-report comment via
+#   /repos/{owner}/{repo}/issues/{ISSUE_NUM}/comments/{COMMENT_ID}
+# That path 404s — GitHub's single-comment endpoint omits the issue number
+#   /repos/{owner}/{repo}/issues/comments/{COMMENT_ID}
+# The 404 was swallowed (2>/dev/null, 2>&1), so the comment was created once and never
+# updated (frozen on its first run, prior-run history lost). Verified live: the bad path
+# returns 404, the canonical path returns the comment.
+#
+# Behavioral testing of post_cost_report is impractical (it shells out to archon + gh +
+# bc), so this is a static guard: the single-comment endpoint must NOT carry an issue
+# number. The list/create endpoint (/issues/{n}/comments, no trailing id) is fine.
+#
+# Run: bash dark-factory/tests/test_cost_report_endpoint.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENTRYPOINT="${SCRIPT_DIR}/../entrypoint.sh"
+FAIL=0
+
+# A single-comment op = the path ends in .../comments/<something>. Such a path must never
+# include the issue number segment (issues/$ISSUE_NUM/comments/<id>).
+if grep -nE 'issues/\$\{?ISSUE_NUM\}?/comments/[^"]' "$ENTRYPOINT"; then
+  echo "  FAIL: single-comment endpoint includes the issue number (404s — see above lines)"
+  FAIL=1
+else
+  echo "  PASS: no issue-number-prefixed single-comment endpoint"
+fi
+
+# And the canonical single-comment endpoint should be present (read + PATCH).
+CANON=$(grep -cE 'issues/comments/\$\{?COMMENT_ID\}?' "$ENTRYPOINT")
+if [ "$CANON" -ge 2 ]; then
+  echo "  PASS: canonical /issues/comments/{id} endpoint used (${CANON} occurrences)"
+else
+  echo "  FAIL: expected >=2 uses of /issues/comments/{id} (read + PATCH), found ${CANON}"
+  FAIL=1
+fi
+
+echo ""
+[ "$FAIL" -eq 0 ] && echo "OK" || echo "FAILED"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Problem

The dark factory's cost-report comment was **created once and never updated** — it froze on its first run, losing all subsequent runs' history. Observed on omniscient/dark-factory#63: the plan was generated, but the cost report still showed only the first `refine` run.

## Root cause

`post_cost_report()` in `entrypoint.sh` looks up the comment via the list endpoint (`/issues/{n}/comments`, correct), but then **reads** and **PATCHes** the single comment via:

```
/repos/omniscient/markethawk/issues/{ISSUE_NUM}/comments/{COMMENT_ID}   → 404 Not Found
```

GitHub's single-comment endpoint omits the issue number:

```
/repos/omniscient/markethawk/issues/comments/{COMMENT_ID}                → 200 OK
```

Both calls suppressed errors (`2>/dev/null` on the read, `2>&1 || echo WARNING` on the PATCH), so the 404 was invisible. Creation worked only because it uses the `gh issue comment` CLI, not the REST API.

## Fix

- Use the canonical `/issues/comments/{id}` path for both the read and the PATCH.
- Surface `gh`'s stderr on PATCH failure instead of swallowing it with `2>&1` — that silent redirect is what hid the bug.

## Verification

- Reproduced live: bad path → 404, canonical path → 200.
- End-to-end: a faithful round-trip PATCH (exact bytes written back) via the corrected command succeeded — `updated_at` moved `17:28:30Z → 19:03:49Z`, exit 0. So the corrected endpoint + `-F body=@file` mechanism both work; forward runs will append correctly.
- Adds `dark-factory/tests/test_cost_report_endpoint.sh` — a static regression guard asserting no issue-number-prefixed single-comment endpoint and that the canonical path is used for read + PATCH (2/2 pass; fails on the old code).
- `bash -n` clean.

Surfaced via omniscient/dark-factory#63. Note: that report's existing content can't be backfilled (the lost runs' cost JSON is gone with their `--rm` containers); only forward runs are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
