### PR TITLE
fix(dark-factory): repair archon-dark-factory workflow YAML (heredoc dedent)

### DIFF
--- a/.archon/workflows/archon-dark-factory.yaml
+++ b/.archon/workflows/archon-dark-factory.yaml
@@ -378,11 +378,11 @@ nodes:
           # Write env file so the validate command can source it reliably without
           # having to parse raw step output or guess the URL.
           mkdir -p "$ARTIFACTS_DIR"
-          cat > "$ARTIFACTS_DIR/preview_env.sh" <<EOF
-export PREVIEW_FRONTEND="http://localhost:1${PADDED}33"
-export PREVIEW_BACKEND="${BACKEND_INTERNAL}"
-export PREVIEW_NET="${PREVIEW_NET}"
-EOF
+          {
+            echo "export PREVIEW_FRONTEND=\"http://localhost:1${PADDED}33\""
+            echo "export PREVIEW_BACKEND=\"${BACKEND_INTERNAL}\""
+            echo "export PREVIEW_NET=\"${PREVIEW_NET}\""
+          } > "$ARTIFACTS_DIR/preview_env.sh"
           exit 0
         fi
         sleep 3


### PR DESCRIPTION
## Problem

Every dark-factory `plan` / `refine` / `fix` / `continue` dispatch has been failing at startup:

```
Workflow 'archon-dark-factory' failed to load: YAML parse error: YAML Parse error: Unexpected token
```

Archon aborts during **workflow discovery** (`loader.ts:190`), so the run exits 1 before doing any work. Issue omniscient/markethawk#140's plan step looped on this **28 times** on 2026-05-30 (one failure comment per ~90s retry).

## Root cause

The `preview-up` node writes `$ARTIFACTS_DIR/preview_env.sh` with a heredoc whose body sits at **column 1**, dedented out of the surrounding `bash: |` block scalar:

```yaml
          cat > "$ARTIFACTS_DIR/preview_env.sh" <<EOF
export PREVIEW_FRONTEND="http://localhost:1${PADDED}33"   # col 1 -> breaks out of the block scalar
export PREVIEW_BACKEND="${BACKEND_INTERNAL}"
export PREVIEW_NET="${PREVIEW_NET}"
EOF
```

YAML ends the block scalar at the dedent, then reads `export PREVIEW_FRONTEND="http` and hits the `:` in the URL → *Implicit keys need to be on a single line*.

Introduced by 787d498 (`feat(dark-factory): collision-free preview port allocation`, issue omniscient/dark-factory#63). It is a **static** syntax error, so it broke *all* subsequent runs — omniscient/markethawk#140 was simply the next issue dispatched.

## Fix

Replace the heredoc with a brace-group of `echo`s that stay inside the block scalar at the correct indentation (matching the existing `echo` style a few lines above). Behaviour is identical: the same three `export` lines, with shell variable expansion, written to the same file.

## Verification

Validated against Archon's **own loader** — clone `main` in the dark-factory container, swap in this file, run `archon workflow list`:

- `yaml@2.8.2 parse(): OK`
- no `failed to load` / `parse error` lines
- `archon-dark-factory` now appears as a loaded workflow

## Follow-ups (filed separately)

- **#143** — CI does not validate `.archon/workflows/*.yaml`; this broken file merged green in omniscient/markethawk#138. A parse gate would have caught it.
- **#144** — scheduler has no retry backoff; it re-ran the deterministically-failing step every ~90s for ~2h and posted a failure comment each time (28 on omniscient/markethawk#140).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
