### PR TITLE
fix: flower env (DATABASE_URL/POLYGON_API_KEY) + gate SQL echo behind LOG_LEVEL=DEBUG

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -17,7 +17,10 @@ engine = create_engine(
     pool_pre_ping=settings.DB_POOL_PRE_PING,
     pool_recycle=settings.DB_POOL_RECYCLE,
     pool_timeout=settings.DB_POOL_TIMEOUT,
-    echo=(settings.ENVIRONMENT == "development"),
+    # Echo every SQL statement only when explicitly debugging. Gating on
+    # ENVIRONMENT == "development" flooded normal dev logs with every query
+    # (twice, via the duplicate handler). LOG_LEVEL=DEBUG re-enables it.
+    echo=(settings.LOG_LEVEL == "DEBUG"),
 )
 
 # Session factory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -276,6 +276,11 @@ services:
     container_name: stockscanner-flower
     command: celery -A app.core.celery_app:celery_app flower --port=5555
     environment:
+      # flower imports app.core.celery_app, which instantiates Settings() at import
+      # time; DATABASE_URL and POLYGON_API_KEY are now required fields, so flower
+      # needs them too (mirrors celery-worker) or it crashes on startup.
+      DATABASE_URL: ${DATABASE_URL}
+      POLYGON_API_KEY: ${POLYGON_API_KEY:-}
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       FLOWER_BASIC_AUTH: ${FLOWER_BASIC_AUTH}


### PR DESCRIPTION
Two small fixes surfaced while doing a fresh `--no-cache` rebuild + redeploy after the latest `main` pull.

## 1. `flower` crash-looped (exit 2)

`flower` runs `celery -A app.core.celery_app:celery_app flower`, which imports `app.core.config` and instantiates `Settings()` at import time. `DATABASE_URL` and `POLYGON_API_KEY` are required fields, but the `flower` service only passed `CELERY_BROKER_URL` / `CELERY_RESULT_BACKEND` / `FLOWER_BASIC_AUTH`:

```
ValueError: Couldn't import 'app.core.celery_app:celery_app': 2 validation errors for Settings
DATABASE_URL    Field required
POLYGON_API_KEY Field required
```

Fix: add `DATABASE_URL` / `POLYGON_API_KEY` to the `flower` service env (mirrors `celery-worker`). Flower now boots and connects to redis.

## 2. SQL was echoed on every query in development

`backend/app/core/database.py` created the engine with `echo=(settings.ENVIRONMENT == "development")`, so every normal dev run logged **every** SQL statement — and twice, via a duplicate logging handler — flooding the backend logs and Seq.

Fix: gate echo on `LOG_LEVEL == "DEBUG"` instead. SQL logging is now opt-in (`LOG_LEVEL=DEBUG`) rather than always-on in development.

## Verification

- `flower`: recreated → running, `Connected to redis://redis:6379/0`, no `Settings` error.
- SQL echo: after restarting the source-mounted services, `0` echoed query lines in the backend logs; backend health `200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
