### PR TITLE
Local dev bind-mounts the working tree into running containers (editing source mutates the live stack)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ docker-compose exec backend bash            # Shell into backend
 docker-compose restart backend              # Restart one service
 ```
 
+> **Dev vs. live stack isolation:** `docker-compose up -d` auto-applies `docker-compose.override.yml` when present (local dev checkout), restoring bind-mounts and hot-reload. To run the baked-image stack without the override: `docker-compose -f docker-compose.yml up -d`.
+
 ### Backend (manual)
 ```bash
 cd backend
@@ -214,7 +216,7 @@ You're ready. Pick an issue from the [backlog](https://github.com/omniscient/mar
 
 ## Dark Factory (Autonomous Docker Development)
 
-An isolated Docker container that autonomously develops features from GitHub issues. Runs Claude Code inside a sandboxed environment with no host access.
+An isolated Docker container that autonomously develops features from GitHub issues. Runs Claude Code inside a sandboxed environment with no host access. Preview stacks and the dark-factory container deliberately omit `docker-compose.override.yml` and always run baked images — do not rely on bind-mount behavior in autonomous workflows.
 
 ### Quick Start
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -104,6 +104,32 @@ docker-compose exec postgres psql -U postgres -d stockscanner
 docker-compose exec redis redis-cli
 ```
 
+## Dev vs. live stack isolation
+
+The base `docker-compose.yml` runs **baked images** — source bind-mounts are absent so that editing files on the host or switching git branches cannot change the behavior of a running stack. This is the mode used by CI, preview environments, and the live trading stack.
+
+`docker-compose.override.yml` is committed to the repo and is **automatically merged** by Docker Compose whenever both files are present (the standard Docker Compose behavior). In a local dev checkout this means `docker-compose up -d` restores bind-mounts and hot-reload commands as if the split never happened.
+
+**Services covered by the override (the six that lose their bind-mount in the base file):**
+- `backend` — restores `./backend:/app:ro` and adds `--reload` to uvicorn
+- `celery-worker` — restores `./backend:/app:ro` and the watchfiles hot-reload command
+- `celery-beat` — restores `./backend:/app:ro`
+- `live-scanner` — restores `./backend:/app:ro`
+- `frontend` — restores `./frontend:/app` and `/app/node_modules`, switches command back to `npm run dev`
+- `backlog-scheduler` — restores `.:/workspace/project:ro`
+
+Services with no source bind-mount (`flower`, `forecast-worker`, and all infrastructure services) are unchanged in both files.
+
+**Run the stable baked-image stack without the override (live/CI mode):**
+```bash
+docker-compose -f docker-compose.yml up -d
+```
+
+**Force a full rebuild before starting (e.g. after dependency changes):**
+```bash
+docker-compose -f docker-compose.yml up -d --build
+```
+
 ## Manual Setup (without Docker)
 
 Use this if you need to run backend or frontend outside Docker, for example to attach a debugger.

--- a/dark-factory/Dockerfile
+++ b/dark-factory/Dockerfile
@@ -64,11 +64,12 @@ RUN git clone -b feat/workflow-cost-tracking https://github.com/omniscient/Archo
 # Workspace directory
 RUN mkdir -p /workspace
 
-# Copy entrypoint, scheduler, preview template, and seed data
+# Copy entrypoint, scheduler, preview template, seed data, and base compose file
 COPY dark-factory/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY dark-factory/scheduler.sh /opt/dark-factory/scheduler.sh
 COPY dark-factory/docker-compose.preview.yml /opt/dark-factory/docker-compose.preview.yml
 COPY dark-factory/seed/ /opt/dark-factory/seed/
+COPY docker-compose.yml /opt/dark-factory/docker-compose.yml
 COPY .claude/skills/refinement/ /opt/refinement-skills/
 RUN chmod +x /usr/local/bin/entrypoint.sh /opt/dark-factory/scheduler.sh
 

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -137,7 +137,7 @@ has_new_comment_after_report() {
 dispatch() {
   local command="$1"
   echo "Dispatching: $command"
-  docker compose -f /workspace/project/docker-compose.yml --profile factory run -d --rm dark-factory "$command"
+  docker compose -f /opt/dark-factory/docker-compose.yml --profile factory run -d --rm dark-factory "$command"
 }
 
 # --- Move an issue to a board status (used by the orphaned-in-progress sweep) ---

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,50 @@
+# docker-compose.override.yml — local development overrides
+#
+# Docker Compose automatically merges this file with docker-compose.yml when
+# both are present (i.e. in a local dev checkout). It restores source bind-mounts
+# and hot-reload commands for the six source-serving services so that
+# "docker-compose up -d" behaves exactly as before the dev/live split.
+#
+# To run the stable baked-image stack without this file (live/CI mode):
+#   docker-compose -f docker-compose.yml up -d
+
+name: markethawk
+
+services:
+  backend:
+    volumes:
+      - ./backend:/app:ro
+      - prometheus_multiproc:/tmp/prometheus_multiproc
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+
+  celery-worker:
+    volumes:
+      - ./backend:/app:ro
+      - prometheus_multiproc:/tmp/prometheus_multiproc
+    command: python -m watchfiles --filter python 'celery -A app.core.celery_app:celery_app worker --loglevel=info' /app/app
+
+  celery-beat:
+    volumes:
+      - ./backend:/app:ro
+
+  live-scanner:
+    volumes:
+      - ./backend:/app:ro
+
+  frontend:
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    command: npm run dev -- --host
+
+  backlog-scheduler:
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - .:/workspace/project:ro
+
+# Named volumes used in service overrides above must be declared here.
+# Docker Compose requires named volumes referenced in an override file to
+# appear in its own top-level volumes: block (even as an empty stub), otherwise
+# "docker-compose up -d" fails with "refers to undefined volume" errors.
+volumes:
+  prometheus_multiproc: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,8 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     container_name: stockscanner-api
+    # Bind-mount (./backend:/app:ro) and --reload are restored in docker-compose.override.yml for local dev.
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
     environment:
       DATABASE_URL: ${DATABASE_URL}
       POLYGON_API_KEY: ${POLYGON_API_KEY:-}
@@ -122,7 +124,6 @@ services:
       ib-gateway:
         condition: service_started
     volumes:
-      - ./backend:/app:ro
       - prometheus_multiproc:/tmp/prometheus_multiproc
     networks:
       - stockscanner-network
@@ -139,14 +140,13 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     container_name: stockscanner-frontend
+    # Bind-mounts (./frontend:/app, /app/node_modules) and npm run dev are restored in docker-compose.override.yml for local dev.
+    command: npx vite preview --host --port 3333
     ports:
       - "3333:3333"
     environment:
       REACT_APP_API_URL: http://localhost:8000
       VITE_API_TARGET: http://backend:8000
-    volumes:
-      - ./frontend:/app
-      - /app/node_modules
     networks:
       - stockscanner-network
     restart: unless-stopped
@@ -157,7 +157,8 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     container_name: stockscanner-celery
-    command: python -m watchfiles --filter python 'celery -A app.core.celery_app:celery_app worker --loglevel=info' /app/app
+    # Bind-mount (./backend:/app:ro) and watchfiles hot-reload are restored in docker-compose.override.yml for local dev.
+    command: celery -A app.core.celery_app:celery_app worker --loglevel=info
     environment:
       DATABASE_URL: ${DATABASE_URL}
       POLYGON_API_KEY: ${POLYGON_API_KEY:-}
@@ -190,7 +191,6 @@ services:
       ib-gateway:
         condition: service_started
     volumes:
-      - ./backend:/app:ro
       - prometheus_multiproc:/tmp/prometheus_multiproc
     networks:
       - stockscanner-network
@@ -226,8 +226,8 @@ services:
         condition: service_healthy
       ib-gateway:
         condition: service_started
-    volumes:
-      - ./backend:/app:ro
+    # Bind-mount (./backend:/app:ro) is restored in docker-compose.override.yml for local dev.
+    volumes: []
     networks:
       - stockscanner-network
     restart: unless-stopped
@@ -258,8 +258,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    volumes:
-      - ./backend:/app:ro
+    # Bind-mount (./backend:/app:ro) is restored in docker-compose.override.yml for local dev.
+    volumes: []
     networks:
       - stockscanner-network
     restart: unless-stopped
@@ -427,9 +427,9 @@ services:
     env_file:
       - path: .archon/.env
         required: true
+    # Bind-mount (.:/workspace/project:ro) is restored in docker-compose.override.yml for local dev.
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - .:/workspace/project:ro
     networks:
       - factory-network
       - stockscanner-network

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,8 @@ RUN npm install
 
 COPY . .
 
-EXPOSE 3000
+RUN npm run build
+
+EXPOSE 3333
 
 CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
## Summary
Automated implementation for issue #146.

## Preview
- Frontend: http://localhost:10333
- Backend API: http://mh-preview-146-backend-1:8000/docs

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #146"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #146"
```

---
*Generated by MarketHawk Dark Factory*