### PR TITLE
dark-factory scheduler: back off and stop comment-spamming on repeated identical failures

### DIFF
--- a/dark-factory/entrypoint.sh
+++ b/dark-factory/entrypoint.sh
@@ -83,6 +83,26 @@ fi
 
 # --- Helper: post or update cost report on issue ---
 COST_MARKER="<!-- dark-factory-cost-report -->"
+REFINE_FAILURE_MARKER="<!-- df-refine-failure -->"
+FACTORY_FAILURE_MARKER="<!-- df-factory-failure -->"
+
+post_or_update_comment() {
+  local marker="$1"
+  local body="$2"
+  local COMMENT_ID
+  COMMENT_ID=$(gh api "repos/omniscient/markethawk/issues/${ISSUE_NUM}/comments" \
+    --jq "[.[] | select(.body | contains(\"$marker\"))] | last | .id // empty" 2>/dev/null || true)
+  local TMPFILE
+  TMPFILE=$(mktemp /tmp/failure-comment-XXXXXX.md)
+  echo "$body" > "$TMPFILE"
+  if [ -n "$COMMENT_ID" ]; then
+    gh api "repos/omniscient/markethawk/issues/comments/${COMMENT_ID}" \
+      --method PATCH -F "body=@${TMPFILE}" >/dev/null 2>&1 || true
+  else
+    gh issue comment "$ISSUE_NUM" --body-file "$TMPFILE" 2>/dev/null || true
+  fi
+  rm -f "$TMPFILE"
+}
 
 post_cost_report() {
   if [ -z "${ISSUE_NUM:-}" ]; then return; fi
@@ -209,7 +229,9 @@ on_failure() {
   if [ -n "${ISSUE_NUM:-}" ] && [ "$INTENT" != "close" ]; then
     if [ "$INTENT" = "refine" ] || [ "$INTENT" = "plan" ]; then
       echo "Refinement pipeline failed (exit $EXIT_CODE) for issue #$ISSUE_NUM"
-      gh issue comment "$ISSUE_NUM" --body "## Refinement Pipeline — Failed
+      post_or_update_comment "$REFINE_FAILURE_MARKER" \
+        "${REFINE_FAILURE_MARKER}
+## Refinement Pipeline — Failed
 
 The refinement pipeline encountered an error (exit code $EXIT_CODE) and could not complete.
 
@@ -219,11 +241,13 @@ docker compose --profile factory run --rm dark-factory \"$ARGUMENTS\"
 \`\`\`
 
 ---
-*Posted by MarketHawk Refinement Pipeline*" 2>/dev/null || true
+*Posted by MarketHawk Refinement Pipeline*"
     else
       echo "Dark factory failed (exit $EXIT_CODE). Moving issue #$ISSUE_NUM back to Ready..."
       set_board_status "$STATUS_BLOCKED" 2>/dev/null || true
-      gh issue comment "$ISSUE_NUM" --body "## Dark Factory Run — Failed
+      post_or_update_comment "$FACTORY_FAILURE_MARKER" \
+        "${FACTORY_FAILURE_MARKER}
+## Dark Factory Run — Failed
 
 The dark factory encountered an error (exit code $EXIT_CODE) and could not complete.
 Issue has been moved to **Blocked**.
@@ -234,7 +258,7 @@ docker compose --profile factory run --rm dark-factory \"$ARGUMENTS\"
 \`\`\`
 
 ---
-*Posted by MarketHawk Dark Factory*" 2>/dev/null || true
+*Posted by MarketHawk Dark Factory*"
     fi
   fi
   # Cost report runs LAST and is non-fatal: a failure here (missing dependency,

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -547,6 +547,29 @@ This issue was left in **In progress** with no running factory container — the
     if is_issue_running "$ISSUE"; then continue; fi
     if [ "$REFINE_RUNNING" -ge "$REFINE_WIP_LIMIT" ]; then break; fi
 
+    RETRIES=$(get_retry_count "${ISSUE}:plan")
+    if [ "$RETRIES" -ge "$REFINE_MAX_RETRIES" ]; then
+      gh issue edit "$ISSUE" --repo "${OWNER}/markethawk" --add-label needs-discussion 2>/dev/null || true
+      gh issue comment "$ISSUE" --repo "${OWNER}/markethawk" --body "## Refinement Pipeline — Retries Exhausted
+
+The scheduler has attempted plan generation **${RETRIES} time(s)** and cannot recover automatically. The issue has been labelled \`needs-discussion\` to pause automation.
+
+**To resume automation:**
+1. Investigate the failure comments above.
+2. Fix the root cause (update the issue body, fix a dependency, or resolve the blocking error).
+3. Remove the \`needs-discussion\` label — the scheduler will resume automatically.
+
+\`\`\`bash
+# Or retry manually:
+docker compose --profile factory run --rm dark-factory \"Plan issue #${ISSUE}\"
+\`\`\`
+
+---
+*Posted by MarketHawk Backlog Scheduler*" 2>/dev/null || true
+      continue
+    fi
+
+    increment_retry "${ISSUE}:plan"
     gh issue comment "$ISSUE" --repo "${OWNER}/markethawk" --body "📋 **Refinement Pipeline** — Starting plan generation and architect validation.
 
 ---

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -24,6 +24,7 @@ STATUS_REFINED="0c79ebe5"
 # Refinement pipeline configuration
 REFINE_WIP_LIMIT="${REFINE_WIP_LIMIT:-2}"
 REFINE_SKIP_LABELS="needs-discussion,epic,spec-pending-review,plan-pending-review"
+REFINE_MAX_RETRIES="${REFINE_MAX_RETRIES:-3}"
 
 # --- Validate required environment ---
 if [ -z "${GH_TOKEN:-}" ]; then

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -590,6 +590,7 @@ docker compose --profile factory run --rm dark-factory \"Plan issue #${ISSUE}\"
       if ! is_issue_running "$ISSUE" && [ "$REFINE_RUNNING" -lt "$REFINE_WIP_LIMIT" ]; then
         HAS_NEW=$(has_new_comment_after_report "$ISSUE" "Posted by MarketHawk Refinement Pipeline")
         if [ "$HAS_NEW" = "yes" ]; then
+          reset_retry "${ISSUE}:refine"
           gh issue edit "$ISSUE" --repo "${OWNER}/markethawk" --remove-label "spec-pending-review" 2>/dev/null || true
           gh issue comment "$ISSUE" --repo "${OWNER}/markethawk" --body "🔄 **Refinement Pipeline** — Re-running with new feedback.
 
@@ -607,6 +608,29 @@ docker compose --profile factory run --rm dark-factory \"Plan issue #${ISSUE}\"
     if is_issue_running "$ISSUE"; then continue; fi
     if [ "$REFINE_RUNNING" -ge "$REFINE_WIP_LIMIT" ]; then break; fi
 
+    RETRIES=$(get_retry_count "${ISSUE}:refine")
+    if [ "$RETRIES" -ge "$REFINE_MAX_RETRIES" ]; then
+      gh issue edit "$ISSUE" --repo "${OWNER}/markethawk" --add-label needs-discussion 2>/dev/null || true
+      gh issue comment "$ISSUE" --repo "${OWNER}/markethawk" --body "## Refinement Pipeline — Retries Exhausted
+
+The scheduler has attempted refinement **${RETRIES} time(s)** and cannot recover automatically. The issue has been labelled \`needs-discussion\` to pause automation.
+
+**To resume automation:**
+1. Investigate the failure comments above.
+2. Fix the root cause (update the issue body, fix a dependency, or resolve the blocking error).
+3. Remove the \`needs-discussion\` label — the scheduler will resume automatically.
+
+\`\`\`bash
+# Or retry manually:
+docker compose --profile factory run --rm dark-factory \"Refine issue #${ISSUE}\"
+\`\`\`
+
+---
+*Posted by MarketHawk Backlog Scheduler*" 2>/dev/null || true
+      continue
+    fi
+
+    increment_retry "${ISSUE}:refine"
     gh issue comment "$ISSUE" --repo "${OWNER}/markethawk" --body "🧠 **Refinement Pipeline** — Starting brainstorming and spec generation.
 
 ---


### PR DESCRIPTION
## Summary
Automated implementation for issue omniscient/dark-factory#68.

## Preview
- Frontend: http://localhost:10433
- Backend API: http://mh-preview-144-backend-1:8000/docs

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#68"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#68"
```

---
*Generated by MarketHawk Dark Factory*