### PR TITLE
fix(#140): activate seeded pocket_pivot ScannerConfig so it appears in UI

### DIFF
--- a/backend/app/alembic/versions/c7e2a9f4b1d3_activate_pocket_pivot_scanner_config.py
+++ b/backend/app/alembic/versions/c7e2a9f4b1d3_activate_pocket_pivot_scanner_config.py
@@ -6,9 +6,14 @@ is_active=true rows, so it never appeared in the Scanner Type dropdown, and it c
 not be selected for a manual on-demand run.
 
 This migration activates it, bringing it in line with the other three seeded configs
-(all is_active=true). It intentionally does NOT add a `universe_id` to parameters —
-the other scheduled configs don't carry one either; the nightly beat's universe wiring
-is a separate, pre-existing concern tracked outside this migration.
+(all is_active=true). Activating it also surfaced a second seed bug: criteria was stored
+as '{}' (a JSON object) while ScannerConfigResponse types it as a list, which 500'd
+GET /scanner/configs once the row became visible. This migration also normalizes criteria
+to '[]' (matching liquidity_hunt's empty-array form).
+
+It intentionally does NOT add a `universe_id` to parameters — the other scheduled configs
+don't carry one either; the nightly beat's universe wiring is a separate, pre-existing
+concern tracked outside this migration (see follow-up issue #156).
 
 Revision ID: c7e2a9f4b1d3
 Revises: 1bf5e10f1111
@@ -28,13 +33,21 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    # Activate the config AND normalize `criteria` to a JSON array. The original seed
+    # (1bf5e10f1111) stored criteria as '{}' (a JSON object), but ScannerConfigResponse
+    # types it as List[Dict[str, Any]]. Serializing the now-active row raised a Pydantic
+    # ValidationError ("Input should be a valid list") and 500'd GET /scanner/configs.
+    # The other configs use an array (liquidity_hunt is '[]').
     op.execute(
-        "UPDATE scanner_configs SET is_active = true "
+        "UPDATE scanner_configs "
+        "SET is_active = true, criteria = '[]'::json "
         "WHERE scanner_type = 'pocket_pivot' AND name = 'Pocket Pivot (Evening)'"
     )
 
 
 def downgrade() -> None:
+    # Reverts activation only. The criteria fix corrects invalid seed data (it was never
+    # a valid object) and is intentionally not reverted.
     op.execute(
         "UPDATE scanner_configs SET is_active = false "
         "WHERE scanner_type = 'pocket_pivot' AND name = 'Pocket Pivot (Evening)'"

--- a/backend/app/alembic/versions/c7e2a9f4b1d3_activate_pocket_pivot_scanner_config.py
+++ b/backend/app/alembic/versions/c7e2a9f4b1d3_activate_pocket_pivot_scanner_config.py
@@ -1,0 +1,41 @@
+"""activate_pocket_pivot_scanner_config
+
+The original seed (1bf5e10f1111) inserted the "Pocket Pivot (Evening)" ScannerConfig
+with is_active=false, which left it unreachable: GET /scanner/configs returns only
+is_active=true rows, so it never appeared in the Scanner Type dropdown, and it could
+not be selected for a manual on-demand run.
+
+This migration activates it, bringing it in line with the other three seeded configs
+(all is_active=true). It intentionally does NOT add a `universe_id` to parameters —
+the other scheduled configs don't carry one either; the nightly beat's universe wiring
+is a separate, pre-existing concern tracked outside this migration.
+
+Revision ID: c7e2a9f4b1d3
+Revises: 1bf5e10f1111
+Create Date: 2026-06-02
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c7e2a9f4b1d3'
+down_revision: Union[str, None] = '1bf5e10f1111'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE scanner_configs SET is_active = true "
+        "WHERE scanner_type = 'pocket_pivot' AND name = 'Pocket Pivot (Evening)'"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE scanner_configs SET is_active = false "
+        "WHERE scanner_type = 'pocket_pivot' AND name = 'Pocket Pivot (Evening)'"
+    )


### PR DESCRIPTION
## What & why

The Pocket Pivot scanner from #140 / PR #151 was invisible in the UI. The Scanner Type dropdown is built dynamically from `GET /scanner/configs`, which returns **`is_active = true` configs only**, but the original seed migration (`1bf5e10f1111`) inserted the "Pocket Pivot (Evening)" config with **`is_active = false`**. That left it unreachable — hidden from the dropdown and not selectable for manual on-demand runs.

Activating it then surfaced a **second** bug in the same seed: `criteria` was stored as `{}` (a JSON object), but `ScannerConfigResponse.criteria` is typed as `List[Dict[str, Any]]`. Serializing the now-visible row raised a Pydantic `ValidationError` and **500'd `GET /scanner/configs` for every config**. This PR fixes both in one migration.

## Changes

- `backend/app/alembic/versions/c7e2a9f4b1d3_activate_pocket_pivot_scanner_config.py`:
  - `is_active = true` (activates the config, matching the other three seeded configs).
  - `criteria = '[]'::json` (normalizes the malformed object to an empty array, matching `liquidity_hunt`).
  - `downgrade()` reverts activation only (the criteria fix corrects invalid data and isn't reverted).

It intentionally does **not** add a `universe_id` to parameters — the other scheduled configs don't carry one either; the nightly-beat universe wiring is a separate, pre-existing concern (see #156).

## Validation

- Migration validated end-to-end via a real `alembic downgrade -1` → `upgrade head` cycle (clean both ways).
- DB verified: `id=28, scanner_type=pocket_pivot, is_active=t, json_typeof(criteria)=array, criteria=[]`.
- Ran the endpoint's exact `_fetch` serialization in-container against all active configs — `ScannerConfigResponse.model_validate(...).model_dump()` now succeeds for all 4 (previously raised `ValidationError`).
- Cleared the `mh:scanner:configs` Redis cache (endpoint caches 300s); the type now appears in the Scanner Type dropdown and is runnable on-demand.
- No frontend change needed — the dropdown is data-driven.

## Related

- Fixes oversights from #140 / PR #151
- Follow-up issue for the scheduled-run gap: #156
