### PR TITLE
fix: restore local dark-factory dispatch broken by #104

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 *
 !dark-factory/
 !.claude/skills/refinement/
+!docker-compose.yml

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -36,6 +36,20 @@ if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; the
   exit 1
 fi
 
+# --- Provision the dispatch env file ---
+# The dispatch runs `docker compose -f /opt/dark-factory/docker-compose.yml run dark-factory`,
+# whose service declares `env_file: .archon/.env (required: true)` — which the compose CLI
+# resolves to /opt/dark-factory/.archon/.env relative to the baked compose file. Secrets are
+# never baked into the image, so materialize that file at startup from the bind-mounted repo.
+# (Regressed by #104/#155 when docker-compose.yml moved to the required env_file format.)
+if [ -f /workspace/project/.archon/.env ]; then
+  mkdir -p /opt/dark-factory/.archon
+  cp /workspace/project/.archon/.env /opt/dark-factory/.archon/.env
+  echo "Provisioned dispatch env file at /opt/dark-factory/.archon/.env from bind mount"
+else
+  echo "WARNING: /workspace/project/.archon/.env not found — dispatched runs will fail env_file resolution" >&2
+fi
+
 # Initialize retry state
 if [ ! -f "$STATE_FILE" ]; then
   echo '{}' > "$STATE_FILE"


### PR DESCRIPTION
## Summary

Restores the **local dark-factory dispatch path**, which regressed when omniscient/markethawk#104 / omniscient/markethawk#155 ("set up container registry and CI/CD", merged 2026-06-02 22:15) retargeted `docker-compose.yml` to GHCR images and the `required` `env_file` format. The first dispatches after that merge (#159, omniscient/dark-factory#72) crash-looped the `backlog-scheduler` and never ran.

Diagnosed from the omniscient/dark-factory#72 incident: the scheduler dispatches `docker compose -f /opt/dark-factory/docker-compose.yml run dark-factory`, and that path broke in two committable ways (a third, GHCR auth, is environmental):

1. **`.dockerignore` excluded `docker-compose.yml`.** The allowlist (`*` then `!dark-factory/`, `!.claude/skills/refinement/`) omitted `docker-compose.yml`, which `dark-factory/Dockerfile:72` `COPY`s into `/opt/dark-factory/`. Every image build failed at that layer (`"/docker-compose.yml": not found`). Fix: add `!docker-compose.yml`.

2. **Dispatch env file unresolved.** The baked compose declares `env_file: { path: .archon/.env, required: true }`, which the compose CLI resolves to `/opt/dark-factory/.archon/.env` — a path never baked into the image (secrets). `scheduler.sh` now materializes it at startup from the bind-mounted repo (`/workspace/project/.archon/.env`).

With no circuit-breaker in the scheduler (tracked separately in omniscient/dark-factory#72), each failure crashed the daemon under `set -e` and restarted, wiping the `/tmp` retry counter, so it re-dispatched and spammed the ticket.

## Verification

- Rebuilt `ghcr.io/omniscient/markethawk-dark-factory:latest` locally with the corrected context — build succeeds.
- Recreated `backlog-scheduler`; it logs `Provisioned dispatch env file …` and `/opt/dark-factory/.archon/.env` is present.
- Re-approved omniscient/dark-factory#72 → a plan container (`markethawk-dark-factory-run-…`) **runs** (clone + deps + workflow) instead of crash-looping; scheduler `RestartCount=0`.

## Notes / follow-ups

- The `scheduler.sh` env provisioning covers the **local** (bind-mounted) path. A deployed scheduler with no bind mount needs env injection handled at deploy — out of scope for this hotfix.
- GHCR pull is `denied` locally (no auth); worked around by building the image locally. Authenticating the host to GHCR, or documenting the local build step, is a separate task.
- The scheduler crash-loop class is the subject of omniscient/dark-factory#72 (durable retry state + crash-resilient dispatch + universal circuit-breaker).

Related: omniscient/markethawk#104, omniscient/markethawk#155, omniscient/dark-factory#72.
