### PR TITLE
docs(#168): give every drifting fact one canonical owner

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,7 +9,7 @@ All services run as Docker containers on the `stockscanner-network` bridge netwo
                          │          stockscanner-network            │
                          │                                          │
   Browser ──HTTP:3333──> │ frontend ──HTTP──> backend:8000          │
-                         │   │ WS:3000/api/v1/live/ws/*             │
+                         │   │ WS:3333/api/v1/live/ws/*             │
                          │                       │                  │
                          │                  asyncpg ──> postgres:5432
                          │                  aioredis ──> redis:6379  │

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,7 +8,7 @@ All services run as Docker containers on the `stockscanner-network` bridge netwo
                          ┌─────────────────────────────────────────┐
                          │          stockscanner-network            │
                          │                                          │
-  Browser ──HTTP:3000──> │ frontend ──HTTP──> backend:8000          │
+  Browser ──HTTP:3333──> │ frontend ──HTTP──> backend:8000          │
                          │   │ WS:3000/api/v1/live/ws/*             │
                          │                       │                  │
                          │                  asyncpg ──> postgres:5432

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,28 +25,7 @@ docker-compose restart backend              # Restart one service
 
 > **Dev vs. live stack isolation:** `docker-compose up -d` auto-applies `docker-compose.override.yml` when present (local dev checkout), restoring bind-mounts and hot-reload. To run the baked-image stack without the override: `docker-compose -f docker-compose.yml up -d`.
 
-### Backend (manual)
-```bash
-cd backend
-pip install -r requirements.txt
-uvicorn app.main:app --reload               # Dev server
-python -m pytest                            # All tests
-python -m pytest tests/api -v              # API tests only
-python -m pytest --cov                      # With coverage
-python -m alembic upgrade head              # Apply migrations
-python -m alembic revision --autogenerate -m "description"  # New migration
-celery -A app.core.celery_app:celery_app worker --loglevel=info  # Run worker
-celery -A app.core.celery_app:celery_app beat                    # Run scheduler
-```
-
-### Frontend (manual)
-```bash
-cd frontend
-npm install
-npm run dev       # Dev server at http://localhost:3000
-npm run build     # Production build
-npm run lint      # ESLint
-```
+> For manual (non-Docker) backend and frontend setup, migration commands, test commands, and pre-commit hook setup, see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Service Ports
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -65,7 +65,7 @@ docker-compose exec backend python -m alembic upgrade head
 
 | Service | URL | Credentials |
 |---------|-----|-------------|
-| Frontend | http://localhost:3000 | — |
+| Frontend | http://localhost:3333 | — |
 | Backend API | http://localhost:8000 | — |
 | Swagger / API Docs | http://localhost:8000/docs | — |
 | pgAdmin | http://localhost:5050 | Values from `PGADMIN_DEFAULT_EMAIL/PASSWORD` in `.env` |
@@ -156,7 +156,7 @@ uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 ```bash
 cd frontend
 npm install
-npm run dev        # Dev server at http://localhost:3000
+npm run dev        # Dev server at http://localhost:3333
 npm run build      # Production build
 npm run lint       # ESLint check
 ```
@@ -331,7 +331,7 @@ SELECT pid, state, query_start, query FROM pg_stat_activity WHERE datname = 'sto
 netstat -ano | findstr :5432   # PostgreSQL
 netstat -ano | findstr :6379   # Redis
 netstat -ano | findstr :8000   # Backend
-netstat -ano | findstr :3000   # Frontend
+netstat -ano | findstr :3333   # Frontend
 ```
 
 ### Containers failing to start

--- a/README.md
+++ b/README.md
@@ -155,20 +155,7 @@ python -m pytest --cov             # with coverage report
 
 ## Environment Variables
 
-| Variable | Required | Purpose |
-|---|---|---|
-| `POLYGON_API_KEY` | Yes | Polygon.io market data |
-| `DATABASE_URL` | Yes | PostgreSQL connection string |
-| `POSTGRES_DB/USER/PASSWORD` | Yes | Used by the postgres container |
-| `SECRET_KEY` | Yes | JWT tokens and sessions |
-| `PGADMIN_DEFAULT_EMAIL/PASSWORD` | Yes | pgAdmin login |
-| `SEQ_ADMIN_PASSWORD_HASH` | Yes | Seq log viewer login |
-| `REDIS_URL` | No | Defaults to `redis://redis:6379/0` |
-| `ENVIRONMENT` | No | `development` / `production` (default: `development`) |
-| `LOG_LEVEL` | No | `DEBUG` / `INFO` / … (default: `INFO`) |
-| `IB_USERNAME/PASSWORD` | No | IB Gateway auto-login credentials |
-| `IB_TRADING_MODE` | No | `paper` or `live` (default: `paper`) |
-| `IBKR_HOST/PORT/CLIENT_ID` | No | Backend connection to IB Gateway |
+See [ENV_VARIABLES.md](ENV_VARIABLES.md) for the complete environment variable reference with defaults and descriptions.
 
 ## Useful Docker Commands
 

--- a/README.md
+++ b/README.md
@@ -132,40 +132,11 @@ npm install
 npm run dev
 ```
 
-> See [DEVELOPMENT.md](DEVELOPMENT.md) for detailed local setup, service connection instructions, and troubleshooting.
-
-## Database Migrations
-
-After changing any SQLAlchemy model:
-
-```bash
-cd backend
-python -m alembic revision --autogenerate -m "describe_the_change"
-python -m alembic upgrade head
-```
-
-## Running Tests
-
-```bash
-cd backend
-python -m pytest                   # all tests
-python -m pytest tests/api -v      # API tests only
-python -m pytest --cov             # with coverage report
-```
+> For detailed setup, manual (non-Docker) configuration, database migrations, running tests, and troubleshooting, see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Environment Variables
 
 See [ENV_VARIABLES.md](ENV_VARIABLES.md) for the complete environment variable reference with defaults and descriptions.
-
-## Useful Docker Commands
-
-```bash
-docker-compose logs -f backend        # stream backend logs
-docker-compose exec backend bash      # shell into backend container
-docker-compose restart backend        # restart one service
-docker-compose down                   # stop everything (data volumes preserved)
-docker-compose down -v                # stop and delete all volumes
-```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ services/       — Business logic (scanner, stock_data, discovery_service,
                   futures_data, chart_indicators, catalyst_parser,
                   journal_service, websocket_manager, data_quality …)
 providers/      — External data integrations (Polygon, IBKR, base interface, bulk ops)
-tasks.py        — Celery background/scheduled tasks
+tasks/          — Celery task package (sync.py, scanning.py, trading.py, quality.py)
 ```
 
 ### Frontend (`frontend/src/`)
@@ -110,7 +110,7 @@ IB Gateway takes ~60 seconds on first startup while IBC authenticates. The backe
 
 | Service | URL |
 |---|---|
-| Frontend | http://localhost:3000 |
+| Frontend | http://localhost:3333 |
 | Backend API | http://localhost:8000 |
 | API Docs (Swagger) | http://localhost:8000/docs |
 | pgAdmin | http://localhost:5050 |


### PR DESCRIPTION
## Summary

- Fixed port drift (`3000`→`3333`) in README.md, DEVELOPMENT.md, and ARCHITECTURE.md topology diagram
- Fixed stale `tasks.py`→`tasks/` reference in README.md backend module map
- Removed duplicated env-var table from README.md (→ link to `ENV_VARIABLES.md`)
- Removed `## Database Migrations`, `## Running Tests`, `## Useful Docker Commands` sections from README.md (→ link to `DEVELOPMENT.md`)
- Removed `### Backend (manual)` and `### Frontend (manual)` command blocks from CLAUDE.md (→ link to `DEVELOPMENT.md`)

**Canonical ownership after this PR:**
| Fact class | Owner |
|---|---|
| Service ports | `CLAUDE.md` service-ports table |
| Env vars | `ENV_VARIABLES.md` |
| Commands (setup/test/docker/migrations) | `DEVELOPMENT.md` |
| README.md | Thin front door: features, criteria, arch diagram, quick-start, docs table |

Closes #168

## Test plan

- [ ] `grep -rn "localhost:3000\|HTTP:3000" README.md DEVELOPMENT.md ARCHITECTURE.md CLAUDE.md` → zero matches
- [ ] `grep -n "tasks\.py" README.md` → zero matches
- [ ] `grep -n "POLYGON_API_KEY" README.md` → zero matches (only in Quick Start comment, not table rows)
- [ ] `grep -n "## Database Migrations\|## Running Tests\|## Useful Docker Commands" README.md` → zero matches
- [ ] `grep -n "pip install -r requirements\|uvicorn app.main" CLAUDE.md` → zero matches
- [ ] `grep -n "localhost:3333" CLAUDE.md` → match in service-ports table ✓
- [ ] `grep -n "POLYGON_API_KEY" ENV_VARIABLES.md` → match confirming canonical owner intact ✓
- [ ] `grep -n "python -m pytest\|alembic upgrade head\|npm run dev" DEVELOPMENT.md` → matches confirming canonical owner intact ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)