### PR TITLE
chore(dark-factory): disable Workflow tool to trim factory token cost

### DIFF
--- a/dark-factory/entrypoint.sh
+++ b/dark-factory/entrypoint.sh
@@ -292,17 +292,22 @@ echo "Installing frontend dependencies..."
 cd "$CLONE_DIR/frontend" && npm install --silent
 cd "$CLONE_DIR"
 
-# --- Register codeindex MCP server for the implement-step agent ---
-# Uses the absolute path (required — Claude Code does not inherit shell PATH).
-# Written to .claude/settings.local.json which is gitignored and never committed.
+# --- Write factory-scoped Claude settings (gitignored, never committed) ---
+# Uses the absolute codeindex path (required — Claude Code does not inherit shell PATH).
+# disableWorkflows: the factory never uses Claude Code's Workflow tool — Archon owns
+# orchestration and refine/plan spawn subagents via the Agent tool — so dropping that
+# tool's (large) schema from each request trims input tokens at no functional cost.
+# Kept here, NOT in the committed .claude/settings.json, so local dev sessions are
+# unaffected and keep the Workflow tool.
 CODEINDEX_BIN=$(which codeindex 2>/dev/null || true)
+mkdir -p "$CLONE_DIR/.claude"
 if [ -n "$CODEINDEX_BIN" ]; then
-  mkdir -p "$CLONE_DIR/.claude"
-  printf '{\n  "mcpServers": {\n    "codeindex": { "command": "%s", "args": ["serve", "--mcp"] }\n  }\n}\n' \
+  printf '{\n  "disableWorkflows": true,\n  "mcpServers": {\n    "codeindex": { "command": "%s", "args": ["serve", "--mcp"] }\n  }\n}\n' \
     "$CODEINDEX_BIN" > "$CLONE_DIR/.claude/settings.local.json"
-  echo "codeindex MCP registered at $CODEINDEX_BIN"
+  echo "codeindex MCP registered at $CODEINDEX_BIN; Workflow tool disabled"
 else
-  echo "WARNING: codeindex not found; MCP server will not be registered"
+  printf '{\n  "disableWorkflows": true\n}\n' > "$CLONE_DIR/.claude/settings.local.json"
+  echo "WARNING: codeindex not found; MCP server will not be registered (Workflow tool disabled)"
 fi
 
 # --- Install pre-commit hooks so codeindex-blast warn hook fires in the run log ---


### PR DESCRIPTION
## Summary

Disables Claude Code's `Workflow` tool inside the dark factory by adding `"disableWorkflows": true` to the runtime-written `.claude/settings.local.json` (in `dark-factory/entrypoint.sh`).

## Why

The factory **never uses** the `Workflow` tool:
- Orchestration (the DAG, retries, `when:`/`depends_on:` branching) is **Archon's** job, a level above Claude — see `archon workflow run archon-dark-factory` in `entrypoint.sh`.
- The multi-agent steps (`refine` brainstorming, `plan` architect) spawn subagents via the **`Agent` tool**, not the `Workflow` tool.

So the tool's (large) schema sits in every factory agent's request context but is never invoked. Disabling it drops that schema, trimming input tokens at **no functional cost**.

## Scope

- Written to the container's **gitignored** `settings.local.json`, created fresh in the clone at runtime — **not** the committed `.claude/settings.json`.
- Local interactive Claude sessions keep the `Workflow` tool; only the factory container is affected.
- The `backlog-scheduler` service shares the same image, so it's covered by the same rebuild.

## Notes

- Both JSON branches the entrypoint writes (codeindex present / absent) were validated as valid JSON.
- Expected saving is **small** — the tool block is prompt-cached after the first turn of each agent session — but it's free and safe.
- Takes effect after rebuilding the image: `docker compose --profile factory build dark-factory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
