### PR TITLE
Differentiate preview-environment creation: skip the stack for non-runtime changes

### DIFF
--- a/.archon/commands/dark-factory-validate.md
+++ b/.archon/commands/dark-factory-validate.md
@@ -15,13 +15,14 @@ Read the implementation context:
 - Read `$ARTIFACTS_DIR/implementation.md` for what was implemented
 - Read `CLAUDE.md` for validation rules
 
-## Phase 1.5: RESOLVE PREVIEW_BACKEND
+## Phase 1.5: RESOLVE PREVIEW STATE
 
-The `preview-up` step wrote the preview URLs to `$ARTIFACTS_DIR/preview_env.sh`.
-Source that file to get the authoritative `PREVIEW_BACKEND` URL:
+The `preview-up` step wrote the preview URLs (and skip marker) to `$ARTIFACTS_DIR/preview_env.sh`.
+Source that file to get all preview state variables:
 
 ```bash
 source "$ARTIFACTS_DIR/preview_env.sh"
+echo "PREVIEW_SKIPPED=$PREVIEW_SKIPPED"
 echo "PREVIEW_BACKEND=$PREVIEW_BACKEND"
 ```
 
@@ -32,24 +33,34 @@ container is kept connected to the preview network from the `preview-up` step.
 Do NOT compute the URL manually or use `localhost:<port>` — the host-exposed port
 is not reachable from inside the dark-factory container.
 
+When `PREVIEW_SKIPPED=true` the preview stack was not built. In that case:
+- Run pytest and tsc (they run inside the factory container and need no stack).
+- **Skip** endpoint curl tests — there is no backend to hit.
+- **Skip** the network disconnect cleanup — no network was connected.
+- Record the skip reason in `$ARTIFACTS_DIR/validation.md`.
+
 ## Phase 2: VALIDATE
 
-Run the full validation suite against the preview stack:
-
-### Backend validation
+### Backend validation (always run)
 ```bash
 cd backend && python -m pytest --no-cov -v
 ```
 
-### Frontend validation (if frontend was modified)
+### Frontend validation (if frontend was modified — always run)
 ```bash
 cd frontend && npx tsc --noEmit
 ```
 
-### Endpoint validation against preview
+### Endpoint validation against preview (skip when PREVIEW_SKIPPED=true)
 
-For each new or changed endpoint identified in the implementation, use `$PREVIEW_BACKEND`
-(sourced from `$ARTIFACTS_DIR/preview_env.sh` above) as the base URL:
+If `PREVIEW_SKIPPED=true`, record this in `validation.md`:
+```
+Endpoint tests skipped — no preview environment (<PREVIEW_SKIP_REASON>).
+```
+and proceed to Phase 4 without running any curl tests or network disconnect.
+
+Otherwise, for each new or changed endpoint identified in the implementation, use
+`$PREVIEW_BACKEND` (sourced from `$ARTIFACTS_DIR/preview_env.sh` above) as the base URL:
 
 ```bash
 # Example — replace with actual endpoints from implementation.md
@@ -68,7 +79,7 @@ Record all results — passes and failures.
 ### PHASE_2_CHECKPOINT
 - [ ] pytest results recorded
 - [ ] tsc results recorded (if applicable)
-- [ ] Endpoint curl tests recorded
+- [ ] Endpoint curl tests recorded (or skip reason noted if PREVIEW_SKIPPED=true)
 - [ ] All results written to `$ARTIFACTS_DIR/validation.md`
 
 ## Phase 3: FIX (if needed)
@@ -83,15 +94,19 @@ Repeat until all validations pass.
 
 ## Phase 4: CLEANUP AND REPORT
 
-Disconnect the dark-factory container from the preview network (the preview-up step
-left it connected so we could run endpoint tests):
+**Only when `PREVIEW_SKIPPED` is not `true`:** disconnect the dark-factory container
+from the preview network (the preview-up step left it connected so we could run endpoint
+tests):
 
 ```bash
 source "$ARTIFACTS_DIR/preview_env.sh"
-docker network disconnect "$PREVIEW_NET" "$(hostname)" 2>/dev/null || true
+if [ "$PREVIEW_SKIPPED" != "true" ]; then
+  docker network disconnect "$PREVIEW_NET" "$(hostname)" 2>/dev/null || true
+fi
 ```
 
 Write validation results to `$ARTIFACTS_DIR/validation.md`:
 - Pass/fail status for each check
 - Specific error details for any failures
+- If preview was skipped: note `Endpoint tests skipped — no preview environment (<reason>).`
 - Final status: PASS or FAIL

--- a/.archon/memory/dark-factory-ops.md
+++ b/.archon/memory/dark-factory-ops.md
@@ -55,6 +55,14 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 
 - [PATTERN] Pre-commit hooks that invoke advisory/optional tools (e.g. `codeindex-blast`) must always exit 0 — use `|| true` or `; exit 0`. A non-zero exit from a pre-commit hook blocks the commit and will abort an autonomous factory run. <!-- issue:#159 date:2026-06-03 expires:2026-12-03 source:implement -->
 
+## Preview Environment Differentiator
+
+- [PATTERN] When a workflow node's tail depends on a conditionally-built resource (e.g. preview stack), use a gated executor pattern rather than a conditional node: always run the node, read the decision from the prior step, and write a `PREVIEW_SKIPPED` marker to `$ARTIFACTS_DIR/preview_env.sh` so all downstream steps can branch on it uniformly. <!-- issue:#178 date:2026-06-04 expires:2026-12-04 source:implement -->
+
+- [PATTERN] `$ARTIFACTS_DIR/preview_env.sh` is the single source of truth for preview state across `preview-up`, `validate`, `push-and-pr`, and `report`. Downstream steps source this file rather than parsing step output, except for the two nodes that need `grep '^PREVIEW_SKIPPED='` on step output directly. <!-- issue:#178 date:2026-06-04 expires:2026-12-04 source:implement -->
+
+- [PATTERN] For fail-safe LLM classifier guards, skip only on explicit `false` (string comparison `[ "$VAR" = "false" ]`); any other value — including empty string or garbled output — falls through to the safe direction (building the preview). This prevents wrongly skipped previews when the classifier errors. <!-- issue:#178 date:2026-06-04 expires:2026-12-04 source:implement -->
+
 ## Environment and Credentials
 
 - [PATTERN] Every new environment variable introduced by a feature must be documented in `ENV_VARIABLES.md` with its default value and a one-line description. CLAUDE.md references ENV_VARIABLES.md as the authoritative env var reference. <!-- bootstrap date:2026-06-02 expires:2026-12-02 source:implement -->

--- a/.archon/workflows/archon-dark-factory.yaml
+++ b/.archon/workflows/archon-dark-factory.yaml
@@ -324,10 +324,93 @@ nodes:
     when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
     timeout: 120000
 
+  # Layer 2.5: Classify whether a preview environment is needed
+  - id: preview-changeset
+    bash: |
+      echo "=== Changed files (main...HEAD) ==="
+      git diff main...HEAD --name-only 2>/dev/null || true
+      echo "=== Stat ==="
+      git diff main...HEAD --stat 2>/dev/null || true
+    depends_on: [regen-codeindex, fetch-issue]
+    when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
+    timeout: 15000
+
+  - id: classify-preview
+    prompt: |
+      You are a classifier deciding whether a dark-factory preview stack (postgres, redis, backend,
+      frontend, celery) is needed for this branch's changeset. A wasted preview costs minutes; a
+      wrongly skipped preview means a code change ships without live endpoint validation.
+
+      ## Config kill-switch
+      Read the preview.enabled flag from .claude/skills/refinement/config.yaml.
+      If preview.enabled is false, ALWAYS output needs_preview=true regardless of the changeset.
+
+      ## Changeset
+      $preview-changeset.output
+
+      ## Issue context (secondary signal only — the diff is authoritative)
+      Title: $fetch-issue.output.title
+      Labels: $fetch-issue.output.labels
+
+      ## Classifier rubric
+
+      Set needs_preview = false ONLY if EVERY changed file falls into one or more of these
+      non-runtime-affecting categories:
+
+      | Category        | Matches |
+      |-----------------|---------|
+      | Documentation   | *.md, *.mdx, anything under docs/ or Docs/, LICENSE |
+      | Agent/workflow config | .archon/**, .claude/**, workflow YAML (NOT docker-compose* or app config) |
+      | Tests           | backend/tests/**, **/*.test.ts(x), **/*.spec.ts(x), conftest.py, **/*_test.py, dark-factory/tests/** |
+      | CI / repo meta  | .github/**, .gitignore, .pre-commit-config.yaml, lint/format config (.eslintrc*, .prettierrc*, ruff/flake8/mypy config), .editorconfig |
+
+      Force needs_preview = true if ANY file touches the running app: backend/app/**, alembic/versions/**,
+      requirements.txt, frontend/src/**, package.json, package-lock.json, Dockerfile*, docker-compose*,
+      .env*, dark-factory/seed/**.
+
+      Fail-safe: an empty changeset, a mix that is not clearly skip-only, or any uncertainty → needs_preview=true.
+      The diff is authoritative — a documentation-labeled issue that touches backend/app/** still gets a preview.
+    allowed_tools: [Read]
+    model: haiku
+    depends_on: [preview-changeset, fetch-issue]
+    when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
+    output_format:
+      type: object
+      properties:
+        needs_preview:
+          type: boolean
+        category:
+          type: string
+          enum: [code, docs, config, tests, ci, mixed]
+        reason:
+          type: string
+      required: [needs_preview, category, reason]
+
   # Layer 3: Spin up preview and validate
   - id: preview-up
     bash: |
       ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
+      NEEDS_PREVIEW=$classify-preview.output.needs_preview
+      SKIP_REASON="$classify-preview.output.reason"
+
+      # Skip ONLY on an explicit "false". Any other value (including garbled or errored
+      # classifier output) falls through to building the preview — fail-safe direction.
+      if [ "$NEEDS_PREVIEW" = "false" ]; then
+        echo "Preview differentiator: skipping preview for issue #${ISSUE}"
+        echo "Reason: ${SKIP_REASON}"
+        mkdir -p "$ARTIFACTS_DIR"
+        {
+          echo "export PREVIEW_SKIPPED=true"
+          echo "export PREVIEW_SKIP_REASON=\"${SKIP_REASON}\""
+          echo "export PREVIEW_FRONTEND=\"\""
+          echo "export PREVIEW_BACKEND=\"\""
+          echo "export PREVIEW_NET=\"\""
+        } > "$ARTIFACTS_DIR/preview_env.sh"
+        echo "PREVIEW_SKIPPED=true"
+        echo "PREVIEW_SKIP_REASON=${SKIP_REASON}"
+        exit 0
+      fi
+
       # Preview ports follow 1{SLOT}{suffix} (e.g. slot 03 -> frontend 10333, backend 10380).
       # Collision-free allocation: recover the slot from the already-running preview stack (Continue runs),
       # or scan docker ps for occupied 1PP33->3333 frontend ports and pick the lowest free 2-digit slot.
@@ -418,6 +501,7 @@ nodes:
           # having to parse raw step output or guess the URL.
           mkdir -p "$ARTIFACTS_DIR"
           {
+            echo "export PREVIEW_SKIPPED=false"
             echo "export PREVIEW_FRONTEND=\"http://localhost:1${PADDED}33\""
             echo "export PREVIEW_BACKEND=\"${BACKEND_INTERNAL}\""
             echo "export PREVIEW_NET=\"${PREVIEW_NET}\""
@@ -429,7 +513,7 @@ nodes:
       echo "WARNING: Backend did not become healthy within 180s"
       docker network disconnect "$PREVIEW_NET" "$(hostname)" 2>/dev/null || true
       exit 1
-    depends_on: [regen-codeindex]
+    depends_on: [classify-preview]
     when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
     timeout: 300000
 
@@ -451,6 +535,8 @@ nodes:
     bash: |
       ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
       EPIC_NUM=$(echo $fetch-issue.output | jq -r '.epic_number // empty')
+      PREVIEW_SKIPPED=$(echo $preview-up.output | grep '^PREVIEW_SKIPPED=' | cut -d= -f2-)
+      PREVIEW_SKIP_REASON=$(echo $preview-up.output | grep '^PREVIEW_SKIP_REASON=' | cut -d= -f2-)
       PREVIEW_FRONTEND=$(echo $preview-up.output | grep '^PREVIEW_FRONTEND=' | cut -d= -f2-)
       PREVIEW_BACKEND=$(echo $preview-up.output | grep '^PREVIEW_BACKEND=' | cut -d= -f2-)
       BRANCH=$(git branch --show-current)
@@ -481,6 +567,14 @@ nodes:
         fi
       fi
 
+      # --- Build the Preview section ---
+      if [ "$PREVIEW_SKIPPED" = "true" ]; then
+        PREVIEW_SECTION="_No preview environment — this change does not affect the running app (${PREVIEW_SKIP_REASON})._"
+      else
+        PREVIEW_SECTION="- Frontend: ${PREVIEW_FRONTEND}
+      - Backend API: ${PREVIEW_BACKEND}/docs"
+      fi
+
       EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number // empty')
       if [ -n "$EXISTING_PR" ]; then
         echo "PR #${EXISTING_PR} already exists, updated with latest push."
@@ -497,8 +591,7 @@ nodes:
       Automated implementation for issue #${ISSUE}.${EPIC_LINE}
 
       ## Preview
-      - Frontend: ${PREVIEW_FRONTEND}
-      - Backend API: ${PREVIEW_BACKEND}/docs
+      ${PREVIEW_SECTION}
 
       ## Commands
       \`\`\`bash
@@ -548,6 +641,8 @@ nodes:
     bash: |
       ISSUE=$(echo $fetch-issue.output | jq -r '.resolved_number')
       EPIC_NUM=$(echo $fetch-issue.output | jq -r '.epic_number // empty')
+      PREVIEW_SKIPPED=$(echo $preview-up.output | grep '^PREVIEW_SKIPPED=' | cut -d= -f2-)
+      PREVIEW_SKIP_REASON=$(echo $preview-up.output | grep '^PREVIEW_SKIP_REASON=' | cut -d= -f2-)
       PREVIEW_SLOT=$(echo $preview-up.output | grep '^PREVIEW_SLOT=' | cut -d= -f2-)
       PREVIEW_FRONTEND=$(echo $preview-up.output | grep '^PREVIEW_FRONTEND=' | cut -d= -f2-)
       PREVIEW_BACKEND=$(echo $preview-up.output | grep '^PREVIEW_BACKEND=' | cut -d= -f2-)
@@ -593,6 +688,19 @@ nodes:
         esac
       fi
 
+      # --- Build the Preview Environment section ---
+      if [ "$PREVIEW_SKIPPED" = "true" ]; then
+        PREVIEW_SECTION="_No preview environment — this change does not affect the running app (${PREVIEW_SKIP_REASON})._"
+      else
+        PREVIEW_SECTION="| Service | URL |
+      |---------|-----|
+      | Frontend | ${PREVIEW_FRONTEND} |
+      | Backend API | ${PREVIEW_BACKEND} |
+      | API Docs | ${PREVIEW_BACKEND}/docs |
+      | PostgreSQL | \`localhost:1${PREVIEW_SLOT}54\` |
+      | Redis | \`localhost:1${PREVIEW_SLOT}63\` |"
+      fi
+
       gh issue comment "$ISSUE" --body "## Dark Factory Run — ${ACTION}
 
       ${PR_LINE}
@@ -607,13 +715,7 @@ nodes:
 
       ### Preview Environment
 
-      | Service | URL |
-      |---------|-----|
-      | Frontend | ${PREVIEW_FRONTEND} |
-      | Backend API | ${PREVIEW_BACKEND} |
-      | API Docs | ${PREVIEW_BACKEND}/docs |
-      | PostgreSQL | \`localhost:1${PREVIEW_SLOT}54\` |
-      | Redis | \`localhost:1${PREVIEW_SLOT}63\` |
+      ${PREVIEW_SECTION}
 
       ### Commands
       \`\`\`bash

--- a/.claude/skills/refinement/config.yaml
+++ b/.claude/skills/refinement/config.yaml
@@ -18,3 +18,7 @@ conformance:
   enabled: true
   max_reconcile_cycles: 3
   block_on_material: true
+
+preview:
+  enabled: true   # false = always build the preview (pre-differentiator behavior) — kill-switch
+  model: haiku

--- a/dark-factory/tests/test_preview_differentiator.sh
+++ b/dark-factory/tests/test_preview_differentiator.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Regression tests for the preview environment differentiator.
+# Tests the preview-up guard logic and validate skip path.
+# Run: bash dark-factory/tests/test_preview_differentiator.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ARTIFACTS_DIR=$(mktemp -d /tmp/preview-diff-test-XXXXXX)
+trap 'rm -rf "$ARTIFACTS_DIR"' EXIT
+
+# ---- Runner ----
+PASSED=0; FAILED=0
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $desc"; PASSED=$((PASSED+1))
+  else
+    echo "  FAIL: $desc — expected='$expected' got='$actual'" >&2; FAILED=$((FAILED+1))
+  fi
+}
+
+assert_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    echo "  PASS: $desc"; PASSED=$((PASSED+1))
+  else
+    echo "  FAIL: $desc — expected to find '$needle' in output" >&2; FAILED=$((FAILED+1))
+  fi
+}
+
+assert_not_contains() {
+  local desc="$1" needle="$2" haystack="$3"
+  if echo "$haystack" | grep -qF "$needle"; then
+    echo "  FAIL: $desc — did not expect '$needle' in output" >&2; FAILED=$((FAILED+1))
+  else
+    echo "  PASS: $desc"; PASSED=$((PASSED+1))
+  fi
+}
+
+# =====================================================================
+# A: preview-up guard — the core gated executor logic
+# Simulate the guard block from preview-up with various NEEDS_PREVIEW values
+# =====================================================================
+echo "--- A: preview-up guard ---"
+
+run_guard() {
+  local needs_preview="$1" skip_reason="${2:-test reason}"
+  local artifacts="$ARTIFACTS_DIR/guard_$1"
+  mkdir -p "$artifacts"
+  # Simulate the guard block
+  OUTPUT=$(
+    NEEDS_PREVIEW="$needs_preview"
+    SKIP_REASON="$skip_reason"
+    ISSUE="99"
+    ARTIFACTS_DIR="$artifacts"
+    if [ "$NEEDS_PREVIEW" = "false" ]; then
+      echo "Preview differentiator: skipping preview for issue #${ISSUE}"
+      echo "Reason: ${SKIP_REASON}"
+      {
+        echo "export PREVIEW_SKIPPED=true"
+        echo "export PREVIEW_SKIP_REASON=\"${SKIP_REASON}\""
+        echo "export PREVIEW_FRONTEND=\"\""
+        echo "export PREVIEW_BACKEND=\"\""
+        echo "export PREVIEW_NET=\"\""
+      } > "$ARTIFACTS_DIR/preview_env.sh"
+      echo "PREVIEW_SKIPPED=true"
+      echo "PREVIEW_SKIP_REASON=${SKIP_REASON}"
+      exit 0
+    fi
+    echo "BUILDING_PREVIEW"
+  )
+  RC=$?
+  echo "$OUTPUT"
+}
+
+# needs_preview=false → should skip
+OUT=$(run_guard "false" "docs-only change")
+assert_contains "false → outputs PREVIEW_SKIPPED=true" "PREVIEW_SKIPPED=true" "$OUT"
+assert_not_contains "false → does not build preview" "BUILDING_PREVIEW" "$OUT"
+
+# Check preview_env.sh was written correctly for skip case
+ENV_FILE="$ARTIFACTS_DIR/guard_false/preview_env.sh"
+assert_eq "preview_env.sh exists after skip" "0" "$(test -f "$ENV_FILE" && echo 0 || echo 1)"
+if [ -f "$ENV_FILE" ]; then
+  SKIPPED_VAL=$(grep 'PREVIEW_SKIPPED' "$ENV_FILE" | head -1 | grep -o 'true\|false')
+  assert_eq "preview_env.sh has PREVIEW_SKIPPED=true" "true" "$SKIPPED_VAL"
+fi
+
+# needs_preview=true → should build
+OUT=$(run_guard "true" "code changed")
+assert_contains "true → proceeds to build" "BUILDING_PREVIEW" "$OUT"
+assert_not_contains "true → does not skip" "PREVIEW_SKIPPED=true" "$OUT"
+
+# needs_preview=garbled → fail-safe: should build (not skip on uncertainty)
+OUT=$(run_guard "garbled_value" "uncertain")
+assert_contains "garbled → fail-safe builds" "BUILDING_PREVIEW" "$OUT"
+assert_not_contains "garbled → does not skip" "PREVIEW_SKIPPED=true" "$OUT"
+
+# needs_preview='' (empty) → fail-safe: should build
+OUT=$(run_guard "" "empty classifier output")
+assert_contains "empty → fail-safe builds" "BUILDING_PREVIEW" "$OUT"
+assert_not_contains "empty → does not skip" "PREVIEW_SKIPPED=true" "$OUT"
+
+# =====================================================================
+# B: validate skip path — when PREVIEW_SKIPPED=true, endpoint tests skipped
+# =====================================================================
+echo ""
+echo "--- B: validate skip path (preview_env.sh parsing) ---"
+
+# Write a skip-mode preview_env.sh
+SKIP_ENV="$ARTIFACTS_DIR/skip_preview_env.sh"
+cat > "$SKIP_ENV" <<'EOF'
+export PREVIEW_SKIPPED=true
+export PREVIEW_SKIP_REASON="docs-only change — no runtime impact"
+export PREVIEW_FRONTEND=""
+export PREVIEW_BACKEND=""
+export PREVIEW_NET=""
+EOF
+
+# Simulate the validate branch logic
+source "$SKIP_ENV"
+assert_eq "PREVIEW_SKIPPED sourced correctly" "true" "$PREVIEW_SKIPPED"
+assert_eq "PREVIEW_BACKEND is empty when skipped" "" "$PREVIEW_BACKEND"
+assert_eq "PREVIEW_NET is empty when skipped" "" "$PREVIEW_NET"
+
+# Simulate the network disconnect guard
+DISCONNECT_RAN=""
+if [ "$PREVIEW_SKIPPED" != "true" ]; then
+  DISCONNECT_RAN="yes"
+fi
+assert_eq "network disconnect skipped when PREVIEW_SKIPPED=true" "" "$DISCONNECT_RAN"
+
+# Write a normal (non-skipped) preview_env.sh
+NORMAL_ENV="$ARTIFACTS_DIR/normal_preview_env.sh"
+cat > "$NORMAL_ENV" <<'EOF'
+export PREVIEW_SKIPPED=false
+export PREVIEW_FRONTEND="http://localhost:10333"
+export PREVIEW_BACKEND="http://mh-preview-99-backend-1:8000"
+export PREVIEW_NET="mh-preview-99_preview-network"
+EOF
+
+source "$NORMAL_ENV"
+assert_eq "PREVIEW_SKIPPED false sourced correctly" "false" "$PREVIEW_SKIPPED"
+assert_eq "PREVIEW_BACKEND populated when not skipped" "http://mh-preview-99-backend-1:8000" "$PREVIEW_BACKEND"
+
+DISCONNECT_RAN=""
+if [ "$PREVIEW_SKIPPED" != "true" ]; then
+  DISCONNECT_RAN="yes"
+fi
+assert_eq "network disconnect runs when not skipped" "yes" "$DISCONNECT_RAN"
+
+# =====================================================================
+# C: push-and-pr preview section rendering
+# =====================================================================
+echo ""
+echo "--- C: push-and-pr preview section rendering ---"
+
+# Skipped case
+PREVIEW_SKIPPED="true"
+PREVIEW_SKIP_REASON="docs-only change — no runtime impact"
+PREVIEW_FRONTEND=""
+PREVIEW_BACKEND=""
+if [ "$PREVIEW_SKIPPED" = "true" ]; then
+  PREVIEW_SECTION="_No preview environment — this change does not affect the running app (${PREVIEW_SKIP_REASON})._"
+else
+  PREVIEW_SECTION="- Frontend: ${PREVIEW_FRONTEND}"$'\n'"- Backend API: ${PREVIEW_BACKEND}/docs"
+fi
+assert_contains "skipped → PR preview section has no-preview note" "No preview environment" "$PREVIEW_SECTION"
+assert_not_contains "skipped → PR section has no Frontend URL" "Frontend:" "$PREVIEW_SECTION"
+
+# Not-skipped case
+PREVIEW_SKIPPED="false"
+PREVIEW_FRONTEND="http://localhost:10333"
+PREVIEW_BACKEND="http://mh-preview-99-backend-1:8000"
+if [ "$PREVIEW_SKIPPED" = "true" ]; then
+  PREVIEW_SECTION="_No preview environment — this change does not affect the running app._"
+else
+  PREVIEW_SECTION="- Frontend: ${PREVIEW_FRONTEND}"$'\n'"- Backend API: ${PREVIEW_BACKEND}/docs"
+fi
+assert_contains "not-skipped → PR preview section has Frontend URL" "Frontend:" "$PREVIEW_SECTION"
+assert_not_contains "not-skipped → PR section has no no-preview note" "No preview environment" "$PREVIEW_SECTION"
+
+# =====================================================================
+# D: report preview section rendering
+# =====================================================================
+echo ""
+echo "--- D: report preview section rendering ---"
+
+# Skipped case
+PREVIEW_SKIPPED="true"
+PREVIEW_SKIP_REASON="docs-only — no runtime impact"
+if [ "$PREVIEW_SKIPPED" = "true" ]; then
+  PREVIEW_SECTION="_No preview environment — this change does not affect the running app (${PREVIEW_SKIP_REASON})._"
+else
+  PREVIEW_SECTION="| Service | URL |"
+fi
+assert_contains "report skipped → no-preview note" "No preview environment" "$PREVIEW_SECTION"
+assert_not_contains "report skipped → no table" "| Service |" "$PREVIEW_SECTION"
+
+# Not-skipped case
+PREVIEW_SKIPPED="false"
+PREVIEW_SLOT="03"
+PREVIEW_FRONTEND="http://localhost:10333"
+PREVIEW_BACKEND="http://mh-preview-99-backend-1:8000"
+if [ "$PREVIEW_SKIPPED" = "true" ]; then
+  PREVIEW_SECTION="_No preview environment._"
+else
+  PREVIEW_SECTION="| Service | URL |
+|---------|-----|
+| Frontend | ${PREVIEW_FRONTEND} |
+| Backend API | ${PREVIEW_BACKEND} |"
+fi
+assert_contains "report not-skipped → table rendered" "| Service |" "$PREVIEW_SECTION"
+assert_not_contains "report not-skipped → no no-preview note" "No preview environment" "$PREVIEW_SECTION"
+
+# =====================================================================
+# Summary
+# =====================================================================
+echo ""
+echo "============================="
+echo "Results: ${PASSED} passed, ${FAILED} failed"
+echo "============================="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
Automated implementation for issue omniscient/dark-factory#76.

## Preview
- Frontend: http://localhost:10033
- Backend API: http://mh-preview-178-backend-1:8000/docs

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#76"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#76"
```

---
*Generated by MarketHawk Dark Factory*