### PR TITLE
docs: ADR hygiene — renumber duplicate 0010 and add a decision-log index

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -89,3 +89,7 @@ _Avoid_: Data source (too generic), feed (that's real-time only)
 > **Dev**: "We confirmed about 70%, rejected the rest — mostly too-late or noise. The enrichment showed a few had news catalysts. We still need to compute outcomes so we can check the scorecard."
 >
 > **Domain expert**: "Good. If the edge holds, let's set up an alert rule to push notifications on high-severity signals and add the hits to the watchlist for live monitoring."
+
+## Architecture Decisions
+
+Past decisions that shape the codebase live in [`docs/adr/`](docs/adr/). The [`docs/adr/README.md`](docs/adr/README.md) is the decision-log index — scan it to find what has been decided before diving into individual records.

--- a/docs/adr/0011-dark-factory-gelf-logging.md
+++ b/docs/adr/0011-dark-factory-gelf-logging.md
@@ -1,4 +1,4 @@
-# ADR-0010: GELF Log Shipping for Dark Factory Containers
+# ADR-0011: GELF Log Shipping for Dark Factory Containers
 
 **Date**: 2026-05-29
 **Status**: Accepted

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,18 @@
+# Architecture Decision Log
+
+This table lists every ADR in the repository. Each row links to the full record.
+To add a new ADR: copy `template.md`, assign the next number, fill in the header, and add a row here.
+
+| Number | Title | Status | Date |
+|--------|-------|--------|------|
+| [0001](0001-polygon-for-historical-market-data.md) | Polygon.io for historical market data | Accepted | — |
+| [0002](0002-jwt-authentication-httponly-cookies.md) | JWT Authentication via HttpOnly Cookies | Accepted | 2026-05-27 |
+| [0003](0003-slowapi-middleware-for-rate-limiting.md) | SlowAPI Middleware for Rate Limiting | Accepted | 2026-05-28 |
+| [0004](0004-synchronous-sqlalchemy.md) | Synchronous SQLAlchemy ORM | Accepted | 2026-05-28 |
+| [0005](0005-jsonb-for-scanner-event-metadata.md) | JSONB Columns for Scanner Event Metadata | Accepted | 2026-05-28 |
+| [0006](0006-celery-redis-for-background-tasks.md) | Celery + Redis for Background Tasks | Accepted | 2026-05-28 |
+| [0007](0007-live-scanner-service-extraction.md) | Live Scanner as a Separate Container | Accepted | 2026-05-28 |
+| [0008](0008-dark-factory-autonomous-development.md) | Dark Factory Autonomous Development Model | Accepted | 2026-05-28 |
+| [0009](0009-naive-utc-timestamps.md) | Naive UTC Timestamps in the Database | Accepted | 2026-05-28 |
+| [0010](0010-api-versioning-policy.md) | API Versioning Policy | Accepted | 2026-05-29 |
+| [0011](0011-dark-factory-gelf-logging.md) | GELF Log Shipping for Dark Factory Containers | Accepted | 2026-05-29 |

--- a/docs/superpowers/plans/2026-05-29-dark-factory-gelf-logging.md
+++ b/docs/superpowers/plans/2026-05-29-dark-factory-gelf-logging.md
@@ -9,7 +9,7 @@
 **Tech Stack:** Docker Compose, GELF protocol, Seq, `datalust/seq-input-gelf`
 
 **Spec:** [`Docs/superpowers/specs/2026-05-29-dark-factory-gelf-logging-design.md`](../specs/2026-05-29-dark-factory-gelf-logging-design.md)
-**ADR:** [`Docs/adr/0010-dark-factory-gelf-logging.md`](../../adr/0010-dark-factory-gelf-logging.md)
+**ADR:** [`docs/adr/0011-dark-factory-gelf-logging.md`](../../adr/0011-dark-factory-gelf-logging.md)
 **Issue:** [#122](https://github.com/omniscient/markethawk/issues/122)
 
 ---
@@ -206,15 +206,15 @@ git commit -m "feat(logging): add GELF log driver to dark-factory and backlog-sc
 
 **Files:**
 - Already on disk: `Docs/superpowers/specs/2026-05-29-dark-factory-gelf-logging-design.md`
-- Already on disk: `Docs/adr/0010-dark-factory-gelf-logging.md`
+- Already on disk: `docs/adr/0011-dark-factory-gelf-logging.md`
 
 These files were written during the brainstorming/design phase but not yet committed.
 
 - [ ] **Step 1: Commit spec and ADR**
 
 ```bash
-git add Docs/superpowers/specs/2026-05-29-dark-factory-gelf-logging-design.md Docs/adr/0010-dark-factory-gelf-logging.md
-git commit -m "docs: add spec and ADR-0010 for dark factory GELF logging (#122)"
+git add docs/superpowers/specs/2026-05-29-dark-factory-gelf-logging-design.md docs/adr/0011-dark-factory-gelf-logging.md
+git commit -m "docs: add spec and ADR-0011 for dark factory GELF logging (#122)"
 ```
 
 ---

--- a/docs/superpowers/specs/2026-05-29-dark-factory-gelf-logging-design.md
+++ b/docs/superpowers/specs/2026-05-29-dark-factory-gelf-logging-design.md
@@ -63,7 +63,7 @@ Both factory services add `stockscanner-network` as a second network (they keep 
 | `docker-compose.yml` — new `seq-gelf` service | `datalust/seq-input-gelf` sidecar, UDP 12201, forwards to Seq |
 | `docker-compose.yml` — `dark-factory` | Add GELF `logging:` block, add `stockscanner-network` |
 | `docker-compose.yml` — `backlog-scheduler` | Add GELF `logging:` block, add `stockscanner-network` |
-| `Docs/adr/0010-dark-factory-gelf-logging.md` | ADR documenting the decision and trade-offs |
+| `docs/adr/0011-dark-factory-gelf-logging.md` | ADR documenting the decision and trade-offs |
 
 No changes to `entrypoint.sh`, `scheduler.sh`, `Dockerfile`, or application code.
 


### PR DESCRIPTION
## Summary
Automated implementation for issue #172.

## Preview
_No preview environment — this change does not affect the running app ('All changes are documentation-only: ADR renumbering, README updates, and design specs under docs/. No runtime code, migrations, config, or dependencies affected.')._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #172"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #172"
```

---
*Generated by MarketHawk Dark Factory*