### PR TITLE
seed: review scanner_config seed file changes (universe_id fix + pocket_pivot simplification)

### DIFF
--- a/.archon/memory/dark-factory-ops.md
+++ b/.archon/memory/dark-factory-ops.md
@@ -15,7 +15,9 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 
 ## Seed Files
 
-- [PATTERN] Seed files in `dark-factory/seed/seed/` are named with a two-digit prefix (`00_`, `01_`, ...) so they apply in deterministic order. The next available slot for a new baseline module is determined by `ls dark-factory/seed/seed/ | sort | tail -1`. <!-- bootstrap date:2026-06-02 expires:2026-12-02 source:implement -->
+- [PATTERN] Seed files in `dark-factory/seed/` are named with a two-digit prefix (`00_`, `01_`, ...) so they apply in deterministic order. `docker-compose.preview.yml` mounts `./seed:/seed:ro` and runs `for f in /seed/*.sql` — only files at the root of `dark-factory/seed/` are executed; subdirectory files (e.g. `dark-factory/seed/seed/`) are NOT run. The next available slot is `ls dark-factory/seed/*.sql | sort | tail -1`. <!-- issue:#207 date:2026-06-04 expires:2026-12-04 source:implement -->
+
+- [AVOID] Seed SQL that INSERTs into `scanner_configs` must always include `universe_id` in the column list (value `1` for the default universe). The column is NOT NULL with no server default (migration c7d8e9f0a1b2 removed nullable after backfill); omitting it causes a NOT NULL violation on fresh preview stacks. <!-- issue:#207 date:2026-06-04 expires:2026-12-04 source:implement -->
 
 - [AVOID] Do not embed data directly in Alembic migration files — migrations are schema-only. Feature-specific seed data goes in `dark-factory/seed/99_feature.sql` (idempotent, `ON CONFLICT DO NOTHING`). Data needed across multiple features goes in a new numbered baseline module. <!-- bootstrap date:2026-06-02 expires:2026-12-02 source:implement -->
 

--- a/dark-factory/seed/seed/01_scanner_configs.sql
+++ b/dark-factory/seed/seed/01_scanner_configs.sql
@@ -16,7 +16,7 @@ VALUES (
   true,
   1
 )
-ON CONFLICT (id) DO UPDATE SET universe_id = EXCLUDED.universe_id;
+ON CONFLICT (id) DO NOTHING;
 
 -- Scanner config: Liquidity Hunt (Evening)
 INSERT INTO scanner_configs (id, uuid, name, description, scanner_type, parameters, criteria, is_active, universe_id)
@@ -31,7 +31,7 @@ VALUES (
   true,
   1
 )
-ON CONFLICT (id) DO UPDATE SET universe_id = EXCLUDED.universe_id;
+ON CONFLICT (id) DO NOTHING;
 
 -- Scanner config: Oversold Bounce
 INSERT INTO scanner_configs (id, uuid, name, description, scanner_type, parameters, criteria, is_active, universe_id)
@@ -46,32 +46,26 @@ VALUES (
   true,
   1
 )
-ON CONFLICT (id) DO UPDATE SET universe_id = EXCLUDED.universe_id;
+ON CONFLICT (id) DO NOTHING;
 
 -- Scanner config: Pocket Pivot (Evening)
--- If a pocket_pivot row already exists with a different id (e.g. auto-assigned by migration),
--- patch it to ensure universe_id=1. Then insert id=4 only if no pocket_pivot row exists at all.
-UPDATE scanner_configs
-SET universe_id = 1
-WHERE scanner_type = 'pocket_pivot'
-  AND id != 4;
-
+-- Migration 1bf5e10f1111 seeds this row via auto-id; migration c7e2a9f4b1d3 activates it
+-- and normalises criteria to []. This INSERT is a no-op when those migrations have run;
+-- it provides the row for any edge case where migrations did not seed it.
 INSERT INTO scanner_configs (id, uuid, name, description, scanner_type, parameters, criteria, is_active, run_frequency, universe_id)
-SELECT
+VALUES (
   4,
   gen_random_uuid(),
   'Pocket Pivot (Evening)',
   'Detects up-days where session volume exceeds the highest down-day volume in the prior 10 trading days (classic Morales/Kacher pocket pivot).',
   'pocket_pivot',
-  '{"lookback_days": 10, "min_lookback_days": 5, "price_floor": 5.0, "volume_floor": 100000}',
-  '{}',
+  '{"lookback_days": 10, "volume_floor": 100000}',
+  '[]',
   true,
   'evening',
   1
-WHERE NOT EXISTS (
-  SELECT 1 FROM scanner_configs WHERE scanner_type = 'pocket_pivot'
 )
-ON CONFLICT (id) DO UPDATE SET universe_id = EXCLUDED.universe_id;
+ON CONFLICT (id) DO NOTHING;
 
 -- System config defaults
 INSERT INTO system_config (key, value)


### PR DESCRIPTION
## Summary
Automated implementation for issue #207.

## Preview
- Frontend: http://localhost:10133
- Backend API: http://mh-preview-207-backend-1:8000/docs

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #207"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #207"
```

---
*Generated by MarketHawk Dark Factory*