### PR TITLE
[#190] Reject empty/weak JWT_SECRET_KEY at startup

### DIFF
--- a/.archon/memory/backend-patterns.md
+++ b/.archon/memory/backend-patterns.md
@@ -27,6 +27,12 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 
 - [PATTERN] Test fixtures that create ScannerConfig rows must now supply `universe_id`; if no universe exists in the test transaction, create one inline (see `seed_scanner_configs` in `tests/fixtures/core.py` for the pattern). <!-- issue:#156 date:2026-06-03 expires:2026-12-03 source:implement -->
 
+## Backend: Config / Settings
+
+- [PATTERN] When adding a `field_validator` to `Settings` in `config.py`, add a matching `os.environ.setdefault("FIELD_NAME", valid_value)` at the top of `backend/tests/conftest.py` (before app imports) — otherwise bare `Settings()` calls in existing tests will hit the new validator with the default value and fail. <!-- issue:#190 date:2026-06-05 expires:2026-12-05 source:implement -->
+
+- [PATTERN] Test a pydantic-settings validator by passing the invalid value as an init kwarg — `Settings(JWT_SECRET_KEY="")` — since init kwargs override env vars. This gives a clean, deterministic test without manipulating environment state. <!-- issue:#190 date:2026-06-05 expires:2026-12-05 source:implement -->
+
 ## Backend: Migrations
 
 - [PATTERN] After any model change: `cd backend && python -m alembic revision --autogenerate -m "description" && python -m alembic upgrade head`. Never skip the `upgrade head` step — the preview stack applies migrations at startup, but the local test suite does not. <!-- bootstrap date:2026-06-02 expires:2026-12-02 source:implement -->

--- a/.env.example
+++ b/.env.example
@@ -46,8 +46,9 @@ SECRET_KEY=your_secret_key_here
 # =============================================================================
 # REQUIRED: Authentication (JWT)
 # =============================================================================
-# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
-JWT_SECRET_KEY=
+# MANDATORY — startup validation will fail if this is missing or shorter than 32 chars.
+# Generate with: python -c "import secrets; print(secrets.token_urlsafe(48))"
+JWT_SECRET_KEY=your_jwt_secret_key_here_minimum_32_chars
 ACCESS_TOKEN_EXPIRE_MINUTES=15
 REFRESH_TOKEN_EXPIRE_DAYS=7
 

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -20,7 +20,7 @@ These must be set before starting the stack. The application will start without 
 | `POSTGRES_PASSWORD` | PostgreSQL superuser password | `change_me` |
 | `DATABASE_URL` | Full PostgreSQL connection string (must match `POSTGRES_*` vars) | `postgresql://postgres:change_me@postgres:5432/stockscanner` |
 | `SECRET_KEY` | JWT and session signing key. Generate with: `python -c "import secrets; print(secrets.token_hex(32))"` | `a3f8d2...` |
-| `JWT_SECRET_KEY` | Signing key for user access tokens. Fail-closed: empty value blocks all non-exempt endpoints. Generate same as `SECRET_KEY`. | `b9e1c4...` |
+| `JWT_SECRET_KEY` | Signing key for user access tokens. **Must be ≥ 32 characters** — startup fails with a `ValidationError` if missing or shorter. Generate with: `python -c "import secrets; print(secrets.token_urlsafe(48))"` | `b9e1c4...` |
 | `PGADMIN_DEFAULT_EMAIL` | Login email for pgAdmin web UI | `admin@example.com` |
 | `PGADMIN_DEFAULT_PASSWORD` | Login password for pgAdmin web UI | `change_me` |
 | `SEQ_ADMIN_PASSWORD_HASH` | Bcrypt hash of the Seq admin password. Generate with: `echo 'YourPassword' \| docker run --rm -i datalust/seq config hash` | `$2a$11$...` |

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -119,6 +119,16 @@ class Settings(BaseSettings):
     def normalize_environment(cls, v: str) -> str:
         return v.lower()
 
+    @field_validator("JWT_SECRET_KEY")
+    @classmethod
+    def validate_jwt_secret_key(cls, v: str) -> str:
+        if len(v) < 32:
+            raise ValueError(
+                "JWT_SECRET_KEY must be at least 32 characters. "
+                "Generate one with: python -c 'import secrets; print(secrets.token_urlsafe(48))'"
+            )
+        return v
+
 
 @lru_cache()
 def get_settings() -> Settings:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,18 +7,20 @@ os.environ.setdefault("RATE_LIMITING_ENABLED", "false")
 
 os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost/test")
 os.environ.setdefault("POLYGON_API_KEY", "test-key-for-unit-tests-only")
+os.environ.setdefault("JWT_SECRET_KEY", "test-jwt-secret-key-for-unit-tests-only-aaa")
 
 import logging as _logging
 from contextlib import contextmanager
 from typing import Generator
 
 import pytest
-from app.core.database import Base
-from app.main import app
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session
 from testcontainers.postgres import PostgresContainer
+
+from app.core.database import Base
+from app.main import app
 
 _conftest_logger = _logging.getLogger(__name__)
 

--- a/backend/tests/core/test_config.py
+++ b/backend/tests/core/test_config.py
@@ -1,5 +1,8 @@
 """Tests for Settings pool configuration defaults."""
 
+import pytest
+from pydantic import ValidationError
+
 from app.core.config import Settings
 
 
@@ -35,3 +38,18 @@ def test_pool_settings_are_correct_types():
     assert isinstance(s.DB_POOL_PRE_PING, bool)
     assert isinstance(s.DB_POOL_RECYCLE, int)
     assert isinstance(s.DB_POOL_TIMEOUT, int)
+
+
+def test_jwt_secret_key_empty_raises_validation_error():
+    with pytest.raises(ValidationError):
+        Settings(JWT_SECRET_KEY="")
+
+
+def test_jwt_secret_key_short_raises_validation_error():
+    with pytest.raises(ValidationError):
+        Settings(JWT_SECRET_KEY="tooshort")
+
+
+def test_jwt_secret_key_32_chars_accepted():
+    s = Settings(JWT_SECRET_KEY="a" * 32)
+    assert s.JWT_SECRET_KEY == "a" * 32


### PR DESCRIPTION
## Summary

- Adds a `field_validator` on `JWT_SECRET_KEY` in `backend/app/core/config.py` that raises `ValidationError` at startup when the key is shorter than 32 characters (including the `""` default)
- Closes the critical vulnerability where a forgotten `JWT_SECRET_KEY` env var lets any caller forge a valid access token signed with an empty string
- Updates `.env.example` and `ENV_VARIABLES.md` to document the key as mandatory with a generation hint

## Test plan

- [x] `test_jwt_secret_key_empty_raises_validation_error` — empty string raises `ValidationError`
- [x] `test_jwt_secret_key_short_raises_validation_error` — key < 32 chars raises `ValidationError`
- [x] `test_jwt_secret_key_32_chars_accepted` — exactly 32 chars is accepted
- [x] All 638 existing tests still pass (65.7% coverage, above the 60% gate)
- [x] `conftest.py` guard ensures existing bare `Settings()` test calls don't break

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)