### PR TITLE
ci: add workflow_dispatch to image publish (on-demand GHCR rebuild)

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -3,6 +3,7 @@ name: Build and Publish Images
 on:
   push:
     branches: [main]
+  workflow_dispatch: {}  # allow on-demand rebuild+push (e.g. to re-bake the vendored Archon clone)
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

GHCR's `ghcr.io/omniscient/markethawk-dark-factory:latest` is built from
`dark-factory/Dockerfile`, which `git clone`s the vendored Archon branch
(`feat/workflow-cost-tracking`) at build time. That branch just received the
**modelUsage camelCase fix** ([omniscient/Archon#1](https://github.com/omniscient/Archon/pull/1)),
which restores the empty **Model** column in the dark-factory cost report.

The local image has been rebuilt with the fix, but **GHCR still has the old
image** — and `ci-publish.yml` only triggered on push to `main`, so there was
no way to re-bake and republish it on demand.

## Change

Add a `workflow_dispatch` trigger to `ci-publish.yml`. One line, no other
behavior change. Backend/frontend/dark-factory builds and the Trivy scan are
untouched.

## How this lands the fix on GHCR

Either path rebuilds + pushes the fixed dark-factory image (CI runners are
fresh, so the Dockerfile re-clones the now-fixed Archon branch — no stale
layer cache):

- **Merging this PR** to `main` fires the existing `push: [main]` trigger → full
  rebuild + push of all three images.
- **On demand afterward**: `gh workflow run "Build and Publish Images"` (or the
  Actions "Run workflow" button) whenever the vendored Archon branch changes.

## Verification

- `ci-publish.yml` parses (triggers: `push`, `workflow_dispatch`).
- Local image already validated: baked Archon HEAD = `37137d22` (Archon PR #1
  merge), fixed provider line present, provider tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
