### PR TITLE
[arch-v2][HIGH] Add CSRF protection for cookie-based auth

### DIFF
--- a/.archon/memory/backend-patterns.md
+++ b/.archon/memory/backend-patterns.md
@@ -33,6 +33,14 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 
 - [PATTERN] Test a pydantic-settings validator by passing the invalid value as an init kwarg — `Settings(JWT_SECRET_KEY="")` — since init kwargs override env vars. This gives a clean, deterministic test without manipulating environment state. <!-- issue:#190 date:2026-06-05 expires:2026-12-05 source:implement -->
 
+## Backend: Middleware
+
+- [PATTERN] Pure-ASGI middleware classes (like `CSRFMiddleware`) should be defined at module level in `main.py`, not inside `create_app()` — module-level placement makes them importable by the test suite without triggering the full app factory. The `AuthMiddleware` is an exception because it closes over `EXEMPT_PREFIXES`. <!-- issue:#192 date:2026-06-05 expires:2026-12-05 source:implement -->
+
+- [PATTERN] When adding new middleware that the test suite needs to pass, update the `inject_auth_into_module_client` autouse fixture in `tests/api/conftest.py` to inject required headers (e.g. `module.client.headers.update({"X-Requested-With": "XMLHttpRequest"})`) so all module-level `TestClient` instances satisfy the new check automatically. <!-- issue:#192 date:2026-06-05 expires:2026-12-05 source:implement -->
+
+- [PATTERN] CSRF_EXEMPT_PREFIXES and AUTH EXEMPT_PREFIXES serve different concerns and must remain separate tuples in `main.py`. Do not merge them — CSRF exempts pre-authentication paths; auth exempts docs/health/metrics paths that are unrelated to CSRF. <!-- issue:#192 date:2026-06-05 expires:2026-12-05 source:implement -->
+
 ## Backend: Migrations
 
 - [PATTERN] After any model change: `cd backend && python -m alembic revision --autogenerate -m "description" && python -m alembic upgrade head`. Never skip the `upgrade head` step — the preview stack applies migrations at startup, but the local test suite does not. <!-- bootstrap date:2026-06-02 expires:2026-12-02 source:implement -->

--- a/.archon/memory/frontend-patterns.md
+++ b/.archon/memory/frontend-patterns.md
@@ -29,6 +29,10 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 
 - [FIX] ESLint `no-restricted-syntax` selector `Literal[value=/\\/api\\//]` matches import paths like `'../api/client'` as false positives. Use the start-anchored form `Literal[value=/^\\/api\\//]` to only flag string literals that actually begin with `/api/`. <!-- issue:#158 date:2026-06-03 expires:2026-12-03 source:implement -->
 
+## Frontend: Security Headers
+
+- [PATTERN] Both `apiClient` and `unversionedClient` in `frontend/src/api/client.ts` must carry any security headers (e.g. `X-Requested-With: XMLHttpRequest`) as static defaults in the `headers` block — never add them only to one client, as auth endpoints use `unversionedClient` and API endpoints use `apiClient`. <!-- issue:#192 date:2026-06-05 expires:2026-12-05 source:implement -->
+
 ## Frontend: Routing
 
 - [PATTERN] New routes are registered in `frontend/src/App.tsx` using React Router `<Route>` elements. Match the existing pattern of lazy-loaded page components (`React.lazy` + `Suspense`). <!-- bootstrap date:2026-06-02 expires:2026-12-02 source:implement -->

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.core.config import get_settings, settings
 from app.core.database import engine
 from app.core.error_tracking import ErrorTrackerFactory
 from app.core.rate_limits import limiter
+from app.core.tracing import OtelTraceIdFilter, instrument_fastapi, setup_otel
 from app.exceptions import MarketHawkError
 from app.routers import (
     alerts_router,
@@ -42,8 +43,42 @@ from app.routers import (
     watchlist_router,
 )
 from app.routers.tweets import router as tweets_router
-from app.core.tracing import OtelTraceIdFilter, instrument_fastapi, setup_otel
 from app.services.websocket_manager import websocket_manager
+
+# CSRF header check — module-level so it is importable by the test suite without
+# triggering the full create_app() factory. Pure ASGI (not BaseHTTPMiddleware) to
+# avoid the chunked-gzip termination bug described at the AuthMiddleware comment below.
+CSRF_EXEMPT_PREFIXES = ("/api/auth/",)
+CSRF_MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+class CSRFMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        method = scope.get("method", "")
+        if method not in CSRF_MUTATING_METHODS:
+            await self.app(scope, receive, send)
+            return
+        path = scope.get("path", "")
+        if any(path.startswith(p) for p in CSRF_EXEMPT_PREFIXES):
+            await self.app(scope, receive, send)
+            return
+        headers = dict(scope.get("headers", []))
+        if b"x-requested-with" not in headers:
+            await JSONResponse(
+                status_code=403,
+                content={
+                    "detail": "CSRF check failed: X-Requested-With header required"
+                },
+            )(scope, receive, send)
+            return
+        await self.app(scope, receive, send)
+
 
 # Celery Configuration
 # celery instance is imported from app.core.celery_app
@@ -275,8 +310,10 @@ def create_app() -> FastAPI:
                 return
             await self.app(scope, receive, send)
 
-    # Added first => innermost middleware (closest to the routes), matching the prior
-    # @app.middleware("http") ordering.
+    # CSRFMiddleware added first = innermost (between AuthMiddleware and routes).
+    # Inbound request flow: AuthMiddleware (401) → CSRFMiddleware (403) → route.
+    app.add_middleware(CSRFMiddleware)
+    # AuthMiddleware added second = outer (validates JWT before CSRF check).
     app.add_middleware(AuthMiddleware)
 
     # CORS middleware

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -15,9 +15,10 @@ from unittest.mock import patch
 
 import fakeredis
 import pytest
+from fastapi.testclient import TestClient
+
 from app.core.database import get_db
 from app.main import app
-from fastapi.testclient import TestClient
 
 
 @pytest.fixture(autouse=True)
@@ -53,11 +54,12 @@ def flush_app_cache():
 
 @pytest.fixture(autouse=True)
 def inject_auth_into_module_client(request):
-    """Inject a valid JWT cookie into any module-level TestClient.
+    """Inject a valid JWT cookie and CSRF header into any module-level TestClient.
 
     Existing test files define `client = TestClient(app)` at module level.
     The auth middleware only validates jwt.decode() — no DB lookup — so any
     token signed with the test secret passes, regardless of subject UUID.
+    The CSRF middleware requires X-Requested-With on mutating requests.
     """
     from app.core.auth import create_access_token
 
@@ -65,3 +67,4 @@ def inject_auth_into_module_client(request):
     if hasattr(module, "client") and isinstance(module.client, TestClient):
         token = create_access_token("00000000-0000-0000-0000-000000000001")
         module.client.cookies.set("access_token", token)
+        module.client.headers.update({"X-Requested-With": "XMLHttpRequest"})

--- a/backend/tests/api/test_csrf.py
+++ b/backend/tests/api/test_csrf.py
@@ -1,0 +1,108 @@
+"""Tests CSRF enforcement via CSRFMiddleware (issue #192)."""
+
+import os
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-unit-tests-only-32chars!")
+os.environ.setdefault("RATE_LIMITING_ENABLED", "false")
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from jose import jwt
+from starlette.requests import Request
+
+from app.core.auth import create_access_token
+from app.core.config import get_settings
+from app.main import CSRFMiddleware  # fails until CSRFMiddleware is added to main.py
+
+
+def _make_app() -> FastAPI:
+    """Minimal test app: auth + CSRF middleware, no DB dependency."""
+    _app = FastAPI()
+    _settings = get_settings()
+
+    class _AuthMiddleware:
+        def __init__(self, app):
+            self.app = app
+
+        async def __call__(self, scope, receive, send):
+            if scope["type"] != "http":
+                await self.app(scope, receive, send)
+                return
+            request = Request(scope)
+            if request.url.path.startswith("/api/auth/"):
+                await self.app(scope, receive, send)
+                return
+            token = request.cookies.get("access_token")
+            if not token:
+                await JSONResponse(
+                    status_code=401, content={"detail": "Not authenticated"}
+                )(scope, receive, send)
+                return
+            try:
+                jwt.decode(
+                    token,
+                    _settings.JWT_SECRET_KEY,
+                    algorithms=[_settings.JWT_ALGORITHM],
+                )
+            except Exception:
+                await JSONResponse(
+                    status_code=401, content={"detail": "Invalid token"}
+                )(scope, receive, send)
+                return
+            await self.app(scope, receive, send)
+
+    # CSRF innermost (added first), auth outer (added second)
+    _app.add_middleware(CSRFMiddleware)
+    _app.add_middleware(_AuthMiddleware)
+
+    @_app.post("/api/v1/resource")
+    async def post_resource():
+        return {"ok": True}
+
+    @_app.get("/api/v1/resource")
+    async def get_resource():
+        return {"ok": True}
+
+    @_app.post("/api/auth/login")
+    async def auth_login():
+        return {"ok": True}
+
+    return _app
+
+
+_test_app = _make_app()
+
+
+def _authed_client() -> TestClient:
+    token = create_access_token("test-user-id")
+    c = TestClient(_test_app)
+    c.cookies.set("access_token", token)
+    return c
+
+
+def test_post_without_csrf_header_returns_403():
+    response = _authed_client().post("/api/v1/resource", json={})
+    assert response.status_code == 403
+    assert "X-Requested-With" in response.json()["detail"]
+
+
+def test_post_with_csrf_header_passes_csrf():
+    response = _authed_client().post(
+        "/api/v1/resource",
+        json={},
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
+    assert response.status_code == 200
+
+
+def test_get_without_csrf_header_passes():
+    response = _authed_client().get("/api/v1/resource")
+    assert response.status_code == 200
+
+
+def test_auth_endpoint_exempt_from_csrf():
+    # no auth cookie — path is CSRF-exempt and auth-exempt
+    c = TestClient(_test_app)
+    response = c.post("/api/auth/login", json={})
+    assert response.status_code != 403

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -20,6 +20,7 @@ export const apiClient = axios.create({
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
+    'X-Requested-With': 'XMLHttpRequest',
   },
 });
 
@@ -30,6 +31,7 @@ export const unversionedClient = axios.create({
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
+    'X-Requested-With': 'XMLHttpRequest',
   },
 });
 


### PR DESCRIPTION
## Summary
Automated implementation for issue #192.

## Preview
- Frontend: http://localhost:10133
- Backend API: http://mh-preview-192-backend-1:8000/docs

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #192"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #192"
```

---
*Generated by MarketHawk Dark Factory*