### PR TITLE
[arch-v2][HIGH] Celery/worker Prometheus metrics never scraped

### DIFF
--- a/.archon/memory/dark-factory-ops.md
+++ b/.archon/memory/dark-factory-ops.md
@@ -3,6 +3,10 @@
 This file is maintained automatically by the dark factory implement agent. Do not edit manually.
 Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, follow those documents.
 
+## Docker Volume Sharing
+
+- [AVOID] Never define a Docker named volume with `driver_opts: type: tmpfs` when the intent is to share files across containers — Docker tmpfs mounts are per-container; each container that mounts the volume gets its own independent tmpfs, making writes from one container invisible to another. Use a regular named volume (no `driver_opts`) for shared-directory patterns like prometheus-client multiprocess mode. <!-- issue:#194 date:2026-06-05 expires:2026-12-05 source:implement -->
+
 ## Preview Stack
 
 - [PATTERN] Preview ports follow the formula `1{ISSUE_NUM_PADDED}XX` where `ISSUE_NUM_PADDED` is zero-padded to two digits and XX is the service suffix (33=frontend, 80=backend, 54=postgres, 63=redis). Example: issue #3 → frontend `:10333`, backend `:10380`. <!-- bootstrap date:2026-06-02 expires:2026-12-02 source:implement -->

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -467,7 +467,7 @@ sequenceDiagram
 
 ### Prometheus metrics (`backend/app/core/metrics.py`)
 
-All custom metrics are registered in `app/core/metrics.py` and exported at `GET /metrics` (excluded from OpenAPI). The backend and `celery-worker` share a tmpfs volume (`prometheus_multiproc`) for `prometheus-client` multiprocess mode so Celery worker metrics aggregate correctly.
+All custom metrics are registered in `app/core/metrics.py` and exported at `GET /metrics` (excluded from OpenAPI). The backend and `celery-worker` share a named Docker volume (`prometheus_multiproc`) mounted at `/tmp/prometheus_multiproc`. Both containers set `PROMETHEUS_MULTIPROC_DIR` to this path; each process writes PID-named `.db` files to the shared volume, and the backend's `/metrics` endpoint uses `MultiProcessCollector` to read and aggregate all of them. The volume must be a regular named volume — not `type: tmpfs` — because Docker tmpfs mounts are per-container and would make worker files invisible to the backend.
 
 | Metric | Type | Labels | Source |
 |--------|------|--------|--------|

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -1,6 +1,8 @@
+import os
+
 from celery import Celery
 from celery.schedules import crontab
-from celery.signals import worker_ready
+from celery.signals import worker_process_shutdown, worker_ready
 
 from app.core.config import settings
 
@@ -18,6 +20,14 @@ def _on_worker_ready(sender, **kwargs):
     from app.tasks.scanning import validate_scheduled_scanner_configs
 
     validate_scheduled_scanner_configs()
+
+
+@worker_process_shutdown.connect
+def _cleanup_prometheus_on_exit(sender, pid, exitcode, **kwargs):
+    if os.environ.get("PROMETHEUS_MULTIPROC_DIR"):
+        from prometheus_client import multiprocess
+
+        multiprocess.mark_process_dead(pid)
 
 
 # News polling runs weekdays only (Mon-Fri).

--- a/backend/tests/api/test_metrics.py
+++ b/backend/tests/api/test_metrics.py
@@ -1,7 +1,8 @@
 """Integration tests for the /metrics endpoint."""
 
-from app.main import app
 from fastapi.testclient import TestClient
+
+from app.main import app
 
 client = TestClient(app)
 
@@ -20,3 +21,21 @@ def test_metrics_endpoint_returns_prometheus_format():
 def test_metrics_endpoint_not_in_openapi_schema():
     response = client.get("/openapi.json")
     assert "/metrics" not in response.json().get("paths", {})
+
+
+def test_metrics_multiprocess_mode_uses_collector(tmp_path, monkeypatch):
+    """When PROMETHEUS_MULTIPROC_DIR is set, /metrics uses MultiProcessCollector.
+
+    Worker containers write PID-named .db files to the shared prometheus_multiproc
+    volume; the backend's /metrics endpoint reads ALL those files via
+    MultiProcessCollector and aggregates them.  The prometheus_multiproc volume
+    must be a regular named volume (not tmpfs) so all containers share the same
+    filesystem — see docker-compose.yml.
+    """
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+    # The endpoint must still return 200 with the multiprocess path active.
+    # An empty PROMETHEUS_MULTIPROC_DIR is valid: MultiProcessCollector finds no
+    # .db files and returns an empty but well-formed Prometheus response.
+    response = client.get("/metrics")
+    assert response.status_code == 200
+    assert "text/plain" in response.headers["content-type"]

--- a/backend/tests/api/test_metrics.py
+++ b/backend/tests/api/test_metrics.py
@@ -1,8 +1,16 @@
 """Integration tests for the /metrics endpoint."""
 
+import os
+
+import pytest
+import yaml
 from fastapi.testclient import TestClient
 
 from app.main import app
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+_COMPOSE_FILE = os.path.join(_REPO_ROOT, "docker-compose.yml")
+_OVERRIDE_FILE = os.path.join(_REPO_ROOT, "docker-compose.override.yml")
 
 client = TestClient(app)
 
@@ -39,3 +47,49 @@ def test_metrics_multiprocess_mode_uses_collector(tmp_path, monkeypatch):
     response = client.get("/metrics")
     assert response.status_code == 200
     assert "text/plain" in response.headers["content-type"]
+
+
+@pytest.mark.skipif(
+    not os.path.exists(_COMPOSE_FILE), reason="docker-compose.yml not accessible"
+)
+def test_docker_compose_backend_command_wipes_prometheus_dir():
+    """docker-compose.yml backend command must wipe stale .db files on cold start."""
+    with open(_COMPOSE_FILE) as f:
+        compose = yaml.safe_load(f)
+    cmd = compose["services"]["backend"]["command"]
+    assert "rm -rf /tmp/prometheus_multiproc/*" in cmd
+
+
+@pytest.mark.skipif(
+    not os.path.exists(_COMPOSE_FILE), reason="docker-compose.yml not accessible"
+)
+def test_docker_compose_celery_worker_command_wipes_prometheus_dir():
+    """docker-compose.yml celery-worker command must wipe stale .db files on cold start."""
+    with open(_COMPOSE_FILE) as f:
+        compose = yaml.safe_load(f)
+    cmd = compose["services"]["celery-worker"]["command"]
+    assert "rm -rf /tmp/prometheus_multiproc/*" in cmd
+
+
+@pytest.mark.skipif(
+    not os.path.exists(_OVERRIDE_FILE),
+    reason="docker-compose.override.yml not accessible",
+)
+def test_docker_compose_override_backend_command_wipes_prometheus_dir():
+    """docker-compose.override.yml backend command must also wipe stale .db files."""
+    with open(_OVERRIDE_FILE) as f:
+        override = yaml.safe_load(f)
+    cmd = override["services"]["backend"]["command"]
+    assert "rm -rf /tmp/prometheus_multiproc/*" in cmd
+
+
+@pytest.mark.skipif(
+    not os.path.exists(_OVERRIDE_FILE),
+    reason="docker-compose.override.yml not accessible",
+)
+def test_docker_compose_override_celery_worker_command_wipes_prometheus_dir():
+    """docker-compose.override.yml celery-worker command must also wipe stale .db files."""
+    with open(_OVERRIDE_FILE) as f:
+        override = yaml.safe_load(f)
+    cmd = override["services"]["celery-worker"]["command"]
+    assert "rm -rf /tmp/prometheus_multiproc/*" in cmd

--- a/backend/tests/core/test_celery_app.py
+++ b/backend/tests/core/test_celery_app.py
@@ -1,0 +1,33 @@
+"""Tests for Celery app configuration and signal handlers."""
+
+
+def test_worker_process_shutdown_calls_mark_process_dead(tmp_path, monkeypatch):
+    """worker_process_shutdown signal must call mark_process_dead to clean up per-PID gauge files."""
+    monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", str(tmp_path))
+
+    from app.core.celery_app import _cleanup_prometheus_on_exit
+
+    dead_pids = []
+    monkeypatch.setattr(
+        "prometheus_client.multiprocess.mark_process_dead",
+        lambda pid: dead_pids.append(pid),
+    )
+
+    _cleanup_prometheus_on_exit(sender=None, pid=99999, exitcode=0)
+    assert 99999 in dead_pids
+
+
+def test_worker_process_shutdown_noop_without_multiproc_dir(monkeypatch):
+    """_cleanup_prometheus_on_exit must be a no-op when PROMETHEUS_MULTIPROC_DIR is unset."""
+    monkeypatch.delenv("PROMETHEUS_MULTIPROC_DIR", raising=False)
+
+    from app.core.celery_app import _cleanup_prometheus_on_exit
+
+    dead_pids = []
+    monkeypatch.setattr(
+        "prometheus_client.multiprocess.mark_process_dead",
+        lambda pid: dead_pids.append(pid),
+    )
+
+    _cleanup_prometheus_on_exit(sender=None, pid=99999, exitcode=0)
+    assert dead_pids == []

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -15,13 +15,13 @@ services:
     volumes:
       - ./backend:/app:ro
       - prometheus_multiproc:/tmp/prometheus_multiproc
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    command: sh -c "rm -rf /tmp/prometheus_multiproc/* 2>/dev/null; uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
 
   celery-worker:
     volumes:
       - ./backend:/app:ro
       - prometheus_multiproc:/tmp/prometheus_multiproc
-    command: python -m watchfiles --filter python 'celery -A app.core.celery_app:celery_app worker --loglevel=info' /app/app
+    command: sh -c "rm -rf /tmp/prometheus_multiproc/* 2>/dev/null; python -m watchfiles --filter python 'celery -A app.core.celery_app:celery_app worker --loglevel=info' /app/app"
 
   celery-beat:
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -541,12 +541,11 @@ volumes:
     name: markethawk_ib_gateway_settings
   scheduler_state:
   timesfm_cache:
+  # Regular named volume (not tmpfs) so all containers (backend + celery-worker)
+  # share the same directory. prometheus-client MultiProcessCollector reads every
+  # PID-named .db file from this volume; with tmpfs each container had its own
+  # private mount so worker metrics were invisible to the backend's /metrics endpoint.
   prometheus_multiproc:
-    driver: local
-    driver_opts:
-      type: tmpfs
-      device: tmpfs
-      o: size=256m
   prometheus_data:
   grafana_data:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
       dockerfile: Dockerfile
     container_name: stockscanner-api
     # Bind-mount (./backend:/app:ro) and --reload are restored in docker-compose.override.yml for local dev.
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    command: sh -c "rm -rf /tmp/prometheus_multiproc/* 2>/dev/null; uvicorn app.main:app --host 0.0.0.0 --port 8000"
     environment:
       DATABASE_URL: ${DATABASE_URL}
       POLYGON_API_KEY: ${POLYGON_API_KEY:-}
@@ -161,7 +161,7 @@ services:
       dockerfile: Dockerfile
     container_name: stockscanner-celery
     # Bind-mount (./backend:/app:ro) and watchfiles hot-reload are restored in docker-compose.override.yml for local dev.
-    command: celery -A app.core.celery_app:celery_app worker --loglevel=info
+    command: sh -c "rm -rf /tmp/prometheus_multiproc/* 2>/dev/null; celery -A app.core.celery_app:celery_app worker --loglevel=info"
     environment:
       DATABASE_URL: ${DATABASE_URL}
       POLYGON_API_KEY: ${POLYGON_API_KEY:-}


### PR DESCRIPTION
## Summary
Automated implementation for issue #194.

## Preview
- Frontend: http://localhost:10233
- Backend API: http://mh-preview-194-backend-1:8000/docs

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #194"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #194"
```

---
*Generated by MarketHawk Dark Factory*