### PR TITLE
fix(compose): forward JWT_SECRET_KEY into backend/celery/beat/live services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,8 @@ services:
       PROMETHEUS_MULTIPROC_DIR: /tmp/prometheus_multiproc
       OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
       OTEL_SERVICE_NAME: markethawk-backend
+      # JWT auth secret — required by Settings validator (>=32 chars), sourced from .env
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
     ports:
       - "8000:8000"
     depends_on:
@@ -186,6 +188,8 @@ services:
       PROMETHEUS_MULTIPROC_DIR: /tmp/prometheus_multiproc
       OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
       OTEL_SERVICE_NAME: markethawk-worker
+      # JWT auth secret — required by Settings validator (>=32 chars), sourced from .env
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
     depends_on:
       postgres:
         condition: service_healthy
@@ -223,6 +227,8 @@ services:
       IBKR_PORT: 4004
       IBKR_CLIENT_ID: 5   # dedicated clientId — never shares with backend or Celery
       PYTHONDONTWRITEBYTECODE: "1"
+      # JWT auth secret — required by Settings validator (>=32 chars), sourced from .env
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
     depends_on:
       postgres:
         condition: service_healthy
@@ -258,6 +264,8 @@ services:
       PYTHONDONTWRITEBYTECODE: "1"
       OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
       OTEL_SERVICE_NAME: markethawk-beat
+      # JWT auth secret — required by Settings validator (>=32 chars), sourced from .env
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Problem

The strict `JWT_SECRET_KEY` validator (≥32 chars) merged to `main` in #220 crash-loops the
`backend`, `celery-worker`, `celery-beat`, and `live-scanner` services. Their
`docker-compose.yml` `environment:` allowlists never forwarded `JWT_SECRET_KEY` from `.env`, so
the containers booted with it unset (pydantic default `''`), failed the validator, and exited.

Symptom: the API on `:8000` returned empty replies (`curl` exit 52 / HTTP `000`) while the
frontend on `:3333` still served static content — i.e. "the site won't load."

## Fix

Forward `JWT_SECRET_KEY: ${JWT_SECRET_KEY}` into all four app services, matching how the existing
VAPID/SMTP secrets are passed. `forecast-worker`, `dark-factory`, and `backlog-scheduler` use
`env_file:` and were already covered.

## Verification

- `docker-compose up -d backend celery-worker celery-beat live-scanner`
- `GET /api/health → 200` (`{"status":"healthy",...}`)
- All four containers stably `Up`; `celery-beat` scheduling tasks again
- No `JWT_SECRET_KEY ... input_value=''` tracebacks in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
