### PR TITLE
[arch-v2][MED] Harden Docker socket mount (dark-factory / scheduler) + non-root containers

### DIFF
--- a/.archon/memory/dark-factory-ops.md
+++ b/.archon/memory/dark-factory-ops.md
@@ -124,3 +124,11 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 ## Analysis and Documentation Outputs
 
 - [PATTERN] Analysis/comparison documents (e.g. `docs/dark-factory-agyn-comparison.html`) must be delivered as self-contained HTML, not Markdown — HTML is preferred for portability and supports visual elements (colored tables, badges, cards) impossible in MD. Use inline CSS with no external dependencies so the file is portable as a single asset. <!-- issue:#184 date:2026-06-04 expires:2026-12-04 source:implement -->
+
+## Non-Root Container Users
+
+- [PATTERN] To relocate Bun from `$HOME/.bun` to a global path (required before non-root user switch), set `BUN_INSTALL=/opt/bun` as an env var BEFORE the install script: `RUN BUN_INSTALL=/opt/bun curl -fsSL https://bun.sh/install | bash` and update `ENV PATH="/opt/bun/bin:${PATH}"`. This makes Bun accessible to all users including non-root. <!-- issue:#203 date:2026-06-05 expires:2026-12-05 source:implement -->
+
+- [PATTERN] When adding a non-root user to a Dockerfile, always grep scripts that run inside the container for hardcoded `/root/` paths — they silently fail when `$HOME` changes to `/home/<user>`. In `dark-factory/entrypoint.sh`, `DECONFLICT_ARTIFACTS_DIR` was the only offender (fixed: `/root/.archon/` → `${HOME}/.archon/`). <!-- issue:#203 date:2026-06-05 expires:2026-12-05 source:implement -->
+
+- [PATTERN] The `docker-socket-proxy` service must have no `profiles:` key so it is a lifecycle superset of both `factory` and `scheduler` profiles. Consumers (`dark-factory`, `backlog-scheduler`) drop their raw `/var/run/docker.sock` volumes and instead set `DOCKER_HOST: tcp://docker-socket-proxy:2375` with `depends_on: [docker-socket-proxy]`. <!-- issue:#203 date:2026-06-05 expires:2026-12-05 source:implement -->

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,6 +26,13 @@ graph TD
         jaeger["jaeger :16686/:4317"]
     end
 
+    subgraph factory["factory-network"]
+        proxy["docker-socket-proxy :2375"]
+        darkfactory["dark-factory (factory profile)"]
+        scheduler["backlog-scheduler (scheduler profile)"]
+    end
+
+    dockersock[/"Docker socket\n/var/run/docker.sock"\]
     polygon(["api.polygon.io"])
 
     Browser -->|"HTTP :3333"| frontend
@@ -59,6 +66,10 @@ graph TD
     jaeger -->|OTLP| backend
     jaeger -->|OTLP| celery
     jaeger -->|OTLP| beat
+
+    proxy -->|":ro"| dockersock
+    darkfactory -->|"tcp :2375"| proxy
+    scheduler -->|"tcp :2375"| proxy
 ```
 
 ## Scan Execution Flow

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,7 +13,12 @@ COPY requirements.txt .
 RUN pip install --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+RUN addgroup --system --gid 1000 appuser \
+ && adduser --system --uid 1000 --ingroup appuser --no-create-home appuser
+
+COPY --chown=appuser:appuser . .
+
+USER appuser
 
 EXPOSE 8000
 

--- a/dark-factory/Dockerfile
+++ b/dark-factory/Dockerfile
@@ -37,9 +37,9 @@ RUN apt-get update && apt-get install -y \
 # pre-commit for the codeindex-blast warn-only hook
 RUN pip install --quiet "git+https://github.com/scheidydude/codeindex.git" pre-commit
 
-# Bun
-RUN curl -fsSL https://bun.sh/install | bash
-ENV PATH="/root/.bun/bin:${PATH}"
+# Bun — install to /opt/bun so it is accessible to non-root users
+RUN BUN_INSTALL=/opt/bun curl -fsSL https://bun.sh/install | bash
+ENV PATH="/opt/bun/bin:${PATH}"
 
 # GitHub CLI
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -77,6 +77,17 @@ COPY docker-compose.yml /opt/dark-factory/docker-compose.yml
 COPY .claude/skills/refinement/ /opt/refinement-skills/
 RUN chmod +x /usr/local/bin/entrypoint.sh /opt/dark-factory/scheduler.sh
 
+# Non-root factory user — must be created AFTER all root-level installs
+RUN groupadd --gid 1000 factory && \
+    useradd --uid 1000 --gid 1000 --create-home --home-dir /home/factory factory
+
+# Transfer workspace ownership to the factory user
+RUN chown -R factory:factory /workspace
+
+# Re-link archon CLI so it remains accessible after user switch
+RUN cd /opt/archon/packages/cli && /opt/bun/bin/bun link
+
+USER factory
 WORKDIR /workspace
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/dark-factory/entrypoint.sh
+++ b/dark-factory/entrypoint.sh
@@ -582,7 +582,7 @@ if [ "$INTENT" = "deconflict" ]; then
   set_board_status "$STATUS_IN_REVIEW" 2>/dev/null || true
 
   # --- Write artifact ---
-  DECONFLICT_ARTIFACTS_DIR="/root/.archon/workspaces/omniscient/markethawk/artifacts"
+  DECONFLICT_ARTIFACTS_DIR="${HOME}/.archon/workspaces/omniscient/markethawk/artifacts"
   mkdir -p "$DECONFLICT_ARTIFACTS_DIR"
   cat > "$DECONFLICT_ARTIFACTS_DIR/conflict_resolution.md" << EOF
 # Conflict Resolution — Issue #${ISSUE_NUM}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -408,6 +408,27 @@ services:
       - stockscanner-network
     restart: unless-stopped
 
+  # Docker Socket Proxy — restricts Docker API access for dark-factory and backlog-scheduler
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:latest
+    container_name: markethawk-docker-socket-proxy
+    restart: unless-stopped
+    environment:
+      CONTAINERS: 1
+      IMAGES: 1
+      NETWORKS: 1
+      VOLUMES: 1
+      BUILD: 1
+      POST: 1
+      SERVICES: 0
+      EXEC: 0
+      AUTH: 0
+      SECRETS: 0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - factory-network
+
   # Dark Factory — autonomous development agent (run on demand)
   dark-factory:
     image: ghcr.io/omniscient/markethawk-dark-factory:${IMAGE_TAG:-latest}
@@ -418,8 +439,10 @@ services:
     env_file:
       - path: .archon/.env
         required: true
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      DOCKER_HOST: tcp://docker-socket-proxy:2375
+    depends_on:
+      - docker-socket-proxy
     networks:
       - factory-network
       - stockscanner-network
@@ -445,9 +468,11 @@ services:
         required: true
     environment:
       FACTORY_IMAGE: "ghcr.io/omniscient/markethawk-dark-factory:${IMAGE_TAG:-latest}"
+      DOCKER_HOST: tcp://docker-socket-proxy:2375
+    depends_on:
+      - docker-socket-proxy
     # Bind-mount (.:/workspace/project:ro) is restored in docker-compose.override.yml for local dev.
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
       - scheduler_state:/var/lib/dark-factory
     networks:
       - factory-network

--- a/docs/adr/0008-dark-factory-autonomous-development.md
+++ b/docs/adr/0008-dark-factory-autonomous-development.md
@@ -1,7 +1,7 @@
 # ADR-008: Dark Factory Autonomous Development Model
 
 **Date**: 2026-05-28  
-**Status**: Accepted
+**Status**: Accepted (updated 2026-06-05 — socket proxy implemented, factory user added)
 
 ## Context
 
@@ -11,7 +11,7 @@ The core challenge is giving an AI agent enough access to build and run Docker c
 
 ### Trust model
 
-The Dark Factory uses `tecnativa/docker-socket-proxy` to restrict the Docker API surface. The proxy allows `CONTAINERS`, `IMAGES`, `NETWORKS`, `VOLUMES`, and `BUILD`, while blocking `SERVICES`, `EXEC`, and write access to `/info` endpoints. The factory container has no bind-mount to the host filesystem — it clones fresh from GitHub each run.
+The Dark Factory routes Docker API calls through a `tecnativa/docker-socket-proxy` sidecar. The proxy allowlist is `CONTAINERS=1, IMAGES=1, NETWORKS=1, VOLUMES=1, BUILD=1, POST=1`; it blocks `SERVICES=0, EXEC=0, AUTH=0, SECRETS=0`. The raw socket is mounted read-only on the proxy only (`/var/run/docker.sock:ro`); `dark-factory` and `backlog-scheduler` connect via `DOCKER_HOST=tcp://docker-socket-proxy:2375`. The factory container has no bind-mount to the host filesystem — it clones fresh from GitHub each run.
 
 ### Known limitation accepted by convention
 
@@ -21,7 +21,7 @@ The Dark Factory uses `tecnativa/docker-socket-proxy` to restrict the Docker API
 
 Dark Factory runs as an ephemeral `--rm` container (`dark-factory`) connected to Docker via a `docker-socket-proxy` sidecar. The factory has no persistent state on the host; all work goes through GitHub (branches, PRs). Preview stacks are named `mh-preview-{issue}` and run on deterministic ports (`1{NN}33` for frontend, `1{NN}80` for backend).
 
-Claude Code runs inside the factory as a non-root user (`factory`, UID 1000). `--dangerously-skip-permissions` is required and is a built-in safety check that fails if run as root.
+Claude Code runs inside the factory as a non-root user (`factory`, UID 1000) — enforced via `USER factory` in `dark-factory/Dockerfile`. `--dangerously-skip-permissions` is required and is a built-in safety check that fails if run as root.
 
 Credentials (`ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`) are injected from `.archon/.env`, mounted read-only. They are kept separate from `.env` to avoid mixing AI credentials with database passwords.
 
@@ -32,3 +32,7 @@ Credentials (`ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`) are i
 - Preview stacks persist after the factory exits so the human can browse them. They must be torn down manually or via `docker compose --profile factory run --rm dark-factory "Close issue #N"`.
 - Port collisions are possible if two issues share the last two digits. The port scheme (`1{NN}33`) uses the issue number directly; issues > 99 use two-digit truncation of the last two digits.
 - The factory is stateless per run: if interrupted, it can be resumed with `"Continue issue #N"` — Archon reads the existing branch and open PR to reconstruct context.
+
+### Residual Risk Acceptance (2026-06-05)
+
+`tecnativa/docker-socket-proxy` does not support label-based container filtering. With `POST=1, CONTAINERS=1`, the factory can create or list any container on the host, not only `mh-preview-*` stacks. This risk is accepted: the factory is a trusted first-party tool run by the repo owner, not an adversarial workload. The entrypoint and Archon workflows operate on `mh-preview-*` resources by convention. A custom proxy with namespace-enforcement would require writing and maintaining a bespoke API gateway — cost not justified at this scale. Reviewed and accepted: issue #203.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,6 +10,10 @@ COPY . .
 
 RUN npm run build
 
+RUN chown -R node:node /app
+
+USER node
+
 EXPOSE 3333
 
 CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
## Summary
Automated implementation for issue omniscient/dark-factory#79.

## Preview
- Frontend: http://localhost:10733
- Backend API: http://mh-preview-203-backend-1:8000/docs

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#79"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#79"
```

---
*Generated by MarketHawk Dark Factory*