### PR TITLE
fix(compose): forward JWT_SECRET_KEY into flower service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -291,10 +291,12 @@ services:
     command: celery -A app.core.celery_app:celery_app flower --port=5555
     environment:
       # flower imports app.core.celery_app, which instantiates Settings() at import
-      # time; DATABASE_URL and POLYGON_API_KEY are now required fields, so flower
-      # needs them too (mirrors celery-worker) or it crashes on startup.
+      # time; DATABASE_URL, POLYGON_API_KEY and JWT_SECRET_KEY are now required
+      # (and validated) fields, so flower needs them too (mirrors celery-worker)
+      # or it crashes on startup.
       DATABASE_URL: ${DATABASE_URL}
       POLYGON_API_KEY: ${POLYGON_API_KEY:-}
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
       CELERY_BROKER_URL: redis://redis:6379/0
       CELERY_RESULT_BACKEND: redis://redis:6379/0
       FLOWER_BASIC_AUTH: ${FLOWER_BASIC_AUTH}


### PR DESCRIPTION
## What

Forward `JWT_SECRET_KEY` into the **flower** service's compose environment.

## Why

`flower` runs the backend image and instantiates `Settings()` at import time.
Since #190 made `JWT_SECRET_KEY` a required, validated (>=32 char) field, flower
crash-loops on a fresh deploy with:

```
ValueError: JWT_SECRET_KEY must be at least 32 characters. (input_value='')
```

PR #236 forwarded `JWT_SECRET_KEY` into `backend`/`celery-worker`/`celery-beat`/
`live-scanner` but missed `flower` — the one remaining backend-image service.

## Change

- Add `JWT_SECRET_KEY: ${JWT_SECRET_KEY}` to flower's `environment:` block,
  mirroring the other four services.
- Update the explanatory comment to list `JWT_SECRET_KEY`.

## Validation

Verified locally on current `main` + this change:

```
$ docker compose up -d --force-recreate flower
$ docker logs stockscanner-flower --tail
[I ... mixins:228] Connected to redis://redis:6379/0
$ docker ps --filter name=stockscanner-flower
stockscanner-flower: Up   # was: Exited (2) crash-loop
```

Fixes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
