### PR TITLE
feat(coverage): include Celery tasks in coverage measurement (#204)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -524,12 +524,11 @@ The test suite uses **pytest** with a transaction-rollback isolation model:
 
 ### Coverage configuration (`backend/pyproject.toml`)
 
-Coverage is measured with **pytest-cov** with a **60% minimum gate**. `app/tasks/` (Celery workers requiring a broker) and `app/services/futures_data.py` (requiring live IBKR) are excluded from measurement — both are tested via integration QA rather than unit tests.
-
-### Test layers
+Coverage is measured with **pytest-cov** with a **60% minimum gate**. `app/tasks/` business logic is covered by unit tests via injectable helper functions (e.g. `_run_universe_scan_logic`, `_run_range_scan_logic`, `_evaluate_scanner_alerts_logic`); only two broker-bound functions carry `# pragma: no cover` — `_poll_live_orders` (IBKR socket) in `trading.py` and `sync_futures_aggregates` (IBKR connection) in `sync.py`. `app/services/futures_data.py` (requiring live IBKR) is also excluded.
 
 | Layer | Location | Isolation strategy |
 |-------|----------|--------------------|
 | Router integration | `tests/api/` | DI override → test session; SAVEPOINT rollback |
 | Service unit | `tests/services/` | `db.flush()` only, or `MagicMock`/`fakeredis` for external deps |
+| Task unit | `tests/tasks/` | `SessionLocal` patched; Celery `.run()` called directly; `asyncio.run` patched |
 | Pure-function | `tests/services/test_*_helpers.py` | No DB or external deps |

--- a/backend/app/tasks/scanning.py
+++ b/backend/app/tasks/scanning.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import logging
 import time as _time
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import redis
 from sqlalchemy.orm import Session
@@ -16,6 +16,314 @@ from app.models.monitored_stock import MonitoredStock
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Testable logic helpers — no Redis/Celery/OTel imports required
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_scanner_alerts_logic(scanner_event_id: int, db: Session) -> None:
+    """Testable core of evaluate_scanner_alerts. No OTel/Celery context needed."""
+    from app.models.scanner_event import ScannerEvent
+    from app.services.alert_service import AlertRuleService, NotificationDispatcher
+
+    event = db.query(ScannerEvent).filter(ScannerEvent.id == scanner_event_id).first()
+    if not event:
+        logger.warning(
+            f"evaluate_scanner_alerts: ScannerEvent id={scanner_event_id} not found."
+        )
+        return
+
+    matching_rules = AlertRuleService.get_matching_rules(event, db)
+    if not matching_rules:
+        return
+
+    logger.info(
+        f"🔔 {len(matching_rules)} alert rule(s) matched "
+        f"event={scanner_event_id} ticker={event.ticker} type={event.scanner_type}"
+    )
+
+    for rule in matching_rules:
+        try:
+            NotificationDispatcher.dispatch(rule, event, db)
+        except Exception as exc:
+            logger.error(f"❌ Dispatch failed for rule {rule.id}: {exc}")
+
+        if rule.auto_trade and rule.trading_strategy_id:
+            from app.tasks.trading import execute_auto_trade
+
+            execute_auto_trade.delay(
+                rule_id=rule.id,
+                scanner_event_id=scanner_event_id,
+            )
+            logger.info(
+                f"🤖 Auto-trade queued for rule={rule.id} "
+                f"strategy={rule.trading_strategy_id} ticker={event.ticker}"
+            )
+
+
+def _run_range_scan_logic(
+    ticker: str,
+    scanner_types: list,
+    start: date,
+    end: date,
+    fetch_missing_data: bool,
+    db: Session,
+    publish,
+) -> int:
+    """Testable core of run_range_scan. Returns events_detected count."""
+    from datetime import timedelta
+
+    from app.exceptions import DataFetchError, ProviderError
+    from app.services.liquidity_hunt import run_liquidity_hunt_scan_for_date as _lh_scan
+    from app.services.pocket_pivot import run_pocket_pivot_scan_for_date as _pp_scan
+    from app.services.scanner import ScannerService
+    from app.services.stock_data import StockDataService
+
+    trading_days = [
+        start + timedelta(days=i)
+        for i in range((end - start).days + 1)
+        if (start + timedelta(days=i)).weekday() < 5
+    ]
+    total = len(trading_days) * len(scanner_types)
+    events_detected = 0
+    done = 0
+
+    if fetch_missing_data:
+        daily_period_days = (date.today() - (start - timedelta(days=90))).days
+        try:
+            StockDataService.refresh_stock_data(
+                db, ticker, timespan="day", period=f"{daily_period_days}d"
+            )
+        except (DataFetchError, ProviderError) as exc:
+            logger.warning("refresh_stock_data (day) failed for %s: %s", ticker, exc)
+        minute_period_days = (date.today() - start).days + 5
+        try:
+            StockDataService.refresh_stock_data(
+                db, ticker, timespan="minute", period=f"{minute_period_days}d"
+            )
+        except (DataFetchError, ProviderError) as exc:
+            logger.warning("refresh_stock_data (minute) failed for %s: %s", ticker, exc)
+
+    scanner_map = {
+        "pre_market_volume_spike": ScannerService.run_pre_market_scan_for_date,
+        "liquidity_hunt": _lh_scan,
+        "liquidity_hunt_pre": _lh_scan,
+        "liquidity_hunt_post": _lh_scan,
+        "oversold_bounce": ScannerService.run_oversold_bounce_scan_for_date,
+        "pocket_pivot": _pp_scan,
+    }
+
+    async def _scan_day(day):
+        results = []
+        for st in scanner_types:
+            fn = scanner_map.get(st)
+            if fn:
+                results.extend(await fn(ticker, day, db))
+        return results
+
+    for day in trading_days:
+        day_results = asyncio.run(_scan_day(day))
+        events_detected += len(day_results)
+        done += len(scanner_types)
+        publish(
+            {
+                "status": "progress",
+                "day": day.isoformat(),
+                "done": done,
+                "total": total,
+            }
+        )
+
+    publish({"status": "completed", "events_detected": events_detected})
+    return events_detected
+
+
+def _run_universe_scan_logic(
+    scan_id: str,
+    scanner_type: str,
+    universe_id: int,
+    start: date,
+    end: date,
+    db: Session,
+    publish,
+    is_cancelled,
+    task_id: str,
+    write_state=None,
+) -> None:
+    """Testable core of run_universe_scan. No Redis/Celery/OTel imports needed."""
+    from datetime import timedelta as _td
+
+    import app.services.liquidity_hunt  # noqa: F401
+    import app.services.oversold_bounce_scan  # noqa: F401
+    import app.services.pocket_pivot  # noqa: F401
+    import app.services.pre_market_scan  # noqa: F401 — triggers self-registration
+    import app.services.scan_orchestrator as _orchestrator
+    from app.models.scanner_run import ScannerRun
+
+    run = db.query(ScannerRun).filter(ScannerRun.uuid == scan_id).first()
+    if run is None:
+        logger.error("run_universe_scan: ScannerRun %s not found", scan_id)
+        return
+
+    tickers = [
+        ms.ticker
+        for ms in db.query(MonitoredStock)
+        .filter(
+            MonitoredStock.universe_id == universe_id,
+            MonitoredStock.is_active.is_(True),
+        )
+        .all()
+    ]
+    if not tickers:
+        run.status = "failed"
+        run.error_message = "Universe has no active tickers"
+        db.commit()
+        publish({"type": "failed", "error": run.error_message})
+        return
+
+    trading_days = [
+        start + _td(days=i)
+        for i in range((end - start).days + 1)
+        if (start + _td(days=i)).weekday() < 5
+    ]
+
+    run.status = "running"
+    run.stocks_scanned = len(tickers)
+    run.scan_start_date = start
+    run.scan_end_date = end
+    db.commit()
+
+    started_at = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    cum = {
+        "evaluated": 0,
+        "no_data": 0,
+        "no_prior_close": 0,
+        "no_baseline": 0,
+        "errors": 0,
+        "fired_pre": 0,
+        "fired_post": 0,
+    }
+    events_total = 0
+
+    def _state_payload(day_index: int) -> dict:
+        return {
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+            "started_at": started_at.replace(tzinfo=timezone.utc).isoformat(),
+            "tickers": len(tickers),
+            "total_days": len(trading_days),
+            "events_detected": events_total,
+            "day_index": day_index,
+            **cum,
+        }
+
+    if write_state:
+        write_state(_state_payload(0))
+    publish(
+        {
+            "type": "started",
+            "scan_id": scan_id,
+            "task_id": task_id,
+            "total_days": len(trading_days),
+            "total_tickers": len(tickers),
+            "estimated_pairs": len(tickers) * len(trading_days),
+            "scanner_type": scanner_type,
+            "start_date": start.isoformat(),
+            "end_date": end.isoformat(),
+        }
+    )
+
+    for i, day in enumerate(trading_days, start=1):
+        if is_cancelled():
+            run.status = "cancelled"
+            run.events_detected = events_total
+            run.execution_time_ms = int(
+                (
+                    datetime.now(timezone.utc).replace(tzinfo=None) - started_at
+                ).total_seconds()
+                * 1000
+            )
+            db.commit()
+            publish(
+                {
+                    "type": "cancelled",
+                    "evaluated_so_far": cum["evaluated"],
+                    "events_detected_so_far": events_total,
+                }
+            )
+            return
+
+        publish(
+            {
+                "type": "day_started",
+                "date": day.isoformat(),
+                "day_index": i,
+                "total_days": len(trading_days),
+            }
+        )
+
+        try:
+            day_events = asyncio.run(
+                _orchestrator.run(
+                    scanner_type, tickers, db=db, event_date=day, scanner_run=run
+                )
+            )
+        except Exception as e:
+            cum["errors"] += 1
+            logger.exception("run_universe_scan: day %s failed", day)
+            publish({"type": "day_error", "date": day.isoformat(), "error": str(e)})
+            continue
+
+        events_total += len(day_events)
+        run.events_detected = events_total
+        db.commit()
+
+        if write_state:
+            write_state(_state_payload(i))
+        publish(
+            {
+                "type": "day_completed",
+                "date": day.isoformat(),
+                "day_index": i,
+                "total_days": len(trading_days),
+                "events": len(day_events),
+                "events_detected": events_total,
+                **cum,
+            }
+        )
+
+    run.status = "completed"
+    run.events_detected = events_total
+    run.execution_time_ms = int(
+        (datetime.now(timezone.utc).replace(tzinfo=None) - started_at).total_seconds()
+        * 1000
+    )
+    db.commit()
+    publish(
+        {
+            "type": "completed",
+            "events_detected": events_total,
+            "diagnostics": {
+                "tickers": len(tickers),
+                "days": len(trading_days),
+                "start_date": start.isoformat(),
+                "end_date": end.isoformat(),
+                **cum,
+            },
+            "execution_time_ms": run.execution_time_ms,
+        }
+    )
+    logger.info(
+        "run_universe_scan %s completed: type=%s universe=%s days=%d events=%d",
+        scan_id,
+        scanner_type,
+        universe_id,
+        len(trading_days),
+        events_total,
+    )
+
+
 @celery_app.task(bind=True, max_retries=2, name="app.tasks.evaluate_scanner_alerts")
 def evaluate_scanner_alerts(self, scanner_event_id: int):
     """
@@ -25,60 +333,15 @@ def evaluate_scanner_alerts(self, scanner_event_id: int):
     Called automatically when a new ScannerEvent is created.
     """
     from opentelemetry import trace as _otel_trace
-    from app.models.scanner_event import ScannerEvent
-    from app.services.alert_service import AlertRuleService, NotificationDispatcher
 
     _tracer = _otel_trace.get_tracer(__name__)
     _task_name = "evaluate_scanner_alerts"
     _start = _time.monotonic()
     db: Session = SessionLocal()
     try:
-        event = (
-            db.query(ScannerEvent).filter(ScannerEvent.id == scanner_event_id).first()
-        )
-        if not event:
-            logger.warning(
-                f"evaluate_scanner_alerts: ScannerEvent id={scanner_event_id} not found."
-            )
-            return
-
-        with _tracer.start_as_current_span("alerts.evaluate") as _eval_span:
-            _eval_span.set_attribute("event_id", scanner_event_id)
-            matching_rules = AlertRuleService.get_matching_rules(event, db)
-            _eval_span.set_attribute("rules_matched", len(matching_rules))
-
-        if not matching_rules:
-            return
-
-        logger.info(
-            f"🔔 {len(matching_rules)} alert rule(s) matched "
-            f"event={scanner_event_id} ticker={event.ticker} type={event.scanner_type}"
-        )
-
-        with _tracer.start_as_current_span("alerts.dispatch") as _dispatch_span:
-            _dispatch_span.set_attribute("event_id", scanner_event_id)
-            _dispatch_span.set_attribute("rules_matched", len(matching_rules))
-            for rule in matching_rules:
-                # Notification dispatch
-                try:
-                    NotificationDispatcher.dispatch(rule, event, db)
-                except Exception as exc:
-                    logger.error(f"❌ Dispatch failed for rule {rule.id}: {exc}")
-
-                # Auto-trade: queue a separate task so notification failures
-                # never block order placement, and vice versa.
-                if rule.auto_trade and rule.trading_strategy_id:
-                    from app.tasks.trading import execute_auto_trade
-
-                    execute_auto_trade.delay(
-                        rule_id=rule.id,
-                        scanner_event_id=scanner_event_id,
-                    )
-                    logger.info(
-                        f"🤖 Auto-trade queued for rule={rule.id} "
-                        f"strategy={rule.trading_strategy_id} ticker={event.ticker}"
-                    )
-
+        with _tracer.start_as_current_span("alerts.evaluate") as _span:
+            _span.set_attribute("event_id", scanner_event_id)
+            _evaluate_scanner_alerts_logic(scanner_event_id, db)
         celery_tasks_total.labels(task_name=_task_name, status="success").inc()
     except Exception as e:
         celery_tasks_total.labels(task_name=_task_name, status="failure").inc()
@@ -103,107 +366,30 @@ def run_range_scan(
     fetch_missing_data: bool,
 ):
     """Background task: run selected scanners over a date range for one ticker."""
-    import asyncio
-    from datetime import date, timedelta
-
-    from app.exceptions import DataFetchError, ProviderError
-    from app.services.liquidity_hunt import run_liquidity_hunt_scan_for_date as _lh_scan
-    from app.services.pocket_pivot import run_pocket_pivot_scan_for_date as _pp_scan
-    from app.services.scanner import ScannerService
-    from app.services.stock_data import StockDataService
-
     _task_name = "run_range_scan"
     _start = _time.monotonic()
     task_id = run_range_scan.request.id
     r = redis.Redis.from_url(settings.REDIS_URL, decode_responses=True)
     channel = f"scan_task:{task_id}"
 
-    from datetime import datetime as _dt
-
     r.set(
         f"scan:{ticker}:range",
-        json.dumps({"task_ids": [task_id], "started_at": _dt.utcnow().isoformat()}),
+        json.dumps(
+            {"task_ids": [task_id], "started_at": datetime.utcnow().isoformat()}
+        ),
         ex=14400,
     )
 
-    start = date.fromisoformat(start_date_str)
-    end = date.fromisoformat(end_date_str)
-
-    trading_days = [
-        start + timedelta(days=i)
-        for i in range((end - start).days + 1)
-        if (start + timedelta(days=i)).weekday() < 5
-    ]
-
-    total = len(trading_days) * len(scanner_types)
-    events_detected = 0
-    done = 0
-
     db: Session = SessionLocal()
     try:
-        if fetch_missing_data:
-            # Daily bars: need 90-day lookback before start for rolling metrics
-            daily_period_days = (date.today() - (start - timedelta(days=90))).days
-            try:
-                StockDataService.refresh_stock_data(
-                    db, ticker, timespan="day", period=f"{daily_period_days}d"
-                )
-            except (DataFetchError, ProviderError) as exc:
-                logger.warning(
-                    "refresh_stock_data (day) failed for %s: %s", ticker, exc
-                )
-            # Minute bars: cover just the requested range
-            minute_period_days = (date.today() - start).days + 5
-            try:
-                StockDataService.refresh_stock_data(
-                    db, ticker, timespan="minute", period=f"{minute_period_days}d"
-                )
-            except (DataFetchError, ProviderError) as exc:
-                logger.warning(
-                    "refresh_stock_data (minute) failed for %s: %s", ticker, exc
-                )
-
-        scanner_map = {
-            "pre_market_volume_spike": ScannerService.run_pre_market_scan_for_date,
-            "liquidity_hunt": _lh_scan,
-            "liquidity_hunt_pre": _lh_scan,
-            "liquidity_hunt_post": _lh_scan,
-            "oversold_bounce": ScannerService.run_oversold_bounce_scan_for_date,
-            "pocket_pivot": _pp_scan,
-        }
-
-        async def _scan_day(day):
-            results = []
-            for st in scanner_types:
-                fn = scanner_map.get(st)
-                if fn:
-                    results.extend(await fn(ticker, day, db))
-            return results
-
-        for day in trading_days:
-            day_results = asyncio.run(_scan_day(day))
-            events_detected += len(day_results)
-            done += len(scanner_types)
-            r.publish(
-                channel,
-                json.dumps(
-                    {
-                        "status": "progress",
-                        "day": day.isoformat(),
-                        "done": done,
-                        "total": total,
-                    }
-                ),
-            )
-
-        r.publish(
-            channel,
-            json.dumps(
-                {
-                    "status": "completed",
-                    "events_detected": events_detected,
-                }
-            ),
+        events_detected = _run_range_scan_logic(
+            ticker=ticker,
+            scanner_types=scanner_types,
+            start=date.fromisoformat(start_date_str),
+            end=date.fromisoformat(end_date_str),
+            fetch_missing_data=fetch_missing_data,
+            db=db,
+            publish=lambda p: r.publish(channel, json.dumps(p)),
         )
         logger.info(f"run_range_scan {task_id}: completed, {events_detected} events")
         celery_tasks_total.labels(task_name=_task_name, status="success").inc()
@@ -213,12 +399,7 @@ def run_range_scan(
         logger.error(f"run_range_scan {task_id} failed: {e}")
         r.publish(
             channel,
-            json.dumps(
-                {
-                    "status": "failed",
-                    "error": str(e),
-                }
-            ),
+            json.dumps({"status": "failed", "error": str(e)}),
         )
     finally:
         celery_task_duration_seconds.labels(task_name=_task_name).observe(
@@ -270,9 +451,7 @@ def run_liquidity_hunt_scheduled(self):
                     "c7d8e9f0a1b2_add_universe_id_to_scanner_configs to backfill.",
                     cfg.id,
                 )
-                raise RuntimeError(
-                    f"ScannerConfig id={cfg.id} has universe_id=NULL"
-                )
+                raise RuntimeError(f"ScannerConfig id={cfg.id} has universe_id=NULL")
 
             tickers = [
                 ms.ticker
@@ -339,18 +518,8 @@ def run_universe_scan(
     deleted in ``finally``; the system tasks aggregator at /api/system/ws/tasks
     discovers active scans by scanning ``universe:*:scan:*``.
     """
-    from datetime import date as _date
-    from datetime import timedelta as _td
-
     from opentelemetry import context as _otel_context
     from opentelemetry import trace as _otel_trace
-
-    import app.services.liquidity_hunt  # noqa: F401
-    import app.services.oversold_bounce_scan  # noqa: F401
-    import app.services.pre_market_scan  # noqa: F401 — triggers self-registration
-    import app.services.pocket_pivot  # noqa: F401 — triggers self-registration
-    import app.services.scan_orchestrator as _orchestrator
-    from app.models.scanner_run import ScannerRun
 
     _tracer = _otel_trace.get_tracer(__name__)
     _root_span = _tracer.start_span("scanner.universe_scan")
@@ -376,202 +545,47 @@ def run_universe_scan(
         except Exception:
             logger.exception("scan_task publish failed")
 
+    def _write_state(progress_extra: dict | None = None) -> None:
+        r.set(
+            state_key,
+            json.dumps(
+                {
+                    "task_ids": [task_id],
+                    "scan_id": scan_id,
+                    "scanner_type": scanner_type,
+                    "universe_id": universe_id,
+                    **(progress_extra or {}),
+                }
+            ),
+            ex=14400,
+        )
+
     db: Session = SessionLocal()
-    started_at = datetime.now(timezone.utc).replace(tzinfo=None)
     try:
-        run = db.query(ScannerRun).filter(ScannerRun.uuid == scan_id).first()
-        if run is None:
-            logger.error("run_universe_scan: ScannerRun %s not found", scan_id)
-            return
-
-        tickers = [
-            ms.ticker
-            for ms in db.query(MonitoredStock)
-            .filter(
-                MonitoredStock.universe_id == universe_id,
-                MonitoredStock.is_active.is_(True),
-            )
-            .all()
-        ]
-        if not tickers:
-            run.status = "failed"
-            run.error_message = "Universe has no active tickers"
-            db.commit()
-            _publish({"type": "failed", "error": run.error_message})
-            return
-
-        start = _date.fromisoformat(start_date_iso)
-        end = _date.fromisoformat(end_date_iso)
-        trading_days = [
-            start + _td(days=i)
-            for i in range((end - start).days + 1)
-            if (start + _td(days=i)).weekday() < 5
-        ]
-
-        run.status = "running"
-        run.stocks_scanned = len(tickers)
-        run.scan_start_date = start
-        run.scan_end_date = end
-        db.commit()
-
-        cum = {
-            "evaluated": 0,
-            "no_data": 0,
-            "no_prior_close": 0,
-            "no_baseline": 0,
-            "errors": 0,
-            "fired_pre": 0,
-            "fired_post": 0,
-        }
-        events_total = 0
-
-        def _write_state(progress_extra: dict | None = None):
-            r.set(
-                state_key,
-                json.dumps(
-                    {
-                        "task_ids": [task_id],
-                        "scan_id": scan_id,
-                        "scanner_type": scanner_type,
-                        "universe_id": universe_id,
-                        "start_date": start.isoformat(),
-                        "end_date": end.isoformat(),
-                        "started_at": started_at.replace(
-                            tzinfo=timezone.utc
-                        ).isoformat(),
-                        "tickers": len(tickers),
-                        "total_days": len(trading_days),
-                        "events_detected": events_total,
-                        **cum,
-                        **(progress_extra or {}),
-                    }
-                ),
-                ex=14400,
-            )
-
-        _write_state({"day_index": 0})
-        _publish(
-            {
-                "type": "started",
-                "scan_id": scan_id,
-                "task_id": task_id,
-                "total_days": len(trading_days),
-                "total_tickers": len(tickers),
-                "estimated_pairs": len(tickers) * len(trading_days),
-                "scanner_type": scanner_type,
-                "start_date": start.isoformat(),
-                "end_date": end.isoformat(),
-            }
-        )
-
-        for i, day in enumerate(trading_days, start=1):
-            if _cancelled():
-                run.status = "cancelled"
-                run.events_detected = events_total
-                run.execution_time_ms = int(
-                    (
-                        datetime.now(timezone.utc).replace(tzinfo=None) - started_at
-                    ).total_seconds()
-                    * 1000
-                )
-                db.commit()
-                _publish(
-                    {
-                        "type": "cancelled",
-                        "evaluated_so_far": cum["evaluated"],
-                        "events_detected_so_far": events_total,
-                    }
-                )
-                return
-
-            _publish(
-                {
-                    "type": "day_started",
-                    "date": day.isoformat(),
-                    "day_index": i,
-                    "total_days": len(trading_days),
-                }
-            )
-
-            try:
-                day_events = asyncio.run(
-                    _orchestrator.run(
-                        scanner_type, tickers, db=db, event_date=day, scanner_run=run
-                    )
-                )
-            except Exception as e:
-                cum["errors"] += 1
-                logger.exception("run_universe_scan: day %s failed", day)
-                _publish(
-                    {"type": "day_error", "date": day.isoformat(), "error": str(e)}
-                )
-                continue
-
-            events_total += len(day_events)
-
-            run.events_detected = events_total
-            db.commit()
-
-            _write_state({"day_index": i})
-            _publish(
-                {
-                    "type": "day_completed",
-                    "date": day.isoformat(),
-                    "day_index": i,
-                    "total_days": len(trading_days),
-                    "events": len(day_events),
-                    "events_detected": events_total,
-                    **cum,
-                }
-            )
-
-        run.status = "completed"
-        run.events_detected = events_total
-        run.execution_time_ms = int(
-            (
-                datetime.now(timezone.utc).replace(tzinfo=None) - started_at
-            ).total_seconds()
-            * 1000
-        )
-        db.commit()
-        _publish(
-            {
-                "type": "completed",
-                "events_detected": events_total,
-                "diagnostics": {
-                    "tickers": len(tickers),
-                    "days": len(trading_days),
-                    "start_date": start.isoformat(),
-                    "end_date": end.isoformat(),
-                    **cum,
-                },
-                "execution_time_ms": run.execution_time_ms,
-            }
-        )
-        logger.info(
-            "run_universe_scan %s completed: type=%s universe=%s days=%d events=%d",
-            scan_id,
-            scanner_type,
-            universe_id,
-            len(trading_days),
-            events_total,
+        _run_universe_scan_logic(
+            scan_id=scan_id,
+            scanner_type=scanner_type,
+            universe_id=universe_id,
+            start=date.fromisoformat(start_date_iso),
+            end=date.fromisoformat(end_date_iso),
+            db=db,
+            publish=_publish,
+            is_cancelled=_cancelled,
+            task_id=task_id,
+            write_state=_write_state,
         )
         celery_tasks_total.labels(task_name=_task_name, status="success").inc()
-
     except Exception as exc:
         celery_tasks_total.labels(task_name=_task_name, status="failure").inc()
         logger.exception("run_universe_scan %s failed", scan_id)
         try:
-            run = db.query(ScannerRun).filter(ScannerRun.uuid == scan_id).first()
-            if run is not None:
-                run.status = "failed"
-                run.error_message = str(exc)
-                run.execution_time_ms = int(
-                    (
-                        datetime.now(timezone.utc).replace(tzinfo=None) - started_at
-                    ).total_seconds()
-                    * 1000
-                )
+            from app.models.scanner_run import ScannerRun as _ScannerRun
+
+            _run = db.query(_ScannerRun).filter(_ScannerRun.uuid == scan_id).first()
+            if _run is not None:
+                _run.status = "failed"
+                _run.error_message = str(exc)
+                _run.execution_time_ms = int((_time.monotonic() - _perf_start) * 1000)
                 db.commit()
         except Exception:
             db.rollback()
@@ -590,9 +604,7 @@ def run_universe_scan(
         _otel_context.detach(_root_token)
 
 
-@celery_app.task(
-    bind=True, max_retries=1, name="app.tasks.run_pocket_pivot_scheduled"
-)
+@celery_app.task(bind=True, max_retries=1, name="app.tasks.run_pocket_pivot_scheduled")
 def run_pocket_pivot_scheduled(self):
     """
     Nightly 02:00 UTC task: run pocket_pivot for today's date over all active
@@ -632,9 +644,7 @@ def run_pocket_pivot_scheduled(self):
                     "c7d8e9f0a1b2_add_universe_id_to_scanner_configs to backfill.",
                     cfg.id,
                 )
-                raise RuntimeError(
-                    f"ScannerConfig id={cfg.id} has universe_id=NULL"
-                )
+                raise RuntimeError(f"ScannerConfig id={cfg.id} has universe_id=NULL")
 
             tickers = [
                 ms.ticker

--- a/backend/app/tasks/sync.py
+++ b/backend/app/tasks/sync.py
@@ -536,7 +536,7 @@ def poll_massive_news(self, limit: int = 50, force: bool = False):
 
 
 @celery_app.task(bind=True, max_retries=3, name="app.tasks.sync_futures_aggregates")
-def sync_futures_aggregates(
+def sync_futures_aggregates(  # pragma: no cover
     self,
     symbol: str,
     exchange: str,

--- a/backend/app/tasks/trading.py
+++ b/backend/app/tasks/trading.py
@@ -324,7 +324,7 @@ def _record_exit_fill(
     )
 
 
-def _poll_live_orders(
+def _poll_live_orders(  # pragma: no cover
     orders: list,
     db: "Session",
     now: "datetime",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -7,11 +7,10 @@ source = ["app"]
 omit = [
     "app/main.py",
     "app/migrations/*",
-    # Celery background tasks — require a running broker; tested via integration QA
-    "app/tasks/*.py",
     # Requires live IBKR connection — tested via manual QA and docker-status agent
     "app/services/futures_data.py",
 ]
+# _poll_live_orders and sync_futures_aggregates carry # pragma: no cover
 
 [tool.coverage.report]
 exclude_lines = [

--- a/backend/tests/tasks/test_quality_tasks.py
+++ b/backend/tests/tasks/test_quality_tasks.py
@@ -1,0 +1,241 @@
+"""Unit tests for quality.py Celery task shells."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_report(universe_id=1, has_data=True, norm_data=None):
+    r = MagicMock()
+    r.universe_id = universe_id
+    r.status = "pending"
+    r.normalization_status = "pending"
+    r.report_data = (
+        {"overall_grade": "B", "overall_score": 80, "ticker_count": 5}
+        if has_data
+        else None
+    )
+    r.normalization_data = norm_data
+    r.overall_grade = None
+    r.overall_score = None
+    r.ticker_count = None
+    r.error_message = None
+    return r
+
+
+class TestAnalyzeUniverseQuality:
+    def _run(self, report, analyze_result=None, analyze_raises=None):
+        import app.tasks.quality as quality_module
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = report
+
+        if analyze_result is None:
+            analyze_result = {
+                "overall_grade": "A",
+                "overall_score": 95,
+                "ticker_count": 10,
+            }
+
+        with (
+            patch("app.tasks.quality.SessionLocal", return_value=db),
+            patch(
+                "app.services.data_quality.DataQualityService.analyze_universe",
+                side_effect=analyze_raises or (lambda *a, **kw: analyze_result),
+            ),
+        ):
+            if analyze_raises:
+                with pytest.raises(Exception):
+                    quality_module.analyze_universe_quality.run(1)
+            else:
+                quality_module.analyze_universe_quality.run(1)
+
+        return db, report
+
+    def test_sets_report_complete_on_success(self):
+        report = _make_report()
+        db, r = self._run(report)
+        assert r.status == "complete"
+        assert r.overall_grade == "A"
+        assert r.overall_score == 95
+
+    def test_creates_report_when_none_exists(self):
+        import app.tasks.quality as quality_module
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        with (
+            patch("app.tasks.quality.SessionLocal", return_value=db),
+            patch(
+                "app.services.data_quality.DataQualityService.analyze_universe",
+                return_value={
+                    "overall_grade": "A",
+                    "overall_score": 95,
+                    "ticker_count": 5,
+                },
+            ),
+        ):
+            quality_module.analyze_universe_quality.run(1)
+
+        db.add.assert_called_once()
+
+    def test_sets_report_error_on_exception(self):
+        import app.tasks.quality as quality_module
+
+        report = _make_report()
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = report
+
+        with (
+            patch("app.tasks.quality.SessionLocal", return_value=db),
+            patch(
+                "app.services.data_quality.DataQualityService.analyze_universe",
+                side_effect=RuntimeError("analysis failed"),
+            ),
+        ):
+            with pytest.raises(RuntimeError):
+                quality_module.analyze_universe_quality.run(1)
+
+        assert report.status == "error"
+        assert "analysis failed" in report.error_message
+
+    def test_running_status_set_before_analysis(self):
+        """report.status must be 'running' before analysis is called."""
+        import app.tasks.quality as quality_module
+
+        report = _make_report()
+        status_at_call = []
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = report
+
+        def _capture_status(*a, **kw):
+            status_at_call.append(report.status)
+            return {"overall_grade": "A", "overall_score": 95, "ticker_count": 5}
+
+        with (
+            patch("app.tasks.quality.SessionLocal", return_value=db),
+            patch(
+                "app.services.data_quality.DataQualityService.analyze_universe",
+                side_effect=_capture_status,
+            ),
+        ):
+            quality_module.analyze_universe_quality.run(1)
+
+        assert status_at_call == ["running"]
+
+
+class TestNormalizeUniverseQuality:
+    def _run(self, report, norm_result=None, norm_raises=None):
+        import app.tasks.quality as quality_module
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = report
+
+        if norm_result is None:
+            norm_result = {"fixes_applied": 3, "status": "complete"}
+
+        with (
+            patch("app.tasks.quality.SessionLocal", return_value=db),
+            patch(
+                "app.services.normalization.NormalizationService.run",
+                side_effect=norm_raises or (lambda **kw: norm_result),
+            ),
+            patch("app.tasks.quality.analyze_universe_quality") as mock_analyze,
+        ):
+            if norm_raises:
+                with pytest.raises(Exception):
+                    quality_module.normalize_universe_quality.run(1)
+            else:
+                quality_module.normalize_universe_quality.run(1)
+            return db, report, mock_analyze
+
+    def test_raises_when_no_quality_report_exists(self):
+        import app.tasks.quality as quality_module
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        with patch("app.tasks.quality.SessionLocal", return_value=db):
+            with pytest.raises(RuntimeError, match="Quality analysis must be run"):
+                quality_module.normalize_universe_quality.run(1)
+
+    def test_raises_when_report_has_no_data(self):
+        import app.tasks.quality as quality_module
+
+        report = _make_report(has_data=False)
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = report
+
+        with patch("app.tasks.quality.SessionLocal", return_value=db):
+            with pytest.raises(RuntimeError, match="Quality analysis must be run"):
+                quality_module.normalize_universe_quality.run(1)
+
+    def test_sets_complete_and_triggers_analysis_on_success(self):
+        report = _make_report()
+        db, r, mock_analyze = self._run(report)
+        assert r.normalization_status == "complete"
+        mock_analyze.delay.assert_called_once_with(1)
+
+    def test_sets_normalization_error_on_failure(self):
+        import app.tasks.quality as quality_module
+
+        report = _make_report()
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = report
+
+        with (
+            patch("app.tasks.quality.SessionLocal", return_value=db),
+            patch(
+                "app.services.normalization.NormalizationService.run",
+                side_effect=RuntimeError("norm failed"),
+            ),
+        ):
+            with pytest.raises(RuntimeError):
+                quality_module.normalize_universe_quality.run(1)
+
+        assert report.normalization_status == "error"
+
+
+class TestAnalyzeSignalFeatures:
+    def test_insufficient_data_sets_failed_status(self):
+        import app.tasks.quality as quality_module
+
+        db = MagicMock()
+        created_run = MagicMock()
+        created_run.id = 1
+
+        # Simulate a query returning fewer than 500 unique events
+        mock_rows = [
+            MagicMock(
+                event_id=i,
+                scanner_type="pre_market",
+                indicators={},
+                interval_key="1h",
+                pct_change=1.0,
+            )
+            for i in range(10)
+        ]
+
+        # The task queries ScannerEvent+joins, returns rows; we simplify by
+        # patching the whole query chain to return our sparse rows
+        query_chain = MagicMock()
+        query_chain.join.return_value = query_chain
+        query_chain.filter.return_value = query_chain
+        query_chain.all.return_value = mock_rows
+        db.query.return_value = query_chain
+
+        # Also handle SignalAnalysisRun creation
+        db.add = MagicMock()
+        db.commit = MagicMock()
+        db.refresh = MagicMock(side_effect=lambda obj: None)
+
+        with patch("app.tasks.quality.SessionLocal", return_value=db):
+            with patch(
+                "app.models.signal_analysis_run.SignalAnalysisRun",
+                return_value=created_run,
+            ):
+                quality_module.analyze_signal_features.run()
+
+        assert created_run.status == "failed"
+        assert "Insufficient" in created_run.error_message

--- a/backend/tests/tasks/test_scanning_tasks.py
+++ b/backend/tests/tasks/test_scanning_tasks.py
@@ -1,0 +1,359 @@
+"""Unit tests for scanning task helpers — no broker required."""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Import checks
+# ---------------------------------------------------------------------------
+
+
+def test_run_universe_scan_logic_is_importable():
+    from app.tasks.scanning import _run_universe_scan_logic
+
+    assert callable(_run_universe_scan_logic)
+
+
+def test_run_range_scan_logic_is_importable():
+    from app.tasks.scanning import _run_range_scan_logic
+
+    assert callable(_run_range_scan_logic)
+
+
+def test_evaluate_scanner_alerts_logic_is_importable():
+    from app.tasks.scanning import _evaluate_scanner_alerts_logic
+
+    assert callable(_evaluate_scanner_alerts_logic)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_run(uuid, status="pending"):
+    run = MagicMock()
+    run.uuid = uuid
+    run.status = status
+    run.events_detected = 0
+    run.execution_time_ms = None
+    return run
+
+
+def _make_ticker(ticker_str):
+    t = MagicMock()
+    t.ticker = ticker_str
+    return t
+
+
+def _make_db(run=None, tickers=None):
+    """Mock DB that returns run from first query().filter().first() and tickers from second."""
+
+    db = MagicMock()
+    call_count = [0]
+
+    def _query_side_effect(model):
+        q = MagicMock()
+        idx = call_count[0]
+        call_count[0] += 1
+        if idx == 0:
+            q.filter.return_value.first.return_value = run
+        else:
+            q.filter.return_value.all.return_value = tickers or []
+        return q
+
+    db.query.side_effect = _query_side_effect
+    return db
+
+
+# ---------------------------------------------------------------------------
+# _run_universe_scan_logic tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunUniverseScanLogic:
+    def _run_logic(self, run, tickers, is_cancelled=False):
+        from app.tasks.scanning import _run_universe_scan_logic
+
+        published = []
+        db = _make_db(run=run, tickers=tickers)
+
+        with patch("app.tasks.scanning.asyncio.run", return_value=[]):
+            _run_universe_scan_logic(
+                scan_id="scan-001",
+                scanner_type="pre_market_volume_spike",
+                universe_id=1,
+                start=date(2026, 6, 2),  # Monday
+                end=date(2026, 6, 2),
+                db=db,
+                publish=lambda p: published.append(p),
+                is_cancelled=lambda: is_cancelled,
+                task_id="task-abc",
+            )
+
+        return published, db
+
+    def test_run_not_found_returns_early(self):
+        published, db = self._run_logic(run=None, tickers=[_make_ticker("AAPL")])
+        assert not any(p.get("type") == "started" for p in published)
+        db.commit.assert_not_called()
+
+    def test_no_tickers_publishes_failed(self):
+        run = _make_run("scan-001")
+        published, db = self._run_logic(run=run, tickers=[])
+        assert run.status == "failed"
+        assert any(p.get("type") == "failed" for p in published)
+
+    def test_happy_path_publishes_started_and_completed(self):
+        run = _make_run("scan-001")
+        published, _ = self._run_logic(run=run, tickers=[_make_ticker("AAPL")])
+        types = [p.get("type") for p in published]
+        assert "started" in types
+        assert "completed" in types
+
+    def test_cancel_flag_sets_status_cancelled(self):
+        from app.tasks.scanning import _run_universe_scan_logic
+
+        run = _make_run("scan-001")
+        published = []
+        db = _make_db(run=run, tickers=[_make_ticker("AAPL")])
+
+        with patch("app.tasks.scanning.asyncio.run", return_value=[]):
+            _run_universe_scan_logic(
+                scan_id="scan-001",
+                scanner_type="pre_market_volume_spike",
+                universe_id=1,
+                start=date(2026, 6, 2),
+                end=date(2026, 6, 2),
+                db=db,
+                publish=lambda p: published.append(p),
+                is_cancelled=lambda: True,
+                task_id="task-abc",
+            )
+
+        assert run.status == "cancelled"
+        assert any(p.get("type") == "cancelled" for p in published)
+
+    def test_day_error_continues_to_completion(self):
+        from app.tasks.scanning import _run_universe_scan_logic
+
+        run = _make_run("scan-001")
+        published = []
+        db = _make_db(run=run, tickers=[_make_ticker("AAPL")])
+
+        with patch(
+            "app.tasks.scanning.asyncio.run", side_effect=RuntimeError("day failed")
+        ):
+            _run_universe_scan_logic(
+                scan_id="scan-001",
+                scanner_type="pre_market_volume_spike",
+                universe_id=1,
+                start=date(2026, 6, 2),
+                end=date(2026, 6, 2),
+                db=db,
+                publish=lambda p: published.append(p),
+                is_cancelled=lambda: False,
+                task_id="task-abc",
+            )
+
+        assert any(p.get("type") == "day_error" for p in published)
+        assert run.status == "completed"
+
+    def test_weekends_excluded_from_trading_days(self):
+        """A Mon-Sun range yields only 5 day_started events (Mon-Fri)."""
+        from app.tasks.scanning import _run_universe_scan_logic
+
+        run = _make_run("scan-001")
+        day_started = []
+        db = _make_db(run=run, tickers=[_make_ticker("AAPL")])
+
+        def _capture(p):
+            if p.get("type") == "day_started":
+                day_started.append(p)
+
+        with patch("app.tasks.scanning.asyncio.run", return_value=[]):
+            _run_universe_scan_logic(
+                scan_id="scan-001",
+                scanner_type="pre_market_volume_spike",
+                universe_id=1,
+                start=date(2026, 6, 1),  # Monday
+                end=date(2026, 6, 7),  # Sunday
+                db=db,
+                publish=_capture,
+                is_cancelled=lambda: False,
+                task_id="task-abc",
+            )
+
+        assert len(day_started) == 5  # Mon-Fri only
+
+    def test_write_state_called_with_payload(self):
+        from app.tasks.scanning import _run_universe_scan_logic
+
+        run = _make_run("scan-001")
+        state_calls = []
+        db = _make_db(run=run, tickers=[_make_ticker("AAPL")])
+
+        with patch("app.tasks.scanning.asyncio.run", return_value=[]):
+            _run_universe_scan_logic(
+                scan_id="scan-001",
+                scanner_type="pre_market_volume_spike",
+                universe_id=1,
+                start=date(2026, 6, 2),
+                end=date(2026, 6, 2),
+                db=db,
+                publish=lambda p: None,
+                is_cancelled=lambda: False,
+                task_id="task-abc",
+                write_state=lambda s: state_calls.append(s),
+            )
+
+        assert len(state_calls) >= 2  # initial + each day
+        assert "start_date" in state_calls[0]
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_scanner_alerts_logic tests
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateScannerAlertsLogic:
+    def _run_logic(self, event=None, matching_rules=None):
+        from app.tasks.scanning import _evaluate_scanner_alerts_logic
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = event
+
+        with (
+            patch(
+                "app.services.alert_service.AlertRuleService.get_matching_rules",
+                return_value=matching_rules or [],
+            ),
+            patch(
+                "app.services.alert_service.NotificationDispatcher.dispatch"
+            ) as mock_dispatch,
+            patch("app.tasks.trading.execute_auto_trade") as mock_trade,
+        ):
+            _evaluate_scanner_alerts_logic(scanner_event_id=42, db=db)
+            return mock_dispatch, mock_trade
+
+    def test_event_not_found_returns_without_dispatch(self):
+        mock_dispatch, _ = self._run_logic(event=None)
+        mock_dispatch.assert_not_called()
+
+    def test_no_matching_rules_returns_without_dispatch(self):
+        event = MagicMock()
+        event.ticker = "AAPL"
+        mock_dispatch, _ = self._run_logic(event=event, matching_rules=[])
+        mock_dispatch.assert_not_called()
+
+    def test_matching_rule_dispatches_notification(self):
+        event = MagicMock()
+        event.ticker = "AAPL"
+        rule = MagicMock()
+        rule.auto_trade = False
+        mock_dispatch, _ = self._run_logic(event=event, matching_rules=[rule])
+        mock_dispatch.assert_called_once()
+
+    def test_auto_trade_rule_queues_execute_auto_trade(self):
+        from app.tasks.scanning import _evaluate_scanner_alerts_logic
+
+        event = MagicMock()
+        event.ticker = "AAPL"
+        rule = MagicMock()
+        rule.id = 7
+        rule.auto_trade = True
+        rule.trading_strategy_id = 3
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = event
+
+        with (
+            patch(
+                "app.services.alert_service.AlertRuleService.get_matching_rules",
+                return_value=[rule],
+            ),
+            patch("app.services.alert_service.NotificationDispatcher.dispatch"),
+            patch("app.tasks.trading.execute_auto_trade") as mock_trade,
+        ):
+            _evaluate_scanner_alerts_logic(scanner_event_id=42, db=db)
+
+        mock_trade.delay.assert_called_once_with(rule_id=7, scanner_event_id=42)
+
+    def test_dispatch_exception_does_not_abort_loop(self):
+        from app.tasks.scanning import _evaluate_scanner_alerts_logic
+
+        event = MagicMock()
+        event.ticker = "AAPL"
+        rule1 = MagicMock()
+        rule1.auto_trade = False
+        rule2 = MagicMock()
+        rule2.auto_trade = False
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = event
+
+        dispatch_calls = []
+
+        def _dispatch(rule, evt, db):
+            dispatch_calls.append(rule)
+            if rule is rule1:
+                raise RuntimeError("dispatch boom")
+
+        with (
+            patch(
+                "app.services.alert_service.AlertRuleService.get_matching_rules",
+                return_value=[rule1, rule2],
+            ),
+            patch(
+                "app.services.alert_service.NotificationDispatcher.dispatch",
+                side_effect=_dispatch,
+            ),
+            patch("app.tasks.trading.execute_auto_trade"),
+        ):
+            _evaluate_scanner_alerts_logic(scanner_event_id=42, db=db)
+
+        # Both rules processed despite first dispatch failing
+        assert len(dispatch_calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# _run_range_scan_logic tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunRangeScanLogic:
+    def _run_logic(self, start, end, scanner_types=None, fetch_missing=False):
+        from app.tasks.scanning import _run_range_scan_logic
+
+        if scanner_types is None:
+            scanner_types = ["pre_market_volume_spike"]
+
+        published = []
+        db = MagicMock()
+
+        with patch("app.tasks.scanning.asyncio.run", return_value=[MagicMock()]):
+            count = _run_range_scan_logic(
+                ticker="AAPL",
+                scanner_types=scanner_types,
+                start=start,
+                end=end,
+                fetch_missing_data=fetch_missing,
+                db=db,
+                publish=lambda p: published.append(p),
+            )
+
+        return count, published
+
+    def test_weekends_skipped_in_trading_days(self):
+        # Mon 2026-06-01 to Sun 2026-06-07 → 5 trading days
+        count, published = self._run_logic(start=date(2026, 6, 1), end=date(2026, 6, 7))
+        progress_days = [p for p in published if p.get("status") == "progress"]
+        assert len(progress_days) == 5
+
+    def test_returns_event_count(self):
+        count, _ = self._run_logic(start=date(2026, 6, 2), end=date(2026, 6, 2))
+        assert isinstance(count, int)
+
+    def test_completed_message_published(self):
+        _, published = self._run_logic(start=date(2026, 6, 2), end=date(2026, 6, 2))
+        assert any(p.get("status") == "completed" for p in published)

--- a/backend/tests/tasks/test_scheduled_scanner_tasks.py
+++ b/backend/tests/tasks/test_scheduled_scanner_tasks.py
@@ -1,16 +1,19 @@
 """Unit tests for scheduled scanner task logic and startup validation."""
-import pytest
-from unittest.mock import MagicMock, patch, call
 
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 # ---------------------------------------------------------------------------
 # Task 1 tests: ScannerConfig.universe_id column exists
 # ---------------------------------------------------------------------------
 
+
 def test_scanner_config_has_universe_id_column():
     """ScannerConfig must declare universe_id as a mapped column."""
-    from app.models.scanner_config import ScannerConfig
     from sqlalchemy import inspect as sa_inspect
+
+    from app.models.scanner_config import ScannerConfig
 
     mapper = sa_inspect(ScannerConfig)
     col_names = [c.key for c in mapper.mapper.column_attrs]
@@ -21,8 +24,9 @@ def test_scanner_config_has_universe_id_column():
 
 def test_scanner_config_universe_id_is_integer():
     """universe_id must be an Integer column."""
-    from app.models.scanner_config import ScannerConfig
     import sqlalchemy as sa
+
+    from app.models.scanner_config import ScannerConfig
 
     col = ScannerConfig.__table__.c["universe_id"]
     assert isinstance(col.type, sa.Integer)
@@ -40,12 +44,18 @@ def test_scanner_config_universe_id_is_not_nullable():
 # Task 2 tests: Alembic migration file exists and has correct revision chain
 # ---------------------------------------------------------------------------
 
+
 def test_migration_file_exists():
     """The add_universe_id migration file must exist at the expected path."""
     import os
+
     path = os.path.join(
         os.path.dirname(__file__),
-        "..", "..", "app", "alembic", "versions",
+        "..",
+        "..",
+        "app",
+        "alembic",
+        "versions",
         "c7d8e9f0a1b2_add_universe_id_to_scanner_configs.py",
     )
     assert os.path.isfile(os.path.abspath(path)), (
@@ -55,12 +65,20 @@ def test_migration_file_exists():
 
 def test_migration_revision_chain():
     """Migration must declare correct revision and a non-None down_revision."""
-    import importlib.util, os
-    path = os.path.abspath(os.path.join(
-        os.path.dirname(__file__),
-        "..", "..", "app", "alembic", "versions",
-        "c7d8e9f0a1b2_add_universe_id_to_scanner_configs.py",
-    ))
+    import importlib.util
+    import os
+
+    path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "app",
+            "alembic",
+            "versions",
+            "c7d8e9f0a1b2_add_universe_id_to_scanner_configs.py",
+        )
+    )
     spec = importlib.util.spec_from_file_location("mig", path)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
@@ -74,14 +92,23 @@ def test_migration_revision_chain():
 # Task 3 tests: Seed SQL correctness
 # ---------------------------------------------------------------------------
 
+
 def test_seed_liquidity_hunt_has_universe_id():
     """The liquidity_hunt seed row (id=2) must include universe_id column and value."""
     import os
-    seed_path = os.path.abspath(os.path.join(
-        os.path.dirname(__file__),
-        "..", "..", "..", "dark-factory", "seed", "seed",
-        "01_scanner_configs.sql",
-    ))
+
+    seed_path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "dark-factory",
+            "seed",
+            "seed",
+            "01_scanner_configs.sql",
+        )
+    )
     with open(seed_path) as f:
         content = f.read()
     assert "universe_id" in content, (
@@ -92,11 +119,19 @@ def test_seed_liquidity_hunt_has_universe_id():
 def test_seed_pocket_pivot_row_exists():
     """A pocket_pivot config row must be present in the seed SQL."""
     import os
-    seed_path = os.path.abspath(os.path.join(
-        os.path.dirname(__file__),
-        "..", "..", "..", "dark-factory", "seed", "seed",
-        "01_scanner_configs.sql",
-    ))
+
+    seed_path = os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "..",
+            "dark-factory",
+            "seed",
+            "seed",
+            "01_scanner_configs.sql",
+        )
+    )
     with open(seed_path) as f:
         content = f.read()
     assert "pocket_pivot" in content, (
@@ -110,6 +145,7 @@ def test_seed_pocket_pivot_row_exists():
 # ---------------------------------------------------------------------------
 # Task 4 tests: Fixed scheduled task logic
 # ---------------------------------------------------------------------------
+
 
 def _make_cfg(id, universe_id, scanner_type="liquidity_hunt", is_active=True):
     """Return a MagicMock resembling a ScannerConfig ORM row."""
@@ -132,7 +168,6 @@ class TestRunLiquidityHuntScheduledFixed:
     def _run_with_configs(self, configs, tickers=None):
         """Invoke the task with a mocked DB returning given configs."""
         from app.models.scanner_config import ScannerConfig
-        from app.models.monitored_stock import MonitoredStock
 
         if tickers is None:
             tickers = [MagicMock(ticker="AAPL"), MagicMock(ticker="MSFT")]
@@ -146,7 +181,8 @@ class TestRunLiquidityHuntScheduledFixed:
 
         mock_db = MagicMock()
         mock_db.query.side_effect = lambda model: (
-            _make_query_mock(configs) if model is ScannerConfig
+            _make_query_mock(configs)
+            if model is ScannerConfig
             else _make_query_mock(tickers)
         )
 
@@ -157,8 +193,14 @@ class TestRunLiquidityHuntScheduledFixed:
             patch("app.tasks.scanning.SessionLocal", return_value=mock_db),
             patch("app.utils.session.get_market_today", return_value="2026-06-03"),
             patch("app.tasks.scanning.asyncio.run", return_value=[]),
-            patch("app.services.liquidity_hunt.run_liquidity_hunt_scan", return_value=[]),
-            patch.object(scanning_module.run_liquidity_hunt_scheduled, "retry", side_effect=_retry_reraises),
+            patch(
+                "app.services.liquidity_hunt.run_liquidity_hunt_scan", return_value=[]
+            ),
+            patch.object(
+                scanning_module.run_liquidity_hunt_scheduled,
+                "retry",
+                side_effect=_retry_reraises,
+            ),
         ):
             # For bind=True tasks .run() already has self bound to the task instance.
             scanning_module.run_liquidity_hunt_scheduled.run()
@@ -171,6 +213,7 @@ class TestRunLiquidityHuntScheduledFixed:
     def test_logs_error_and_raises_when_zero_configs(self, caplog):
         """Task must log an error when no active ScannerConfig rows are found."""
         import logging
+
         with caplog.at_level(logging.ERROR, logger="app.tasks.scanning"):
             with pytest.raises(Exception):
                 self._run_with_configs([])
@@ -181,11 +224,27 @@ class TestRunLiquidityHuntScheduledFixed:
     def test_logs_error_when_universe_id_is_null(self, caplog):
         """Task must log a loud error when cfg.universe_id is None."""
         import logging
+
         cfg = _make_cfg(id=2, universe_id=None)
         with caplog.at_level(logging.ERROR, logger="app.tasks.scanning"):
             with pytest.raises(Exception):
                 self._run_with_configs([cfg])
         assert any("universe_id" in r.message.lower() for r in caplog.records)
+
+    def test_no_tickers_logs_warning_and_does_not_raise(self, caplog):
+        """Universe with no active tickers should log a warning and skip, not raise."""
+        import logging
+
+        cfg = _make_cfg(id=2, universe_id=1)
+        with caplog.at_level(logging.WARNING, logger="app.tasks.scanning"):
+            self._run_with_configs([cfg], tickers=[])
+        assert any("no active tickers" in r.message.lower() for r in caplog.records)
+
+    def test_success_with_tickers_does_not_raise(self):
+        """Happy path: valid config + tickers completes without exception."""
+        cfg = _make_cfg(id=2, universe_id=1)
+        tickers = [MagicMock(ticker="AAPL"), MagicMock(ticker="TSLA")]
+        self._run_with_configs([cfg], tickers=tickers)
 
 
 class TestRunPocketPivotScheduledFixed:
@@ -193,7 +252,6 @@ class TestRunPocketPivotScheduledFixed:
 
     def _run_with_configs(self, configs, tickers=None):
         from app.models.scanner_config import ScannerConfig
-        from app.models.monitored_stock import MonitoredStock
 
         if tickers is None:
             tickers = [MagicMock(ticker="AAPL")]
@@ -207,7 +265,8 @@ class TestRunPocketPivotScheduledFixed:
 
         mock_db = MagicMock()
         mock_db.query.side_effect = lambda model: (
-            _make_query_mock(configs) if model is ScannerConfig
+            _make_query_mock(configs)
+            if model is ScannerConfig
             else _make_query_mock(tickers)
         )
 
@@ -219,7 +278,11 @@ class TestRunPocketPivotScheduledFixed:
             patch("app.utils.session.get_market_today", return_value="2026-06-03"),
             patch("app.tasks.scanning.asyncio.run", return_value=[]),
             patch("app.services.pocket_pivot.run_pocket_pivot_scan", return_value=[]),
-            patch.object(scanning_module.run_pocket_pivot_scheduled, "retry", side_effect=_retry_reraises),
+            patch.object(
+                scanning_module.run_pocket_pivot_scheduled,
+                "retry",
+                side_effect=_retry_reraises,
+            ),
         ):
             scanning_module.run_pocket_pivot_scheduled.run()
 
@@ -231,6 +294,7 @@ class TestRunPocketPivotScheduledFixed:
     def test_logs_error_and_raises_when_zero_configs(self, caplog):
         """Task must log an error when no active pocket_pivot configs are found."""
         import logging
+
         with caplog.at_level(logging.ERROR, logger="app.tasks.scanning"):
             with pytest.raises(Exception):
                 self._run_with_configs([])
@@ -239,16 +303,33 @@ class TestRunPocketPivotScheduledFixed:
     def test_logs_error_when_universe_id_is_null(self, caplog):
         """Task must log a loud error when cfg.universe_id is None."""
         import logging
+
         cfg = _make_cfg(id=4, universe_id=None, scanner_type="pocket_pivot")
         with caplog.at_level(logging.ERROR, logger="app.tasks.scanning"):
             with pytest.raises(Exception):
                 self._run_with_configs([cfg])
         assert any("universe_id" in r.message.lower() for r in caplog.records)
 
+    def test_no_tickers_logs_warning_and_does_not_raise(self, caplog):
+        """Universe with no active tickers should log a warning and skip, not raise."""
+        import logging
+
+        cfg = _make_cfg(id=4, universe_id=1, scanner_type="pocket_pivot")
+        with caplog.at_level(logging.WARNING, logger="app.tasks.scanning"):
+            self._run_with_configs([cfg], tickers=[])
+        assert any("no active tickers" in r.message.lower() for r in caplog.records)
+
+    def test_success_with_tickers_does_not_raise(self):
+        """Happy path: valid config + tickers completes without exception."""
+        cfg = _make_cfg(id=4, universe_id=1, scanner_type="pocket_pivot")
+        tickers = [MagicMock(ticker="AAPL")]
+        self._run_with_configs([cfg], tickers=tickers)
+
 
 # ---------------------------------------------------------------------------
 # Task 5 tests: validate_scheduled_scanner_configs startup validation
 # ---------------------------------------------------------------------------
+
 
 class TestValidateScheduledScannerConfigs:
     """Tests for the validate_scheduled_scanner_configs() startup check."""
@@ -273,7 +354,9 @@ class TestValidateScheduledScannerConfigs:
             return f
 
         mock_db = MagicMock()
-        mock_db.query.return_value.filter.side_effect = lambda *a, **kw: _make_filter_chain()
+        mock_db.query.return_value.filter.side_effect = lambda *a, **kw: (
+            _make_filter_chain()
+        )
 
         with patch("app.tasks.scanning.SessionLocal", return_value=mock_db):
             scanning_module.validate_scheduled_scanner_configs()
@@ -281,6 +364,7 @@ class TestValidateScheduledScannerConfigs:
     def test_validate_passes_when_both_types_configured(self, caplog):
         """No error logged when both scanner types have a valid config."""
         import logging
+
         lh = _make_cfg(id=2, universe_id=1, scanner_type="liquidity_hunt")
         pp = _make_cfg(id=4, universe_id=1, scanner_type="pocket_pivot")
         with caplog.at_level(logging.ERROR, logger="app.tasks.scanning"):
@@ -292,6 +376,7 @@ class TestValidateScheduledScannerConfigs:
     def test_validate_logs_error_for_missing_liquidity_hunt(self, caplog):
         """Error logged when no active liquidity_hunt config exists."""
         import logging
+
         pp = _make_cfg(id=4, universe_id=1, scanner_type="pocket_pivot")
         with caplog.at_level(logging.ERROR, logger="app.tasks.scanning"):
             self._run_validation([], [pp])
@@ -300,6 +385,7 @@ class TestValidateScheduledScannerConfigs:
     def test_validate_logs_error_for_missing_pocket_pivot(self, caplog):
         """Error logged when no active pocket_pivot config exists."""
         import logging
+
         lh = _make_cfg(id=2, universe_id=1, scanner_type="liquidity_hunt")
         with caplog.at_level(logging.ERROR, logger="app.tasks.scanning"):
             self._run_validation([lh], [])
@@ -308,6 +394,7 @@ class TestValidateScheduledScannerConfigs:
     def test_validate_logs_error_when_universe_id_null(self, caplog):
         """Error logged when a config has universe_id=NULL."""
         import logging
+
         lh = _make_cfg(id=2, universe_id=None, scanner_type="liquidity_hunt")
         pp = _make_cfg(id=4, universe_id=1, scanner_type="pocket_pivot")
         with caplog.at_level(logging.ERROR, logger="app.tasks.scanning"):
@@ -328,10 +415,12 @@ class TestValidateScheduledScannerConfigs:
 def test_worker_ready_signal_wired_in_celery_app():
     """celery_app.py must import and wire validate_scheduled_scanner_configs."""
     import app.core.celery_app as celery_module
+
     assert hasattr(celery_module, "_on_worker_ready"), (
         "celery_app.py is missing _on_worker_ready — add @worker_ready.connect decorator"
     )
     from celery.signals import worker_ready
+
     assert len(worker_ready.receivers) > 0, (
         "worker_ready signal has no receivers — "
         "wire _on_worker_ready in celery_app.py with @worker_ready.connect"

--- a/backend/tests/tasks/test_sync_tasks.py
+++ b/backend/tests/tasks/test_sync_tasks.py
@@ -1,0 +1,348 @@
+"""Unit tests for sync.py tasks — httpx.Client mocked per established convention."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# poll_massive_news — trading-hours guard
+# ---------------------------------------------------------------------------
+
+
+class TestPollMassiveNewsGuard:
+    """Verify the weekday/hour guard without hitting the DB."""
+
+    def _run_check_db_reached(self, weekday, hour, force=False):
+        import app.tasks.sync as sync_module
+
+        fake_now = MagicMock()
+        fake_now.weekday.return_value = weekday
+        fake_now.hour = hour
+
+        db_called = [False]
+        mock_db = MagicMock()
+        mock_db.query.return_value.first.return_value = None  # no pref → early return
+
+        def _track_session():
+            db_called[0] = True
+            return mock_db
+
+        with (
+            patch("app.tasks.sync.SessionLocal", side_effect=_track_session),
+            patch("app.tasks.sync.datetime") as mock_dt,
+        ):
+            mock_dt.now.return_value = fake_now
+            mock_dt.strptime = datetime.strptime
+            sync_module.poll_massive_news.run(force=force)
+
+        return db_called[0]
+
+    def test_saturday_skips_db(self):
+        assert not self._run_check_db_reached(weekday=5, hour=10)
+
+    def test_sunday_skips_db(self):
+        assert not self._run_check_db_reached(weekday=6, hour=10)
+
+    def test_monday_before_2am_skips_db(self):
+        assert not self._run_check_db_reached(weekday=0, hour=1)
+
+    def test_friday_at_20_skips_db(self):
+        assert not self._run_check_db_reached(weekday=4, hour=20)
+
+    def test_force_bypasses_guard(self):
+        import app.tasks.sync as sync_module
+
+        db = MagicMock()
+        db.query.return_value.first.return_value = None
+
+        with patch("app.tasks.sync.SessionLocal", return_value=db):
+            sync_module.poll_massive_news.run(force=True)
+
+        db.query.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# sync_tickers_batch — upsert loop
+# ---------------------------------------------------------------------------
+
+
+class TestSyncTickersBatch:
+    def _build_client(self, results, next_url=None, status_code=200):
+        response = MagicMock()
+        response.status_code = status_code
+        response.json.return_value = {"results": results, "next_url": next_url}
+        response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = response
+        return mock_client
+
+    def _run(self, results, next_url=None, status_code=200):
+        import app.tasks.sync as sync_module
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        mock_client = self._build_client(results, next_url, status_code)
+
+        def _retry_reraises(exc=None, **kw):
+            raise (exc or Exception("retry"))
+
+        with (
+            patch("app.tasks.sync.SessionLocal", return_value=db),
+            patch("app.tasks.sync.httpx.Client", return_value=mock_client),
+            patch.object(
+                sync_module.sync_tickers_batch, "retry", side_effect=_retry_reraises
+            ),
+        ):
+            sync_module.sync_tickers_batch.run()
+
+        return db, mock_client
+
+    def test_upserts_ticker_row_for_each_result(self):
+        results = [
+            {
+                "ticker": "AAPL",
+                "name": "Apple Inc.",
+                "active": True,
+                "market": "stocks",
+                "type": "CS",
+                "primary_exchange": "XNAS",
+            },
+            {
+                "ticker": "MSFT",
+                "name": "Microsoft",
+                "active": True,
+                "market": "stocks",
+                "type": "CS",
+                "primary_exchange": "XNAS",
+            },
+        ]
+        db, _ = self._run(results)
+        assert db.add.call_count == 2
+        db.commit.assert_called_once()
+
+    def test_skips_result_without_ticker_field(self):
+        results = [{"name": "No ticker here"}]
+        db, _ = self._run(results)
+        db.add.assert_not_called()
+
+    def test_schedules_next_batch_when_next_url_present(self):
+        import app.tasks.sync as sync_module
+
+        results = [
+            {
+                "ticker": "AAPL",
+                "name": "Apple",
+                "active": True,
+                "market": "stocks",
+                "type": "CS",
+                "primary_exchange": "X",
+            }
+        ]
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+        next_url = "https://api.polygon.io/v3/reference/tickers?cursor=abc"
+        mock_client = self._build_client(results, next_url)
+
+        with (
+            patch("app.tasks.sync.SessionLocal", return_value=db),
+            patch("app.tasks.sync.httpx.Client", return_value=mock_client),
+            patch.object(sync_module.sync_tickers_batch, "apply_async") as mock_apply,
+        ):
+            sync_module.sync_tickers_batch.run()
+
+        mock_apply.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# sync_stock_splits — dedup logic
+# ---------------------------------------------------------------------------
+
+
+class TestSyncStockSplits:
+    def _build_client(self, results, status_code=200):
+        response = MagicMock()
+        response.status_code = status_code
+        response.json.return_value = {"results": results}
+        response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = response
+        return mock_client
+
+    def _run(self, results, existing_split=None):
+        import app.tasks.sync as sync_module
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = existing_split
+
+        mock_client = self._build_client(results)
+
+        def _retry_reraises(exc=None, **kw):
+            raise (exc or Exception("retry"))
+
+        with (
+            patch("app.tasks.sync.SessionLocal", return_value=db),
+            patch("app.tasks.sync.httpx.Client", return_value=mock_client),
+            patch(
+                "app.services.split_adjustment.SplitAdjustmentService.apply_all_pending",
+                return_value=[],
+            ),
+            patch.object(
+                sync_module.sync_stock_splits, "retry", side_effect=_retry_reraises
+            ),
+        ):
+            sync_module.sync_stock_splits.run()
+
+        return db
+
+    def test_new_split_is_inserted(self):
+        results = [
+            {
+                "ticker": "AAPL",
+                "execution_date": "2026-05-01",
+                "split_from": 1,
+                "split_to": 4,
+            }
+        ]
+        db = self._run(results, existing_split=None)
+        db.add.assert_called_once()
+
+    def test_existing_split_is_not_duplicated(self):
+        results = [
+            {
+                "ticker": "AAPL",
+                "execution_date": "2026-05-01",
+                "split_from": 1,
+                "split_to": 4,
+            }
+        ]
+        existing = MagicMock()
+        db = self._run(results, existing_split=existing)
+        db.add.assert_not_called()
+
+    def test_missing_required_fields_skipped(self):
+        results = [{"ticker": "AAPL"}]  # missing execution_date, split_from, split_to
+        db = self._run(results)
+        db.add.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# sync_stock_aggregates — bulk-insert path
+# ---------------------------------------------------------------------------
+
+
+class TestSyncStockAggregates:
+    def _run(self, aggs=None, raises=None):
+        import app.tasks.sync as sync_module
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.delete = MagicMock(return_value=0)
+
+        def _retry_reraises(exc=None, **kw):
+            raise (exc or Exception("retry"))
+
+        with (
+            patch("app.tasks.sync.SessionLocal", return_value=db),
+            patch(
+                "app.services.stock_data.StockDataService.get_aggregates",
+                side_effect=raises or (lambda **kw: aggs or []),
+            ),
+            patch("app.utils.session.classify_session", return_value=(False, False)),
+            patch.object(
+                sync_module.sync_stock_aggregates, "retry", side_effect=_retry_reraises
+            ),
+        ):
+            sync_module.sync_stock_aggregates.run(
+                ticker="AAPL",
+                from_date="2026-06-01",
+                to_date="2026-06-05",
+            )
+
+        return db
+
+    def test_no_aggs_returns_early_without_insert(self):
+        db = self._run(aggs=[])
+        db.bulk_save_objects.assert_not_called()
+
+    def test_aggs_are_bulk_inserted(self):
+        agg = {
+            "timestamp": datetime(2026, 6, 2, 9, 30, tzinfo=timezone.utc),
+            "open": 100.0,
+            "high": 105.0,
+            "low": 99.0,
+            "close": 103.0,
+            "volume": 50000,
+            "vwap": 102.0,
+            "transactions": 300,
+        }
+        db = self._run(aggs=[agg])
+        db.bulk_save_objects.assert_called_once()
+        inserted = db.bulk_save_objects.call_args[0][0]
+        assert len(inserted) == 1
+        assert inserted[0].ticker == "AAPL"
+
+    def test_existing_range_deleted_before_insert(self):
+        agg = {
+            "timestamp": datetime(2026, 6, 2, 9, 30, tzinfo=timezone.utc),
+            "open": 100.0,
+            "high": 105.0,
+            "low": 99.0,
+            "close": 103.0,
+            "volume": 50000,
+            "vwap": 102.0,
+            "transactions": 300,
+        }
+        db = self._run(aggs=[agg])
+        db.query.return_value.filter.return_value.delete.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# trigger_tweet_monitor — success and retry
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerTweetMonitor:
+    def test_success_returns_response_json(self):
+        import app.tasks.sync as sync_module
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {"status": "ok", "tweets": 3}
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = response
+
+        with patch("app.tasks.sync.httpx.Client", return_value=mock_client):
+            result = sync_module.trigger_tweet_monitor.run()
+
+        assert result == {"status": "ok", "tweets": 3}
+        mock_client.post.assert_called_once_with("http://tweet-monitor:8000/poll")
+
+    def test_http_error_triggers_retry(self):
+        import app.tasks.sync as sync_module
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.side_effect = Exception("connection refused")
+
+        def _retry_reraises(exc=None, **kw):
+            raise exc
+
+        with (
+            patch("app.tasks.sync.httpx.Client", return_value=mock_client),
+            patch.object(
+                sync_module.trigger_tweet_monitor, "retry", side_effect=_retry_reraises
+            ),
+        ):
+            with pytest.raises(Exception, match="connection refused"):
+                sync_module.trigger_tweet_monitor.run()

--- a/backend/tests/tasks/test_trading_task_shells.py
+++ b/backend/tests/tasks/test_trading_task_shells.py
@@ -1,0 +1,171 @@
+"""Unit tests for trading.py Celery task shells."""
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+
+class TestExecuteAutoTrade:
+    def _run(self, rule=None, event=None):
+        import app.tasks.trading as trading_module
+
+        db = MagicMock()
+        call_count = [0]
+
+        def _query_side(model):
+            q = MagicMock()
+            if call_count[0] == 0:
+                q.filter.return_value.first.return_value = rule
+            else:
+                q.filter.return_value.first.return_value = event
+            call_count[0] += 1
+            return q
+
+        db.query.side_effect = _query_side
+
+        def _retry_reraises(exc, **kw):
+            raise exc
+
+        with (
+            patch("app.tasks.trading.SessionLocal", return_value=db),
+            patch(
+                "app.services.auto_trade_service.auto_trade_executor"
+            ) as mock_executor,
+            patch.object(
+                trading_module.execute_auto_trade, "retry", side_effect=_retry_reraises
+            ),
+        ):
+            trading_module.execute_auto_trade.run(rule_id=1, scanner_event_id=2)
+            return mock_executor, db
+
+    def test_rule_not_found_returns_without_execute(self):
+        mock_executor, _ = self._run(rule=None, event=MagicMock())
+        mock_executor.maybe_execute.assert_not_called()
+
+    def test_event_not_found_returns_without_execute(self):
+        mock_executor, _ = self._run(rule=MagicMock(), event=None)
+        mock_executor.maybe_execute.assert_not_called()
+
+    def test_success_calls_maybe_execute(self):
+        rule = MagicMock()
+        event = MagicMock()
+        event.ticker = "AAPL"
+        mock_executor, _ = self._run(rule=rule, event=event)
+        mock_executor.maybe_execute.assert_called_once()
+
+
+class TestSubmitApprovedOrder:
+    def _run(self, order=None):
+        import app.tasks.trading as trading_module
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = order
+
+        def _retry_reraises(exc, **kw):
+            raise exc
+
+        with (
+            patch("app.tasks.trading.SessionLocal", return_value=db),
+            patch(
+                "app.services.auto_trade_service.auto_trade_executor"
+            ) as mock_executor,
+            patch.object(
+                trading_module.submit_approved_order,
+                "retry",
+                side_effect=_retry_reraises,
+            ),
+        ):
+            trading_module.submit_approved_order.run(order_id=5)
+            return mock_executor, db
+
+    def test_order_not_found_returns_without_submit(self):
+        mock_executor, _ = self._run(order=None)
+        mock_executor.submit_existing_order.assert_not_called()
+
+    def test_wrong_status_returns_without_submit(self):
+        order = MagicMock()
+        order.id = 5
+        order.status = "open"  # not "pending"
+        mock_executor, _ = self._run(order=order)
+        mock_executor.submit_existing_order.assert_not_called()
+
+    def test_pending_order_calls_submit(self):
+        import app.tasks.trading as trading_module
+
+        order = MagicMock()
+        order.id = 5
+        order.status = "pending"
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = order
+
+        def _retry_reraises(exc, **kw):
+            raise exc
+
+        with (
+            patch("app.tasks.trading.SessionLocal", return_value=db),
+            patch(
+                "app.services.auto_trade_service.auto_trade_executor"
+            ) as mock_executor,
+            patch.object(
+                trading_module.submit_approved_order,
+                "retry",
+                side_effect=_retry_reraises,
+            ),
+        ):
+            trading_module.submit_approved_order.run(order_id=5)
+
+        mock_executor.submit_existing_order.assert_called_once_with(order, db)
+
+
+class TestPollAutoTradeFillsPaperPath:
+    def test_no_pending_orders_returns_early(self):
+        import app.tasks.trading as trading_module
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = []
+
+        with patch("app.tasks.trading.SessionLocal", return_value=db):
+            trading_module.poll_auto_trade_fills.run()
+
+        # No calls to _record_entry_fill or _simulate_paper_exit expected
+
+    def test_submitted_paper_order_calls_record_entry_fill(self):
+        import app.tasks.trading as trading_module
+
+        order = MagicMock()
+        order.status = "submitted"
+        order.is_paper = True
+        order.trigger_price = Decimal("100.0")
+        order.entry_price_target = None
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = [order]
+
+        with (
+            patch("app.tasks.trading.SessionLocal", return_value=db),
+            patch("app.tasks.trading._record_entry_fill") as mock_fill,
+        ):
+            trading_module.poll_auto_trade_fills.run()
+
+        mock_fill.assert_called_once()
+        args = mock_fill.call_args[0]
+        assert args[0] is order
+        assert args[1] == 100.0  # fill_price from trigger_price
+
+    def test_open_paper_order_calls_simulate_paper_exit(self):
+        import app.tasks.trading as trading_module
+
+        order = MagicMock()
+        order.status = "open"
+        order.is_paper = True
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.all.return_value = [order]
+
+        with (
+            patch("app.tasks.trading.SessionLocal", return_value=db),
+            patch("app.tasks.trading._simulate_paper_exit") as mock_exit,
+        ):
+            trading_module.poll_auto_trade_fills.run()
+
+        mock_exit.assert_called_once()

--- a/backend/tests/test_coverage_config.py
+++ b/backend/tests/test_coverage_config.py
@@ -1,0 +1,15 @@
+"""Assert the coverage config no longer omits the full tasks package."""
+
+import pathlib
+import tomllib
+
+
+def test_tasks_glob_not_in_coverage_omit():
+    cfg = tomllib.loads(
+        (pathlib.Path(__file__).parent.parent / "pyproject.toml").read_text()
+    )
+    omit = cfg["tool"]["coverage"]["run"]["omit"]
+    assert "app/tasks/*.py" not in omit, (
+        "app/tasks/*.py must be removed from [tool.coverage.run] omit — "
+        "use # pragma: no cover on the two broker-bound functions instead"
+    )

--- a/codeindex.json
+++ b/codeindex.json
@@ -1,8 +1,8 @@
 {
   "meta": {
     "root": "markethawk/",
-    "total_files": 455,
-    "total_loc": 64896,
+    "total_files": 460,
+    "total_loc": 66134,
     "languages": [
       "python",
       "javascript",
@@ -6879,8 +6879,8 @@
       "id": "backend/app/tasks/scanning.py",
       "type": "module",
       "language": "python",
-      "size": 749,
-      "loc": 749,
+      "size": 759,
+      "loc": 759,
       "group": 9,
       "imports": [
         "asyncio",
@@ -6900,43 +6900,64 @@
       "imported_by": [],
       "symbols": [
         {
+          "name": "_evaluate_scanner_alerts_logic",
+          "line": 24,
+          "kind": "function",
+          "exported": false,
+          "doc": "Testable core of evaluate_scanner_alerts. No OTel/Celery context needed."
+        },
+        {
+          "name": "_run_range_scan_logic",
+          "line": 64,
+          "kind": "function",
+          "exported": false,
+          "doc": "Testable core of run_range_scan. Returns events_detected count."
+        },
+        {
+          "name": "_run_universe_scan_logic",
+          "line": 141,
+          "kind": "function",
+          "exported": false,
+          "doc": "Testable core of run_universe_scan. No Redis/Celery/OTel imports needed."
+        },
+        {
           "name": "evaluate_scanner_alerts",
-          "line": 20,
+          "line": 328,
           "kind": "function",
           "exported": true,
           "doc": "Evaluate all active alert rules against a newly-saved ScannerEvent."
         },
         {
           "name": "run_range_scan",
-          "line": 98,
+          "line": 361,
           "kind": "function",
           "exported": true,
           "doc": "Background task: run selected scanners over a date range for one ticker."
         },
         {
           "name": "run_liquidity_hunt_scheduled",
-          "line": 234,
+          "line": 415,
           "kind": "function",
           "exported": true,
           "doc": "Nightly 02:00 UTC task: run liquidity_hunt_pre and liquidity_hunt_post"
         },
         {
           "name": "run_universe_scan",
-          "line": 325,
+          "line": 504,
           "kind": "function",
           "exported": true,
           "doc": "Run a scanner across (universe, [start_date..end_date]) with progress reporting."
         },
         {
           "name": "run_pocket_pivot_scheduled",
-          "line": 596,
+          "line": 608,
           "kind": "function",
           "exported": true,
           "doc": "Nightly 02:00 UTC task: run pocket_pivot for today's date over all active"
         },
         {
           "name": "validate_scheduled_scanner_configs",
-          "line": 687,
+          "line": 697,
           "kind": "function",
           "exported": true,
           "doc": "Check that every beat-scheduled scanner type has at least one active"
@@ -13943,17 +13964,177 @@
       ]
     },
     {
+      "id": "backend/tests/tasks/test_quality_tasks.py",
+      "type": "module",
+      "language": "python",
+      "size": 242,
+      "loc": 242,
+      "group": 21,
+      "imports": [
+        "unittest",
+        "pytest",
+        "app"
+      ],
+      "layer": "backend",
+      "direct_dependents": 0,
+      "transitive_dependents": 0,
+      "blast_score": 0.0,
+      "imported_by": [],
+      "symbols": [
+        {
+          "name": "_make_report",
+          "line": 8,
+          "kind": "function",
+          "exported": false
+        },
+        {
+          "name": "TestAnalyzeUniverseQuality",
+          "line": 26,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_sets_report_complete_on_success",
+            "test_creates_report_when_none_exists",
+            "test_sets_report_error_on_exception",
+            "test_running_status_set_before_analysis"
+          ]
+        },
+        {
+          "name": "TestNormalizeUniverseQuality",
+          "line": 128,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_raises_when_no_quality_report_exists",
+            "test_raises_when_report_has_no_data",
+            "test_sets_complete_and_triggers_analysis_on_success",
+            "test_sets_normalization_error_on_failure"
+          ]
+        },
+        {
+          "name": "TestAnalyzeSignalFeatures",
+          "line": 200,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "test_insufficient_data_sets_failed_status"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "backend/tests/tasks/test_scanning_tasks.py",
+      "type": "module",
+      "language": "python",
+      "size": 360,
+      "loc": 360,
+      "group": 21,
+      "imports": [
+        "datetime",
+        "unittest",
+        "app"
+      ],
+      "layer": "backend",
+      "direct_dependents": 0,
+      "transitive_dependents": 0,
+      "blast_score": 0.0,
+      "imported_by": [],
+      "symbols": [
+        {
+          "name": "test_run_universe_scan_logic_is_importable",
+          "line": 11,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_run_range_scan_logic_is_importable",
+          "line": 17,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_evaluate_scanner_alerts_logic_is_importable",
+          "line": 23,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "_make_run",
+          "line": 34,
+          "kind": "function",
+          "exported": false
+        },
+        {
+          "name": "_make_ticker",
+          "line": 43,
+          "kind": "function",
+          "exported": false
+        },
+        {
+          "name": "_make_db",
+          "line": 49,
+          "kind": "function",
+          "exported": false,
+          "doc": "Mock DB that returns run from first query().filter().first() and tickers from se"
+        },
+        {
+          "name": "TestRunUniverseScanLogic",
+          "line": 74,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run_logic",
+            "test_run_not_found_returns_early",
+            "test_no_tickers_publishes_failed",
+            "test_happy_path_publishes_started_and_completed",
+            "test_cancel_flag_sets_status_cancelled",
+            "test_day_error_continues_to_completion",
+            "test_weekends_excluded_from_trading_days",
+            "test_write_state_called_with_payload"
+          ]
+        },
+        {
+          "name": "TestEvaluateScannerAlertsLogic",
+          "line": 219,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run_logic",
+            "test_event_not_found_returns_without_dispatch",
+            "test_no_matching_rules_returns_without_dispatch",
+            "test_matching_rule_dispatches_notification",
+            "test_auto_trade_rule_queues_execute_auto_trade",
+            "test_dispatch_exception_does_not_abort_loop"
+          ]
+        },
+        {
+          "name": "TestRunRangeScanLogic",
+          "line": 324,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run_logic",
+            "test_weekends_skipped_in_trading_days",
+            "test_returns_event_count",
+            "test_completed_message_published"
+          ]
+        }
+      ]
+    },
+    {
       "id": "backend/tests/tasks/test_scheduled_scanner_tasks.py",
       "type": "module",
       "language": "python",
-      "size": 339,
-      "loc": 339,
+      "size": 428,
+      "loc": 428,
       "group": 21,
       "imports": [
-        "pytest",
         "unittest",
-        "app",
+        "pytest",
         "sqlalchemy",
+        "app",
         "os",
         "importlib",
         "celery",
@@ -13967,89 +14148,93 @@
       "symbols": [
         {
           "name": "test_scanner_config_has_universe_id_column",
-          "line": 10,
+          "line": 12,
           "kind": "function",
           "exported": true,
           "doc": "ScannerConfig must declare universe_id as a mapped column."
         },
         {
           "name": "test_scanner_config_universe_id_is_integer",
-          "line": 22,
+          "line": 25,
           "kind": "function",
           "exported": true,
           "doc": "universe_id must be an Integer column."
         },
         {
           "name": "test_scanner_config_universe_id_is_not_nullable",
-          "line": 31,
+          "line": 35,
           "kind": "function",
           "exported": true,
           "doc": "universe_id must be NOT NULL (nullable=False)."
         },
         {
           "name": "test_migration_file_exists",
-          "line": 43,
+          "line": 48,
           "kind": "function",
           "exported": true,
           "doc": "The add_universe_id migration file must exist at the expected path."
         },
         {
           "name": "test_migration_revision_chain",
-          "line": 56,
+          "line": 66,
           "kind": "function",
           "exported": true,
           "doc": "Migration must declare correct revision and a non-None down_revision."
         },
         {
           "name": "test_seed_liquidity_hunt_has_universe_id",
-          "line": 77,
+          "line": 96,
           "kind": "function",
           "exported": true,
           "doc": "The liquidity_hunt seed row (id=2) must include universe_id column and value."
         },
         {
           "name": "test_seed_pocket_pivot_row_exists",
-          "line": 92,
+          "line": 119,
           "kind": "function",
           "exported": true,
           "doc": "A pocket_pivot config row must be present in the seed SQL."
         },
         {
           "name": "_make_cfg",
-          "line": 114,
+          "line": 150,
           "kind": "function",
           "exported": false,
           "doc": "Return a MagicMock resembling a ScannerConfig ORM row."
         },
         {
           "name": "TestRunLiquidityHuntScheduledFixed",
-          "line": 129,
+          "line": 165,
           "kind": "class",
           "exported": true,
           "methods": [
             "_run_with_configs",
             "test_does_not_call_parameters_get",
             "test_logs_error_and_raises_when_zero_configs",
-            "test_logs_error_when_universe_id_is_null"
+            "test_logs_error_when_universe_id_is_null",
+            "test_no_tickers_logs_warning_and_does_not_raise",
+            "test_success_with_tickers_does_not_raise"
           ],
           "doc": "Tests for the fixed run_liquidity_hunt_scheduled task."
         },
         {
           "name": "TestRunPocketPivotScheduledFixed",
-          "line": 191,
+          "line": 250,
           "kind": "class",
           "exported": true,
           "methods": [
             "_run_with_configs",
             "test_does_not_call_parameters_get",
             "test_logs_error_and_raises_when_zero_configs",
-            "test_logs_error_when_universe_id_is_null"
+            "test_logs_error_when_universe_id_is_null",
+            "test_no_tickers_logs_warning_and_does_not_raise",
+            "test_success_with_tickers_does_not_raise"
           ],
           "doc": "Tests for the fixed run_pocket_pivot_scheduled task."
         },
         {
           "name": "TestValidateScheduledScannerConfigs",
-          "line": 253,
+          "line": 334,
           "kind": "class",
           "exported": true,
           "methods": [
@@ -14064,7 +14249,7 @@
         },
         {
           "name": "test_worker_ready_signal_wired_in_celery_app",
-          "line": 328,
+          "line": 415,
           "kind": "function",
           "exported": true,
           "doc": "celery_app.py must import and wire validate_scheduled_scanner_configs."
@@ -14109,6 +14294,145 @@
             "test_no_strategy_bypasses_check",
             "test_no_entry_price_target_bypasses_check",
             "test_short_side_negative_slippage_is_caught"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "backend/tests/tasks/test_sync_tasks.py",
+      "type": "module",
+      "language": "python",
+      "size": 349,
+      "loc": 349,
+      "group": 21,
+      "imports": [
+        "datetime",
+        "unittest",
+        "pytest",
+        "app"
+      ],
+      "layer": "backend",
+      "direct_dependents": 0,
+      "transitive_dependents": 0,
+      "blast_score": 0.0,
+      "imported_by": [],
+      "symbols": [
+        {
+          "name": "TestPollMassiveNewsGuard",
+          "line": 13,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run_check_db_reached",
+            "test_saturday_skips_db",
+            "test_sunday_skips_db",
+            "test_monday_before_2am_skips_db",
+            "test_friday_at_20_skips_db",
+            "test_force_bypasses_guard"
+          ],
+          "doc": "Verify the weekday/hour guard without hitting the DB."
+        },
+        {
+          "name": "TestSyncTickersBatch",
+          "line": 70,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_build_client",
+            "_run",
+            "test_upserts_ticker_row_for_each_result",
+            "test_skips_result_without_ticker_field",
+            "test_schedules_next_batch_when_next_url_present"
+          ]
+        },
+        {
+          "name": "TestSyncStockSplits",
+          "line": 166,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_build_client",
+            "_run",
+            "test_new_split_is_inserted",
+            "test_existing_split_is_not_duplicated",
+            "test_missing_required_fields_skipped"
+          ]
+        },
+        {
+          "name": "TestSyncStockAggregates",
+          "line": 241,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_no_aggs_returns_early_without_insert",
+            "test_aggs_are_bulk_inserted",
+            "test_existing_range_deleted_before_insert"
+          ]
+        },
+        {
+          "name": "TestTriggerTweetMonitor",
+          "line": 311,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "test_success_returns_response_json",
+            "test_http_error_triggers_retry"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "backend/tests/tasks/test_trading_task_shells.py",
+      "type": "module",
+      "language": "python",
+      "size": 172,
+      "loc": 172,
+      "group": 21,
+      "imports": [
+        "decimal",
+        "unittest",
+        "app"
+      ],
+      "layer": "backend",
+      "direct_dependents": 0,
+      "transitive_dependents": 0,
+      "blast_score": 0.0,
+      "imported_by": [],
+      "symbols": [
+        {
+          "name": "TestExecuteAutoTrade",
+          "line": 7,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_rule_not_found_returns_without_execute",
+            "test_event_not_found_returns_without_execute",
+            "test_success_calls_maybe_execute"
+          ]
+        },
+        {
+          "name": "TestSubmitApprovedOrder",
+          "line": 56,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_order_not_found_returns_without_submit",
+            "test_wrong_status_returns_without_submit",
+            "test_pending_order_calls_submit"
+          ]
+        },
+        {
+          "name": "TestPollAutoTradeFillsPaperPath",
+          "line": 120,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "test_no_pending_orders_returns_early",
+            "test_submitted_paper_order_calls_record_entry_fill",
+            "test_open_paper_order_calls_simulate_paper_exit"
           ]
         }
       ]
@@ -14184,6 +14508,31 @@
         {
           "name": "test_jwt_secret_key_field_exists",
           "line": 26,
+          "kind": "function",
+          "exported": true
+        }
+      ]
+    },
+    {
+      "id": "backend/tests/test_coverage_config.py",
+      "type": "module",
+      "language": "python",
+      "size": 16,
+      "loc": 16,
+      "group": 14,
+      "imports": [
+        "pathlib",
+        "tomllib"
+      ],
+      "layer": "backend",
+      "direct_dependents": 0,
+      "transitive_dependents": 0,
+      "blast_score": 0.0,
+      "imported_by": [],
+      "symbols": [
+        {
+          "name": "test_tasks_glob_not_in_coverage_omit",
+          "line": 7,
           "kind": "function",
           "exported": true
         }
@@ -15827,9 +16176,9 @@
       "group": 9000,
       "imports": [],
       "layer": "backend",
-      "direct_dependents": 203,
+      "direct_dependents": 207,
       "transitive_dependents": 88,
-      "blast_score": 247.0,
+      "blast_score": 251.0,
       "imported_by": [
         "backend/app/alembic/env.py",
         "backend/app/core/__init__.py",
@@ -16020,8 +16369,12 @@
         "backend/tests/tasks/test_metrics_instrumentation.py",
         "backend/tests/tasks/test_package_exports.py",
         "backend/tests/tasks/test_paper_exit.py",
+        "backend/tests/tasks/test_quality_tasks.py",
+        "backend/tests/tasks/test_scanning_tasks.py",
         "backend/tests/tasks/test_scheduled_scanner_tasks.py",
         "backend/tests/tasks/test_slippage.py",
+        "backend/tests/tasks/test_sync_tasks.py",
+        "backend/tests/tasks/test_trading_task_shells.py",
         "backend/tests/test_auth_core.py",
         "backend/tests/test_config.py",
         "backend/tests/test_exceptions.py",
@@ -16526,9 +16879,9 @@
       "group": 9000,
       "imports": [],
       "layer": "backend",
-      "direct_dependents": 132,
+      "direct_dependents": 134,
       "transitive_dependents": 89,
-      "blast_score": 176.5,
+      "blast_score": 178.5,
       "imported_by": [
         "backend/app/core/auth.py",
         "backend/app/core/error_tracking.py",
@@ -16653,6 +17006,8 @@
         "backend/tests/services/test_session_utils.py",
         "backend/tests/services/test_stock_data_service_methods.py",
         "backend/tests/services/test_system_service.py",
+        "backend/tests/tasks/test_scanning_tasks.py",
+        "backend/tests/tasks/test_sync_tasks.py",
         "scripts/fetch_metrics.py",
         "services/tweet-monitor/app/browser.py",
         "services/tweet-monitor/app/classifier.py",
@@ -17312,9 +17667,9 @@
       "group": 9000,
       "imports": [],
       "layer": "backend",
-      "direct_dependents": 15,
+      "direct_dependents": 16,
       "transitive_dependents": 0,
-      "blast_score": 15.0,
+      "blast_score": 16.0,
       "imported_by": [
         "backend/app/schemas/journal.py",
         "backend/app/services/auto_trade_service.py",
@@ -17330,7 +17685,8 @@
         "backend/tests/services/test_split_adjustment.py",
         "backend/tests/services/test_stock_data_service_methods.py",
         "backend/tests/tasks/test_paper_exit.py",
-        "backend/tests/tasks/test_slippage.py"
+        "backend/tests/tasks/test_slippage.py",
+        "backend/tests/tasks/test_trading_task_shells.py"
       ]
     },
     {
@@ -17705,9 +18061,9 @@
       "group": 9000,
       "imports": [],
       "layer": "backend",
-      "direct_dependents": 30,
+      "direct_dependents": 34,
       "transitive_dependents": 0,
-      "blast_score": 30.0,
+      "blast_score": 34.0,
       "imported_by": [
         "backend/tests/api/conftest.py",
         "backend/tests/api/test_analysis.py",
@@ -17737,8 +18093,12 @@
         "backend/tests/services/test_timeseries_forecast.py",
         "backend/tests/services/test_universe_stats_service.py",
         "backend/tests/tasks/test_paper_exit.py",
+        "backend/tests/tasks/test_quality_tasks.py",
+        "backend/tests/tasks/test_scanning_tasks.py",
         "backend/tests/tasks/test_scheduled_scanner_tasks.py",
-        "backend/tests/tasks/test_slippage.py"
+        "backend/tests/tasks/test_slippage.py",
+        "backend/tests/tasks/test_sync_tasks.py",
+        "backend/tests/tasks/test_trading_task_shells.py"
       ]
     },
     {
@@ -17769,9 +18129,9 @@
       "group": 9000,
       "imports": [],
       "layer": "backend",
-      "direct_dependents": 32,
+      "direct_dependents": 34,
       "transitive_dependents": 0,
-      "blast_score": 32.0,
+      "blast_score": 34.0,
       "imported_by": [
         "backend/tests/api/conftest.py",
         "backend/tests/api/test_alerts.py",
@@ -17799,7 +18159,9 @@
         "backend/tests/services/test_signal_ranker.py",
         "backend/tests/services/test_split_adjustment.py",
         "backend/tests/services/test_system_service.py",
+        "backend/tests/tasks/test_quality_tasks.py",
         "backend/tests/tasks/test_scheduled_scanner_tasks.py",
+        "backend/tests/tasks/test_sync_tasks.py",
         "backend/tests/test_settings.py",
         "services/tweet-monitor/tests/test_classifier.py",
         "services/tweet-monitor/tests/test_extractor.py",
@@ -18051,12 +18413,13 @@
       "group": 9000,
       "imports": [],
       "layer": "backend",
-      "direct_dependents": 11,
+      "direct_dependents": 12,
       "transitive_dependents": 0,
-      "blast_score": 11.0,
+      "blast_score": 12.0,
       "imported_by": [
         "backend/tests/live_scanner/test_main_imports.py",
         "backend/tests/live_scanner/test_publisher.py",
+        "backend/tests/test_coverage_config.py",
         "dark-factory/tests/test_code_review_command.py",
         "dark-factory/tests/test_code_review_payload.py",
         "dark-factory/tests/test_code_review_prompt.py",
@@ -18066,6 +18429,22 @@
         "scripts/render_report.py",
         "tests/scripts/test_fetch_metrics.py",
         "tests/scripts/test_render_report.py"
+      ]
+    },
+    {
+      "id": "tomllib",
+      "type": "import",
+      "language": "python",
+      "size": 40,
+      "loc": 0,
+      "group": 9000,
+      "imports": [],
+      "layer": "backend",
+      "direct_dependents": 1,
+      "transitive_dependents": 0,
+      "blast_score": 1.0,
+      "imported_by": [
+        "backend/tests/test_coverage_config.py"
       ]
     },
     {
@@ -26744,43 +27123,64 @@
           "exported": true
         },
         {
+          "name": "_evaluate_scanner_alerts_logic",
+          "line": 24,
+          "kind": "function",
+          "exported": false,
+          "doc": "Testable core of evaluate_scanner_alerts. No OTel/Celery context needed."
+        },
+        {
+          "name": "_run_range_scan_logic",
+          "line": 64,
+          "kind": "function",
+          "exported": false,
+          "doc": "Testable core of run_range_scan. Returns events_detected count."
+        },
+        {
+          "name": "_run_universe_scan_logic",
+          "line": 141,
+          "kind": "function",
+          "exported": false,
+          "doc": "Testable core of run_universe_scan. No Redis/Celery/OTel imports needed."
+        },
+        {
           "name": "evaluate_scanner_alerts",
-          "line": 20,
+          "line": 328,
           "kind": "function",
           "exported": true,
           "doc": "Evaluate all active alert rules against a newly-saved ScannerEvent."
         },
         {
           "name": "run_range_scan",
-          "line": 98,
+          "line": 361,
           "kind": "function",
           "exported": true,
           "doc": "Background task: run selected scanners over a date range for one ticker."
         },
         {
           "name": "run_liquidity_hunt_scheduled",
-          "line": 234,
+          "line": 415,
           "kind": "function",
           "exported": true,
           "doc": "Nightly 02:00 UTC task: run liquidity_hunt_pre and liquidity_hunt_post"
         },
         {
           "name": "run_universe_scan",
-          "line": 325,
+          "line": 504,
           "kind": "function",
           "exported": true,
           "doc": "Run a scanner across (universe, [start_date..end_date]) with progress reporting."
         },
         {
           "name": "run_pocket_pivot_scheduled",
-          "line": 596,
+          "line": 608,
           "kind": "function",
           "exported": true,
           "doc": "Nightly 02:00 UTC task: run pocket_pivot for today's date over all active"
         },
         {
           "name": "validate_scheduled_scanner_configs",
-          "line": 687,
+          "line": 697,
           "kind": "function",
           "exported": true,
           "doc": "Check that every beat-scheduled scanner type has at least one active"
@@ -31580,90 +31980,214 @@
           ]
         },
         {
+          "name": "_make_report",
+          "line": 8,
+          "kind": "function",
+          "exported": false
+        },
+        {
+          "name": "TestAnalyzeUniverseQuality",
+          "line": 26,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_sets_report_complete_on_success",
+            "test_creates_report_when_none_exists",
+            "test_sets_report_error_on_exception",
+            "test_running_status_set_before_analysis"
+          ]
+        },
+        {
+          "name": "TestNormalizeUniverseQuality",
+          "line": 128,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_raises_when_no_quality_report_exists",
+            "test_raises_when_report_has_no_data",
+            "test_sets_complete_and_triggers_analysis_on_success",
+            "test_sets_normalization_error_on_failure"
+          ]
+        },
+        {
+          "name": "TestAnalyzeSignalFeatures",
+          "line": 200,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "test_insufficient_data_sets_failed_status"
+          ]
+        },
+        {
+          "name": "test_run_universe_scan_logic_is_importable",
+          "line": 11,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_run_range_scan_logic_is_importable",
+          "line": 17,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_evaluate_scanner_alerts_logic_is_importable",
+          "line": 23,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "_make_run",
+          "line": 34,
+          "kind": "function",
+          "exported": false
+        },
+        {
+          "name": "_make_ticker",
+          "line": 43,
+          "kind": "function",
+          "exported": false
+        },
+        {
+          "name": "_make_db",
+          "line": 49,
+          "kind": "function",
+          "exported": false,
+          "doc": "Mock DB that returns run from first query().filter().first() and tickers from se"
+        },
+        {
+          "name": "TestRunUniverseScanLogic",
+          "line": 74,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run_logic",
+            "test_run_not_found_returns_early",
+            "test_no_tickers_publishes_failed",
+            "test_happy_path_publishes_started_and_completed",
+            "test_cancel_flag_sets_status_cancelled",
+            "test_day_error_continues_to_completion",
+            "test_weekends_excluded_from_trading_days",
+            "test_write_state_called_with_payload"
+          ]
+        },
+        {
+          "name": "TestEvaluateScannerAlertsLogic",
+          "line": 219,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run_logic",
+            "test_event_not_found_returns_without_dispatch",
+            "test_no_matching_rules_returns_without_dispatch",
+            "test_matching_rule_dispatches_notification",
+            "test_auto_trade_rule_queues_execute_auto_trade",
+            "test_dispatch_exception_does_not_abort_loop"
+          ]
+        },
+        {
+          "name": "TestRunRangeScanLogic",
+          "line": 324,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run_logic",
+            "test_weekends_skipped_in_trading_days",
+            "test_returns_event_count",
+            "test_completed_message_published"
+          ]
+        },
+        {
           "name": "test_scanner_config_has_universe_id_column",
-          "line": 10,
+          "line": 12,
           "kind": "function",
           "exported": true,
           "doc": "ScannerConfig must declare universe_id as a mapped column."
         },
         {
           "name": "test_scanner_config_universe_id_is_integer",
-          "line": 22,
+          "line": 25,
           "kind": "function",
           "exported": true,
           "doc": "universe_id must be an Integer column."
         },
         {
           "name": "test_scanner_config_universe_id_is_not_nullable",
-          "line": 31,
+          "line": 35,
           "kind": "function",
           "exported": true,
           "doc": "universe_id must be NOT NULL (nullable=False)."
         },
         {
           "name": "test_migration_file_exists",
-          "line": 43,
+          "line": 48,
           "kind": "function",
           "exported": true,
           "doc": "The add_universe_id migration file must exist at the expected path."
         },
         {
           "name": "test_migration_revision_chain",
-          "line": 56,
+          "line": 66,
           "kind": "function",
           "exported": true,
           "doc": "Migration must declare correct revision and a non-None down_revision."
         },
         {
           "name": "test_seed_liquidity_hunt_has_universe_id",
-          "line": 77,
+          "line": 96,
           "kind": "function",
           "exported": true,
           "doc": "The liquidity_hunt seed row (id=2) must include universe_id column and value."
         },
         {
           "name": "test_seed_pocket_pivot_row_exists",
-          "line": 92,
+          "line": 119,
           "kind": "function",
           "exported": true,
           "doc": "A pocket_pivot config row must be present in the seed SQL."
         },
         {
           "name": "_make_cfg",
-          "line": 114,
+          "line": 150,
           "kind": "function",
           "exported": false,
           "doc": "Return a MagicMock resembling a ScannerConfig ORM row."
         },
         {
           "name": "TestRunLiquidityHuntScheduledFixed",
-          "line": 129,
+          "line": 165,
           "kind": "class",
           "exported": true,
           "methods": [
             "_run_with_configs",
             "test_does_not_call_parameters_get",
             "test_logs_error_and_raises_when_zero_configs",
-            "test_logs_error_when_universe_id_is_null"
+            "test_logs_error_when_universe_id_is_null",
+            "test_no_tickers_logs_warning_and_does_not_raise",
+            "test_success_with_tickers_does_not_raise"
           ],
           "doc": "Tests for the fixed run_liquidity_hunt_scheduled task."
         },
         {
           "name": "TestRunPocketPivotScheduledFixed",
-          "line": 191,
+          "line": 250,
           "kind": "class",
           "exported": true,
           "methods": [
             "_run_with_configs",
             "test_does_not_call_parameters_get",
             "test_logs_error_and_raises_when_zero_configs",
-            "test_logs_error_when_universe_id_is_null"
+            "test_logs_error_when_universe_id_is_null",
+            "test_no_tickers_logs_warning_and_does_not_raise",
+            "test_success_with_tickers_does_not_raise"
           ],
           "doc": "Tests for the fixed run_pocket_pivot_scheduled task."
         },
         {
           "name": "TestValidateScheduledScannerConfigs",
-          "line": 253,
+          "line": 334,
           "kind": "class",
           "exported": true,
           "methods": [
@@ -31678,7 +32202,7 @@
         },
         {
           "name": "test_worker_ready_signal_wired_in_celery_app",
-          "line": 328,
+          "line": 415,
           "kind": "function",
           "exported": true,
           "doc": "celery_app.py must import and wire validate_scheduled_scanner_configs."
@@ -31703,6 +32227,104 @@
             "test_no_strategy_bypasses_check",
             "test_no_entry_price_target_bypasses_check",
             "test_short_side_negative_slippage_is_caught"
+          ]
+        },
+        {
+          "name": "TestPollMassiveNewsGuard",
+          "line": 13,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run_check_db_reached",
+            "test_saturday_skips_db",
+            "test_sunday_skips_db",
+            "test_monday_before_2am_skips_db",
+            "test_friday_at_20_skips_db",
+            "test_force_bypasses_guard"
+          ],
+          "doc": "Verify the weekday/hour guard without hitting the DB."
+        },
+        {
+          "name": "TestSyncTickersBatch",
+          "line": 70,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_build_client",
+            "_run",
+            "test_upserts_ticker_row_for_each_result",
+            "test_skips_result_without_ticker_field",
+            "test_schedules_next_batch_when_next_url_present"
+          ]
+        },
+        {
+          "name": "TestSyncStockSplits",
+          "line": 166,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_build_client",
+            "_run",
+            "test_new_split_is_inserted",
+            "test_existing_split_is_not_duplicated",
+            "test_missing_required_fields_skipped"
+          ]
+        },
+        {
+          "name": "TestSyncStockAggregates",
+          "line": 241,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_no_aggs_returns_early_without_insert",
+            "test_aggs_are_bulk_inserted",
+            "test_existing_range_deleted_before_insert"
+          ]
+        },
+        {
+          "name": "TestTriggerTweetMonitor",
+          "line": 311,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "test_success_returns_response_json",
+            "test_http_error_triggers_retry"
+          ]
+        },
+        {
+          "name": "TestExecuteAutoTrade",
+          "line": 7,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_rule_not_found_returns_without_execute",
+            "test_event_not_found_returns_without_execute",
+            "test_success_calls_maybe_execute"
+          ]
+        },
+        {
+          "name": "TestSubmitApprovedOrder",
+          "line": 56,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_order_not_found_returns_without_submit",
+            "test_wrong_status_returns_without_submit",
+            "test_pending_order_calls_submit"
+          ]
+        },
+        {
+          "name": "TestPollAutoTradeFillsPaperPath",
+          "line": 120,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "test_no_pending_orders_returns_early",
+            "test_submitted_paper_order_calls_record_entry_fill",
+            "test_open_paper_order_calls_simulate_paper_exit"
           ]
         },
         {
@@ -31738,6 +32360,12 @@
         {
           "name": "test_jwt_secret_key_field_exists",
           "line": 26,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_tasks_glob_not_in_coverage_omit",
+          "line": 7,
           "kind": "function",
           "exported": true
         },
@@ -37157,43 +37785,64 @@
           "exported": true
         },
         {
+          "name": "_evaluate_scanner_alerts_logic",
+          "line": 24,
+          "kind": "function",
+          "exported": false,
+          "doc": "Testable core of evaluate_scanner_alerts. No OTel/Celery context needed."
+        },
+        {
+          "name": "_run_range_scan_logic",
+          "line": 64,
+          "kind": "function",
+          "exported": false,
+          "doc": "Testable core of run_range_scan. Returns events_detected count."
+        },
+        {
+          "name": "_run_universe_scan_logic",
+          "line": 141,
+          "kind": "function",
+          "exported": false,
+          "doc": "Testable core of run_universe_scan. No Redis/Celery/OTel imports needed."
+        },
+        {
           "name": "evaluate_scanner_alerts",
-          "line": 20,
+          "line": 328,
           "kind": "function",
           "exported": true,
           "doc": "Evaluate all active alert rules against a newly-saved ScannerEvent."
         },
         {
           "name": "run_range_scan",
-          "line": 98,
+          "line": 361,
           "kind": "function",
           "exported": true,
           "doc": "Background task: run selected scanners over a date range for one ticker."
         },
         {
           "name": "run_liquidity_hunt_scheduled",
-          "line": 234,
+          "line": 415,
           "kind": "function",
           "exported": true,
           "doc": "Nightly 02:00 UTC task: run liquidity_hunt_pre and liquidity_hunt_post"
         },
         {
           "name": "run_universe_scan",
-          "line": 325,
+          "line": 504,
           "kind": "function",
           "exported": true,
           "doc": "Run a scanner across (universe, [start_date..end_date]) with progress reporting."
         },
         {
           "name": "run_pocket_pivot_scheduled",
-          "line": 596,
+          "line": 608,
           "kind": "function",
           "exported": true,
           "doc": "Nightly 02:00 UTC task: run pocket_pivot for today's date over all active"
         },
         {
           "name": "validate_scheduled_scanner_configs",
-          "line": 687,
+          "line": 697,
           "kind": "function",
           "exported": true,
           "doc": "Check that every beat-scheduled scanner type has at least one active"
@@ -41993,90 +42642,214 @@
           ]
         },
         {
+          "name": "_make_report",
+          "line": 8,
+          "kind": "function",
+          "exported": false
+        },
+        {
+          "name": "TestAnalyzeUniverseQuality",
+          "line": 26,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_sets_report_complete_on_success",
+            "test_creates_report_when_none_exists",
+            "test_sets_report_error_on_exception",
+            "test_running_status_set_before_analysis"
+          ]
+        },
+        {
+          "name": "TestNormalizeUniverseQuality",
+          "line": 128,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_raises_when_no_quality_report_exists",
+            "test_raises_when_report_has_no_data",
+            "test_sets_complete_and_triggers_analysis_on_success",
+            "test_sets_normalization_error_on_failure"
+          ]
+        },
+        {
+          "name": "TestAnalyzeSignalFeatures",
+          "line": 200,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "test_insufficient_data_sets_failed_status"
+          ]
+        },
+        {
+          "name": "test_run_universe_scan_logic_is_importable",
+          "line": 11,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_run_range_scan_logic_is_importable",
+          "line": 17,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_evaluate_scanner_alerts_logic_is_importable",
+          "line": 23,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "_make_run",
+          "line": 34,
+          "kind": "function",
+          "exported": false
+        },
+        {
+          "name": "_make_ticker",
+          "line": 43,
+          "kind": "function",
+          "exported": false
+        },
+        {
+          "name": "_make_db",
+          "line": 49,
+          "kind": "function",
+          "exported": false,
+          "doc": "Mock DB that returns run from first query().filter().first() and tickers from se"
+        },
+        {
+          "name": "TestRunUniverseScanLogic",
+          "line": 74,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run_logic",
+            "test_run_not_found_returns_early",
+            "test_no_tickers_publishes_failed",
+            "test_happy_path_publishes_started_and_completed",
+            "test_cancel_flag_sets_status_cancelled",
+            "test_day_error_continues_to_completion",
+            "test_weekends_excluded_from_trading_days",
+            "test_write_state_called_with_payload"
+          ]
+        },
+        {
+          "name": "TestEvaluateScannerAlertsLogic",
+          "line": 219,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run_logic",
+            "test_event_not_found_returns_without_dispatch",
+            "test_no_matching_rules_returns_without_dispatch",
+            "test_matching_rule_dispatches_notification",
+            "test_auto_trade_rule_queues_execute_auto_trade",
+            "test_dispatch_exception_does_not_abort_loop"
+          ]
+        },
+        {
+          "name": "TestRunRangeScanLogic",
+          "line": 324,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run_logic",
+            "test_weekends_skipped_in_trading_days",
+            "test_returns_event_count",
+            "test_completed_message_published"
+          ]
+        },
+        {
           "name": "test_scanner_config_has_universe_id_column",
-          "line": 10,
+          "line": 12,
           "kind": "function",
           "exported": true,
           "doc": "ScannerConfig must declare universe_id as a mapped column."
         },
         {
           "name": "test_scanner_config_universe_id_is_integer",
-          "line": 22,
+          "line": 25,
           "kind": "function",
           "exported": true,
           "doc": "universe_id must be an Integer column."
         },
         {
           "name": "test_scanner_config_universe_id_is_not_nullable",
-          "line": 31,
+          "line": 35,
           "kind": "function",
           "exported": true,
           "doc": "universe_id must be NOT NULL (nullable=False)."
         },
         {
           "name": "test_migration_file_exists",
-          "line": 43,
+          "line": 48,
           "kind": "function",
           "exported": true,
           "doc": "The add_universe_id migration file must exist at the expected path."
         },
         {
           "name": "test_migration_revision_chain",
-          "line": 56,
+          "line": 66,
           "kind": "function",
           "exported": true,
           "doc": "Migration must declare correct revision and a non-None down_revision."
         },
         {
           "name": "test_seed_liquidity_hunt_has_universe_id",
-          "line": 77,
+          "line": 96,
           "kind": "function",
           "exported": true,
           "doc": "The liquidity_hunt seed row (id=2) must include universe_id column and value."
         },
         {
           "name": "test_seed_pocket_pivot_row_exists",
-          "line": 92,
+          "line": 119,
           "kind": "function",
           "exported": true,
           "doc": "A pocket_pivot config row must be present in the seed SQL."
         },
         {
           "name": "_make_cfg",
-          "line": 114,
+          "line": 150,
           "kind": "function",
           "exported": false,
           "doc": "Return a MagicMock resembling a ScannerConfig ORM row."
         },
         {
           "name": "TestRunLiquidityHuntScheduledFixed",
-          "line": 129,
+          "line": 165,
           "kind": "class",
           "exported": true,
           "methods": [
             "_run_with_configs",
             "test_does_not_call_parameters_get",
             "test_logs_error_and_raises_when_zero_configs",
-            "test_logs_error_when_universe_id_is_null"
+            "test_logs_error_when_universe_id_is_null",
+            "test_no_tickers_logs_warning_and_does_not_raise",
+            "test_success_with_tickers_does_not_raise"
           ],
           "doc": "Tests for the fixed run_liquidity_hunt_scheduled task."
         },
         {
           "name": "TestRunPocketPivotScheduledFixed",
-          "line": 191,
+          "line": 250,
           "kind": "class",
           "exported": true,
           "methods": [
             "_run_with_configs",
             "test_does_not_call_parameters_get",
             "test_logs_error_and_raises_when_zero_configs",
-            "test_logs_error_when_universe_id_is_null"
+            "test_logs_error_when_universe_id_is_null",
+            "test_no_tickers_logs_warning_and_does_not_raise",
+            "test_success_with_tickers_does_not_raise"
           ],
           "doc": "Tests for the fixed run_pocket_pivot_scheduled task."
         },
         {
           "name": "TestValidateScheduledScannerConfigs",
-          "line": 253,
+          "line": 334,
           "kind": "class",
           "exported": true,
           "methods": [
@@ -42091,7 +42864,7 @@
         },
         {
           "name": "test_worker_ready_signal_wired_in_celery_app",
-          "line": 328,
+          "line": 415,
           "kind": "function",
           "exported": true,
           "doc": "celery_app.py must import and wire validate_scheduled_scanner_configs."
@@ -42116,6 +42889,104 @@
             "test_no_strategy_bypasses_check",
             "test_no_entry_price_target_bypasses_check",
             "test_short_side_negative_slippage_is_caught"
+          ]
+        },
+        {
+          "name": "TestPollMassiveNewsGuard",
+          "line": 13,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run_check_db_reached",
+            "test_saturday_skips_db",
+            "test_sunday_skips_db",
+            "test_monday_before_2am_skips_db",
+            "test_friday_at_20_skips_db",
+            "test_force_bypasses_guard"
+          ],
+          "doc": "Verify the weekday/hour guard without hitting the DB."
+        },
+        {
+          "name": "TestSyncTickersBatch",
+          "line": 70,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_build_client",
+            "_run",
+            "test_upserts_ticker_row_for_each_result",
+            "test_skips_result_without_ticker_field",
+            "test_schedules_next_batch_when_next_url_present"
+          ]
+        },
+        {
+          "name": "TestSyncStockSplits",
+          "line": 166,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_build_client",
+            "_run",
+            "test_new_split_is_inserted",
+            "test_existing_split_is_not_duplicated",
+            "test_missing_required_fields_skipped"
+          ]
+        },
+        {
+          "name": "TestSyncStockAggregates",
+          "line": 241,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_no_aggs_returns_early_without_insert",
+            "test_aggs_are_bulk_inserted",
+            "test_existing_range_deleted_before_insert"
+          ]
+        },
+        {
+          "name": "TestTriggerTweetMonitor",
+          "line": 311,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "test_success_returns_response_json",
+            "test_http_error_triggers_retry"
+          ]
+        },
+        {
+          "name": "TestExecuteAutoTrade",
+          "line": 7,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_rule_not_found_returns_without_execute",
+            "test_event_not_found_returns_without_execute",
+            "test_success_calls_maybe_execute"
+          ]
+        },
+        {
+          "name": "TestSubmitApprovedOrder",
+          "line": 56,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "_run",
+            "test_order_not_found_returns_without_submit",
+            "test_wrong_status_returns_without_submit",
+            "test_pending_order_calls_submit"
+          ]
+        },
+        {
+          "name": "TestPollAutoTradeFillsPaperPath",
+          "line": 120,
+          "kind": "class",
+          "exported": true,
+          "methods": [
+            "test_no_pending_orders_returns_early",
+            "test_submitted_paper_order_calls_record_entry_fill",
+            "test_open_paper_order_calls_simulate_paper_exit"
           ]
         },
         {
@@ -42151,6 +43022,12 @@
         {
           "name": "test_jwt_secret_key_field_exists",
           "line": 26,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_tasks_glob_not_in_coverage_omit",
+          "line": 7,
           "kind": "function",
           "exported": true
         },
@@ -49071,7 +49948,7 @@
     {
       "source": "backend/app/tasks/scanning.py",
       "target": "asyncio",
-      "weight": 2,
+      "weight": 1,
       "kind": "imports"
     },
     {
@@ -49095,7 +49972,7 @@
     {
       "source": "backend/app/tasks/scanning.py",
       "target": "datetime",
-      "weight": 5,
+      "weight": 3,
       "kind": "imports"
     },
     {
@@ -49113,7 +49990,7 @@
     {
       "source": "backend/app/tasks/scanning.py",
       "target": "app",
-      "weight": 26,
+      "weight": 27,
       "kind": "imports"
     },
     {
@@ -51343,9 +52220,39 @@
       "kind": "imports"
     },
     {
-      "source": "backend/tests/tasks/test_scheduled_scanner_tasks.py",
+      "source": "backend/tests/tasks/test_quality_tasks.py",
+      "target": "unittest",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/tasks/test_quality_tasks.py",
       "target": "pytest",
       "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/tasks/test_quality_tasks.py",
+      "target": "app",
+      "weight": 9,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/tasks/test_scanning_tasks.py",
+      "target": "datetime",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/tasks/test_scanning_tasks.py",
+      "target": "unittest",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/tasks/test_scanning_tasks.py",
+      "target": "app",
+      "weight": 12,
       "kind": "imports"
     },
     {
@@ -51356,14 +52263,20 @@
     },
     {
       "source": "backend/tests/tasks/test_scheduled_scanner_tasks.py",
-      "target": "app",
-      "weight": 12,
+      "target": "pytest",
+      "weight": 1,
       "kind": "imports"
     },
     {
       "source": "backend/tests/tasks/test_scheduled_scanner_tasks.py",
       "target": "sqlalchemy",
       "weight": 2,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/tasks/test_scheduled_scanner_tasks.py",
+      "target": "app",
+      "weight": 10,
       "kind": "imports"
     },
     {
@@ -51387,7 +52300,7 @@
     {
       "source": "backend/tests/tasks/test_scheduled_scanner_tasks.py",
       "target": "logging",
-      "weight": 8,
+      "weight": 10,
       "kind": "imports"
     },
     {
@@ -51406,6 +52319,48 @@
       "source": "backend/tests/tasks/test_slippage.py",
       "target": "app",
       "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/tasks/test_sync_tasks.py",
+      "target": "datetime",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/tasks/test_sync_tasks.py",
+      "target": "unittest",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/tasks/test_sync_tasks.py",
+      "target": "pytest",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/tasks/test_sync_tasks.py",
+      "target": "app",
+      "weight": 8,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/tasks/test_trading_task_shells.py",
+      "target": "decimal",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/tasks/test_trading_task_shells.py",
+      "target": "unittest",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/tasks/test_trading_task_shells.py",
+      "target": "app",
+      "weight": 6,
       "kind": "imports"
     },
     {
@@ -51442,6 +52397,18 @@
       "source": "backend/tests/test_config.py",
       "target": "app",
       "weight": 3,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/test_coverage_config.py",
+      "target": "pathlib",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "backend/tests/test_coverage_config.py",
+      "target": "tomllib",
+      "weight": 1,
       "kind": "imports"
     },
     {


### PR DESCRIPTION
## Summary

- Removed the blanket `app/tasks/*.py` exclusion from `[tool.coverage.run] omit` in `pyproject.toml`
- Extracted testable business logic from three task bodies into injectable `_*_logic(db, publish, ...)` helpers
- Added 52 unit tests across 4 new test files; coverage rises from ~31% (tasks included, no tests) to **64.36%**, clearing the 60% gate
- Added `# pragma: no cover` to the two genuinely broker-bound functions only: `_poll_live_orders` (IBKR socket) and `sync_futures_aggregates` (IBKR connection)
- Regression guard `test_coverage_config.py` pins that the tasks glob stays out of the omit list

## Test plan

- [ ] `cd backend && python -m pytest tests/test_coverage_config.py -v` — passes
- [ ] `cd backend && python -m pytest tests/tasks/ -v` — 52+ tests pass (pre-existing `test_seed_*` failures are unrelated to this issue)
- [ ] `cd backend && python -m pytest --cov=app --cov-fail-under=60` — exits 0
- [ ] `cd backend && python -m pytest tests/tasks/test_scanning_tasks.py tests/tasks/test_sync_tasks.py tests/tasks/test_quality_tasks.py tests/tasks/test_trading_task_shells.py -v` — all new tests pass

## Out of scope

Pre-existing seed SQL defect (`dark-factory/seed/seed/01_scanner_configs.sql` missing `universe_id`) causes two `test_seed_*` failures — recorded in `out-of-scope.md`, not touched here.

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)