### PR TITLE
Add vite-env.d.ts scaffold file to frontend (scope spillover from #193)

### DIFF
--- a/codeindex.json
+++ b/codeindex.json
@@ -1,8 +1,8 @@
 {
   "meta": {
     "root": "markethawk/",
-    "total_files": 462,
-    "total_loc": 66680,
+    "total_files": 464,
+    "total_loc": 66835,
     "languages": [
       "python",
       "javascript",
@@ -23102,6 +23102,24 @@
       ]
     },
     {
+      "id": "frontend/src/utils/indicators.test.ts",
+      "type": "module",
+      "language": "typescript",
+      "framework": null,
+      "size": 165,
+      "loc": 165,
+      "group": 46,
+      "imports": [
+        "vitest",
+        "frontend/src/utils/indicators.ts"
+      ],
+      "layer": "frontend",
+      "direct_dependents": 0,
+      "transitive_dependents": 0,
+      "blast_score": 0.0,
+      "imported_by": []
+    },
+    {
       "id": "frontend/src/utils/indicators.ts",
       "type": "module",
       "language": "typescript",
@@ -23111,11 +23129,12 @@
       "group": 46,
       "imports": [],
       "layer": "frontend",
-      "direct_dependents": 1,
+      "direct_dependents": 2,
       "transitive_dependents": 7,
-      "blast_score": 4.5,
+      "blast_score": 5.5,
       "imported_by": [
-        "frontend/src/components/ui/StockChart.tsx"
+        "frontend/src/components/ui/StockChart.tsx",
+        "frontend/src/utils/indicators.test.ts"
       ],
       "symbols": [
         {
@@ -23137,6 +23156,21 @@
           "exported": true
         }
       ]
+    },
+    {
+      "id": "frontend/src/vite-env.d.ts",
+      "type": "module",
+      "language": "typescript",
+      "framework": null,
+      "size": 2,
+      "loc": 2,
+      "group": 32,
+      "imports": [],
+      "layer": "frontend",
+      "direct_dependents": 0,
+      "transitive_dependents": 0,
+      "blast_score": 0.0,
+      "imported_by": []
     },
     {
       "id": "frontend/vite.config.ts",
@@ -23491,9 +23525,9 @@
       "group": 9000,
       "imports": [],
       "layer": "frontend",
-      "direct_dependents": 22,
+      "direct_dependents": 23,
       "transitive_dependents": 0,
-      "blast_score": 22.0,
+      "blast_score": 23.0,
       "imported_by": [
         "frontend/src/api/client.test.ts",
         "frontend/src/components/Layout.test.tsx",
@@ -23516,6 +23550,7 @@
         "frontend/src/pages/Login/Login.test.tsx",
         "frontend/src/pages/Scanner/ScanConfigPanel.test.tsx",
         "frontend/src/pages/Scanner/Scanner.test.tsx",
+        "frontend/src/utils/indicators.test.ts",
         "frontend/vitest.config.ts"
       ]
     },
@@ -45609,8 +45644,8 @@
       "type": "service",
       "language": "docker",
       "image": "",
-      "size": 26,
-      "loc": 26,
+      "size": 33,
+      "loc": 33,
       "group": 12,
       "imports": [
         "python"
@@ -56140,6 +56175,18 @@
     {
       "source": "frontend/src/test-utils/renderWithQuery.tsx",
       "target": "react",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "frontend/src/utils/indicators.test.ts",
+      "target": "vitest",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "frontend/src/utils/indicators.test.ts",
+      "target": "frontend/src/utils/indicators.ts",
       "weight": 1,
       "kind": "imports"
     },

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
Automated implementation for issue #226.

## Preview
- Frontend: http://localhost:10233
- Backend API: http://mh-preview-226-backend-1:8000/docs

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #226"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #226"
```

---
*Generated by MarketHawk Dark Factory*