### PR TITLE
Dark-factory scope-enforcement over-reports ruff/isort reformatting of touched files as scope spillover

### DIFF
--- a/.archon/memory/dark-factory-ops.md
+++ b/.archon/memory/dark-factory-ops.md
@@ -25,6 +25,10 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 
 - [AVOID] Do not embed data directly in Alembic migration files — migrations are schema-only. Feature-specific seed data goes in `dark-factory/seed/99_feature.sql` (idempotent, `ON CONFLICT DO NOTHING`). Data needed across multiple features goes in a new numbered baseline module. <!-- bootstrap date:2026-06-02 expires:2026-12-02 source:implement -->
 
+## Diff Computation
+
+- [PATTERN] When fetching base file content to compute a formatter delta for a `main...HEAD` three-dot diff, use `git merge-base main HEAD` for the base ref, then `git show "$MERGE_BASE:{filepath}"`. Using `git show "main:{filepath}"` references main's current tip — on branches where main later updated the file, the wrong base produces false positives (feature hunk mis-classified as formatter-only) or false negatives. path:dark-factory/scripts/fmt_hunk_filter.py <!-- issue:#276 date:2026-06-11 expires:2026-12-11 source:implement -->
+
 ## Scope Enforcement
 
 - [PATTERN] When an out-of-scope defect is noticed during implementation, write it to `$ARTIFACTS_DIR/out-of-scope.md` with `- <file>: <one-sentence description>` and leave the defect unfixed. The conformance gate reads this file and converts each entry into a `scope-spillover`-labelled backlog ticket automatically. <!-- issue:#206 date:2026-06-04 expires:2026-12-04 source:implement -->

--- a/codeindex.json
+++ b/codeindex.json
@@ -1,8 +1,8 @@
 {
   "meta": {
     "root": "markethawk/",
-    "total_files": 483,
-    "total_loc": 68630,
+    "total_files": 487,
+    "total_loc": 69460,
     "languages": [
       "python",
       "javascript",
@@ -15134,6 +15134,78 @@
       ]
     },
     {
+      "id": "dark-factory/scripts/fmt_hunk_filter.py",
+      "type": "module",
+      "language": "python",
+      "size": 289,
+      "loc": 289,
+      "group": 22,
+      "imports": [
+        "difflib",
+        "os",
+        "re",
+        "shutil",
+        "subprocess",
+        "sys",
+        "tempfile"
+      ],
+      "layer": "backend",
+      "direct_dependents": 0,
+      "transitive_dependents": 0,
+      "blast_score": 0.0,
+      "imported_by": [],
+      "symbols": [
+        {
+          "name": "parse_file_hunks",
+          "line": 32,
+          "kind": "function",
+          "exported": true,
+          "doc": "Return list of hunk dicts for one file from a unified diff."
+        },
+        {
+          "name": "overlaps",
+          "line": 61,
+          "kind": "function",
+          "exported": true,
+          "doc": "True if the old-file line ranges of two hunks overlap."
+        },
+        {
+          "name": "_apply_hunk",
+          "line": 69,
+          "kind": "function",
+          "exported": false,
+          "doc": "Return lines produced by hunk: added lines and context lines (no removed)."
+        },
+        {
+          "name": "is_formatter_only",
+          "line": 83,
+          "kind": "function",
+          "exported": true,
+          "doc": "Check if applying actual hunk to base_lines produces the same file content"
+        },
+        {
+          "name": "_run_formatter",
+          "line": 126,
+          "kind": "function",
+          "exported": false,
+          "doc": "Apply ruff format + ruff check --fix --select I to content, return result."
+        },
+        {
+          "name": "filter_diff",
+          "line": 169,
+          "kind": "function",
+          "exported": true,
+          "doc": "Strip formatter-only hunks from raw_diff for each file in py_files."
+        },
+        {
+          "name": "main",
+          "line": 269,
+          "kind": "function",
+          "exported": true
+        }
+      ]
+    },
+    {
       "id": "dark-factory/tests/test_code_review_command.py",
       "type": "module",
       "language": "python",
@@ -15321,6 +15393,252 @@
           "line": 6,
           "kind": "function",
           "exported": true
+        }
+      ]
+    },
+    {
+      "id": "dark-factory/tests/test_conformance_formatter_step.py",
+      "type": "module",
+      "language": "python",
+      "size": 40,
+      "loc": 40,
+      "group": 23,
+      "imports": [
+        "pathlib"
+      ],
+      "layer": "backend",
+      "direct_dependents": 0,
+      "transitive_dependents": 0,
+      "blast_score": 0.0,
+      "imported_by": [],
+      "symbols": [
+        {
+          "name": "test_step_30_invokes_filter_script",
+          "line": 9,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_step_30_guards_on_ruff_absence_via_script",
+          "line": 14,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_step_30_writes_py_files_list",
+          "line": 20,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_step_30_pre_triage_annotation_variable",
+          "line": 26,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_step_31_uses_triaged_diff",
+          "line": 32,
+          "kind": "function",
+          "exported": true
+        }
+      ]
+    },
+    {
+      "id": "dark-factory/tests/test_conformance_prompt_formatter_rule.py",
+      "type": "module",
+      "language": "python",
+      "size": 24,
+      "loc": 24,
+      "group": 23,
+      "imports": [
+        "pathlib"
+      ],
+      "layer": "backend",
+      "direct_dependents": 0,
+      "transitive_dependents": 0,
+      "blast_score": 0.0,
+      "imported_by": [],
+      "symbols": [
+        {
+          "name": "test_formatter_exception_rule_present",
+          "line": 9,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_formatter_rule_precedes_oos_bullet_format",
+          "line": 17,
+          "kind": "function",
+          "exported": true
+        }
+      ]
+    },
+    {
+      "id": "dark-factory/tests/test_fmt_hunk_filter.py",
+      "type": "module",
+      "language": "python",
+      "size": 477,
+      "loc": 477,
+      "group": 23,
+      "imports": [
+        "sys",
+        "textwrap",
+        "pathlib",
+        "unittest",
+        "fmt_hunk_filter"
+      ],
+      "layer": "backend",
+      "direct_dependents": 0,
+      "transitive_dependents": 0,
+      "blast_score": 0.0,
+      "imported_by": [],
+      "symbols": [
+        {
+          "name": "test_parse_file_hunks_returns_two_hunks",
+          "line": 41,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_parse_file_hunks_captures_hunk_lines",
+          "line": 46,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_parse_file_hunks_unknown_file_returns_empty",
+          "line": 53,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_overlaps_true_when_adjacent",
+          "line": 61,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_overlaps_false_when_disjoint",
+          "line": 68,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "_make_hunk",
+          "line": 79,
+          "kind": "function",
+          "exported": false,
+          "doc": "Build a hunk dict with the given body (list of diff lines, no @@ header)."
+        },
+        {
+          "name": "test_apply_hunk_produces_added_and_context_lines",
+          "line": 90,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_apply_hunk_skips_removed_lines",
+          "line": 100,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_is_formatter_only_true_for_reorder_despite_different_diff_grouping",
+          "line": 112,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_is_formatter_only_false_when_actual_adds_feature_line",
+          "line": 128,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_is_formatter_only_false_when_no_overlap",
+          "line": 142,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "_make_mock_run",
+          "line": 177,
+          "kind": "function",
+          "exported": false
+        },
+        {
+          "name": "test_filter_diff_strips_formatter_only_hunk",
+          "line": 195,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_filter_diff_leaves_interleaved_hunk_intact",
+          "line": 205,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_filter_diff_new_file_skipped",
+          "line": 225,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_filter_diff_no_ruff_returns_raw",
+          "line": 247,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_is_formatter_only_true_when_second_formatter_hunk_matches",
+          "line": 258,
+          "kind": "function",
+          "exported": true,
+          "doc": "First overlapping fmt hunk doesn't match; second does \u2014 should still return True"
+        },
+        {
+          "name": "test_apply_hunk_ignores_no_newline_marker",
+          "line": 284,
+          "kind": "function",
+          "exported": true,
+          "doc": "Lines starting with \\ (the diff no-newline marker) should be silently skipped."
+        },
+        {
+          "name": "test_run_formatter_returns_content_unchanged_on_ruff_format_error",
+          "line": 295,
+          "kind": "function",
+          "exported": true,
+          "doc": "If ruff format exits non-zero, _run_formatter returns the original content."
+        },
+        {
+          "name": "test_filter_diff_body_line_starting_with_triple_dash_not_treated_as_file_header",
+          "line": 317,
+          "kind": "function",
+          "exported": true,
+          "doc": "A removed body line whose content starts with '-- ' (diff line '--- ...') must n"
+        },
+        {
+          "name": "test_filter_diff_uses_merge_base_for_git_show",
+          "line": 364,
+          "kind": "function",
+          "exported": true,
+          "doc": "filter_diff must call git merge-base and use its SHA for git show."
+        },
+        {
+          "name": "test_run_formatter_returns_fmt_only_on_ruff_check_error",
+          "line": 404,
+          "kind": "function",
+          "exported": true,
+          "doc": "If ruff check returns rc>1, return post-format content (not partial isort fix)."
+        },
+        {
+          "name": "test_filter_diff_strips_hunk_with_function_context_in_header",
+          "line": 448,
+          "kind": "function",
+          "exported": true,
+          "doc": "Git sometimes adds optional context to @@ headers: '@@ -1,4 +1,4 @@ def foo():'."
         }
       ]
     },
@@ -16934,9 +17252,9 @@
       "group": 9000,
       "imports": [],
       "layer": "backend",
-      "direct_dependents": 20,
+      "direct_dependents": 21,
       "transitive_dependents": 56,
-      "blast_score": 48.0,
+      "blast_score": 49.0,
       "imported_by": [
         "backend/app/alembic/env.py",
         "backend/app/core/celery_app.py",
@@ -16956,6 +17274,7 @@
         "backend/tests/tasks/test_scheduled_scanner_tasks.py",
         "backend/tests/test_auth_core.py",
         "backend/tests/test_config.py",
+        "dark-factory/scripts/fmt_hunk_filter.py",
         "services/tweet-monitor/tests/test_classifier.py",
         "services/tweet-monitor/tests/test_extractor.py"
       ]
@@ -16969,9 +17288,9 @@
       "group": 9000,
       "imports": [],
       "layer": "backend",
-      "direct_dependents": 11,
+      "direct_dependents": 13,
       "transitive_dependents": 2,
-      "blast_score": 12.0,
+      "blast_score": 14.0,
       "imported_by": [
         "backend/app/alembic/env.py",
         "backend/live_scanner/main.py",
@@ -16979,7 +17298,9 @@
         "backend/scripts/generate_schema_doc.py",
         "backend/scripts/scratch_erd.py",
         "dark-factory/scripts/code_review_payload.py",
+        "dark-factory/scripts/fmt_hunk_filter.py",
         "dark-factory/tests/test_code_review_payload.py",
+        "dark-factory/tests/test_fmt_hunk_filter.py",
         "scripts/fetch_metrics.py",
         "scripts/render_report.py",
         "services/tweet-monitor/tests/test_classifier.py",
@@ -18153,12 +18474,13 @@
       "group": 9000,
       "imports": [],
       "layer": "backend",
-      "direct_dependents": 7,
+      "direct_dependents": 8,
       "transitive_dependents": 1,
-      "blast_score": 7.5,
+      "blast_score": 8.5,
       "imported_by": [
         "backend/app/services/catalyst_parser.py",
         "dark-factory/scripts/code_review_payload.py",
+        "dark-factory/scripts/fmt_hunk_filter.py",
         "scripts/fetch_metrics.py",
         "services/tweet-monitor/app/classifier.py",
         "services/tweet-monitor/app/extractor.py",
@@ -18452,9 +18774,9 @@
       "group": 9000,
       "imports": [],
       "layer": "backend",
-      "direct_dependents": 35,
+      "direct_dependents": 36,
       "transitive_dependents": 0,
-      "blast_score": 35.0,
+      "blast_score": 36.0,
       "imported_by": [
         "backend/tests/api/conftest.py",
         "backend/tests/api/test_analysis.py",
@@ -18490,7 +18812,8 @@
         "backend/tests/tasks/test_scheduled_scanner_tasks.py",
         "backend/tests/tasks/test_slippage.py",
         "backend/tests/tasks/test_sync_tasks.py",
-        "backend/tests/tasks/test_trading_task_shells.py"
+        "backend/tests/tasks/test_trading_task_shells.py",
+        "dark-factory/tests/test_fmt_hunk_filter.py"
       ]
     },
     {
@@ -18804,9 +19127,9 @@
       "group": 9000,
       "imports": [],
       "layer": "backend",
-      "direct_dependents": 12,
+      "direct_dependents": 15,
       "transitive_dependents": 0,
-      "blast_score": 12.0,
+      "blast_score": 15.0,
       "imported_by": [
         "backend/tests/live_scanner/test_main_imports.py",
         "backend/tests/live_scanner/test_publisher.py",
@@ -18815,6 +19138,9 @@
         "dark-factory/tests/test_code_review_payload.py",
         "dark-factory/tests/test_code_review_prompt.py",
         "dark-factory/tests/test_config_code_review.py",
+        "dark-factory/tests/test_conformance_formatter_step.py",
+        "dark-factory/tests/test_conformance_prompt_formatter_rule.py",
+        "dark-factory/tests/test_fmt_hunk_filter.py",
         "dark-factory/tests/test_report_code_review_section.py",
         "dark-factory/tests/test_workflow_code_review.py",
         "scripts/render_report.py",
@@ -18839,6 +19165,74 @@
       ]
     },
     {
+      "id": "difflib",
+      "type": "import",
+      "language": "python",
+      "size": 40,
+      "loc": 0,
+      "group": 9000,
+      "imports": [],
+      "layer": "backend",
+      "direct_dependents": 1,
+      "transitive_dependents": 0,
+      "blast_score": 1.0,
+      "imported_by": [
+        "dark-factory/scripts/fmt_hunk_filter.py"
+      ]
+    },
+    {
+      "id": "shutil",
+      "type": "import",
+      "language": "python",
+      "size": 40,
+      "loc": 0,
+      "group": 9000,
+      "imports": [],
+      "layer": "backend",
+      "direct_dependents": 2,
+      "transitive_dependents": 0,
+      "blast_score": 2.0,
+      "imported_by": [
+        "dark-factory/scripts/fmt_hunk_filter.py",
+        "tests/scripts/test_render_report.py"
+      ]
+    },
+    {
+      "id": "subprocess",
+      "type": "import",
+      "language": "python",
+      "size": 40,
+      "loc": 0,
+      "group": 9000,
+      "imports": [],
+      "layer": "backend",
+      "direct_dependents": 4,
+      "transitive_dependents": 1,
+      "blast_score": 4.5,
+      "imported_by": [
+        "dark-factory/scripts/fmt_hunk_filter.py",
+        "dark-factory/tests/test_code_review_payload.py",
+        "scripts/fetch_metrics.py",
+        "tests/scripts/test_render_report.py"
+      ]
+    },
+    {
+      "id": "tempfile",
+      "type": "import",
+      "language": "python",
+      "size": 40,
+      "loc": 0,
+      "group": 9000,
+      "imports": [],
+      "layer": "backend",
+      "direct_dependents": 1,
+      "transitive_dependents": 0,
+      "blast_score": 1.0,
+      "imported_by": [
+        "dark-factory/scripts/fmt_hunk_filter.py"
+      ]
+    },
+    {
       "id": "code_review_payload",
       "type": "import",
       "language": "python",
@@ -18855,7 +19249,7 @@
       ]
     },
     {
-      "id": "subprocess",
+      "id": "textwrap",
       "type": "import",
       "language": "python",
       "size": 40,
@@ -18863,13 +19257,27 @@
       "group": 9000,
       "imports": [],
       "layer": "backend",
-      "direct_dependents": 3,
-      "transitive_dependents": 1,
-      "blast_score": 3.5,
+      "direct_dependents": 1,
+      "transitive_dependents": 0,
+      "blast_score": 1.0,
       "imported_by": [
-        "dark-factory/tests/test_code_review_payload.py",
-        "scripts/fetch_metrics.py",
-        "tests/scripts/test_render_report.py"
+        "dark-factory/tests/test_fmt_hunk_filter.py"
+      ]
+    },
+    {
+      "id": "fmt_hunk_filter",
+      "type": "import",
+      "language": "python",
+      "size": 40,
+      "loc": 0,
+      "group": 9000,
+      "imports": [],
+      "layer": "backend",
+      "direct_dependents": 1,
+      "transitive_dependents": 0,
+      "blast_score": 1.0,
+      "imported_by": [
+        "dark-factory/tests/test_fmt_hunk_filter.py"
       ]
     },
     {
@@ -18920,22 +19328,6 @@
       "imported_by": [
         "services/tweet-monitor/app/browser.py",
         "services/tweet-monitor/app/scraper.py"
-      ]
-    },
-    {
-      "id": "shutil",
-      "type": "import",
-      "language": "python",
-      "size": 40,
-      "loc": 0,
-      "group": 9000,
-      "imports": [],
-      "layer": "backend",
-      "direct_dependents": 1,
-      "transitive_dependents": 0,
-      "blast_score": 1.0,
-      "imported_by": [
-        "tests/scripts/test_render_report.py"
       ]
     },
     {
@@ -46443,6 +46835,54 @@
           "exported": true
         },
         {
+          "name": "parse_file_hunks",
+          "line": 32,
+          "kind": "function",
+          "exported": true,
+          "doc": "Return list of hunk dicts for one file from a unified diff."
+        },
+        {
+          "name": "overlaps",
+          "line": 61,
+          "kind": "function",
+          "exported": true,
+          "doc": "True if the old-file line ranges of two hunks overlap."
+        },
+        {
+          "name": "_apply_hunk",
+          "line": 69,
+          "kind": "function",
+          "exported": false,
+          "doc": "Return lines produced by hunk: added lines and context lines (no removed)."
+        },
+        {
+          "name": "is_formatter_only",
+          "line": 83,
+          "kind": "function",
+          "exported": true,
+          "doc": "Check if applying actual hunk to base_lines produces the same file content"
+        },
+        {
+          "name": "_run_formatter",
+          "line": 126,
+          "kind": "function",
+          "exported": false,
+          "doc": "Apply ruff format + ruff check --fix --select I to content, return result."
+        },
+        {
+          "name": "filter_diff",
+          "line": 169,
+          "kind": "function",
+          "exported": true,
+          "doc": "Strip formatter-only hunks from raw_diff for each file in py_files."
+        },
+        {
+          "name": "main",
+          "line": 269,
+          "kind": "function",
+          "exported": true
+        },
+        {
           "name": "test_command_wires_the_contract",
           "line": 6,
           "kind": "function",
@@ -46555,6 +46995,194 @@
           "line": 6,
           "kind": "function",
           "exported": true
+        },
+        {
+          "name": "test_step_30_invokes_filter_script",
+          "line": 9,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_step_30_guards_on_ruff_absence_via_script",
+          "line": 14,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_step_30_writes_py_files_list",
+          "line": 20,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_step_30_pre_triage_annotation_variable",
+          "line": 26,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_step_31_uses_triaged_diff",
+          "line": 32,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_formatter_exception_rule_present",
+          "line": 9,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_formatter_rule_precedes_oos_bullet_format",
+          "line": 17,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_parse_file_hunks_returns_two_hunks",
+          "line": 41,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_parse_file_hunks_captures_hunk_lines",
+          "line": 46,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_parse_file_hunks_unknown_file_returns_empty",
+          "line": 53,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_overlaps_true_when_adjacent",
+          "line": 61,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_overlaps_false_when_disjoint",
+          "line": 68,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "_make_hunk",
+          "line": 79,
+          "kind": "function",
+          "exported": false,
+          "doc": "Build a hunk dict with the given body (list of diff lines, no @@ header)."
+        },
+        {
+          "name": "test_apply_hunk_produces_added_and_context_lines",
+          "line": 90,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_apply_hunk_skips_removed_lines",
+          "line": 100,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_is_formatter_only_true_for_reorder_despite_different_diff_grouping",
+          "line": 112,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_is_formatter_only_false_when_actual_adds_feature_line",
+          "line": 128,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_is_formatter_only_false_when_no_overlap",
+          "line": 142,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "_make_mock_run",
+          "line": 177,
+          "kind": "function",
+          "exported": false
+        },
+        {
+          "name": "test_filter_diff_strips_formatter_only_hunk",
+          "line": 195,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_filter_diff_leaves_interleaved_hunk_intact",
+          "line": 205,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_filter_diff_new_file_skipped",
+          "line": 225,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_filter_diff_no_ruff_returns_raw",
+          "line": 247,
+          "kind": "function",
+          "exported": true
+        },
+        {
+          "name": "test_is_formatter_only_true_when_second_formatter_hunk_matches",
+          "line": 258,
+          "kind": "function",
+          "exported": true,
+          "doc": "First overlapping fmt hunk doesn't match; second does \u2014 should still return True"
+        },
+        {
+          "name": "test_apply_hunk_ignores_no_newline_marker",
+          "line": 284,
+          "kind": "function",
+          "exported": true,
+          "doc": "Lines starting with \\ (the diff no-newline marker) should be silently skipped."
+        },
+        {
+          "name": "test_run_formatter_returns_content_unchanged_on_ruff_format_error",
+          "line": 295,
+          "kind": "function",
+          "exported": true,
+          "doc": "If ruff format exits non-zero, _run_formatter returns the original content."
+        },
+        {
+          "name": "test_filter_diff_body_line_starting_with_triple_dash_not_treated_as_file_header",
+          "line": 317,
+          "kind": "function",
+          "exported": true,
+          "doc": "A removed body line whose content starts with '-- ' (diff line '--- ...') must n"
+        },
+        {
+          "name": "test_filter_diff_uses_merge_base_for_git_show",
+          "line": 364,
+          "kind": "function",
+          "exported": true,
+          "doc": "filter_diff must call git merge-base and use its SHA for git show."
+        },
+        {
+          "name": "test_run_formatter_returns_fmt_only_on_ruff_check_error",
+          "line": 404,
+          "kind": "function",
+          "exported": true,
+          "doc": "If ruff check returns rc>1, return post-format content (not partial isort fix)."
+        },
+        {
+          "name": "test_filter_diff_strips_hunk_with_function_context_in_header",
+          "line": 448,
+          "kind": "function",
+          "exported": true,
+          "doc": "Git sometimes adds optional context to @@ headers: '@@ -1,4 +1,4 @@ def foo():'."
         },
         {
           "name": "test_report_node_renders_code_review_section",
@@ -53996,6 +54624,48 @@
       "kind": "imports"
     },
     {
+      "source": "dark-factory/scripts/fmt_hunk_filter.py",
+      "target": "difflib",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "dark-factory/scripts/fmt_hunk_filter.py",
+      "target": "os",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "dark-factory/scripts/fmt_hunk_filter.py",
+      "target": "re",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "dark-factory/scripts/fmt_hunk_filter.py",
+      "target": "shutil",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "dark-factory/scripts/fmt_hunk_filter.py",
+      "target": "subprocess",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "dark-factory/scripts/fmt_hunk_filter.py",
+      "target": "sys",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "dark-factory/scripts/fmt_hunk_filter.py",
+      "target": "tempfile",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
       "source": "dark-factory/tests/test_code_review_command.py",
       "target": "pathlib",
       "weight": 1,
@@ -54046,6 +54716,48 @@
     {
       "source": "dark-factory/tests/test_config_code_review.py",
       "target": "yaml",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "dark-factory/tests/test_conformance_formatter_step.py",
+      "target": "pathlib",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "dark-factory/tests/test_conformance_prompt_formatter_rule.py",
+      "target": "pathlib",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "dark-factory/tests/test_fmt_hunk_filter.py",
+      "target": "sys",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "dark-factory/tests/test_fmt_hunk_filter.py",
+      "target": "textwrap",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "dark-factory/tests/test_fmt_hunk_filter.py",
+      "target": "pathlib",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "dark-factory/tests/test_fmt_hunk_filter.py",
+      "target": "unittest",
+      "weight": 1,
+      "kind": "imports"
+    },
+    {
+      "source": "dark-factory/tests/test_fmt_hunk_filter.py",
+      "target": "fmt_hunk_filter",
       "weight": 1,
       "kind": "imports"
     },

--- a/dark-factory/scripts/fmt_hunk_filter.py
+++ b/dark-factory/scripts/fmt_hunk_filter.py
@@ -127,8 +127,7 @@ def _run_formatter(content):
     """Apply ruff format + ruff check --fix --select I to content, return result.
 
     Passes --config backend/pyproject.toml so the formatter uses the project's
-    line-length (88) and rule-set — temp files in /tmp/ are outside the project
-    tree and ruff won't auto-discover the config from there.
+    line-length (88) and rule-set regardless of where the temp file lands.
     """
     with tempfile.NamedTemporaryFile(
         suffix=".py", mode="w", delete=False, encoding="utf-8"
@@ -147,6 +146,8 @@ def _run_formatter(content):
                 file=sys.stderr,
             )
             return content
+        with open(tmp, encoding="utf-8") as f:
+            fmt_only = f.read()  # post-ruff-format, pre-isort
         result = subprocess.run(
             ["ruff", "check", "--fix", "--select", "I",
              "--config", "backend/pyproject.toml", tmp],
@@ -155,9 +156,10 @@ def _run_formatter(content):
         if result.returncode > 1:
             print(
                 f"[fmt_hunk_filter] ruff check warning (rc={result.returncode})"
-                " — using partial result",
+                " — skipping isort delta for this file",
                 file=sys.stderr,
             )
+            return fmt_only
         with open(tmp, encoding="utf-8") as f:
             return f.read()
     finally:
@@ -173,14 +175,25 @@ def filter_diff(raw_diff, py_files):
     if not shutil.which("ruff"):
         return raw_diff, []
 
-    headers_to_strip = {}  # filepath → set of hunk header strings to remove
+    headers_to_strip = {}  # filepath → set of (old_start, old_count) tuples to remove
+
+    merge_base_proc = subprocess.run(
+        ["git", "merge-base", "main", "HEAD"], capture_output=True
+    )
+    merge_base = (
+        merge_base_proc.stdout.decode().strip()
+        if merge_base_proc.returncode == 0
+        else "main"
+    )
 
     for filepath in py_files:
         actual_hunks = parse_file_hunks(raw_diff, filepath)
         if not actual_hunks:
             continue
 
-        proc = subprocess.run(["git", "show", f"main:{filepath}"], capture_output=True)
+        proc = subprocess.run(
+            ["git", "show", f"{merge_base}:{filepath}"], capture_output=True
+        )
         if proc.returncode != 0:
             continue  # new file — no base version to compare against
 
@@ -206,7 +219,7 @@ def filter_diff(raw_diff, py_files):
             continue
 
         to_strip = {
-            ah["header"]
+            (ah["old_start"], ah["old_count"])
             for ah in actual_hunks
             if is_formatter_only(ah, fmt_hunks, base_lines)
         }
@@ -235,9 +248,11 @@ def filter_diff(raw_diff, py_files):
             skip = False
             output.append(line)
         elif cur_file and cur_file in headers_to_strip:
-            m = re.match(r"^@@ ", line)
+            m = re.match(r"^@@ -(\d+)(?:,(\d+))? \+", line)
             if m:
-                skip = line in headers_to_strip[cur_file]
+                old_start = int(m.group(1))
+                old_count = int(m.group(2) or 1)
+                skip = (old_start, old_count) in headers_to_strip[cur_file]
             if not skip:
                 output.append(line)
         else:

--- a/dark-factory/tests/test_fmt_hunk_filter.py
+++ b/dark-factory/tests/test_fmt_hunk_filter.py
@@ -178,9 +178,13 @@ def _make_mock_run(base_content, formatted_content):
     def _run(args, **kwargs):
         mock = MagicMock()
         mock.returncode = 0
-        mock.stdout = base_content.encode() if "show" in args else b""
+        if "merge-base" in args:
+            mock.stdout = b"deadbeef1234\n"
+        elif "show" in args:
+            mock.stdout = base_content.encode()
+        else:
+            mock.stdout = b""
         if "format" in args or "check" in args:
-            import os as _os
             tmpfile = args[-1]
             with open(tmpfile, "w", encoding="utf-8") as f:
                 f.write(formatted_content)
@@ -351,3 +355,122 @@ def test_filter_diff_body_line_starting_with_triple_dash_not_treated_as_file_hea
     # Pre-fix: it would appear because the reconstruction loop misidentified it as a
     # file header and reset skip=False.
     assert "--- deprecated" not in filtered
+
+
+# ---------------------------------------------------------------------------
+# Fix 5: filter_diff — use merge-base for git show, not main's tip
+# ---------------------------------------------------------------------------
+
+def test_filter_diff_uses_merge_base_for_git_show():
+    """filter_diff must call git merge-base and use its SHA for git show."""
+    calls = []
+
+    def _mock_run_capture(args, **kwargs):
+        mock = MagicMock()
+        calls.append(list(args))
+        if "merge-base" in args:
+            mock.returncode = 0
+            mock.stdout = b"abc123\n"
+        elif "show" in args:
+            mock.returncode = 0
+            mock.stdout = BASE_CONTENT.encode()
+        else:
+            mock.returncode = 0
+            mock.stdout = b""
+        if "format" in args or "check" in args:
+            tmpfile = args[-1]
+            with open(tmpfile, "w", encoding="utf-8") as f:
+                f.write(FORMATTED_CONTENT)
+        return mock
+
+    with patch("fmt_hunk_filter.subprocess.run", side_effect=_mock_run_capture):
+        with patch("fmt_hunk_filter.shutil.which", return_value="/usr/bin/ruff"):
+            fhf.filter_diff(FMT_DIFF, ["backend/app/core/tracing.py"])
+
+    merge_base_calls = [c for c in calls if "merge-base" in c]
+    assert len(merge_base_calls) == 1, "merge-base must be called exactly once"
+
+    show_calls = [c for c in calls if "show" in c]
+    assert len(show_calls) >= 1
+    # git show must use the merge-base SHA, not "main"
+    assert any("abc123:backend/app/core/tracing.py" in " ".join(c) for c in show_calls)
+    assert not any("main:backend/app/core/tracing.py" in " ".join(c) for c in show_calls)
+
+
+# ---------------------------------------------------------------------------
+# Fix 7: _run_formatter — rc>1 from ruff check returns post-format content
+# ---------------------------------------------------------------------------
+
+def test_run_formatter_returns_fmt_only_on_ruff_check_error(capsys):
+    """If ruff check returns rc>1, return post-format content (not partial isort fix)."""
+    content = "import os\nprint('hello')\n"
+    fmt_content = "import os\n\nprint('hello')\n"  # post-format, pre-isort
+    isort_content = "import os\n\nprint('ISORT_APPLIED')\n"  # partial isort fix
+
+    call_count = [0]
+
+    def _mock_run(args, **kwargs):
+        m = MagicMock()
+        call_count[0] += 1
+        if "format" in args:
+            m.returncode = 0
+            m.stdout = b""
+            tmpfile = args[-1]
+            with open(tmpfile, "w", encoding="utf-8") as f:
+                f.write(fmt_content)
+        elif "check" in args:
+            m.returncode = 2  # real error (not just "fixes applied")
+            m.stdout = b""
+            # Writes partial isort content — should NOT be returned
+            tmpfile = args[-1]
+            with open(tmpfile, "w", encoding="utf-8") as f:
+                f.write(isort_content)
+        else:
+            m.returncode = 0
+            m.stdout = b""
+        return m
+
+    with patch("fmt_hunk_filter.subprocess.run", side_effect=_mock_run):
+        result = fhf._run_formatter(content)
+
+    # Must return fmt_only, not the partial isort_content
+    assert result == fmt_content
+    assert result != isort_content
+    captured = capsys.readouterr()
+    assert "warning" in captured.err.lower() or "fmt_hunk_filter" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Fix 8: reconstruction loop — hunk keyed by (old_start, old_count) tuple,
+# so @@ headers with optional function context still match correctly.
+# ---------------------------------------------------------------------------
+
+def test_filter_diff_strips_hunk_with_function_context_in_header():
+    """
+    Git sometimes adds optional context to @@ headers: '@@ -1,4 +1,4 @@ def foo():'.
+    With string-based keying, a mismatch between the parsed header and the raw diff
+    line would prevent stripping. With tuple-based keying on (old_start, old_count),
+    the strip is range-based and immune to the optional context suffix.
+    """
+    # Raw diff has function context in the @@ header
+    diff_with_context = textwrap.dedent("""\
+        diff --git a/backend/app/core/tracing.py b/backend/app/core/tracing.py
+        index aaa..bbb 100644
+        --- a/backend/app/core/tracing.py
+        +++ b/backend/app/core/tracing.py
+        @@ -1,4 +1,4 @@ def module_init():
+        -import os
+        -import sys
+        +import sys
+        +import os
+         x = 1
+         y = 2
+    """)
+
+    with patch("fmt_hunk_filter.subprocess.run", side_effect=_make_mock_run(BASE_CONTENT, FORMATTED_CONTENT)):
+        with patch("fmt_hunk_filter.shutil.which", return_value="/usr/bin/ruff"):
+            filtered, stripped = fhf.filter_diff(diff_with_context, ["backend/app/core/tracing.py"])
+
+    # The formatter-only hunk should be stripped despite the function context in the header
+    assert "backend/app/core/tracing.py" in stripped
+    assert "@@ -1,4" not in filtered


### PR DESCRIPTION
Closes omniscient/dark-factory#95

## Summary
Automated implementation for issue omniscient/dark-factory#95.

## Preview
_No preview environment — this change does not affect the running app ('Changeset contains only agent/workflow config, metadata artifacts, dark-factory infrastructure scripts, and tests — no backend/frontend code, migrations, dependencies, or Docker changes that would require a preview stack (postgres, redis, backend, frontend, celery) for validation.')._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#95"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#95"
```

---
*Generated by MarketHawk Dark Factory*