### PR TITLE
feat(factory): configurable concurrent-run limit via FACTORY_WIP_LIMIT

### DIFF
--- a/dark-factory/entrypoint.sh
+++ b/dark-factory/entrypoint.sh
@@ -51,15 +51,20 @@ ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oP '#\K\d+' | head -1)
 INTENT=$(echo "$ARGUMENTS" | grep -oiP '^\s*\K(fix|continue|close|refine|plan|deconflict)' | head -1 | tr '[:upper:]' '[:lower:]')
 INTENT=${INTENT:-fix}
 
-# --- Concurrency guard: only one factory container at a time ---
+# --- Concurrency guard: cap factory containers at FACTORY_WIP_LIMIT ---
+# RUNNING counts OTHER run containers (self excluded), so at-capacity is
+# RUNNING >= limit. Must stay in sync with the scheduler's capacity guard —
+# the scheduler dispatches into free slots and this backstop must not veto
+# them (#347). The var arrives via the service env_file (.archon/.env).
+FACTORY_WIP_LIMIT="${FACTORY_WIP_LIMIT:-1}"
 MY_ID=$(cat /proc/self/cgroup 2>/dev/null | grep -oP '[a-f0-9]{64}' | head -1 || hostname)
 RUNNING=$(docker ps --format '{{.ID}} {{.Names}}' 2>/dev/null \
   | grep 'markethawk-dark-factory-run-' \
   | grep -vc "${MY_ID:0:12}" || true)
 RUNNING=${RUNNING:-0}
-if [ "$RUNNING" -gt 0 ]; then
-  echo "ERROR: Another dark factory container is already running. Only one allowed at a time (Claude Max rate limit)." >&2
-  echo "       Use 'docker ps --filter name=dark-factory' to see it." >&2
+if [ "$RUNNING" -ge "$FACTORY_WIP_LIMIT" ]; then
+  echo "ERROR: ${RUNNING} other dark factory container(s) already running — at FACTORY_WIP_LIMIT=${FACTORY_WIP_LIMIT}." >&2
+  echo "       Use 'docker ps --filter name=dark-factory' to see them." >&2
   exit 1
 fi
 

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -12,6 +12,9 @@ DIRECT_TO_PR_LABEL="${DIRECT_TO_PR_LABEL:-direct-to-pr}"
 SPEC_GRACE_MINUTES="${SPEC_GRACE_MINUTES:-30}"
 PLAN_GRACE_MINUTES="${PLAN_GRACE_MINUTES:-30}"
 CONFLICT_RESOLUTION_ENABLED="${CONFLICT_RESOLUTION_ENABLED:-true}"
+# Max concurrent factory containers, any run type (implement/refine/plan/deconflict/
+# close). Override in .archon/.env — takes effect on scheduler recreate, no rebuild.
+FACTORY_WIP_LIMIT="${FACTORY_WIP_LIMIT:-1}"
 
 # Board constants
 PROJECT_NUMBER=1
@@ -113,6 +116,11 @@ is_issue_running() {
 
 count_factory_running() {
   docker ps --format '{{.Names}}' 2>/dev/null | grep -c 'markethawk-dark-factory-run-' || true
+}
+
+# True when the running factory-container count ($1) has reached FACTORY_WIP_LIMIT.
+factory_at_capacity() {
+  [ "$1" -ge "$FACTORY_WIP_LIMIT" ]
 }
 
 count_refine_running() {
@@ -629,7 +637,7 @@ trap '_sched_err_trap' ERR
 WIP_DATA=$(fetch_wip_limits)
 MAX_IN_PROGRESS=$(get_column_limit "$WIP_DATA" "$STATUS_IN_PROGRESS")
 MAX_IN_REVIEW=$(get_column_limit "$WIP_DATA" "$STATUS_IN_REVIEW")
-echo "WIP limits: in_progress=${MAX_IN_PROGRESS} in_review=${MAX_IN_REVIEW}"
+echo "WIP limits: in_progress=${MAX_IN_PROGRESS} in_review=${MAX_IN_REVIEW} factory=${FACTORY_WIP_LIMIT}"
 
 # --- Startup probe: verify factory image is available locally ---
 # `docker compose run` does not build inline by default, so a missing image causes every
@@ -716,19 +724,21 @@ ${FAIL_LIST}
     CI_BLOCKED="${CI_BLOCKED} ${ISSUE} "
   done < <(echo "$IN_REVIEW" | jq -c '.[]')
 
-  # Guard: only one factory container at a time (Claude Max rate limit). Everything
-  # below DISPATCHES factory work, so it waits for the current run; the CI gate above
-  # has already run regardless of factory activity.
+  # Guard: cap concurrent factory containers at FACTORY_WIP_LIMIT (Claude Max 5h-window
+  # burn scales with concurrency — default 1, override in .archon/.env). Everything
+  # below DISPATCHES factory work, so it waits for a free slot; the CI gate above has
+  # already run regardless of factory activity.
   FACTORY_RUNNING=$(count_factory_running)
-  if [ "$FACTORY_RUNNING" -gt 0 ]; then
-    echo "[$(date -u +%FT%TZ)] skip=factory_running count=${FACTORY_RUNNING}"
+  if factory_at_capacity "$FACTORY_RUNNING"; then
+    echo "[$(date -u +%FT%TZ)] skip=factory_at_capacity running=${FACTORY_RUNNING}/${FACTORY_WIP_LIMIT}"
     sleep "$POLL_INTERVAL"
     continue
   fi
 
   # --- Sweep: recover orphaned "In progress" items ---
-  # We only reach here when no factory container is running (FACTORY_RUNNING guard
-  # above), so any issue still in "In progress" was abandoned mid-run. The usual
+  # We reach here whenever a factory slot is free (capacity guard above). An issue in
+  # "In progress" whose container is alive is skipped by is_issue_running below; one
+  # with no container was abandoned mid-run. The usual
   # failure path (entrypoint on_failure -> Blocked) cannot fire for untrappable
   # deaths — host reboot, OOM/SIGKILL — so those issues would otherwise sit stuck
   # forever and silently consume a WIP slot. Route them into the Blocked retry path,
@@ -938,9 +948,9 @@ This issue was left in **In progress** with no running factory container — the
   # --- Log cycle summary ---
   BUDGET=$(gh api rate_limit --jq '.resources.graphql | "\(.used)/\(.limit)"' 2>/dev/null) || BUDGET="?"
   if [ -n "$DISPATCHED" ]; then
-    echo "[$(date -u +%FT%TZ)] backlog=${BACKLOG_COUNT} refined=${REFINED_COUNT} in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} refine_running=${REFINE_RUNNING}/${REFINE_WIP_LIMIT} dispatched=\"${DISPATCHED}\" graphql=${BUDGET}"
+    echo "[$(date -u +%FT%TZ)] backlog=${BACKLOG_COUNT} refined=${REFINED_COUNT} in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} factory_running=${FACTORY_RUNNING}/${FACTORY_WIP_LIMIT} refine_running=${REFINE_RUNNING}/${REFINE_WIP_LIMIT} dispatched=\"${DISPATCHED}\" graphql=${BUDGET}"
   else
-    echo "[$(date -u +%FT%TZ)] backlog=${BACKLOG_COUNT} refined=${REFINED_COUNT} in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} refine_running=${REFINE_RUNNING}/${REFINE_WIP_LIMIT} skip=nothing_to_do graphql=${BUDGET}"
+    echo "[$(date -u +%FT%TZ)] backlog=${BACKLOG_COUNT} refined=${REFINED_COUNT} in_progress=${IN_PROGRESS_COUNT}/${MAX_IN_PROGRESS} in_review=${IN_REVIEW_COUNT}/${MAX_IN_REVIEW} factory_running=${FACTORY_RUNNING}/${FACTORY_WIP_LIMIT} refine_running=${REFINE_RUNNING}/${REFINE_WIP_LIMIT} skip=nothing_to_do graphql=${BUDGET}"
   fi
 
   sleep "$POLL_INTERVAL"

--- a/dark-factory/tests/test_scheduler.sh
+++ b/dark-factory/tests/test_scheduler.sh
@@ -620,6 +620,35 @@ dispatch() { echo "dispatch $*" >> "$STUB_LOG"; return 0; }
 export -f gh get_pr_for_issue is_issue_running check_pr_mergeable dispatch
 
 # ==========================================
+# L: factory_at_capacity / FACTORY_WIP_LIMIT
+# ==========================================
+echo ""
+echo "--- L: factory_at_capacity ---"
+
+assert_eq "L0: FACTORY_WIP_LIMIT defaults to 1" "1" "${FACTORY_WIP_LIMIT:-}"
+
+FACTORY_WIP_LIMIT=1
+factory_at_capacity 0 \
+  && assert_eq "L1: 0 running, limit 1 → below capacity" "0" "1" \
+  || assert_eq "L1: 0 running, limit 1 → below capacity" "0" "0"
+factory_at_capacity 1 \
+  && assert_eq "L2: 1 running, limit 1 → at capacity" "0" "0" \
+  || assert_eq "L2: 1 running, limit 1 → at capacity" "0" "1"
+
+FACTORY_WIP_LIMIT=2
+factory_at_capacity 1 \
+  && assert_eq "L3: 1 running, limit 2 → below capacity" "0" "1" \
+  || assert_eq "L3: 1 running, limit 2 → below capacity" "0" "0"
+factory_at_capacity 2 \
+  && assert_eq "L4: 2 running, limit 2 → at capacity" "0" "0" \
+  || assert_eq "L4: 2 running, limit 2 → at capacity" "0" "1"
+factory_at_capacity 3 \
+  && assert_eq "L5: 3 running, limit 2 → at capacity" "0" "0" \
+  || assert_eq "L5: 3 running, limit 2 → at capacity" "0" "1"
+
+FACTORY_WIP_LIMIT=1
+
+# ==========================================
 # Cleanup
 # ==========================================
 rm -f "$STATE_FILE" "$STUB_LOG"

--- a/docs/superpowers/plans/2026-06-11-factory-concurrency-limit.md
+++ b/docs/superpowers/plans/2026-06-11-factory-concurrency-limit.md
@@ -1,0 +1,214 @@
+# Dark Factory Configurable Concurrency Limit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the backlog scheduler run up to `FACTORY_WIP_LIMIT` concurrent dark-factory containers (default 1, locally set to 2), changeable via `.archon/.env` without an image rebuild.
+
+**Architecture:** `dark-factory/scheduler.sh` gains a `FACTORY_WIP_LIMIT` config var and a tiny `factory_at_capacity()` helper; the hardcoded "any running container → skip cycle" guard in the main loop calls the helper instead. The helper lives above the `SCHEDULER_SOURCE_ONLY` line so the existing bash unit-test harness can source and test it. No compose changes: the scheduler already loads `.archon/.env` via `env_file`.
+
+**Tech Stack:** Bash, Docker Compose. Tests: `dark-factory/tests/test_scheduler.sh` (sourced-function harness with stubs, run via `bash`).
+
+**Spec:** `docs/superpowers/specs/2026-06-11-factory-concurrency-limit-design.md` · **Ticket:** #347
+
+---
+
+### Task 1: `factory_at_capacity()` + `FACTORY_WIP_LIMIT` (TDD)
+
+**Files:**
+- Modify: `dark-factory/scheduler.sh` (config block ~line 14, helpers ~line 116, startup log ~line 632, main-loop guard ~lines 719–727, orphan-sweep comment ~lines 729–735, cycle-summary echoes ~lines 940–944)
+- Test: `dark-factory/tests/test_scheduler.sh` (new section L, insert before the `Cleanup` section at the bottom)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `dark-factory/tests/test_scheduler.sh`, insert immediately before the `# Cleanup` section (after section K's stub-restore block):
+
+```bash
+# ==========================================
+# L: factory_at_capacity / FACTORY_WIP_LIMIT
+# ==========================================
+echo ""
+echo "--- L: factory_at_capacity ---"
+
+assert_eq "L0: FACTORY_WIP_LIMIT defaults to 1" "1" "${FACTORY_WIP_LIMIT:-}"
+
+FACTORY_WIP_LIMIT=1
+factory_at_capacity 0 \
+  && assert_eq "L1: 0 running, limit 1 → below capacity" "0" "1" \
+  || assert_eq "L1: 0 running, limit 1 → below capacity" "0" "0"
+factory_at_capacity 1 \
+  && assert_eq "L2: 1 running, limit 1 → at capacity" "0" "0" \
+  || assert_eq "L2: 1 running, limit 1 → at capacity" "0" "1"
+
+FACTORY_WIP_LIMIT=2
+factory_at_capacity 1 \
+  && assert_eq "L3: 1 running, limit 2 → below capacity" "0" "1" \
+  || assert_eq "L3: 1 running, limit 2 → below capacity" "0" "0"
+factory_at_capacity 2 \
+  && assert_eq "L4: 2 running, limit 2 → at capacity" "0" "0" \
+  || assert_eq "L4: 2 running, limit 2 → at capacity" "0" "1"
+factory_at_capacity 3 \
+  && assert_eq "L5: 3 running, limit 2 → at capacity" "0" "0" \
+  || assert_eq "L5: 3 running, limit 2 → at capacity" "0" "1"
+
+FACTORY_WIP_LIMIT=1
+```
+
+(The `&& assert / || assert` pattern matches sections D/H — `assert_eq "desc" "0" "0"` records pass, `"0" "1"` records fail.)
+
+- [ ] **Step 2: Run tests to verify the new section fails**
+
+Run: `bash dark-factory/tests/test_scheduler.sh`
+Expected: L0 FAILs (`expected='1' got=''`); L1–L5 fail with `factory_at_capacity: command not found` (counted as FAIL or visible as command errors). All pre-existing sections A–K still PASS. Final line shows non-zero failed count.
+
+- [ ] **Step 3: Implement in `dark-factory/scheduler.sh`**
+
+3a. Config block — after the `CONFLICT_RESOLUTION_ENABLED` line (line 14), add:
+
+```bash
+# Max concurrent factory containers, any run type (implement/refine/plan/deconflict/
+# close). Override in .archon/.env — takes effect on scheduler recreate, no rebuild.
+FACTORY_WIP_LIMIT="${FACTORY_WIP_LIMIT:-1}"
+```
+
+3b. Helper — directly below `count_factory_running()` (after line 116), add:
+
+```bash
+# True when the running factory-container count ($1) has reached FACTORY_WIP_LIMIT.
+factory_at_capacity() {
+  [ "$1" -ge "$FACTORY_WIP_LIMIT" ]
+}
+```
+
+3c. Main-loop guard — replace lines 719–727:
+
+```bash
+  # Guard: only one factory container at a time (Claude Max rate limit). Everything
+  # below DISPATCHES factory work, so it waits for the current run; the CI gate above
+  # has already run regardless of factory activity.
+  FACTORY_RUNNING=$(count_factory_running)
+  if [ "$FACTORY_RUNNING" -gt 0 ]; then
+    echo "[$(date -u +%FT%TZ)] skip=factory_running count=${FACTORY_RUNNING}"
+    sleep "$POLL_INTERVAL"
+    continue
+  fi
+```
+
+with:
+
+```bash
+  # Guard: cap concurrent factory containers at FACTORY_WIP_LIMIT (Claude Max 5h-window
+  # burn scales with concurrency — default 1, override in .archon/.env). Everything
+  # below DISPATCHES factory work, so it waits for a free slot; the CI gate above has
+  # already run regardless of factory activity.
+  FACTORY_RUNNING=$(count_factory_running)
+  if factory_at_capacity "$FACTORY_RUNNING"; then
+    echo "[$(date -u +%FT%TZ)] skip=factory_at_capacity running=${FACTORY_RUNNING}/${FACTORY_WIP_LIMIT}"
+    sleep "$POLL_INTERVAL"
+    continue
+  fi
+```
+
+3d. Orphan-sweep comment — in the comment block starting `# --- Sweep: recover orphaned "In progress" items ---` (~line 729), replace the two sentences:
+
+```
+  # We only reach here when no factory container is running (FACTORY_RUNNING guard
+  # above), so any issue still in "In progress" was abandoned mid-run. The usual
+```
+
+with:
+
+```
+  # We reach here whenever a factory slot is free (capacity guard above). An issue in
+  # "In progress" whose container is alive is skipped by is_issue_running below; one
+  # with no container was abandoned mid-run. The usual
+```
+
+3e. Startup WIP log line (~line 632) — replace:
+
+```bash
+echo "WIP limits: in_progress=${MAX_IN_PROGRESS} in_review=${MAX_IN_REVIEW}"
+```
+
+with:
+
+```bash
+echo "WIP limits: in_progress=${MAX_IN_PROGRESS} in_review=${MAX_IN_REVIEW} factory=${FACTORY_WIP_LIMIT}"
+```
+
+3f. Cycle-summary echoes (~lines 940–944) — in BOTH the `dispatched=` and `skip=nothing_to_do` echo lines, insert `factory_running=${FACTORY_RUNNING}/${FACTORY_WIP_LIMIT} ` immediately before `refine_running=`.
+
+- [ ] **Step 4: Run tests to verify everything passes**
+
+Run: `bash dark-factory/tests/test_scheduler.sh`
+Expected: all sections A–L PASS, `Results: N passed, 0 failed`, exit 0.
+
+Also run the other two suites (they source the same script and must not regress):
+`bash dark-factory/tests/test_159_regression.sh && bash dark-factory/tests/test_has_new_comment_after_report.sh`
+Expected: 0 failed in each.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dark-factory/scheduler.sh dark-factory/tests/test_scheduler.sh
+git commit -m "feat(factory): configurable concurrent-run limit via FACTORY_WIP_LIMIT (#347)"
+```
+
+---
+
+### Task 2: Set local limit to 2 in `.archon/.env`
+
+**Files:**
+- Modify: `.archon/.env` (gitignored — verify with `git check-ignore .archon/.env` before editing; do NOT commit)
+
+- [ ] **Step 1: Append the override**
+
+Add this line to `.archon/.env` (Edit tool, or append preserving existing content — never truncate this file, it holds secrets):
+
+```bash
+FACTORY_WIP_LIMIT=2
+```
+
+- [ ] **Step 2: Confirm it is not staged**
+
+Run: `git status --short .archon/`
+Expected: no output (file ignored).
+
+---
+
+### Task 3: Rebuild image, recreate scheduler, validate live
+
+`scheduler.sh` is baked into the shared dark-factory image, so this needs one rebuild. The same image serves dispatched factory runs (which don't read this var) — harmless.
+
+- [ ] **Step 1: Rebuild and recreate**
+
+```bash
+docker compose --profile scheduler build backlog-scheduler
+docker compose --profile scheduler up -d --force-recreate backlog-scheduler
+```
+
+Expected: build succeeds; `backlog-scheduler` container recreated and running.
+
+- [ ] **Step 2: Validate startup + cycle logs**
+
+Run: `docker logs backlog-scheduler --tail 30`
+Expected:
+- `WIP limits: in_progress=999 in_review=999 factory=2`
+- `Backlog scheduler started (poll every 60s)`
+- cycle summary lines containing `factory_running=0/2` (or `1/2` if a run is active), OR `skip=factory_at_capacity running=2/2` once both slots fill.
+- No `SCHED_UNHANDLED_ERR` lines.
+
+- [ ] **Step 3: Validate the changeability story (the actual feature)**
+
+Flip the knob down and back to prove env-only changes work without rebuild:
+
+```bash
+# Temporarily set FACTORY_WIP_LIMIT=1 in .archon/.env, then:
+docker compose --profile scheduler up -d backlog-scheduler
+docker logs backlog-scheduler --tail 5
+```
+
+Expected: compose recreates the container (env change detected) and the new startup line shows `factory=1`. Restore `FACTORY_WIP_LIMIT=2` and `up -d` again; expect `factory=2`.
+
+- [ ] **Step 4: Post plan summary + close out ticket #347**
+
+Comment on the ticket (use a temp file + `--body-file`, never a heredoc): one-paragraph summary of the change, the commit SHA, and the validation evidence from Steps 2–3. Push `main` (`git push`) so the committed default ships.

--- a/docs/superpowers/specs/2026-06-11-factory-concurrency-limit-design.md
+++ b/docs/superpowers/specs/2026-06-11-factory-concurrency-limit-design.md
@@ -1,0 +1,74 @@
+# Dark Factory — Configurable Concurrent Run Limit
+
+**Date:** 2026-06-11
+**Status:** Approved
+
+## Problem
+
+The backlog scheduler serializes all dark-factory work: the guard in
+`dark-factory/scheduler.sh` skips every dispatch cycle whenever *any*
+`markethawk-dark-factory-run-*` container is running. Throughput is capped at
+one ticket at a time, and the only way to change that is to edit a baked-in
+script and rebuild the image. The existing `REFINE_WIP_LIMIT=2` is unreachable
+in practice because this guard blocks at 1 total container first.
+
+## Decision
+
+Replace the hardcoded "any running container → skip" guard with an env-driven
+limit on **total concurrent factory containers** (all run types: implement,
+refine, plan, deconflict, close).
+
+- New config var in `scheduler.sh`: `FACTORY_WIP_LIMIT="${FACTORY_WIP_LIMIT:-1}"`
+- Guard becomes: `if [ "$FACTORY_RUNNING" -ge "$FACTORY_WIP_LIMIT" ]; then skip cycle`
+- Committed default stays **1** (safe for the Claude Max 5h window).
+- Local value **2** set in `.archon/.env` (gitignored), which is already the
+  scheduler's `env_file` — no compose change needed.
+
+## How to change the limit later
+
+1. Edit `FACTORY_WIP_LIMIT` in `.archon/.env`
+2. `docker compose --profile scheduler up -d backlog-scheduler`
+   (compose recreates the container on env change; no image rebuild)
+
+## Changes
+
+1. `dark-factory/scheduler.sh`
+   - Add `FACTORY_WIP_LIMIT` to the configuration block.
+   - Change the factory-concurrency guard to compare against the limit; update
+     its comment (it currently cites "only one factory container at a time").
+   - Update the orphaned-in-progress sweep comment: its claim "we only reach
+     here when no factory container is running" no longer holds. The sweep
+     remains correct because it already checks `is_issue_running` per issue.
+   - Add `factory_running=${FACTORY_RUNNING}/${FACTORY_WIP_LIMIT}` to the
+     per-cycle summary log line for observability.
+2. `.archon/.env` (local only, not committed): `FACTORY_WIP_LIMIT=2`
+
+No changes to `docker-compose.yml`, the dispatch path, retry/circuit-breaker
+state, or board WIP-limit parsing.
+
+## Behaviour under concurrency 2
+
+- One dispatch per poll cycle is unchanged, so the second run starts on the
+  next 60s poll — a natural stagger.
+- `REFINE_WIP_LIMIT=2` becomes reachable (e.g. 1 implement + 1 refine, or
+  2 refines).
+- Per-issue duplicate-dispatch prevention (`is_issue_running`) is unchanged and
+  still prevents two runs on the same ticket.
+
+## Accepted trade-offs
+
+- **Claude Max burn rate roughly doubles** while two runs are active; past runs
+  have exhausted the 5h window. Mitigation: dial `.archon/.env` back to 1.
+- **Host load**: two per-issue preview stacks may run simultaneously.
+- **More deconflict runs**: two PRs branched off the same main conflict more
+  often; the existing conflict-resolution pipeline handles this.
+
+## Validation
+
+1. Rebuild + recreate: `docker compose --profile scheduler build backlog-scheduler`
+   then `docker compose --profile scheduler up -d backlog-scheduler`.
+2. Startup log shows the scheduler running; cycle summary lines include
+   `factory_running=N/2`.
+3. With two Ready/Backlog-eligible tickets, observe two
+   `markethawk-dark-factory-run-*` containers within two poll cycles, and a
+   `skip=factory_running` line only once both slots are full.

--- a/docs/superpowers/specs/2026-06-11-factory-concurrency-limit-design.md
+++ b/docs/superpowers/specs/2026-06-11-factory-concurrency-limit-design.md
@@ -41,10 +41,17 @@ refine, plan, deconflict, close).
      remains correct because it already checks `is_issue_running` per issue.
    - Add `factory_running=${FACTORY_RUNNING}/${FACTORY_WIP_LIMIT}` to the
      per-cycle summary log line for observability.
-2. `.archon/.env` (local only, not committed): `FACTORY_WIP_LIMIT=2`
+2. `dark-factory/entrypoint.sh` *(discovered during live validation)* — the
+   entrypoint has its own single-run mutex ("Another dark factory container is
+   already running") that vetoed scheduler dispatches into the second slot.
+   It now reads `FACTORY_WIP_LIMIT` (same default 1) and aborts only when the
+   count of *other* run containers is `>= limit`. The var reaches dispatched
+   containers via the service `env_file` (the scheduler's startup-provisioned
+   copy of `.archon/.env`).
+3. `.archon/.env` (local only, not committed): `FACTORY_WIP_LIMIT=2`
 
-No changes to `docker-compose.yml`, the dispatch path, retry/circuit-breaker
-state, or board WIP-limit parsing.
+No changes to `docker-compose.yml`, retry/circuit-breaker state, or board
+WIP-limit parsing.
 
 ## Behaviour under concurrency 2
 


### PR DESCRIPTION
## Summary
- Replace the backlog scheduler's hardcoded one-factory-container guard with an env-driven cap: `FACTORY_WIP_LIMIT` (committed default **1**; local override `2` in `.archon/.env`, the scheduler's `env_file`). Changing it later is a one-line env edit + `docker compose --profile scheduler up -d backlog-scheduler` — no image rebuild.
- Fix the second, baked-in mutex discovered during live validation: `entrypoint.sh` aborted any run when another factory container existed, vetoing scheduler dispatches into slot 2. It now honors the same `FACTORY_WIP_LIMIT` (default 1 = old behavior).
- Observability: startup line gains `factory=N`, cycle summaries gain `factory_running=N/limit`; orphan-sweep comment corrected for concurrency.
- Tests: new section L in `dark-factory/tests/test_scheduler.sh` (default + capacity boundaries).

## Validation (live)
- `WIP limits: in_progress=999 in_review=999 factory=2` on startup
- Two concurrent runs observed: pre-existing `…4f854368ce7a` + `Continue issue omniscient/markethawk#288` (`…54bd09de2ddd`) dispatched into slot 2, not vetoed by the entrypoint
- Dial-back proof without rebuild: env flip to 1 → `factory=1` + `skip=factory_at_capacity running=2/1`; flip back → `factory=2`
- All bash suites green: 65 + 7 + 5 passed, 0 failed

## Test Plan
- [x] `bash dark-factory/tests/test_scheduler.sh` — 65 passed, 0 failed (incl. new section L)
- [x] `bash dark-factory/tests/test_159_regression.sh` / `test_has_new_comment_after_report.sh` — green
- [x] Live: two concurrent factory containers under limit 2; at-capacity skip under limit 1

Closes omniscient/dark-factory#111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
