### PR TITLE
[arch-v3][MED] Tweet-monitor cookie auth: expiry alerting or official API (3 reviews unticketed)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -382,6 +382,34 @@ docker-compose down
 docker-compose up -d
 ```
 
+### Tweet-Monitor: X.com Cookie Rotation
+
+`X_AUTH_TOKEN` and `X_CSRF_TOKEN` are X.com session cookies that expire roughly every 30 days. When they expire, the tweet-monitor detects the `/i/flow/login` redirect and raises `AuthExpiredError`, setting `tweet_monitor_auth_ok = 0`.
+
+**Alert signature:**
+- Grafana alert `Tweet-Monitor Auth Expired` fires in the `MarketHawk / Infrastructure` panel
+- Seq error log: `@<handle>: auth expired — X.com redirected to login for @<handle>`
+- `/health` endpoint returns `"auth_expired": true, "healthy": false`
+
+**To rotate cookies:**
+
+1. Log in to X.com in Chrome (use the account the scraper monitors)
+2. Open DevTools → Application → Cookies → `https://x.com`
+3. Copy the value of `auth_token` → this is `X_AUTH_TOKEN`
+4. Copy the value of `ct0` → this is `X_CSRF_TOKEN`
+5. Update `.env`:
+   ```
+   X_AUTH_TOKEN=<new_auth_token>
+   X_CSRF_TOKEN=<new_ct0_value>
+   ```
+6. Restart the tweet-monitor container:
+   ```bash
+   docker-compose restart tweet-monitor
+   ```
+7. Verify recovery: `curl http://localhost:8001/health` should return `"auth_expired": false, "healthy": true`
+
+The `tweet_monitor_auth_ok` gauge returns to `1` on the next poll cycle (within 45 seconds) after a successful restart.
+
 ## Codeindex (local visualization)
 
 The symbol index (`symbolindex.json`) and dependency graph (`codeindex.json`) are committed

--- a/docs/codeindex-hotspots.md
+++ b/docs/codeindex-hotspots.md
@@ -5,7 +5,7 @@ Files with blast score ≥ 5.0  (31 found)
     41.5  frontend/src/api/scanner.ts  (31d / 21t)  809 loc
     31.0  frontend/src/components/ui/Card.tsx  (21d / 20t)  44 loc
     29.0  backend/app/routers/system.py  (2d / 54t)  141 loc
-    29.0  services/tweet-monitor/app/main.py  (2d / 54t)  247 loc
+    29.0  services/tweet-monitor/app/main.py  (2d / 54t)  266 loc
     27.0  backend/app/main.py  (1d / 52t)  507 loc
     27.0  backend/app/routers/futures.py  (1d / 52t)  188 loc
     27.0  backend/app/routers/scanner.py  (1d / 52t)  709 loc

--- a/grafana/provisioning/alerting/rules.yaml
+++ b/grafana/provisioning/alerting/rules.yaml
@@ -112,3 +112,31 @@ groups:
             model:
               type: math
               expression: $B > 5
+
+      - uid: tweet-monitor-auth-expired
+        title: Tweet-Monitor Auth Expired
+        condition: C
+        for: 2m
+        annotations:
+          summary: >
+            Tweet-monitor X.com cookie auth has been failing for 2+ minutes.
+            Rotate X_AUTH_TOKEN and X_CSRF_TOKEN in .env and restart tweet-monitor.
+        labels:
+          severity: warning
+        data:
+          - refId: B
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: tweet_monitor_auth_ok
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: "-- Grafana --"
+            model:
+              type: math
+              expression: $B < 1

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -7,3 +7,8 @@ scrape_configs:
     static_configs:
       - targets: ["backend:8000"]
     metrics_path: /metrics
+
+  - job_name: tweet_monitor
+    static_configs:
+      - targets: ["tweet-monitor:8000"]
+    metrics_path: /metrics

--- a/services/tweet-monitor/app/browser.py
+++ b/services/tweet-monitor/app/browser.py
@@ -153,10 +153,6 @@ class BrowserManager:
             logger.warning(f"Health check failed: {exc}")
             return False
 
-    def is_auth_expired(self) -> bool:
-        """Detect if X returned a login redirect (auth_expired)."""
-        return not settings.x_auth_token
-
     @property
     def age_seconds(self) -> float:
         if not self._started_at:

--- a/services/tweet-monitor/app/health.py
+++ b/services/tweet-monitor/app/health.py
@@ -9,6 +9,7 @@ import logging
 import redis
 from sqlalchemy import create_engine, text
 
+import app.state as state
 from app.browser import browser_manager
 from app.config import settings
 
@@ -19,7 +20,7 @@ _engine = create_engine(settings.database_url, pool_pre_ping=True)
 
 async def check_health() -> dict:
     browser_ok = browser_manager.is_running
-    auth_expired = not settings.x_auth_token or not settings.x_csrf_token
+    auth_expired = not state.auth_ok
 
     db_ok = _check_db()
     redis_ok = _check_redis()

--- a/services/tweet-monitor/app/main.py
+++ b/services/tweet-monitor/app/main.py
@@ -8,6 +8,7 @@ Endpoints:
   GET  /accounts          — List monitored accounts
   POST /accounts          — Create/update a monitored account
   POST /poll/{account_id} — Manual single-account trigger (debugging)
+  GET  /metrics           — Prometheus metrics
 """
 import asyncio
 import logging
@@ -18,9 +19,11 @@ from typing import Any
 
 import redis as redis_lib
 from fastapi import FastAPI, HTTPException
+from prometheus_client import Gauge, make_asgi_app
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+import app.state as state
 from app.browser import browser_manager
 from app.classifier import TweetClassifier
 from app.config import settings
@@ -31,7 +34,7 @@ from app.pipeline import SignalPipeline
 from app.schemas import (
     AccountCreate, AccountStatus, HealthResponse, PollSummary, StatusResponse,
 )
-from app.scraper import XProfileScraper
+from app.scraper import AuthExpiredError, XProfileScraper
 
 logging.basicConfig(level=settings.log_level.upper())
 logger = logging.getLogger(__name__)
@@ -58,11 +61,21 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="Tweet Monitor", lifespan=lifespan)
 
+TWEET_MONITOR_AUTH_OK = Gauge(
+    "tweet_monitor_auth_ok",
+    "1 = X.com cookie auth healthy, 0 = auth expired or login redirect detected",
+)
+TWEET_MONITOR_AUTH_OK.set(1)  # assume healthy at startup
+
+metrics_app = make_asgi_app()
+app.mount("/metrics", metrics_app)
+
 
 @app.post("/poll", response_model=PollSummary)
 async def poll_all():
     """Scrape all enabled accounts and process new tweets."""
     start = time.perf_counter()
+    state.auth_ok = True  # optimistic reset each cycle
     with _SessionLocal() as db:
         accounts = db.query(MonitoredAccount).filter(MonitoredAccount.enabled == True).all()
 
@@ -76,11 +89,17 @@ async def poll_all():
             promoted = await _poll_account(account, summary)
             summary.accounts_polled += 1
             summary.tweets_promoted += promoted
+        except AuthExpiredError as exc:
+            state.auth_ok = False
+            msg = f"@{account.handle}: auth expired — {exc}"
+            logger.error(msg)
+            errors.append(msg)
         except Exception as exc:
             msg = f"@{account.handle}: {exc}"
             logger.error(msg)
             errors.append(msg)
 
+    TWEET_MONITOR_AUTH_OK.set(1 if state.auth_ok else 0)
     summary.duration_ms = round((time.perf_counter() - start) * 1000, 1)
     summary.errors = errors
     return summary

--- a/services/tweet-monitor/app/scraper.py
+++ b/services/tweet-monitor/app/scraper.py
@@ -14,6 +14,10 @@ from playwright.async_api import Page
 
 from app.browser import browser_manager
 
+
+class AuthExpiredError(Exception):
+    """Raised when X.com redirects to the login flow (cookie expired)."""
+
 logger = logging.getLogger(__name__)
 
 # X DOM selectors (data-testid — more stable than class names)
@@ -39,8 +43,14 @@ class XProfileScraper:
             page = await browser_manager.new_page()
             url = _PROFILE_URL.format(handle=handle)
             await page.goto(url, timeout=_LOAD_TIMEOUT_MS, wait_until="domcontentloaded")
+
+            if "/i/flow/login" in page.url:
+                raise AuthExpiredError(f"X.com redirected to login for @{handle}")
+
             await page.wait_for_selector(_TWEET_ARTICLE, timeout=_LOAD_TIMEOUT_MS)
             raw = await self._extract_tweets(page)
+        except AuthExpiredError:
+            raise
         except Exception as exc:
             logger.error(f"Scrape failed for @{handle}: {exc}")
             return []

--- a/services/tweet-monitor/app/state.py
+++ b/services/tweet-monitor/app/state.py
@@ -1,0 +1,1 @@
+auth_ok: bool = True  # False = login redirect detected on last poll cycle

--- a/services/tweet-monitor/requirements.txt
+++ b/services/tweet-monitor/requirements.txt
@@ -8,3 +8,4 @@ httpx==0.27.2
 pydantic-settings==2.5.2
 seqlog==0.3.24
 psutil==6.0.0
+prometheus_client>=0.17

--- a/services/tweet-monitor/tests/test_health.py
+++ b/services/tweet-monitor/tests/test_health.py
@@ -1,0 +1,63 @@
+"""Unit tests for check_health() — runtime auth state."""
+import asyncio
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from unittest.mock import patch
+
+import app.state as state
+from app.health import check_health
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _mock_externals():
+    return [
+        patch("app.health._check_db", return_value=True),
+        patch("app.health._check_redis", return_value=True),
+        patch("app.health.browser_manager"),
+    ]
+
+
+def test_auth_expired_false_when_state_auth_ok_true():
+    state.auth_ok = True
+    patches = _mock_externals()
+    with patches[0], patches[1], patches[2] as mock_bm:
+        mock_bm.is_running = True
+        mock_bm.age_seconds = 10.0
+        result = _run(check_health())
+    assert result["auth_expired"] is False
+
+
+def test_auth_expired_true_when_state_auth_ok_false():
+    state.auth_ok = False
+    patches = _mock_externals()
+    with patches[0], patches[1], patches[2] as mock_bm:
+        mock_bm.is_running = True
+        mock_bm.age_seconds = 10.0
+        result = _run(check_health())
+    assert result["auth_expired"] is True
+    assert result["healthy"] is False
+
+
+def test_healthy_is_false_when_auth_expired():
+    state.auth_ok = False
+    patches = _mock_externals()
+    with patches[0], patches[1], patches[2] as mock_bm:
+        mock_bm.is_running = True
+        mock_bm.age_seconds = 10.0
+        result = _run(check_health())
+    assert result["healthy"] is False
+
+
+def test_healthy_is_true_when_all_ok():
+    state.auth_ok = True
+    patches = _mock_externals()
+    with patches[0], patches[1], patches[2] as mock_bm:
+        mock_bm.is_running = True
+        mock_bm.age_seconds = 10.0
+        result = _run(check_health())
+    assert result["healthy"] is True

--- a/services/tweet-monitor/tests/test_scraper.py
+++ b/services/tweet-monitor/tests/test_scraper.py
@@ -1,0 +1,65 @@
+"""Unit tests for XProfileScraper — auth expiry detection."""
+import asyncio
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.scraper import AuthExpiredError, XProfileScraper
+
+
+def _make_page(url="https://x.com/testhandle"):
+    page = AsyncMock()
+    page.url = url
+    page.goto = AsyncMock()
+    page.wait_for_selector = AsyncMock()
+    page.query_selector_all = AsyncMock(return_value=[])
+    page.close = AsyncMock()
+    return page
+
+
+def test_auth_expired_error_is_exception():
+    err = AuthExpiredError("test")
+    assert isinstance(err, Exception)
+
+
+def test_scrape_raises_auth_expired_on_login_redirect():
+    page = _make_page(url="https://x.com/i/flow/login?redirect_after_login=...")
+    with patch("app.scraper.browser_manager") as mock_bm:
+        mock_bm.new_page = AsyncMock(return_value=page)
+        scraper = XProfileScraper()
+        with pytest.raises(AuthExpiredError):
+            asyncio.run(scraper.scrape("testhandle"))
+
+
+def test_scrape_raises_auth_expired_on_exact_login_path():
+    page = _make_page(url="https://x.com/i/flow/login")
+    with patch("app.scraper.browser_manager") as mock_bm:
+        mock_bm.new_page = AsyncMock(return_value=page)
+        scraper = XProfileScraper()
+        with pytest.raises(AuthExpiredError):
+            asyncio.run(scraper.scrape("testhandle"))
+
+
+def test_scrape_returns_empty_list_on_non_auth_error():
+    page = _make_page(url="https://x.com/realDonaldTrump")
+    page.wait_for_selector = AsyncMock(side_effect=Exception("timeout"))
+    with patch("app.scraper.browser_manager") as mock_bm:
+        mock_bm.new_page = AsyncMock(return_value=page)
+        scraper = XProfileScraper()
+        result = asyncio.run(scraper.scrape("realDonaldTrump"))
+        assert result == []
+
+
+def test_scrape_does_not_raise_on_non_login_url():
+    page = _make_page(url="https://x.com/testhandle")
+    page.wait_for_selector = AsyncMock()
+    page.query_selector_all = AsyncMock(return_value=[])
+    with patch("app.scraper.browser_manager") as mock_bm:
+        mock_bm.new_page = AsyncMock(return_value=page)
+        scraper = XProfileScraper()
+        result = asyncio.run(scraper.scrape("testhandle"))
+        assert isinstance(result, list)


### PR DESCRIPTION
Closes #290

## Summary
Automated implementation for issue #290.

## Preview
⚠️ _Preview environment failed to start (preview failed: docker compose up --build failed (see preview_build.log tail below)) — endpoint validation was skipped; see the failure comment on the issue._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #290"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #290"
```

---
*Generated by MarketHawk Dark Factory*