### PR TITLE
fix(compose): remove duplicate volumes key on dark-factory service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -467,8 +467,6 @@ services:
       options:
         gelf-address: "udp://host.docker.internal:12201"
         tag: "dark-factory"
-    volumes:
-      - scheduler_state:/var/lib/dark-factory
     profiles:
       - factory
 


### PR DESCRIPTION
## What

Removes a duplicate `volumes:` mapping key on the `dark-factory` service in `docker-compose.yml`.

Closes omniscient/dark-factory#113

## Why

The merges of omniscient/dark-factory#100 (`00245bd`) and omniscient/dark-factory#101 (`ca85cb4`) each independently added the **identical** mount `scheduler_state:/var/lib/dark-factory` to the `dark-factory` service, at different positions in the service block. Git merged both without conflict, leaving two `volumes:` keys on one mapping. YAML rejects duplicate keys, so `docker compose` could not parse the file at all on `main`:

```
yaml: construct errors:
  line 470: mapping key "volumes" already defined at line 458
```

This blocked **every** `docker compose` operation against `main`, including rebuilding/recreating the `dark-factory` and `backlog-scheduler` services after a merge.

## The fix

The two blocks were byte-identical, so this removes the redundant second one and keeps the block paired with its companion `SEQ_URL` env from the same logical change. Net diff is a 2-line deletion.

## Verification

- `docker compose --profile scheduler --profile factory config --quiet` — parses with **no errors** (previously a hard parse failure).
- `dark-factory` resolves to a single `scheduler_state -> /var/lib/dark-factory` mount.
- `backlog-scheduler` image rebuilt against this branch (now includes the new `smoke_gate.sh` COPY from omniscient/dark-factory#100) and force-recreated — boots clean, passes its `image_ok` self-probe, polling every 60s.

## Follow-up (out of scope)

A `docker compose config` lint step in CI would catch duplicate-key parse errors before they reach `main`. Worth a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
