### PR TITLE
fix(factory): self-clear main-red sentinel via throttled Recheck main dispatch

### DIFF
--- a/dark-factory/entrypoint.sh
+++ b/dark-factory/entrypoint.sh
@@ -43,12 +43,15 @@ if [ -z "$ARGUMENTS" ]; then
   echo "       docker compose --profile factory run --rm dark-factory \"Close issue #3\""
   echo "       docker compose --profile factory run --rm dark-factory \"Refine issue #3\""
   echo "       docker compose --profile factory run --rm dark-factory \"Plan issue #3\""
+  echo "       docker compose --profile factory run --rm dark-factory \"Recheck main\""
   exit 1
 fi
 
 # --- Extract issue number and intent immediately (no AI needed) ---
-ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oP '#\K\d+' | head -1)
-INTENT=$(echo "$ARGUMENTS" | grep -oiP '^\s*\K(fix|continue|close|refine|plan|deconflict)' | head -1 | tr '[:upper:]' '[:lower:]')
+# "Recheck main" carries no "#N" — the || true keeps the no-match grep (exit 1)
+# from killing the script under set -euo pipefail.
+ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oP '#\K\d+' | head -1 || true)
+INTENT=$(echo "$ARGUMENTS" | grep -oiP '^\s*\K(fix|continue|close|refine|plan|deconflict|recheck)' | head -1 | tr '[:upper:]' '[:lower:]')
 INTENT=${INTENT:-fix}
 
 # --- Canonical run identity and artifact directory ---
@@ -530,12 +533,21 @@ fi
 pre-commit install --allow-missing-config 2>/dev/null || true
 
 # --- Smoke gate: verify origin/main is green before any per-ticket work ---
-# Applies to fix (new), continue, and deconflict (resolve) intents only.
+# Applies to fix (new), continue, deconflict (resolve), and recheck intents.
 # On red main: exits 0 (no per-ticket failure), files a regression ticket, writes sentinel.
 # On green: cleans up any prior red state and proceeds.
-if [ "$INTENT" = "fix" ] || [ "$INTENT" = "continue" ] || [ "$INTENT" = "deconflict" ]; then
+if [ "$INTENT" = "fix" ] || [ "$INTENT" = "continue" ] || [ "$INTENT" = "deconflict" ] || [ "$INTENT" = "recheck" ]; then
   source /opt/dark-factory/smoke_gate.sh
   run_smoke_gate
+fi
+
+# --- Recheck flow: the run exists solely to re-evaluate the gate (#365) ---
+# Reaching this line means the gate passed (on red, run_smoke_gate exits 0 inside
+# _smoke_on_red). _smoke_on_green has already cleared the sentinel and closed the
+# regression ticket — there is no per-ticket work to do.
+if [ "$INTENT" = "recheck" ]; then
+  echo "[recheck] main is green — sentinel cleared; done."
+  exit 0
 fi
 
 # =============================================================================

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -15,6 +15,12 @@ CONFLICT_RESOLUTION_ENABLED="${CONFLICT_RESOLUTION_ENABLED:-true}"
 # Max concurrent factory containers, any run type (implement/refine/plan/deconflict/
 # close). Override in .archon/.env — takes effect on scheduler recreate, no rebuild.
 FACTORY_WIP_LIMIT="${FACTORY_WIP_LIMIT:-1}"
+# While main-is-red is latched, dispatch a "Recheck main" run (clone + smoke gate
+# only) at most this often, so a green main clears the sentinel without waiting for
+# a human comment on an in-review PR (#365).
+MAIN_RED_RECHECK_ENABLED="${MAIN_RED_RECHECK_ENABLED:-true}"
+MAIN_RED_RECHECK_MINUTES="${MAIN_RED_RECHECK_MINUTES:-20}"
+RECHECK_STAMP_FILE="${SCHEDULER_STATE_DIR}/main-red-last-recheck"
 
 # Board constants
 PROJECT_NUMBER=1
@@ -121,6 +127,40 @@ count_factory_running() {
 # True when the running factory-container count ($1) has reached FACTORY_WIP_LIMIT.
 factory_at_capacity() {
   [ "$1" -ge "$FACTORY_WIP_LIMIT" ]
+}
+
+# True when a "Recheck main" container is already running (dedupe — recheck runs
+# carry no "#N", so is_issue_running cannot see them).
+is_recheck_running() {
+  docker ps --no-trunc --format '{{.Command}}' 2>/dev/null | grep -q 'Recheck main' && return 0
+  return 1
+}
+
+# True when the recheck throttle window has elapsed (or no recheck happened yet).
+# Throttled via the stamp file's mtime — survives scheduler restarts on the state volume.
+recheck_due() {
+  [ -f "$RECHECK_STAMP_FILE" ] || return 0
+  local last now
+  last=$(stat -c %Y "$RECHECK_STAMP_FILE" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  [ $(( now - last )) -ge $(( MAIN_RED_RECHECK_MINUTES * 60 )) ]
+}
+
+# --- Main-red self-clear: throttled "Recheck main" dispatch (#365) ---
+# The main-is-red sentinel pauses implementation dispatches, but the only code that
+# CLEARS it is _smoke_on_green() inside a dispatched container — and those dispatches
+# are exactly what the sentinel blocks. Without this, the latch is one-way: main goes
+# green and the factory stays paused until a human comments on an in-review PR.
+# Callers guarantee a free factory slot (runs after the capacity guard).
+main_red_recheck_check() {
+  [ "$MAIN_RED_RECHECK_ENABLED" = "true" ] || return 0
+  is_recheck_running && return 0
+  recheck_due || return 0
+  if dispatch "Recheck main"; then
+    DISPATCHED="Recheck main"
+    touch "$RECHECK_STAMP_FILE"
+    echo "[$(date -u +%FT%TZ)] main_red_recheck=dispatched interval=${MAIN_RED_RECHECK_MINUTES}m"
+  fi
 }
 
 count_refine_running() {
@@ -758,11 +798,13 @@ This issue was left in **In progress** with no running factory container — the
   done < <(echo "$IN_PROGRESS" | jq -c '.[]')
 
   # --- Read main-is-red sentinel (written by smoke_gate.sh in dispatched containers) ---
-  # When present, skip Priority 1.5/2/3 (implementation dispatches); 1/4/5 continue.
+  # When present, skip Priority 1.5/2/3 (implementation dispatches); 1/4/5 continue,
+  # and a throttled "Recheck main" run gives the gate a chance to self-clear (#365).
   MAIN_IS_RED=false
   [ -f "${SCHEDULER_STATE_DIR}/main-is-red" ] && MAIN_IS_RED=true
   if [ "$MAIN_IS_RED" = "true" ]; then
     echo "[$(date -u +%FT%TZ)] main_red_gate=active action=skip_implement_dispatch"
+    main_red_recheck_check
   fi
 
   # --- Priority 1.5: In Review items with merge conflicts (proactive auto-resolve) ---

--- a/dark-factory/smoke_gate.sh
+++ b/dark-factory/smoke_gate.sh
@@ -17,8 +17,17 @@ _smoke_check_main() {
     return 1
   fi
   echo "[smoke_gate] Checking backend Python import graph..."
+  # Settings() is instantiated at import time and requires DATABASE_URL /
+  # POLYGON_API_KEY / JWT_SECRET_KEY (>=32 chars; preview env contract, #190).
+  # The gate verifies the import graph compiles, NOT that config is real —
+  # without throwaway values the check is red in every factory container, so
+  # every fix/continue/deconflict run false-latches the sentinel (#365). Same
+  # pattern as docker-compose.preview.yml and ci.yml.
   if ! (cd "${CLONE_DIR:-/workspace/markethawk}/backend" \
-        && python -c "import app.main" 2>&1); then
+        && DATABASE_URL="postgresql://smoke:smoke@localhost:5432/smoke" \
+           POLYGON_API_KEY="smoke-gate-only-not-a-real-key" \
+           JWT_SECRET_KEY="smoke-gate-only-not-secret-0123456789abcdef" \
+           python -c "import app.main" 2>&1); then
     echo "[smoke_gate] python import FAILED — main is red"
     return 1
   fi

--- a/dark-factory/smoke_gate.sh
+++ b/dark-factory/smoke_gate.sh
@@ -30,6 +30,9 @@ _smoke_on_red() {
   echo "[smoke_gate] main is RED — halting factory run cleanly (exit 0, no per-ticket failure)"
   mkdir -p "${SMOKE_STATE_DIR}"
   touch "${SMOKE_STATE_DIR}/main-is-red"
+  # Stamp the recheck throttle: red was just confirmed, so the scheduler's first
+  # "Recheck main" dispatch (#365) should wait a full MAIN_RED_RECHECK_MINUTES.
+  touch "${SMOKE_STATE_DIR}/main-red-last-recheck"
 
   local ISSUE_FILE="${SMOKE_STATE_DIR}/main-is-red-issue"
   if [ -f "$ISSUE_FILE" ]; then
@@ -67,7 +70,7 @@ _smoke_on_green() {
     return 0
   fi
   echo "[smoke_gate] main is GREEN — removing red sentinel and closing regression ticket"
-  rm -f "${SMOKE_STATE_DIR}/main-is-red"
+  rm -f "${SMOKE_STATE_DIR}/main-is-red" "${SMOKE_STATE_DIR}/main-red-last-recheck"
 
   local ISSUE_FILE="${SMOKE_STATE_DIR}/main-is-red-issue"
   if [ -f "$ISSUE_FILE" ]; then

--- a/dark-factory/tests/test_scheduler.sh
+++ b/dark-factory/tests/test_scheduler.sh
@@ -14,6 +14,11 @@ set_board_status() { echo "set_board_status $*" >> "$STUB_LOG"; return 0; }
 export -f gh docker set_board_status
 
 # ---- Source scheduler helpers only ----
+# Point the state dir at a temp dir BEFORE sourcing: scheduler.sh derives STATE_FILE
+# and RECHECK_STAMP_FILE from it (and mkdir-s it), so tests must not touch the real
+# /var/lib/dark-factory.
+SCHEDULER_STATE_DIR=$(mktemp -d /tmp/sched-test-statedir-XXXXXX)
+export SCHEDULER_STATE_DIR
 STATE_FILE=$(mktemp /tmp/sched-test-state-XXXXXX.json)
 echo '{}' > "$STATE_FILE"
 export STATE_FILE
@@ -649,9 +654,80 @@ factory_at_capacity 3 \
 FACTORY_WIP_LIMIT=1
 
 # ==========================================
+# M: Main-red recheck self-clear (#365)
+# ==========================================
+echo ""
+echo "--- M: main-red recheck self-clear ---"
+> "$STUB_LOG"
+DISPATCHED=""
+
+dispatch() { echo "dispatch $*" >> "$STUB_LOG"; return 0; }
+is_recheck_running() { return 1; }
+export -f dispatch is_recheck_running
+
+# M1: no stamp → due
+rm -f "$RECHECK_STAMP_FILE"
+recheck_due \
+  && assert_eq "M1: no stamp → due" "0" "0" \
+  || assert_eq "M1: no stamp → due" "0" "1"
+
+# M2: fresh stamp → throttled
+touch "$RECHECK_STAMP_FILE"
+recheck_due \
+  && assert_eq "M2: fresh stamp → throttled" "0" "1" \
+  || assert_eq "M2: fresh stamp → throttled" "0" "0"
+
+# M3: stale stamp (older than MAIN_RED_RECHECK_MINUTES=20) → due
+touch -d "25 minutes ago" "$RECHECK_STAMP_FILE"
+recheck_due \
+  && assert_eq "M3: stale stamp → due" "0" "0" \
+  || assert_eq "M3: stale stamp → due" "0" "1"
+
+# M4: due → dispatches "Recheck main", sets DISPATCHED, refreshes the stamp
+rm -f "$RECHECK_STAMP_FILE"; DISPATCHED=""
+main_red_recheck_check
+assert_eq "M4: Recheck main dispatched" \
+  "1" "$(grep -c 'dispatch Recheck main' "$STUB_LOG" || echo 0)"
+assert_eq "M4: DISPATCHED set" "Recheck main" "$DISPATCHED"
+[ -f "$RECHECK_STAMP_FILE" ] \
+  && assert_eq "M4: stamp refreshed" "0" "0" \
+  || assert_eq "M4: stamp refreshed" "0" "1"
+
+# M5: stamp fresh from M4 → throttled, no dispatch
+> "$STUB_LOG"; DISPATCHED=""
+main_red_recheck_check
+assert_eq "M5: throttled → no dispatch" \
+  "0" "$(grep -c 'dispatch' "$STUB_LOG" || true)"
+
+# M6: recheck container already running → no dispatch even when due
+> "$STUB_LOG"; DISPATCHED=""
+rm -f "$RECHECK_STAMP_FILE"
+is_recheck_running() { return 0; }
+export -f is_recheck_running
+main_red_recheck_check
+assert_eq "M6: running recheck → no dispatch" \
+  "0" "$(grep -c 'dispatch' "$STUB_LOG" || true)"
+
+# M7: kill switch off → no dispatch even when due
+> "$STUB_LOG"; DISPATCHED=""
+is_recheck_running() { return 1; }
+export -f is_recheck_running
+MAIN_RED_RECHECK_ENABLED=false
+main_red_recheck_check
+assert_eq "M7: kill switch → no dispatch" \
+  "0" "$(grep -c 'dispatch' "$STUB_LOG" || true)"
+MAIN_RED_RECHECK_ENABLED=true
+
+# Restore stubs
+is_recheck_running() { return 1; }
+dispatch() { echo "dispatch $*" >> "$STUB_LOG"; return 0; }
+export -f is_recheck_running dispatch
+
+# ==========================================
 # Cleanup
 # ==========================================
 rm -f "$STATE_FILE" "$STUB_LOG"
+rm -rf "$SCHEDULER_STATE_DIR"
 echo ""
 echo "Results: ${PASSED} passed, ${FAILED} failed"
 [ "$FAILED" -eq 0 ]

--- a/dark-factory/tests/test_smoke_gate.sh
+++ b/dark-factory/tests/test_smoke_gate.sh
@@ -86,6 +86,7 @@ rm -f "${SMOKE_STATE_DIR}/main-is-red" "${SMOKE_STATE_DIR}/main-is-red-issue"
 
 assert_file_exists "sentinel file created" "${SMOKE_STATE_DIR}/main-is-red"
 assert_file_exists "issue number file created" "${SMOKE_STATE_DIR}/main-is-red-issue"
+assert_file_exists "recheck throttle stamp created on red (#365)" "${SMOKE_STATE_DIR}/main-red-last-recheck"
 GH_CREATES=$(grep -c "gh.*issue create" "$STUB_LOG" 2>/dev/null || true)
 assert_eq "gh issue create called once on first red" "1" "$GH_CREATES"
 
@@ -113,6 +114,7 @@ GATE_RC=0
 assert_eq "gate exits/returns 0 on green" "0" "$GATE_RC"
 assert_file_absent "sentinel removed on green" "${SMOKE_STATE_DIR}/main-is-red"
 assert_file_absent "issue number file removed on green" "${SMOKE_STATE_DIR}/main-is-red-issue"
+assert_file_absent "recheck throttle stamp removed on green (#365)" "${SMOKE_STATE_DIR}/main-red-last-recheck"
 GH_CLOSES=$(grep -c "gh.*issue close" "$STUB_LOG" 2>/dev/null || true)
 assert_eq "gh issue close called once" "1" "$GH_CLOSES"
 
@@ -123,10 +125,10 @@ TSC_FAIL=1; export TSC_FAIL
 > "$STUB_LOG"
 rm -f "${SMOKE_STATE_DIR}/main-is-red" "${SMOKE_STATE_DIR}/main-is-red-issue"
 
-# Mirror the entrypoint.sh intent guard: only fix/continue/deconflict trigger the gate
+# Mirror the entrypoint.sh intent guard: only fix/continue/deconflict/recheck trigger the gate
 for INTENT in refine plan close; do
   export INTENT
-  if [ "$INTENT" = "fix" ] || [ "$INTENT" = "continue" ] || [ "$INTENT" = "deconflict" ]; then
+  if [ "$INTENT" = "fix" ] || [ "$INTENT" = "continue" ] || [ "$INTENT" = "deconflict" ] || [ "$INTENT" = "recheck" ]; then
     (run_smoke_gate) || true
   fi
 done
@@ -134,6 +136,26 @@ done
 TSC_CALLS=$(grep -cE "npx|tsc" "$STUB_LOG" 2>/dev/null || true)
 assert_eq "no tsc calls for refine/plan/close" "0" "$TSC_CALLS"
 assert_file_absent "no sentinel created for skip intents" "${SMOKE_STATE_DIR}/main-is-red"
+
+# ---- Phase 4: Recheck intent (#365) — runs the gate and clears red state on green ----
+echo ""
+echo "--- Phase 4: Recheck intent clears latched red state on green ---"
+TSC_FAIL=0; PY_FAIL=0; export TSC_FAIL PY_FAIL
+> "$STUB_LOG"
+touch "${SMOKE_STATE_DIR}/main-is-red" "${SMOKE_STATE_DIR}/main-red-last-recheck"
+echo "999" > "${SMOKE_STATE_DIR}/main-is-red-issue"
+
+INTENT=recheck; export INTENT
+if [ "$INTENT" = "fix" ] || [ "$INTENT" = "continue" ] || [ "$INTENT" = "deconflict" ] || [ "$INTENT" = "recheck" ]; then
+  (run_smoke_gate) || true
+fi
+
+TSC_CALLS4=$(grep -c "npx" "$STUB_LOG" 2>/dev/null || true)
+assert_eq "recheck intent runs the gate (tsc called)" "1" "$TSC_CALLS4"
+assert_file_absent "sentinel removed by green recheck" "${SMOKE_STATE_DIR}/main-is-red"
+assert_file_absent "throttle stamp removed by green recheck" "${SMOKE_STATE_DIR}/main-red-last-recheck"
+GH_CLOSES4=$(grep -c "gh.*issue close" "$STUB_LOG" 2>/dev/null || true)
+assert_eq "regression ticket closed by green recheck" "1" "$GH_CLOSES4"
 
 # ---- Summary ----
 echo ""

--- a/dark-factory/tests/test_smoke_gate.sh
+++ b/dark-factory/tests/test_smoke_gate.sh
@@ -33,7 +33,17 @@ npx() { echo "npx $*" >> "$STUB_LOG"; return "$TSC_FAIL"; }
 # shellcheck disable=SC2317
 python() {
   echo "python $*" >> "$STUB_LOG"
-  if echo "$*" | grep -q "import app"; then return "$PY_FAIL"; fi
+  if echo "$*" | grep -q "import app"; then
+    # Mimic import-time Settings() (#190/#365): app.main cannot even import
+    # unless the harness supplies the required env vars (JWT >= 32 chars) —
+    # regardless of whether the code itself is green.
+    local jwt="${JWT_SECRET_KEY:-}"
+    if [ -z "${DATABASE_URL:-}" ] || [ -z "${POLYGON_API_KEY:-}" ] || [ "${#jwt}" -lt 32 ]; then
+      echo "python_import_env_missing" >> "$STUB_LOG"
+      return 1
+    fi
+    return "$PY_FAIL"
+  fi
   return 0
 }
 # shellcheck disable=SC2317


### PR DESCRIPTION
## Problem

Closes omniscient/dark-factory#114.

Two stacked defects kept the dark factory paused:

### 1. The main-red latch is one-way

`smoke_gate.sh` writes the `main-is-red` sentinel and the scheduler correctly pauses implementation dispatches (Priority 1.5/2/3) — but the only code that clears the sentinel is `_smoke_on_green()`, which runs inside dispatched `fix`/`continue`/`deconflict` containers: exactly the dispatches the sentinel blocks. The only organic escape is a human comment on an in-review PR.

### 2. The gate's python check can never pass in a factory container (found validating this fix live)

`Settings()` is instantiated at **import time** (`app/core/config.py`) and requires `DATABASE_URL`, `POLYGON_API_KEY`, and `JWT_SECRET_KEY` (≥32 chars) — none of which the run container sets. So `python -c "import app.main"` fails with a `ValidationError` in every factory run **regardless of code state**. Both of today's latches (#361 at 11:38, omniscient/markethawk#364 at 12:23 — the latter two minutes after a manual sentinel clear) were this false positive. The smoke gate is the one harness that missed the preview env contract (#190).

Reproduced in `ghcr.io/omniscient/markethawk-dark-factory:latest` against a fresh clone: pip install clean, import fails with 3 validation errors, tsc passes.

## Fix

**Self-clear (commit 1):** while the sentinel is latched, the scheduler dispatches a dedicated **`Recheck main`** run — clone + deps + smoke gate, nothing else — at most every `MAIN_RED_RECHECK_MINUTES` (default 20). On green, the existing `_smoke_on_green()` removes the sentinel and auto-closes the regression ticket; on red, the existing `_smoke_on_red()` posts the "still red" update and halts cleanly.

**Honest gate (commit 2):** the import check now supplies throwaway env values scoped to that single command, mirroring the not-secret pattern in `docker-compose.preview.yml` and `ci.yml`. The gate verifies the import graph compiles, not that config is real.

### Changes

| File | Change |
|---|---|
| `dark-factory/scheduler.sh` | `main_red_recheck_check()` called from the sentinel block (after the capacity guard, so a slot is guaranteed). Throttled via stamp-file mtime on the state volume; deduped via `is_recheck_running()`; kill switch `MAIN_RED_RECHECK_ENABLED`. |
| `dark-factory/entrypoint.sh` | New `recheck` intent: runs the gate, exits 0 before any per-ticket work. Also hardens `ISSUE_NUM` extraction — a dispatch command without `#N` previously crashed the script under `set -euo pipefail`. |
| `dark-factory/smoke_gate.sh` | Import check satisfies the env contract (#190). `_smoke_on_red` stamps the recheck throttle so the first recheck waits a full interval after latching; `_smoke_on_green` removes the stamp. |
| `dark-factory/tests/test_scheduler.sh` | Section M: due/throttled/stale-stamp, dispatch + stamp refresh, running-recheck dedupe, kill switch. Also points the test state dir at a temp dir instead of `/var/lib/dark-factory`. |
| `dark-factory/tests/test_smoke_gate.sh` | Phase 4: `recheck` intent triggers the gate and clears latched red state on green. The python stub now mimics import-time `Settings()` — green phases fail if any harness drops the env contract again. |

## Validation

- `bash dark-factory/tests/test_scheduler.sh` — 74 passed, 0 failed
- `bash dark-factory/tests/test_smoke_gate.sh` — 18 passed, 0 failed
- `bash -n` clean on all three scripts
- Intent parsing verified under `set -euo pipefail`: `"Recheck main"` → `ISSUE_NUM=""`, `INTENT=recheck`; `"Fix issue #42"` unchanged
- **End-to-end:** fixed gate executed inside the factory image against a fresh clone with bare env → `GATE_RESULT=GREEN` (unfixed gate: `ValidationError`, red)
- Security audit of both staged diffs: PASS, no findings (throwaway values verified non-secret, scoped to the import subprocess)

## Deploy note

All three scripts are baked into `ghcr.io/omniscient/markethawk-dark-factory:latest` — after merge this needs the CI image publish plus a local `docker pull` / scheduler recreate to take effect. Until then the live factory keeps false-latching (#364 stays open; it will auto-close on the first green gate pass from the fixed image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
