### PR TITLE
[arch-v3][LOW] SQL aggregates in get_trade_stats + selectinload pagination fix

### DIFF
--- a/.archon/memory/backend-patterns.md
+++ b/.archon/memory/backend-patterns.md
@@ -9,6 +9,8 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 
 ## Backend: API Routes
 
+- [AVOID] Never use `joinedload()` with paginated queries (`LIMIT/OFFSET`) on one-to-many relationships — it produces a JOIN that row-multiplies the parent before LIMIT is applied, so paginated pages return fewer rows than `limit` when children exist. Use `selectinload()` instead, which issues a separate `SELECT … WHERE id IN (…)` after the paginated parent query. See `routers/scanner.py` `joinedload(ScannerEvent.reviews)` → `selectinload` fix. <!-- issue:#291 date:2026-06-12 expires:2026-12-12 source:implement -->
+
 - [PATTERN] `AuthMiddleware` in `main.py` short-circuits for non-HTTP scopes — WebSocket routes are NOT covered. Protect WS endpoints by adding `_user: User = Depends(ws_get_current_user)` from `app.core.auth`; this raises `WebSocketException(code=1008)` before `accept()` if the cookie is absent or invalid. <!-- issue:#191 date:2026-06-05 expires:2026-12-05 source:implement -->
 
 - [AVOID] Do not raise `HTTPException` inside a WebSocket dependency — FastAPI will not convert it to a WS close frame. Use `WebSocketException(code=1008, reason="...")` (importable from `fastapi`) instead, which FastAPI closes gracefully before `accept()` is called. <!-- issue:#191 date:2026-06-05 expires:2026-12-05 source:implement -->
@@ -54,6 +56,8 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 - [AVOID] Never use `except (pybreaker.CircuitBreakerError, Exception)` — `CircuitBreakerError` is an `Exception` subclass so the tuple is redundant, and the broad catch masks real defects as missing data. Use two separate handlers: `except pybreaker.CircuitBreakerError` → raise `ProviderError`, `except Exception` → log and return empty. <!-- issue:#205 date:2026-06-07 expires:2026-12-07 source:implement -->
 
 ## Backend: Utilities
+
+- [PATTERN] For aggregate stats functions (count/sum of a model column split by condition), use a single `db.query(func.count(), func.count(case((Model.col > 0, 1))), func.coalesce(func.sum(case((Model.col > 0, Model.col))), 0)).one()` query instead of a full-table `db.query(Model).all()`. Wrap numeric results in `Decimal(str(row.value))` to handle the psycopg2 Numeric bridge. See `journal_service.get_trade_stats()` for the reference implementation. <!-- issue:#291 date:2026-06-12 expires:2026-12-12 source:implement -->
 
 - [PATTERN] Use `from app.utils.time import utc_now, to_utc_naive` for any naive-UTC datetime need: `utc_now()` replaces `datetime.now(timezone.utc).replace(tzinfo=None)`, `to_utc_naive(dt)` replaces `.astimezone(timezone.utc).replace(tzinfo=None)`. Column defaults use the callable ref (`default=utc_now`), inline expressions call it (`utc_now()`). <!-- issue:#286 date:2026-06-11 expires:2026-12-11 source:implement -->
 

--- a/backend/app/routers/scanner.py
+++ b/backend/app/routers/scanner.py
@@ -16,7 +16,7 @@ from fastapi import (
     WebSocket,
     WebSocketDisconnect,
 )
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, selectinload
 
 from app.core.auth import ws_get_current_user
 from app.core.cache import cache_response, get_cached
@@ -374,7 +374,7 @@ def get_scanner_results(
     db: Session = Depends(get_db),
 ):
     """Get scanner results with filtering."""
-    query = db.query(ScannerEvent).options(joinedload(ScannerEvent.reviews))
+    query = db.query(ScannerEvent).options(selectinload(ScannerEvent.reviews))
 
     if ticker:
         query = query.filter(ScannerEvent.ticker == ticker.upper())

--- a/backend/app/services/journal_service.py
+++ b/backend/app/services/journal_service.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Optional
 
+from sqlalchemy import case, func
 from sqlalchemy.orm import Session, selectinload
 
 from app.models.trade import JournalEntry, Tag, Trade, TradeExecution
@@ -61,25 +62,29 @@ def update_trade(db: Session, trade_id: int, trade_update: TradeUpdate):
 
 
 def get_trade_stats(db: Session) -> TradeStats:
-    trades = db.query(Trade).all()
+    row = db.query(
+        func.count().label("total"),
+        func.count(case((Trade.net_pnl > 0, 1))).label("winners"),
+        func.count(case((Trade.net_pnl < 0, 1))).label("losers"),
+        func.coalesce(func.sum(Trade.net_pnl), 0).label("total_pnl"),
+        func.coalesce(func.sum(case((Trade.net_pnl > 0, Trade.net_pnl))), 0).label(
+            "gross_profit"
+        ),
+        func.coalesce(func.sum(case((Trade.net_pnl < 0, Trade.net_pnl))), 0).label(
+            "gross_loss"
+        ),
+    ).one()
 
-    total_trades = len(trades)
-    winning_trades = len([t for t in trades if t.net_pnl and t.net_pnl > 0])
-    losing_trades = len([t for t in trades if t.net_pnl and t.net_pnl < 0])
+    total_trades = row.total
+    winning_trades = row.winners
+    losing_trades = row.losers
+    total_pnl = Decimal(str(row.total_pnl))
+    gross_profit = Decimal(str(row.gross_profit)) or Decimal("1")
+    gross_loss = abs(Decimal(str(row.gross_loss))) or Decimal("1")
 
     win_rate = (winning_trades / total_trades) if total_trades > 0 else 0
-    total_pnl = sum([t.net_pnl for t in trades if t.net_pnl]) or Decimal("0")
     avg_profit = (total_pnl / total_trades) if total_trades > 0 else Decimal("0")
-
-    gross_profit = sum(
-        [t.net_pnl for t in trades if t.net_pnl and t.net_pnl > 0]
-    ) or Decimal("1")
-    gross_loss = abs(
-        sum([t.net_pnl for t in trades if t.net_pnl and t.net_pnl < 0])
-    ) or Decimal("1")
-    profit_factor = (
-        float(gross_profit / gross_loss) if gross_loss != 0 else float(gross_profit)
-    )
+    profit_factor = float(gross_profit / gross_loss)
 
     return TradeStats(
         total_trades=total_trades,

--- a/backend/tests/services/test_journal_service.py
+++ b/backend/tests/services/test_journal_service.py
@@ -117,6 +117,64 @@ def test_trade_stats_win_rate(db: Session):
     assert pytest.approx(stats.win_rate, rel=1e-3) == 0.5
 
 
+def test_trade_stats_aggregates_pnl_and_profit_factor(db: Session):
+    """get_trade_stats must compute total_pnl and profit_factor via SQL aggregates."""
+    from app.models.trade import Trade
+
+    db.add_all(
+        [
+            Trade(symbol="A", status="closed", net_pnl=Decimal("200")),
+            Trade(symbol="B", status="closed", net_pnl=Decimal("100")),
+            Trade(symbol="C", status="closed", net_pnl=Decimal("-50")),
+        ]
+    )
+    db.flush()
+    stats = get_trade_stats(db)
+    assert stats.total_trades == 3
+    assert stats.winning_trades == 2
+    assert stats.losing_trades == 1
+    assert stats.total_pnl == Decimal("250")
+    assert pytest.approx(float(stats.avg_profit), rel=1e-3) == pytest.approx(
+        250 / 3, rel=1e-3
+    )
+    # gross_profit=300, gross_loss=50 → profit_factor=6.0
+    assert pytest.approx(stats.profit_factor, rel=1e-3) == 6.0
+
+
+def test_trade_stats_profit_factor_all_winners(db: Session):
+    """profit_factor falls back to gross_profit/1 when gross_loss is zero."""
+    from app.models.trade import Trade
+
+    db.add_all(
+        [
+            Trade(symbol="W1", status="closed", net_pnl=Decimal("100")),
+            Trade(symbol="W2", status="closed", net_pnl=Decimal("200")),
+        ]
+    )
+    db.flush()
+    stats = get_trade_stats(db)
+    assert stats.losing_trades == 0
+    # gross_loss=0 → fallback to Decimal("1"), profit_factor = 300/1 = 300.0
+    assert pytest.approx(stats.profit_factor, rel=1e-3) == 300.0
+
+
+def test_trade_stats_ignores_null_pnl(db: Session):
+    """Trades with NULL net_pnl must not count as winners or losers."""
+    from app.models.trade import Trade
+
+    db.add_all(
+        [
+            Trade(symbol="OPEN", status="open"),  # net_pnl=None
+            Trade(symbol="WIN", status="closed", net_pnl=Decimal("50")),
+        ]
+    )
+    db.flush()
+    stats = get_trade_stats(db)
+    assert stats.total_trades == 2
+    assert stats.winning_trades == 1
+    assert stats.losing_trades == 0
+
+
 # ── journal entries ────────────────────────────────────────────────────────
 
 

--- a/docs/codeindex-hotspots.md
+++ b/docs/codeindex-hotspots.md
@@ -5,7 +5,7 @@ Files with blast score ≥ 5.0  (31 found)
     41.5  frontend/src/api/scanner.ts  (31d / 21t)  809 loc
     31.0  frontend/src/components/ui/Card.tsx  (21d / 20t)  44 loc
     29.0  backend/app/routers/system.py  (2d / 54t)  141 loc
-    29.0  services/tweet-monitor/app/main.py  (2d / 54t)  247 loc
+    29.0  services/tweet-monitor/app/main.py  (2d / 54t)  266 loc
     27.0  backend/app/main.py  (1d / 52t)  508 loc
     27.0  backend/app/routers/futures.py  (1d / 52t)  188 loc
     27.0  backend/app/routers/scanner.py  (1d / 52t)  709 loc


### PR DESCRIPTION
Closes #291

## Summary
Automated implementation for issue #291.

## Preview
⚠️ _Preview environment failed to start (preview failed: docker compose up --build failed (see preview_build.log tail below)) — endpoint validation was skipped; see the failure comment on the issue._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #291"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #291"
```

---
*Generated by MarketHawk Dark Factory*