### PR TITLE
feat(scheduler): size/type-aware dispatch ceiling (#339)

### DIFF
--- a/.claude/skills/refinement/config.yaml
+++ b/.claude/skills/refinement/config.yaml
@@ -45,3 +45,13 @@ blast_radius:
   hotspot_score_floor: 5.0      # files at or above this codeindex blast score trigger HUMAN_REQUIRED
   size_budget_lines: 400        # total added+deleted lines threshold (0 = disabled)
   size_budget_blocks: false     # true = size alone is blocking; false = advisory only
+
+dispatch_ceiling:
+  enabled: true                # mirror of $DISPATCH_CEILING_ENABLED — kill-switch (set false in .archon/.env)
+  label: above-ceiling         # mirror of $ABOVE_CEILING_LABEL
+  keywords: "migration|migrate|performance|perf|architectur|refactor"  # mirror of $ABOVE_CEILING_KEYWORDS
+  # Doc-only mirror: the scheduler reads env-var defaults in scheduler.sh, not this file.
+  # L tickets (and M tickets with a keyword title match) park in Blocked for human pairing;
+  # M tickets lose the plan-pending-review grace-window auto-advance. S is unaffected.
+  # See docs/superpowers/specs/2026-06-12-size-type-aware-dispatch-ceiling-design.md
+  # Revisit: 2026-09-12

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -21,6 +21,15 @@ FACTORY_WIP_LIMIT="${FACTORY_WIP_LIMIT:-1}"
 MAIN_RED_RECHECK_ENABLED="${MAIN_RED_RECHECK_ENABLED:-true}"
 MAIN_RED_RECHECK_MINUTES="${MAIN_RED_RECHECK_MINUTES:-20}"
 RECHECK_STAMP_FILE="${SCHEDULER_STATE_DIR}/main-red-last-recheck"
+# Dispatch ceiling policy (#339): L tickets — and M tickets whose title matches an
+# ABOVE_CEILING_KEYWORDS pattern — are never auto-dispatched to implement; they park in
+# Blocked under ABOVE_CEILING_LABEL for human-paired implementation. M tickets also lose
+# the plan-pending-review grace-window auto-advance (S keeps full autonomy).
+# Kill-switch and keyword list overridable in .archon/.env without a code change.
+# See docs/superpowers/specs/2026-06-12-size-type-aware-dispatch-ceiling-design.md; revisit 2026-09-12.
+DISPATCH_CEILING_ENABLED="${DISPATCH_CEILING_ENABLED:-true}"
+ABOVE_CEILING_LABEL="${ABOVE_CEILING_LABEL:-above-ceiling}"
+ABOVE_CEILING_KEYWORDS="${ABOVE_CEILING_KEYWORDS:-migration|migrate|performance|perf|architectur|refactor}"
 
 # Board constants
 PROJECT_NUMBER=1
@@ -192,6 +201,38 @@ has_direct_to_pr_label() {
   echo "$item" | jq -r '.labels[]?' 2>/dev/null | grep -qi "$DIRECT_TO_PR_LABEL"
 }
 
+# --- Dispatch ceiling classification (#339) ---
+# Returns "S", "M", "L", or "" from the item's labels
+get_size_label() {
+  echo "$1" | jq -r '.labels[]?' 2>/dev/null | grep -oi 'size: [SML]' | awk '{print $2}' | head -1
+}
+
+# True (returns 0) if item is above the dispatch ceiling: size L always, or size M
+# when the title matches an ABOVE_CEILING_KEYWORDS pattern (escalation only — the
+# keyword heuristic never demotes).
+is_above_ceiling() {
+  local item="$1" title size
+  title=$(echo "$item" | jq -r '.content.title // ""' 2>/dev/null)
+  size=$(get_size_label "$item")
+  case "$size" in
+    L) return 0 ;;
+    M) echo "$title" | grep -qiE "${ABOVE_CEILING_KEYWORDS}" && return 0 || return 1 ;;
+    *) return 1 ;;
+  esac
+}
+
+# True if item already carries the above-ceiling label (board-fetch snapshot)
+has_above_ceiling_label() {
+  echo "$1" | jq -r '.labels[]?' 2>/dev/null | grep -qi "^${ABOVE_CEILING_LABEL}$"
+}
+
+# True if item is S-size or has no size label (unlabelled is treated as S per spec)
+is_below_ceiling() {
+  local size
+  size=$(get_size_label "$1")
+  case "$size" in S|"") return 0 ;; *) return 1 ;; esac
+}
+
 # Returns minutes elapsed since the last comment matching $marker_re on the given issue.
 # Returns "" if no matching comment exists or if the timestamp cannot be parsed.
 elapsed_minutes_since_marker() {
@@ -264,6 +305,11 @@ plan_advance_check() {
       DISPATCHED="Plan issue #${issue_num}"
       REFINE_RUNNING=$((REFINE_RUNNING + 1))
     fi
+    return 0
+  fi
+  # Dispatch ceiling (#339): timer-based advance applies only to S-size items. M and L
+  # require explicit human plan approval; the human-feedback path above is untouched.
+  if [ "${DISPATCH_CEILING_ENABLED:-true}" = "true" ] && ! is_below_ceiling "$item"; then
     return 0
   fi
   if has_direct_to_pr_label "$item"; then
@@ -898,6 +944,37 @@ This issue was left in **In progress** with no running factory container — the
       if ! dependencies_met "$ISSUE" "$BOARD_ITEMS"; then continue; fi
       if is_issue_running "$ISSUE"; then continue; fi
 
+      # Dispatch ceiling (#339): park above-ceiling work for human pairing. The label
+      # check stops the comment/board-move from repeating every poll cycle — the label
+      # persists and comes back in the next fetch_board_items snapshot.
+      if [ "${DISPATCH_CEILING_ENABLED:-true}" = "true" ] && is_above_ceiling "$item"; then
+        if ! has_above_ceiling_label "$item"; then
+          echo "[$(date -u +%FT%TZ)] ceiling_gate issue=#${ISSUE} action=above_ceiling_blocked"
+          gh issue edit "$ISSUE" --repo "${OWNER}/markethawk" \
+            --add-label "$ABOVE_CEILING_LABEL" 2>/dev/null || true
+          set_board_status "$ISSUE" "$STATUS_BLOCKED" || true
+          gh issue comment "$ISSUE" --repo "${OWNER}/markethawk" --body \
+"## Scheduler — Above Dispatch Ceiling
+
+This ticket has been classified as **above the autonomous dispatch ceiling** \
+(size: L, or size: M with a perf/architectural/migration title keyword).
+
+Spec and plan are complete. **A human must pair on implementation.**
+
+To proceed:
+1. Remove the \`$ABOVE_CEILING_LABEL\` label.
+2. Dispatch manually:
+   \`\`\`bash
+   docker compose --profile factory run --rm dark-factory \"Fix issue #${ISSUE}\"
+   \`\`\`
+   Or implement directly in a local worktree.
+
+---
+*Posted by MarketHawk Backlog Scheduler*" 2>/dev/null || true
+        fi
+        continue
+      fi
+
       if dispatch "Fix issue #${ISSUE}"; then
         DISPATCHED="Fix issue #${ISSUE}"
       fi
@@ -912,6 +989,9 @@ This issue was left in **In progress** with no running factory container — the
       [ -n "$DISPATCHED" ] && break
       ISSUE=$(get_issue_number "$item")
       if has_skip_label "$item"; then continue; fi
+      # Above-ceiling items in Blocked are parked by design (#339), not failed — the
+      # retry loop must not auto-dispatch them.
+      if has_above_ceiling_label "$item"; then continue; fi
       if is_issue_running "$ISSUE"; then continue; fi
 
       RETRIES=$(get_retry_count "$ISSUE")

--- a/dark-factory/tests/test_dispatch_ceiling.sh
+++ b/dark-factory/tests/test_dispatch_ceiling.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Unit tests for the dispatch ceiling (issue #339): size/type classification helpers,
+# Priority 2 ceiling gate, Priority 3 guard, and plan_advance_check suppression.
+# Run: bash dark-factory/tests/test_dispatch_ceiling.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCHED="$SCRIPT_DIR/../scheduler.sh"
+
+# ---- Stubs ----
+STUB_LOG=$(mktemp /tmp/sched-ceiling-stubs-XXXXXX.log)
+gh()               { echo "gh $*"               >> "$STUB_LOG"; return 0; }
+docker()           { echo "docker $*"           >> "$STUB_LOG"; return 0; }
+set_board_status() { echo "set_board_status $*" >> "$STUB_LOG"; return 0; }
+export -f gh docker set_board_status
+
+# ---- Source scheduler helpers only ----
+SCHEDULER_STATE_DIR=$(mktemp -d /tmp/sched-ceiling-statedir-XXXXXX)
+export SCHEDULER_STATE_DIR
+STATE_FILE=$(mktemp /tmp/sched-ceiling-state-XXXXXX.json)
+echo '{}' > "$STATE_FILE"
+export STATE_FILE
+export GH_TOKEN="${GH_TOKEN:-stub-token}"
+export CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN:-stub-token}"
+SCHEDULER_SOURCE_ONLY=1 source "$SCHED"
+
+# Re-stub set_board_status — scheduler.sh defines its own, overriding the export above
+set_board_status() { echo "set_board_status $*" >> "$STUB_LOG"; return 0; }
+
+# ---- Runner ----
+PASSED=0; FAILED=0
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $desc"; PASSED=$((PASSED+1))
+  else
+    echo "  FAIL: $desc — expected='$expected' got='$actual'" >&2; FAILED=$((FAILED+1))
+  fi
+}
+assert_true() {
+  local desc="$1"; shift
+  if "$@"; then assert_eq "$desc" "0" "0"; else assert_eq "$desc" "0" "1"; fi
+}
+assert_false() {
+  local desc="$1"; shift
+  if "$@"; then assert_eq "$desc" "0" "1"; else assert_eq "$desc" "0" "0"; fi
+}
+
+# ---- Mock items ----
+ITEM_S='{"content":{"number":1,"title":"Fix login bug"},"labels":["size: S","priority: must-have"],"status":"Ready"}'
+ITEM_M='{"content":{"number":2,"title":"Add new chart panel"},"labels":["size: M","priority: must-have"],"status":"Ready"}'
+ITEM_M_MIGRATION='{"content":{"number":3,"title":"Run database migration for users table"},"labels":["size: M"],"status":"Ready"}'
+ITEM_M_PERF='{"content":{"number":4,"title":"Improve performance of scanner query"},"labels":["size: M"],"status":"Ready"}'
+ITEM_M_ARCH='{"content":{"number":5,"title":"Architectural refactor of provider layer"},"labels":["size: M"],"status":"Ready"}'
+ITEM_L='{"content":{"number":6,"title":"Big new feature"},"labels":["size: L"],"status":"Ready"}'
+ITEM_NO_SIZE='{"content":{"number":7,"title":"No size label here"},"labels":["priority: must-have"],"status":"Ready"}'
+ITEM_ABOVE_LABELED='{"content":{"number":8,"title":"Perf work"},"labels":["above-ceiling","size: L"],"status":"Blocked"}'
+
+# ==========================================
+# N: get_size_label
+# ==========================================
+echo "--- N: get_size_label ---"
+assert_eq "S item → S"            "S" "$(get_size_label "$ITEM_S")"
+assert_eq "M item → M"            "M" "$(get_size_label "$ITEM_M")"
+assert_eq "L item → L"            "L" "$(get_size_label "$ITEM_L")"
+assert_eq "no size label → empty" ""  "$(get_size_label "$ITEM_NO_SIZE")"
+
+# ==========================================
+# O: is_above_ceiling
+# ==========================================
+echo ""
+echo "--- O: is_above_ceiling ---"
+assert_false "S → below"                       is_above_ceiling "$ITEM_S"
+assert_false "M without keyword → not above"   is_above_ceiling "$ITEM_M"
+assert_true  "M + migration keyword → above"   is_above_ceiling "$ITEM_M_MIGRATION"
+assert_true  "M + performance keyword → above" is_above_ceiling "$ITEM_M_PERF"
+assert_true  "M + architectural keyword → above" is_above_ceiling "$ITEM_M_ARCH"
+assert_true  "L → always above"                is_above_ceiling "$ITEM_L"
+assert_false "no size label → treated as S"    is_above_ceiling "$ITEM_NO_SIZE"
+
+# ==========================================
+# P: has_above_ceiling_label / is_below_ceiling
+# ==========================================
+echo ""
+echo "--- P: has_above_ceiling_label / is_below_ceiling ---"
+assert_false "label absent → false"  has_above_ceiling_label "$ITEM_M"
+assert_true  "label present → true"  has_above_ceiling_label "$ITEM_ABOVE_LABELED"
+assert_true  "S → below ceiling"           is_below_ceiling "$ITEM_S"
+assert_true  "no size → below ceiling"     is_below_ceiling "$ITEM_NO_SIZE"
+assert_false "M → not below ceiling"       is_below_ceiling "$ITEM_M"
+assert_false "L → not below ceiling"       is_below_ceiling "$ITEM_L"
+
+# ==========================================
+# Q: Priority 2 ceiling gate (mirrors the inserted loop code)
+# ==========================================
+echo ""
+echo "--- Q: Priority 2 ceiling gate ---"
+
+# Mirrors the gate inserted in the Priority 2 loop so the branch logic is exercised
+# with the real helpers. Outcomes: dispatch | block_and_label | already_labeled_skip
+p2_gate_outcome() {
+  local item="$1"
+  local ISSUE
+  ISSUE=$(get_issue_number "$item")
+  if [ "${DISPATCH_CEILING_ENABLED:-true}" = "true" ] && is_above_ceiling "$item"; then
+    if ! has_above_ceiling_label "$item"; then
+      gh issue edit "$ISSUE" --repo "${OWNER}/markethawk" --add-label "$ABOVE_CEILING_LABEL" 2>/dev/null || true
+      set_board_status "$ISSUE" "$STATUS_BLOCKED" || true
+      echo "block_and_label"
+    else
+      echo "already_labeled_skip"
+    fi
+    return 0
+  fi
+  echo "dispatch"
+}
+
+DISPATCH_CEILING_ENABLED=true
+> "$STUB_LOG"
+assert_eq "S → dispatch"                    "dispatch"             "$(p2_gate_outcome "$ITEM_S")"
+assert_eq "M without keyword → dispatch"    "dispatch"             "$(p2_gate_outcome "$ITEM_M")"
+assert_eq "M + keyword → block and label"   "block_and_label"      "$(p2_gate_outcome "$ITEM_M_MIGRATION")"
+assert_eq "L → block and label"             "block_and_label"      "$(p2_gate_outcome "$ITEM_L")"
+assert_eq "already labeled → silent skip"   "already_labeled_skip" "$(p2_gate_outcome "$ITEM_ABOVE_LABELED")"
+assert_eq "block path adds the label" \
+  "1" "$(grep -c "issue edit 3.*--add-label above-ceiling" "$STUB_LOG" || echo 0)"
+assert_eq "block path moves board to Blocked" \
+  "1" "$(grep -c "set_board_status 3 ${STATUS_BLOCKED}" "$STUB_LOG" || echo 0)"
+
+DISPATCH_CEILING_ENABLED=false
+assert_eq "kill-switch off: L → dispatch"   "dispatch" "$(p2_gate_outcome "$ITEM_L")"
+DISPATCH_CEILING_ENABLED=true
+
+# ==========================================
+# R: Priority 3 guard
+# ==========================================
+echo ""
+echo "--- R: Priority 3 guard ---"
+assert_false "normal blocked item → retried"        has_above_ceiling_label "$ITEM_M"
+assert_true  "above-ceiling blocked item → skipped" has_above_ceiling_label "$ITEM_ABOVE_LABELED"
+
+# ==========================================
+# S: plan_advance_check suppression (real function, stubbed collaborators)
+# ==========================================
+echo ""
+echo "--- S: plan_advance_check ceiling suppression ---"
+echo '{}' > "$STATE_FILE"
+REFINE_RUNNING=0
+DISPATCHED=""
+export PLAN_GRACE_MINUTES=30
+
+_ITEM_S_PPR='{"content":{"number":70,"title":"Small fix"},"labels":["size: S","direct-to-pr","plan-pending-review"],"status":"Refined"}'
+_ITEM_M_PPR='{"content":{"number":71,"title":"Add new chart panel"},"labels":["size: M","direct-to-pr","plan-pending-review"],"status":"Refined"}'
+_ITEM_L_PPR='{"content":{"number":72,"title":"Big new feature"},"labels":["size: L","direct-to-pr","plan-pending-review"],"status":"Refined"}'
+
+has_new_comment_after_report() { echo "no"; }
+elapsed_minutes_since_marker() { echo "99"; }
+dispatch() { echo "dispatch $*" >> "$STUB_LOG"; return 0; }
+export -f has_new_comment_after_report elapsed_minutes_since_marker dispatch
+
+# S1: S item past grace → advances to Ready (unchanged behaviour)
+> "$STUB_LOG"
+plan_advance_check 70 "$_ITEM_S_PPR"
+assert_eq "S1: S-size advances to Ready" \
+  "1" "$(grep -c "set_board_status 70 ${STATUS_READY}" "$STUB_LOG" || echo 0)"
+
+# S2: M item past grace → suppressed (requires explicit human approval)
+> "$STUB_LOG"
+plan_advance_check 71 "$_ITEM_M_PPR"
+assert_eq "S2: M-size grace-advance suppressed" \
+  "0" "$(grep -c 'set_board_status' "$STUB_LOG" || true)"
+
+# S3: L item past grace → suppressed
+> "$STUB_LOG"
+plan_advance_check 72 "$_ITEM_L_PPR"
+assert_eq "S3: L-size grace-advance suppressed" \
+  "0" "$(grep -c 'set_board_status' "$STUB_LOG" || true)"
+
+# S4: human feedback on an M item → re-plan still dispatched (feedback path not suppressed)
+> "$STUB_LOG"
+has_new_comment_after_report() { echo "yes"; }
+export -f has_new_comment_after_report
+plan_advance_check 71 "$_ITEM_M_PPR"
+assert_eq "S4: M-size human feedback still re-plans" \
+  "1" "$(grep -c 'dispatch Plan issue #71' "$STUB_LOG" || echo 0)"
+has_new_comment_after_report() { echo "no"; }
+export -f has_new_comment_after_report
+
+# S5: kill-switch off → M item past grace advances again
+> "$STUB_LOG"
+DISPATCH_CEILING_ENABLED=false
+plan_advance_check 71 "$_ITEM_M_PPR"
+assert_eq "S5: kill-switch restores M grace-advance" \
+  "1" "$(grep -c "set_board_status 71 ${STATUS_READY}" "$STUB_LOG" || echo 0)"
+DISPATCH_CEILING_ENABLED=true
+
+# S6: spec_advance_check is NOT ceiling-gated — M item spec still auto-advances
+> "$STUB_LOG"
+export SPEC_GRACE_MINUTES=30
+_ITEM_M_SPR='{"content":{"number":73,"title":"Add new chart panel"},"labels":["size: M","direct-to-pr","spec-pending-review"],"status":"Backlog"}'
+spec_advance_check 73 "$_ITEM_M_SPR"
+assert_eq "S6: M-size spec advance unaffected by ceiling" \
+  "1" "$(grep -c "set_board_status 73 ${STATUS_REFINED}" "$STUB_LOG" || echo 0)"
+
+# ==========================================
+# Cleanup
+# ==========================================
+rm -f "$STATE_FILE" "$STUB_LOG"
+rm -rf "$SCHEDULER_STATE_DIR"
+echo ""
+echo "Results: ${PASSED} passed, ${FAILED} failed"
+[ "$FAILED" -eq 0 ]

--- a/docs/superpowers/plans/2026-06-12-size-type-aware-dispatch-ceiling.md
+++ b/docs/superpowers/plans/2026-06-12-size-type-aware-dispatch-ceiling.md
@@ -1,0 +1,607 @@
+# Plan: Size/Type-Aware Dispatch Ceiling in the Scheduler
+
+**Date:** 2026-06-12
+**Issue:** #339
+**Spec:** docs/superpowers/specs/2026-06-12-size-type-aware-dispatch-ceiling-design.md
+**Branch:** refine/issue-339-size-type-aware-dispatch-ceiling-in-the-
+
+---
+
+## Goal
+
+Extend `dark-factory/scheduler.sh` with a dispatch ceiling that classifies every Ready ticket as
+below-ceiling (S), at-ceiling (M), or above-ceiling (L / keyword-escalated M) before dispatching.
+Above-ceiling tickets are parked in Blocked with a new `above-ceiling` label and a human-pairing
+comment; at-ceiling M tickets lose the `plan-pending-review` grace-window auto-advance.
+
+## Architecture
+
+All changes are confined to two files:
+- `dark-factory/scheduler.sh` — three new env-var constants, four new bash helpers, and three
+  insertion points (Priority 2 ceiling gate, Priority 3 guard, `plan_advance_check` suppression).
+- `.claude/skills/refinement/config.yaml` — doc-only mirror of the three new constants, matching
+  the existing pattern for `PLAN_GRACE_MINUTES`, `FACTORY_WIP_LIMIT`, etc.
+
+No new services, Docker containers, database models, or migrations are required.
+`ABOVE_CEILING_LABEL` is intentionally NOT added to `SKIP_LABELS` so refinement and plan dispatch
+remain unaffected for above-ceiling tickets.
+
+## Tech Stack
+
+Bash (`scheduler.sh`), YAML (`config.yaml`). Tested with a standalone bash test script at
+`dark-factory/test_dispatch_ceiling.sh`.
+
+---
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `dark-factory/scheduler.sh` | +3 constants, +4 helpers, +P2 gate, +P3 guard, +`plan_advance_check` suppression, +inline comment |
+| `.claude/skills/refinement/config.yaml` | +`dispatch_ceiling` doc-only section |
+| `dark-factory/test_dispatch_ceiling.sh` | new — bash test harness for the 4 helpers and gate logic |
+
+---
+
+## Tasks
+
+### Task 1 — Constants, helper functions, and inline comment
+
+**Files:** `dark-factory/scheduler.sh`, `dark-factory/test_dispatch_ceiling.sh`
+
+#### TDD steps
+
+**Step 1.1 — Write test harness (failing baseline)**
+
+Create `dark-factory/test_dispatch_ceiling.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Test harness for dispatch ceiling helpers (issue #339)
+set -euo pipefail
+PASS=0; FAIL=0
+
+assert_eq() {
+  local label="$1" got="$2" expected="$3"
+  if [ "$got" = "$expected" ]; then
+    echo "PASS: $label"; PASS=$((PASS+1))
+  else
+    echo "FAIL: $label — got='$got' expected='$expected'"; FAIL=$((FAIL+1))
+  fi
+}
+assert_rc() {
+  local label="$1" expected_rc="$2"; shift 2
+  local rc=0; "$@" || rc=$?
+  if [ "$rc" = "$expected_rc" ]; then
+    echo "PASS: $label"; PASS=$((PASS+1))
+  else
+    echo "FAIL: $label — got rc=$rc expected rc=$expected_rc"; FAIL=$((FAIL+1))
+  fi
+}
+
+# --- Env defaults required by helpers ---
+DISPATCH_CEILING_ENABLED="true"
+ABOVE_CEILING_LABEL="above-ceiling"
+ABOVE_CEILING_KEYWORDS="migration|migrate|performance|perf|architectur|refactor"
+
+# --- Helpers under test (sourced inline for isolation) ---
+get_size_label() {
+  echo "$1" | jq -r '.labels[]?' 2>/dev/null | grep -oi 'size: [SML]' | awk '{print $2}' | head -1
+}
+is_above_ceiling() {
+  local item="$1" title size
+  title=$(echo "$item" | jq -r '.content.title // ""' 2>/dev/null)
+  size=$(get_size_label "$item")
+  case "$size" in
+    L) return 0 ;;
+    M) echo "$title" | grep -qiE "${ABOVE_CEILING_KEYWORDS}" && return 0 || return 1 ;;
+    *) return 1 ;;
+  esac
+}
+has_above_ceiling_label() {
+  echo "$1" | jq -r '.labels[]?' 2>/dev/null | grep -qi "^${ABOVE_CEILING_LABEL}$"
+}
+is_below_ceiling() {
+  local size; size=$(get_size_label "$1")
+  case "$size" in S|"") return 0 ;; *) return 1 ;; esac
+}
+
+# --- Mock items ---
+ITEM_S='{"labels":["size: S","priority: must-have"],"content":{"title":"Fix login bug"}}'
+ITEM_M='{"labels":["size: M","priority: must-have"],"content":{"title":"Add new chart"}}'
+ITEM_M_MIGRATION='{"labels":["size: M"],"content":{"title":"Run database migration for users table"}}'
+ITEM_M_PERF='{"labels":["size: M"],"content":{"title":"Improve performance of scanner query"}}'
+ITEM_M_ARCH='{"labels":["size: M"],"content":{"title":"Architectural refactor of provider layer"}}'
+ITEM_L='{"labels":["size: L"],"content":{"title":"Big architectural feature"}}'
+ITEM_NO_SIZE='{"labels":["priority: must-have"],"content":{"title":"No size label here"}}'
+ITEM_ABOVE_LABELED='{"labels":["above-ceiling","size: L"],"content":{"title":"Perf work"}}'
+
+# --- get_size_label ---
+assert_eq "get_size_label: S"    "$(get_size_label "$ITEM_S")" "S"
+assert_eq "get_size_label: M"    "$(get_size_label "$ITEM_M")" "M"
+assert_eq "get_size_label: L"    "$(get_size_label "$ITEM_L")" "L"
+assert_eq "get_size_label: none" "$(get_size_label "$ITEM_NO_SIZE")" ""
+
+# --- is_above_ceiling ---
+assert_rc "is_above_ceiling: S → false"              1 is_above_ceiling "$ITEM_S"
+assert_rc "is_above_ceiling: M no keyword → false"   1 is_above_ceiling "$ITEM_M"
+assert_rc "is_above_ceiling: M+migration → true"     0 is_above_ceiling "$ITEM_M_MIGRATION"
+assert_rc "is_above_ceiling: M+perf → true"          0 is_above_ceiling "$ITEM_M_PERF"
+assert_rc "is_above_ceiling: M+architectur → true"   0 is_above_ceiling "$ITEM_M_ARCH"
+assert_rc "is_above_ceiling: L → true"               0 is_above_ceiling "$ITEM_L"
+assert_rc "is_above_ceiling: no size → false"        1 is_above_ceiling "$ITEM_NO_SIZE"
+
+# --- has_above_ceiling_label ---
+assert_rc "has_above_ceiling_label: absent → false"  1 has_above_ceiling_label "$ITEM_M"
+assert_rc "has_above_ceiling_label: present → true"  0 has_above_ceiling_label "$ITEM_ABOVE_LABELED"
+
+# --- is_below_ceiling ---
+assert_rc "is_below_ceiling: S → true"               0 is_below_ceiling "$ITEM_S"
+assert_rc "is_below_ceiling: no size → true"         0 is_below_ceiling "$ITEM_NO_SIZE"
+assert_rc "is_below_ceiling: M → false"              1 is_below_ceiling "$ITEM_M"
+assert_rc "is_below_ceiling: L → false"              1 is_below_ceiling "$ITEM_L"
+
+# --- P2 gate simulation ---
+p2_gate_outcome() {
+  local item="$1"
+  if [ "${DISPATCH_CEILING_ENABLED:-true}" = "true" ] && is_above_ceiling "$item"; then
+    has_above_ceiling_label "$item" && echo "already_labeled_skip" || echo "block_and_label"
+  else
+    echo "dispatch"
+  fi
+}
+assert_eq "P2 gate: S → dispatch"            "$(p2_gate_outcome "$ITEM_S")"            "dispatch"
+assert_eq "P2 gate: M no kw → dispatch"      "$(p2_gate_outcome "$ITEM_M")"            "dispatch"
+assert_eq "P2 gate: M+migration → block"     "$(p2_gate_outcome "$ITEM_M_MIGRATION")"  "block_and_label"
+assert_eq "P2 gate: L → block"               "$(p2_gate_outcome "$ITEM_L")"            "block_and_label"
+assert_eq "P2 gate: L already labeled → skip" "$(p2_gate_outcome "$ITEM_ABOVE_LABELED")" "already_labeled_skip"
+
+# --- P3 guard simulation ---
+p3_guard_outcome() {
+  has_above_ceiling_label "$1" && echo "skip" || echo "retry"
+}
+assert_eq "P3 guard: normal blocked → retry"         "$(p3_guard_outcome "$ITEM_M")"           "retry"
+assert_eq "P3 guard: above-ceiling labeled → skip"   "$(p3_guard_outcome "$ITEM_ABOVE_LABELED")" "skip"
+
+# --- plan_advance_check suppression ---
+plan_advance_ceiling_outcome() {
+  local item="$1"
+  if [ "${DISPATCH_CEILING_ENABLED:-true}" = "true" ] && ! is_below_ceiling "$item"; then
+    echo "suppressed"
+  else
+    echo "allowed"
+  fi
+}
+assert_eq "plan_advance: S → allowed"       "$(plan_advance_ceiling_outcome "$ITEM_S")"          "allowed"
+assert_eq "plan_advance: no size → allowed" "$(plan_advance_ceiling_outcome "$ITEM_NO_SIZE")"    "allowed"
+assert_eq "plan_advance: M → suppressed"    "$(plan_advance_ceiling_outcome "$ITEM_M")"          "suppressed"
+assert_eq "plan_advance: M+kw → suppressed" "$(plan_advance_ceiling_outcome "$ITEM_M_MIGRATION")" "suppressed"
+assert_eq "plan_advance: L → suppressed"    "$(plan_advance_ceiling_outcome "$ITEM_L")"          "suppressed"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" = "0" ] || exit 1
+```
+
+**Step 1.2 — Verify test passes (baseline logic confirmed)**
+
+```bash
+bash dark-factory/test_dispatch_ceiling.sh
+```
+
+Expected output:
+```
+PASS: get_size_label: S
+...
+Results: 27 passed, 0 failed
+```
+
+**Step 1.3 — Add constants to `scheduler.sh`**
+
+In `dark-factory/scheduler.sh`, insert after line 17 (`FACTORY_WIP_LIMIT` line),
+immediately before the blank line before `# Board constants`:
+
+```bash
+# Dispatch ceiling policy (see docs/superpowers/specs/2026-06-12-size-type-aware-dispatch-ceiling-design.md; revisit 2026-09-12)
+DISPATCH_CEILING_ENABLED="${DISPATCH_CEILING_ENABLED:-true}"
+ABOVE_CEILING_LABEL="${ABOVE_CEILING_LABEL:-above-ceiling}"
+ABOVE_CEILING_KEYWORDS="${ABOVE_CEILING_KEYWORDS:-migration|migrate|performance|perf|architectur|refactor}"
+```
+
+**Step 1.4 — Add the four helper functions to `scheduler.sh`**
+
+Insert after the closing `}` of `has_direct_to_pr_label()` (line 153),
+before `# Returns minutes elapsed since...` / `elapsed_minutes_since_marker`:
+
+```bash
+# Returns "S", "M", "L", or "" from the item's labels
+get_size_label() {
+  echo "$1" | jq -r '.labels[]?' 2>/dev/null | grep -oi 'size: [SML]' | awk '{print $2}' | head -1
+}
+
+# True (returns 0) if item is at or above the dispatch ceiling
+is_above_ceiling() {
+  local item="$1" title size
+  title=$(echo "$item" | jq -r '.content.title // ""' 2>/dev/null)
+  size=$(get_size_label "$item")
+  case "$size" in
+    L) return 0 ;;
+    M) echo "$title" | grep -qiE "${ABOVE_CEILING_KEYWORDS}" && return 0 || return 1 ;;
+    *) return 1 ;;
+  esac
+}
+
+# True if item carries the above-ceiling label (board-fetch snapshot)
+has_above_ceiling_label() {
+  echo "$1" | jq -r '.labels[]?' 2>/dev/null | grep -qi "^${ABOVE_CEILING_LABEL}$"
+}
+
+# True if item is S-size or has no size label (treated as S per spec)
+is_below_ceiling() {
+  local size
+  size=$(get_size_label "$1")
+  case "$size" in S|"") return 0 ;; *) return 1 ;; esac
+}
+```
+
+**Step 1.5 — Verify syntax**
+
+```bash
+bash -n dark-factory/scheduler.sh && echo "syntax OK"
+```
+
+Expected: `syntax OK`
+
+**Step 1.6 — Commit Task 1**
+
+```bash
+git add dark-factory/scheduler.sh dark-factory/test_dispatch_ceiling.sh
+git commit -m "feat(scheduler): add dispatch ceiling constants and helper functions (#339)
+
+- DISPATCH_CEILING_ENABLED / ABOVE_CEILING_LABEL / ABOVE_CEILING_KEYWORDS constants
+- get_size_label / is_above_ceiling / has_above_ceiling_label / is_below_ceiling helpers
+- test_dispatch_ceiling.sh harness (27 assertions)"
+```
+
+---
+
+### Task 2 — Priority 2 ceiling gate (above-ceiling → Blocked + label + comment)
+
+**Files:** `dark-factory/scheduler.sh`
+
+#### TDD steps
+
+**Step 2.1 — Confirm test already covers P2 gate logic**
+
+The `p2_gate_outcome` assertions added in Task 1's test script cover this. Run to confirm:
+
+```bash
+bash dark-factory/test_dispatch_ceiling.sh
+```
+
+Expected: `Results: 27 passed, 0 failed` (all pass, including the 5 P2 gate tests).
+
+**Step 2.2 — Insert ceiling gate in Priority 2 loop**
+
+In `dark-factory/scheduler.sh`, locate the Priority 2 loop (around line 832+).
+Find the line `if is_issue_running "$ISSUE"; then continue; fi` inside the Ready loop.
+Insert the ceiling gate immediately after that line, before `if dispatch "Fix issue #${ISSUE}"; then`:
+
+```bash
+    if [ "${DISPATCH_CEILING_ENABLED:-true}" = "true" ] && is_above_ceiling "$item"; then
+      if ! has_above_ceiling_label "$item"; then
+        echo "[$(date -u +%FT%TZ)] ceiling_gate issue=#${ISSUE} action=above_ceiling_blocked"
+        gh issue edit "$ISSUE" --repo "${OWNER}/markethawk" \
+          --add-label "$ABOVE_CEILING_LABEL" 2>/dev/null || true
+        set_board_status "$ISSUE" "$STATUS_BLOCKED" || true
+        gh issue comment "$ISSUE" --repo "${OWNER}/markethawk" --body \
+"## Scheduler — Above Dispatch Ceiling
+
+This ticket has been classified as **above the autonomous dispatch ceiling** \
+(size: L, or size: M with a perf/architectural/migration title keyword).
+
+Spec and plan are complete. **A human must pair on implementation.**
+
+To proceed:
+1. Remove the \`$ABOVE_CEILING_LABEL\` label.
+2. Dispatch manually:
+   \`\`\`bash
+   docker compose --profile factory run --rm dark-factory \"Fix issue #${ISSUE}\"
+   \`\`\`
+   Or implement directly in a local worktree.
+
+---
+*Posted by MarketHawk Backlog Scheduler*" 2>/dev/null || true
+      fi
+      continue
+    fi
+```
+
+The final `continue` after the `fi` block ensures the loop moves on regardless of whether
+the label was just added or was already present — no dispatch happens.
+
+**Step 2.3 — Verify syntax**
+
+```bash
+bash -n dark-factory/scheduler.sh && echo "syntax OK"
+```
+
+**Step 2.4 — Commit Task 2**
+
+```bash
+git add dark-factory/scheduler.sh
+git commit -m "feat(scheduler): Priority 2 ceiling gate — block L/M+keyword tickets (#339)
+
+Above-ceiling items: add above-ceiling label, move to Blocked, post
+human-pairing comment, and skip dispatch. Guard against re-posting
+on every cycle via has_above_ceiling_label check."
+```
+
+---
+
+### Task 3 — Priority 3 guard (skip above-ceiling blocked items)
+
+**Files:** `dark-factory/scheduler.sh`
+
+#### TDD steps
+
+**Step 3.1 — Confirm test already covers P3 guard logic**
+
+```bash
+bash dark-factory/test_dispatch_ceiling.sh
+```
+
+Expected: `Results: 27 passed, 0 failed` (including the 2 P3 guard tests).
+
+**Step 3.2 — Insert guard in Priority 3 loop**
+
+In `dark-factory/scheduler.sh`, locate the Priority 3 loop (around line 847+).
+Find the line `if has_skip_label "$item"; then continue; fi` inside the Blocked loop.
+Insert the above-ceiling guard on the very next line after it:
+
+```bash
+    if has_above_ceiling_label "$item"; then continue; fi
+```
+
+This single line prevents the retry loop from dispatching a "Continue" or "Fix" run on any
+Blocked item that carries the `above-ceiling` label — whether placed there by the P2 gate
+or by a human who manually moved the ticket.
+
+**Step 3.3 — Verify syntax**
+
+```bash
+bash -n dark-factory/scheduler.sh && echo "syntax OK"
+```
+
+**Step 3.4 — Commit Task 3**
+
+```bash
+git add dark-factory/scheduler.sh
+git commit -m "feat(scheduler): Priority 3 guard — skip above-ceiling blocked items (#339)"
+```
+
+---
+
+### Task 4 — Suppress plan_advance_check grace-advance for M and L
+
+**Files:** `dark-factory/scheduler.sh`
+
+#### TDD steps
+
+**Step 4.1 — Confirm test already covers plan_advance suppression**
+
+```bash
+bash dark-factory/test_dispatch_ceiling.sh
+```
+
+Expected: `Results: 27 passed, 0 failed` (including the 5 plan_advance tests).
+
+**Step 4.2 — Insert suppression block in `plan_advance_check()`**
+
+In `dark-factory/scheduler.sh`, locate `plan_advance_check()` (around line 208).
+Find the line `if has_direct_to_pr_label "$item"; then` (the grace-window branch).
+Insert the suppression block immediately before that line:
+
+```bash
+  # Suppress timer-based advance for at/above-ceiling items: M and L require
+  # explicit human plan approval; the grace window applies only to S-size.
+  if [ "${DISPATCH_CEILING_ENABLED:-true}" = "true" ] && ! is_below_ceiling "$item"; then
+    return 0
+  fi
+```
+
+The "new human feedback re-runs plan" path (the `has_new` block above this point) is NOT
+suppressed — human feedback always triggers a re-run regardless of size.
+
+**Step 4.3 — Verify syntax**
+
+```bash
+bash -n dark-factory/scheduler.sh && echo "syntax OK"
+```
+
+**Step 4.4 — Run full test suite**
+
+```bash
+bash dark-factory/test_dispatch_ceiling.sh
+```
+
+Expected: `Results: 27 passed, 0 failed`
+
+**Step 4.5 — Commit Task 4**
+
+```bash
+git add dark-factory/scheduler.sh
+git commit -m "feat(scheduler): suppress plan grace-advance for M/L tickets (#339)
+
+plan_advance_check() now returns early for M and L items before
+reaching the has_direct_to_pr grace-window branch. Human feedback
+path is unaffected."
+```
+
+---
+
+### Task 5 — Mirror constants in config.yaml and verify YAML validity
+
+**Files:** `.claude/skills/refinement/config.yaml`
+
+#### TDD steps
+
+**Step 5.1 — Confirm the mirror gap**
+
+```bash
+grep -c "dispatch_ceiling" .claude/skills/refinement/config.yaml || echo "0 (expected)"
+```
+
+Expected: `0 (expected)` — section does not yet exist.
+
+**Step 5.2 — Append the `dispatch_ceiling` section**
+
+At the end of `.claude/skills/refinement/config.yaml`, append:
+
+```yaml
+
+dispatch_ceiling:
+  enabled: true                # mirror of $DISPATCH_CEILING_ENABLED (set false in .archon/.env to disable)
+  label: above-ceiling         # mirror of $ABOVE_CEILING_LABEL
+  keywords: "migration|migrate|performance|perf|architectur|refactor"  # mirror of $ABOVE_CEILING_KEYWORDS
+  # Doc-only: the scheduler reads env-var defaults in scheduler.sh, not this file.
+  # To override without a code change, set these vars in .archon/.env.
+  # See docs/superpowers/specs/2026-06-12-size-type-aware-dispatch-ceiling-design.md for rationale.
+  # Revisit: 2026-09-12
+```
+
+**Step 5.3 — Verify YAML validity**
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.claude/skills/refinement/config.yaml'))" \
+  && echo "config.yaml: YAML valid"
+```
+
+Expected: `config.yaml: YAML valid`
+
+**Step 5.4 — Commit Task 5**
+
+```bash
+git add .claude/skills/refinement/config.yaml
+git commit -m "chore(config): mirror dispatch ceiling constants in config.yaml (#339)"
+```
+
+---
+
+### Task 6 — File the revisit GitHub issue
+
+**Files:** (no file changes — GitHub issue creation only)
+
+#### Steps
+
+**Step 6.1 — Check revisit issue does not already exist**
+
+```bash
+gh issue list --repo omniscient/markethawk \
+  --search "Revisit dispatch ceiling" \
+  --json number,title \
+  --jq '.[] | "\(.number): \(.title)"'
+```
+
+Expected: no output (issue does not exist yet).
+
+**Step 6.2 — Create the revisit issue**
+
+```bash
+gh issue create \
+  --repo omniscient/markethawk \
+  --title "Revisit dispatch ceiling (C9) — re-measure success-by-size/type" \
+  --body "$(cat <<'EOF'
+## Purpose
+
+Quarterly revisit of the dispatch ceiling policy introduced in #339.
+
+## What to review
+
+1. Pull Factory Scorecard (#331) success-by-S/M/L numbers from the last quarter.
+2. Compare against the initial thresholds (L = always above-ceiling; M + keyword = above-ceiling).
+3. Assess keyword false-positive rate — especially for "refactor". If high, narrow the list.
+4. Adjust \`ABOVE_CEILING_KEYWORDS\` in \`.archon/.env\` if data warrants, without a code change.
+
+## References
+
+- Spec: \`docs/superpowers/specs/2026-06-12-size-type-aware-dispatch-ceiling-design.md\`
+- Architecture review candidate C9: \`docs/dark-factory-architecture-review-2026-06-11.html\`
+- Factory Scorecard: #331
+
+## Target date
+
+**2026-09-12** (quarterly from 2026-06-12 policy introduction).
+The primary trigger is #331 producing per-bucket success rates over a full quarter;
+2026-09-12 is the time-boxed backstop if the data hasn't converged.
+
+---
+*Filed automatically by issue #339 plan generation*
+EOF
+)" \
+  --label "priority: should-have" \
+  --label "Dark Factory"
+```
+
+**Step 6.3 — Verify issue was created**
+
+```bash
+gh issue list --repo omniscient/markethawk \
+  --search "Revisit dispatch ceiling" \
+  --json number,title \
+  --jq '.[] | "\(.number): \(.title)"'
+```
+
+Expected: one line like `350: Revisit dispatch ceiling (C9) — re-measure success-by-size/type`
+
+**Step 6.4 — Final integration check**
+
+```bash
+# Syntax check
+bash -n dark-factory/scheduler.sh && echo "scheduler.sh: syntax OK"
+
+# Full test suite
+bash dark-factory/test_dispatch_ceiling.sh
+
+# YAML validity
+python3 -c "import yaml; yaml.safe_load(open('.claude/skills/refinement/config.yaml'))" \
+  && echo "config.yaml: valid"
+
+# Spec checklist coverage
+echo "Constants defined:"
+grep -c "DISPATCH_CEILING_ENABLED\|ABOVE_CEILING_LABEL\|ABOVE_CEILING_KEYWORDS" \
+  dark-factory/scheduler.sh
+
+echo "Helpers defined:"
+grep -c "^get_size_label\|^is_above_ceiling\|^has_above_ceiling_label\|^is_below_ceiling" \
+  dark-factory/scheduler.sh
+
+echo "P2 ceiling gate present:"
+grep -c "ceiling_gate" dark-factory/scheduler.sh
+
+echo "P3 guard present:"
+grep -c "has_above_ceiling_label.*continue" dark-factory/scheduler.sh
+
+echo "plan_advance_check suppression present:"
+grep -c "is_below_ceiling" dark-factory/scheduler.sh
+
+echo "config.yaml mirror present:"
+grep -c "dispatch_ceiling" .claude/skills/refinement/config.yaml
+```
+
+Expected output:
+```
+scheduler.sh: syntax OK
+Results: 27 passed, 0 failed
+config.yaml: valid
+Constants defined: 3
+Helpers defined: 4
+P2 ceiling gate present: 1
+P3 guard present: 1
+plan_advance_check suppression present: 1
+config.yaml mirror present: 1
+```
+
+---
+
+*Plan generated by MarketHawk Refinement Pipeline — 2026-06-12*

--- a/docs/superpowers/specs/2026-06-12-size-type-aware-dispatch-ceiling-design.md
+++ b/docs/superpowers/specs/2026-06-12-size-type-aware-dispatch-ceiling-design.md
@@ -1,0 +1,278 @@
+# Size/Type-Aware Dispatch Ceiling in the Scheduler
+
+**Date:** 2026-06-12
+**Issue:** #339
+**Depends on:** #331 (Factory Scorecard — closed)
+**Status:** Spec
+
+---
+
+## Problem
+
+The scheduler dispatches every Ready ticket identically regardless of size or
+task type. Published research shows agent success rates vary ~30 points by task
+type (chores merge at 84%, perf work at 55% — MSR '26 / arXiv 2602.08915) and
+collapse above a size threshold (METR time-horizon data). Dispatching L-size or
+architectural/migration/perf tickets to autonomous implement burns 5-hour Max
+windows on work the factory predictably fails.
+
+---
+
+## Requirements
+
+1. The scheduler classifies every Ready ticket before dispatch: **below ceiling**
+   (S), **at ceiling** (M), or **above ceiling** (L / keyword-escalated M).
+2. Above-ceiling tickets are moved to Blocked with a new `above-ceiling` label,
+   never auto-dispatched to implement.
+3. At-ceiling (M) tickets with `direct-to-pr` lose the `plan-pending-review`
+   grace-window auto-advance; they require explicit human plan approval.
+4. Below-ceiling (S) tickets: no change to current behaviour (both spec and plan
+   grace-windows apply, `direct-to-pr` fully autonomous).
+5. Policy constants live in `scheduler.sh` as env-var defaults (consistent with
+   `SKIP_LABELS`, `FACTORY_WIP_LIMIT`, etc.); #338 consolidates them later.
+6. Ceiling rationale and revisit date documented; a quarterly revisit issue filed.
+
+---
+
+## Architecture / Approach
+
+### Classification
+
+Two signals combine, with escalation only (the heuristic never demotes):
+
+| Size label | + keyword match? | Tier |
+|------------|-----------------|------|
+| `size: S` or absent | — | Below ceiling |
+| `size: M` | No | At ceiling |
+| `size: M` | Yes (title contains keyword) | Above ceiling |
+| `size: L` | — | Above ceiling (always) |
+
+**Keywords** (`ABOVE_CEILING_KEYWORDS` env var):
+`migration|migrate|performance|perf|architectur|refactor`
+
+These are the three task types the issue names — perf, architectural, migrations
+— expressed as grep-able title substrings. A keyword match on an M-size ticket
+is the only escalation path; L is unconditionally above-ceiling.
+
+### New constants in `scheduler.sh`
+
+```bash
+# Dispatch ceiling policy (see docs/superpowers/specs/2026-06-12-*.md; revisit 2026-09-12)
+DISPATCH_CEILING_ENABLED="${DISPATCH_CEILING_ENABLED:-true}"
+ABOVE_CEILING_LABEL="${ABOVE_CEILING_LABEL:-above-ceiling}"
+ABOVE_CEILING_KEYWORDS="${ABOVE_CEILING_KEYWORDS:-migration|migrate|performance|perf|architectur|refactor}"
+```
+
+`DISPATCH_CEILING_ENABLED` is a kill-switch: set to `false` in `.archon/.env` to
+restore the old flat-dispatch behaviour without code changes.
+
+### New helper functions
+
+```bash
+# Returns "S", "M", "L", or "" from the item's labels
+get_size_label() {
+  echo "$1" | jq -r '.labels[]?' 2>/dev/null | grep -oi 'size: [SML]' | awk '{print $2}' | head -1
+}
+
+# True (returns 0) if item is at or above the dispatch ceiling
+is_above_ceiling() {
+  local item="$1" title size
+  title=$(echo "$item" | jq -r '.content.title // ""' 2>/dev/null)
+  size=$(get_size_label "$item")
+  case "$size" in
+    L) return 0 ;;
+    M) echo "$title" | grep -qiE "${ABOVE_CEILING_KEYWORDS}" && return 0 || return 1 ;;
+    *) return 1 ;;
+  esac
+}
+
+# True if item carries the above-ceiling label (board-fetch snapshot)
+has_above_ceiling_label() {
+  echo "$1" | jq -r '.labels[]?' 2>/dev/null | grep -qi "^${ABOVE_CEILING_LABEL}$"
+}
+
+# True if item is S-size or has no size label
+is_below_ceiling() {
+  local size
+  size=$(get_size_label "$1")
+  case "$size" in S|"") return 0 ;; *) return 1 ;; esac
+}
+```
+
+### Changes to the dispatch loops
+
+**Priority 2 — Ready items**
+
+Before the `dispatch "Fix issue #${ISSUE}"` call, insert a ceiling gate:
+
+```bash
+if [ "${DISPATCH_CEILING_ENABLED:-true}" = "true" ] && is_above_ceiling "$item"; then
+  if ! has_above_ceiling_label "$item"; then
+    echo "[...] ceiling_gate issue=#${ISSUE} action=above_ceiling_blocked"
+    gh issue edit "$ISSUE" --repo "${OWNER}/markethawk" \
+      --add-label "$ABOVE_CEILING_LABEL" 2>/dev/null || true
+    set_board_status "$ISSUE" "$STATUS_BLOCKED" || true
+    gh issue comment "$ISSUE" --repo "${OWNER}/markethawk" --body \
+"## Scheduler — Above Dispatch Ceiling
+
+This ticket has been classified as **above the autonomous dispatch ceiling** \
+(size: L, or size: M with a perf/architectural/migration title keyword).
+
+Spec and plan are complete. **A human must pair on implementation.**
+
+To proceed:
+1. Remove the \`$ABOVE_CEILING_LABEL\` label.
+2. Dispatch manually:
+   \`\`\`bash
+   docker compose --profile factory run --rm dark-factory \"Fix issue #${ISSUE}\"
+   \`\`\`
+   Or implement directly in a local worktree.
+
+---
+*Posted by MarketHawk Backlog Scheduler*" 2>/dev/null || true
+  fi
+  continue
+fi
+```
+
+`has_above_ceiling_label` guards against re-posting the comment and re-moving
+the board on every cycle (the label persists across cycles via GitHub issue
+labels returned by the next `fetch_board_items` call).
+
+**Priority 3 — Blocked items**
+
+Add a single guard at the top of the per-item block, immediately after the
+`has_skip_label` check:
+
+```bash
+if has_above_ceiling_label "$item"; then continue; fi
+```
+
+This prevents the retry loop from auto-dispatching a "Fix" or "Continue" run
+on an above-ceiling ticket that was moved to Blocked by the gate above, or by a
+human who manually moved it there.
+
+**`plan_advance_check()` — suppress grace-advance for M and L**
+
+Inside `plan_advance_check`, immediately before the `has_direct_to_pr_label`
+grace-window branch, add:
+
+```bash
+# Suppress timer-based advance for at/above-ceiling items: M and L require
+# explicit human plan approval; the grace window applies only to S-size.
+if [ "${DISPATCH_CEILING_ENABLED:-true}" = "true" ] && ! is_below_ceiling "$item"; then
+  return 0
+fi
+```
+
+The existing "new human feedback re-runs plan" path (the `has_new` block) is
+NOT suppressed — human feedback always re-runs. Only the timer-based
+auto-advance is blocked.
+
+### What is NOT changed
+
+- `spec_advance_check()` — spec grace-advance is unaffected for M tickets. The
+  ceiling gates *implement dispatch*, not spec or plan generation. An M ticket's
+  spec auto-advances to Refined; it then hits the human gate at `plan-pending-review`.
+- Refine and plan dispatch (Priorities 4 and 5) — above-ceiling tickets are still
+  refined and planned normally. `ABOVE_CEILING_LABEL` is NOT added to `SKIP_LABELS`.
+- Circuit-breaker (`trip_to_blocked` / `needs-discussion`) — semantics unchanged.
+  `above-ceiling` is a deliberate routing decision, not a failure state; the two
+  label types must remain distinct.
+- Board WIP limits and all other scheduler machinery — no changes.
+
+---
+
+## Alternatives Considered
+
+### A: Size-only, no type heuristic
+
+Drop the keyword escalation and enforce ceiling on size label alone. Simpler,
+but fails the acceptance criterion ("policy keyed on existing `size:` labels
+*plus* a small task-type heuristic"). Also misses the concrete failure mode the
+issue names: an M-size db-migration ticket that is really above-ceiling.
+Rejected.
+
+### B: Introduce `task-type:` label taxonomy
+
+Create `task-type: perf`, `task-type: architectural`, `task-type: migration`
+labels and enforce ceiling from those. More precise but requires label tooling
+changes and manual tagging discipline not currently in place. The issue says use
+"existing" labels; new taxonomy is out of scope. Rejected for now; the keyword
+heuristic is the lightweight proxy the issue describes, and a full taxonomy is a
+natural future upgrade once the policy matures.
+
+### C: Parse `config.yaml` for ceiling policy
+
+Pre-empt #338 by making `scheduler.sh` read `config.yaml` with `yq`. Adds a
+YAML-parsing dependency to a `set -euo pipefail` bash daemon; #338 owns that
+consolidation. Env-var constants in `scheduler.sh` is the established pattern
+and is what `config.yaml` already mirrors for other scheduler settings. Rejected.
+
+### D: Move above-ceiling tickets back to Backlog
+
+Would re-trigger refinement (`Refine issue #N`) on items that already have a
+complete spec + plan, wasting a Max window and looping forever (size never
+changes). Rejected; Blocked with `above-ceiling` label is the correct park state.
+
+---
+
+## Evidence
+
+Threshold rationale drawn from:
+
+- **MSR '26** (arXiv 2602.08915): task-stratified PR acceptance — chores 84%,
+  perf/architectural work 55%. The ~30-point gap makes type-aware gating
+  worthwhile.
+- **METR time-horizon data**: success rate collapses above a task-size threshold;
+  L-size tickets are in the regime where autonomous completion is below break-even.
+- **Dark Factory Architecture Review 2026-06-11** (`docs/dark-factory-architecture-review-2026-06-11.html`),
+  candidate **C9**: specifically recommends this ceiling as a measurable,
+  revisitable policy rather than a guessed constant.
+
+---
+
+## Revisit
+
+**First revisit:** 2026-09-12 (quarterly).
+**Filed as:** GitHub issue "Revisit dispatch ceiling (C9) — re-measure success-by-size/type".
+**Primary trigger:** Factory Scorecard (#331) producing success-by-S/M/L numbers
+over a full quarter — that data drives any threshold adjustment. The date is a
+time-boxed backstop if the scorecard data doesn't converge.
+
+To adjust the ceiling without a code change, update `.archon/.env`:
+```bash
+ABOVE_CEILING_KEYWORDS="migration|migrate|performance|perf|architectur|refactor"
+DISPATCH_CEILING_ENABLED=false   # kill-switch
+```
+
+---
+
+## Open Questions (non-blocking)
+
+1. **Keyword false-positive rate** — "refactor" may catch reasonable M-size
+   cleanups that the factory handles fine. If false positives accumulate, narrow
+   the keyword list (e.g. remove "refactor") in `.archon/.env` before the revisit.
+2. **Unsize-labelled tickets** — treated as S (below ceiling). If unlabelled
+   L-size tickets accumulate, triage policy should require the `size:` label on
+   every ticket before it reaches Ready.
+3. **Scorecard integration** — once #331 produces per-bucket success rates, the
+   ceiling thresholds can be moved from keyword heuristics to data-driven cutoffs.
+   At that point, #338's config consolidation and this revisit should land together.
+
+---
+
+## Implementation Checklist
+
+- [ ] Add `DISPATCH_CEILING_ENABLED`, `ABOVE_CEILING_LABEL`, `ABOVE_CEILING_KEYWORDS` constants to `scheduler.sh`
+- [ ] Add `get_size_label`, `is_above_ceiling`, `has_above_ceiling_label`, `is_below_ceiling` helpers
+- [ ] Priority 2 (Ready) ceiling gate: move above-ceiling → Blocked + label + comment
+- [ ] Priority 3 (Blocked-retry): skip `has_above_ceiling_label` items
+- [ ] `plan_advance_check()`: suppress grace-advance for non-below-ceiling items
+- [ ] Mirror new constants in `config.yaml` as doc-only entries (matching existing pattern)
+- [ ] File revisit issue for 2026-09-12
+- [ ] Inline comment in `scheduler.sh` constants block citing spec path and revisit date
+
+---
+
+*Spec generated by MarketHawk Refinement Pipeline — 2026-06-12*


### PR DESCRIPTION
Closes omniscient/dark-factory#107

## Summary

Human-paired implementation (per this ticket's own above-ceiling policy — it's a size-M architectural scheduler change). Based on the factory-generated spec + plan; the out-of-scope implementation commits on `refine/issue-339-*` were scrapped (stale, 67 commits behind, never validated — see omniscient/dark-factory#118).

- **Priority 2 ceiling gate**: Ready tickets classified before dispatch. `size: L` always — and `size: M` with a perf/architectural/migration title keyword — are parked in **Blocked** under the new `above-ceiling` label with a human-pairing comment, never auto-dispatched to implement.
- **Priority 3 guard**: the Blocked retry loop skips `above-ceiling` items (parked by design, not failed).
- **`plan_advance_check` suppression**: M/L tickets lose the `plan-pending-review` grace-window auto-advance; the human-feedback re-plan path and spec auto-advance are untouched. S keeps full autonomy.
- **Kill-switch**: `DISPATCH_CEILING_ENABLED=false` in `.archon/.env` restores flat dispatch; `ABOVE_CEILING_KEYWORDS` overridable the same way.
- Spec + plan docs archived under `docs/superpowers/`; config.yaml doc-mirror added; quarterly revisit filed as omniscient/dark-factory#119.

## Deviations from the generated plan

1. Test harness lives at `dark-factory/tests/test_dispatch_ceiling.sh` and **sources the real `scheduler.sh`** via `SCHEDULER_SOURCE_ONLY=1` (existing harness convention), instead of the plan's standalone copy of the helpers — drift between tests and implementation is now impossible.
2. Created the **`above-ceiling` label** in the repo (plan omitted it). Without it, `gh issue edit --add-label` fails silently and the gate would re-post the comment + re-move the board every 60s cycle.

## Validation

- `bash -n dark-factory/scheduler.sh` — syntax OK
- `bash dark-factory/tests/test_dispatch_ceiling.sh` — **33 passed, 0 failed**
- `bash dark-factory/tests/test_scheduler.sh` — **75 passed, 0 failed** (no regression)
- `config.yaml` YAML-validated
- (`test_has_new_comment_after_report.sh` / `test_159_regression.sh` fail at source-time on Windows hosts — pre-existing `mkdir /var` issue, unrelated)

## Deploy note

`scheduler.sh` is **baked into the dark-factory image**. After merge:

```bash
docker compose build backlog-scheduler
docker compose up -d --force-recreate backlog-scheduler
```

Related: omniscient/dark-factory#117 (dependencies_met bug that masked this ticket's dispatch), omniscient/dark-factory#118 (plan-stage overreach), omniscient/dark-factory#119 (quarterly revisit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
