### PR TITLE
fix(factory): parseable when: on classify-preview - stop silent work-discard (#397)

### DIFF
--- a/.archon/workflows/archon-dark-factory.yaml
+++ b/.archon/workflows/archon-dark-factory.yaml
@@ -537,15 +537,22 @@ nodes:
     when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
     timeout: 15000
 
-  # Bench mode probe: outputs 'stub' when BENCH_MODE=stub so classify-preview can gate on it.
-  # This prevents classify-preview from making a Haiku call during replay benchmark runs.
+  # Bench mode probe: outputs 'stub' when BENCH_MODE=stub, 'live' otherwise, so
+  # classify-preview can gate on it (prevents a Haiku call during replay benchmark runs).
+  # Unconditional and always emits a value: classify-preview's `when:` references this
+  # output, and Archon's when-parser supports only simple/single-operator expressions —
+  # NO parentheses. The parenthesized intent+probe compound (b675ecd) was unparseable,
+  # so classify-preview skipped fail-closed and the all_success trigger-rule cascade
+  # skipped validate/push-and-pr/report: every implement run exited 0 while silently
+  # discarding its work (#397).
   - id: bench-mode-probe
     bash: |
       if [ "${BENCH_MODE:-}" = "stub" ]; then
         echo "stub"
+      else
+        echo "live"
       fi
     depends_on: [fetch-issue]
-    when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
     timeout: 5000
 
   - id: classify-preview
@@ -586,7 +593,10 @@ nodes:
     allowed_tools: [Read]
     model: haiku
     depends_on: [preview-changeset, fetch-issue, bench-mode-probe]
-    when: "($parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue') && $bench-mode-probe.output != 'stub'"
+    # Intent gating (new/continue) is enforced structurally: preview-changeset only runs
+    # for those intents, and its skip cascades here via the default all_success trigger
+    # rule. Keep this `when:` in the parser-supported simple form (#397).
+    when: "$bench-mode-probe.output == 'live'"
     output_format:
       type: object
       properties:


### PR DESCRIPTION
Closes omniscient/dark-factory#120

## What broke

Commit `b675ecd` (PR omniscient/markethawk#359, merged 14:54 UTC today, authored by the factory's own conformance cycle) gave `classify-preview` a parenthesized `when:` expression. Archon's `when:` parser supports only simple/single-operator expressions — no parentheses — so the node skipped **fail-closed**, and the default `all_success` trigger rules cascaded the skip through `preview-up` → `validate` → `conformance` → `push-and-pr` → `code-review` → `status-in-review` → `report`.

Result: **every implement run since 14:54 UTC completed its work, committed locally, then exited 0 without pushing anything** — no PR, no comment, no board move. Tickets stranded In progress → orphan-sweep → Blocked → retry → identical no-op → omniscient/markethawk#90 circuit-broke; omniscient/markethawk#106/#309/#311 burned 2-3 Max-window runs each.

## The fix

- `bench-mode-probe` is now **unconditional** and always emits `live` or `stub` (previously it only ran for new/continue intents and emitted nothing in live mode).
- `classify-preview`'s gate becomes the parser-supported simple form: `when: "$bench-mode-probe.output == 'live'"`.
- The intent gating (new/continue) the old expression carried is already enforced structurally: `classify-preview` depends on `preview-changeset`, which only runs for those intents, and skips cascade via `all_success` — the very mechanism that caused this outage proves the cascade works.

Bench/replay semantics from omniscient/dark-factory#103 are preserved: in `BENCH_MODE=stub`, classify-preview (the Haiku call) still skips.

## Validation

- YAML parses (UTF-8).
- No parenthesized `when:` expressions remain in the workflow (grep-verified).
- Diagnosed by reproducing with a manual foreground `Fix issue omniscient/markethawk#311` run — full trail in omniscient/dark-factory#120.
- Post-merge validation: re-run `Fix issue omniscient/markethawk#311` and confirm `classify-preview` executes and `push-and-pr` produces a draft PR. (Workflow YAML is clone-read — takes effect on the next dispatch after merge, no image rebuild.)

## Follow-ups (in omniscient/dark-factory#120)

- Archon engine: unparseable `when:` should fail the run, not silently skip.
- CI lint for `when:` grammar in `.archon/workflows/*.yaml`.
- Recovery for stranded tickets (#90 needs-discussion removal, retry-counter reset, scheduler restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
