### PR TITLE
[security] F-AUTH-01: Swagger/openapi.json/metrics unauthenticated in production

### DIFF
--- a/.archon/memory/backend-patterns.md
+++ b/.archon/memory/backend-patterns.md
@@ -75,6 +75,8 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 
 - [PATTERN] CSRF_EXEMPT_PREFIXES and AUTH EXEMPT_PREFIXES serve different concerns and must remain separate tuples in `main.py`. Do not merge them — CSRF exempts pre-authentication paths; auth exempts docs/health/metrics paths that are unrelated to CSRF. <!-- issue:#192 date:2026-06-05 expires:2026-12-05 source:implement -->
 
+- [PATTERN] Keep `/metrics` in `EXEMPT_PREFIXES` (no bearer-token auth) and rely on Caddyfile `handle /metrics { respond 404 }` as defense-in-depth — Prometheus scrapes `backend:8000/metrics` on the internal Docker network (Caddy doesn't proxy `/metrics`), and adding app-level auth would break Prometheus scraping since it cannot send JWT cookies. <!-- issue:#369 date:2026-06-13 expires:2026-12-13 source:implement -->
+
 - [AVOID] EnrichedSignal must carry raw:RawSignal and day_metrics:dict stage-boundary fields per spec; omitting them severs the seam contract and blocks recovery of the original signal from enriched output <!-- issue:#288 date:2026-06-12 expires:2026-12-12 source:conformance path:backend/app/services/ -->
 - [AVOID] Stage functions (especially _enrich_one / per-ticker helpers) must stay under ~80 lines; when a helper grows large, extract the indicator-building body into a named _build_indicators() sub-helper rather than leaving it inline <!-- issue:#288 date:2026-06-12 expires:2026-12-12 source:conformance path:backend/app/services/ -->
 ---

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -56,6 +56,9 @@ class Settings(BaseSettings):
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7
     # Secure cookies — default True; set to false in docker-compose.override.yml for local HTTP dev
     COOKIE_SECURE: bool = True
+    # API docs (Swagger/ReDoc/openapi.json) — default False (secure-by-default).
+    # Set to true in docker-compose.override.yml for local dev. Never enable in production.
+    DOCS_ENABLED: bool = False
 
     # Connection pool
     DB_POOL_SIZE: int = 20

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -249,11 +249,18 @@ def create_app() -> FastAPI:
 
         logging.info("Advanced SQL Logging enabled (Copy-Paste friendly)")
 
+    _docs_url = "/docs" if settings.DOCS_ENABLED else None
+    _redoc_url = "/redoc" if settings.DOCS_ENABLED else None
+    _openapi_url = "/openapi.json" if settings.DOCS_ENABLED else None
+
     app = FastAPI(
         title=settings.APP_NAME,
         description="Professional stock scanning and alert system",
         version=settings.APP_VERSION,
         lifespan=lifespan,
+        docs_url=_docs_url,
+        redoc_url=_redoc_url,
+        openapi_url=_openapi_url,
     )
 
     setup_otel(
@@ -263,16 +270,15 @@ def create_app() -> FastAPI:
     )
     instrument_fastapi(app)
 
-    EXEMPT_PREFIXES = (
+    _base_exempt = (
         "/api/auth/",
         "/api/health",
         "/api/ready",
         "/metrics",
         "/api/alerts/infrastructure",
-        "/docs",
-        "/redoc",
-        "/openapi.json",
     )
+    _doc_prefixes = ("/docs", "/redoc", "/openapi.json")
+    EXEMPT_PREFIXES = _base_exempt + (_doc_prefixes if settings.DOCS_ENABLED else ())
 
     # Pure ASGI auth middleware (deliberately NOT BaseHTTPMiddleware). BaseHTTPMiddleware
     # re-emits every response as a stream, which forces GZipMiddleware into chunked mode;

--- a/backend/tests/core/test_docs_enabled.py
+++ b/backend/tests/core/test_docs_enabled.py
@@ -1,0 +1,145 @@
+"""Tests for DOCS_ENABLED: Settings field, route registration, and auth gating."""
+
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost/test")
+os.environ.setdefault("POLYGON_API_KEY", "test-key-for-unit-tests-only")
+os.environ.setdefault("JWT_SECRET_KEY", "test-jwt-secret-key-for-unit-tests-only-aaa")
+os.environ.setdefault("RATE_LIMITING_ENABLED", "false")
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    from app.core.config import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ── Settings: DOCS_ENABLED field ──────────────────────────────────────────────
+
+
+class TestDocsEnabledSetting:
+    def test_default_is_false(self):
+        from app.core.config import Settings
+
+        s = Settings(
+            DATABASE_URL="postgresql://test:test@localhost/test",
+            POLYGON_API_KEY="test-key",
+        )
+        assert s.DOCS_ENABLED is False
+
+    def test_init_kwarg_true(self):
+        from app.core.config import Settings
+
+        s = Settings(
+            DATABASE_URL="postgresql://test:test@localhost/test",
+            POLYGON_API_KEY="test-key",
+            DOCS_ENABLED=True,
+        )
+        assert s.DOCS_ENABLED is True
+
+    def test_env_var_coercion(self, monkeypatch):
+        monkeypatch.setenv("DOCS_ENABLED", "true")
+        from app.core.config import Settings
+
+        s = Settings(
+            DATABASE_URL="postgresql://test:test@localhost/test",
+            POLYGON_API_KEY="test-key",
+        )
+        assert s.DOCS_ENABLED is True
+
+
+# ── App factory: route registration ───────────────────────────────────────────
+
+
+def _make_test_app(docs_enabled: bool):
+    """Create a fresh app instance with the given DOCS_ENABLED value."""
+    import app.main as main_mod
+    from app.core.config import Settings
+    from app.main import create_app
+
+    fake_settings = Settings(
+        DATABASE_URL="postgresql://test:test@localhost/test",
+        POLYGON_API_KEY="test-key",
+        DOCS_ENABLED=docs_enabled,
+    )
+    original = main_mod.settings
+    main_mod.settings = fake_settings
+    try:
+        test_app = create_app()
+    finally:
+        main_mod.settings = original
+    return test_app
+
+
+class TestDocsUrlsWhenDisabled:
+    def test_docs_url_is_none(self):
+        test_app = _make_test_app(docs_enabled=False)
+        assert test_app.docs_url is None
+
+    def test_redoc_url_is_none(self):
+        test_app = _make_test_app(docs_enabled=False)
+        assert test_app.redoc_url is None
+
+    def test_openapi_url_is_none(self):
+        test_app = _make_test_app(docs_enabled=False)
+        assert test_app.openapi_url is None
+
+
+class TestDocsUrlsWhenEnabled:
+    def test_docs_url_set(self):
+        test_app = _make_test_app(docs_enabled=True)
+        assert test_app.docs_url == "/docs"
+
+    def test_redoc_url_set(self):
+        test_app = _make_test_app(docs_enabled=True)
+        assert test_app.redoc_url == "/redoc"
+
+    def test_openapi_url_set(self):
+        test_app = _make_test_app(docs_enabled=True)
+        assert test_app.openapi_url == "/openapi.json"
+
+
+# ── Auth gating via EXEMPT_PREFIXES ───────────────────────────────────────────
+
+
+class TestAuthGating:
+    def test_docs_unauthenticated_401_when_disabled(self):
+        """When disabled, /docs is not exempt — AuthMiddleware returns 401."""
+        test_app = _make_test_app(docs_enabled=False)
+        client = TestClient(test_app, raise_server_exceptions=False)
+        response = client.get("/docs", follow_redirects=False)
+        assert response.status_code == 401
+
+    def test_openapi_json_unauthenticated_401_when_disabled(self):
+        """/openapi.json without auth returns 401 (not exempt, not registered)."""
+        test_app = _make_test_app(docs_enabled=False)
+        client = TestClient(test_app, raise_server_exceptions=False)
+        response = client.get("/openapi.json")
+        assert response.status_code == 401
+
+    def test_docs_unauthenticated_200_when_enabled(self):
+        """When enabled, /docs is exempt from auth — accessible without a cookie."""
+        test_app = _make_test_app(docs_enabled=True)
+        client = TestClient(test_app, raise_server_exceptions=False)
+        response = client.get("/docs")
+        assert response.status_code == 200
+
+    def test_metrics_always_exempt_when_disabled(self):
+        """/metrics is always accessible — DOCS_ENABLED does not affect it."""
+        test_app = _make_test_app(docs_enabled=False)
+        client = TestClient(test_app, raise_server_exceptions=False)
+        response = client.get("/metrics")
+        assert response.status_code == 200
+
+    def test_metrics_always_exempt_when_enabled(self):
+        """/metrics remains accessible when DOCS_ENABLED=True."""
+        test_app = _make_test_app(docs_enabled=True)
+        client = TestClient(test_app, raise_server_exceptions=False)
+        response = client.get("/metrics")
+        assert response.status_code == 200

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -2,6 +2,12 @@
     # HSTS: instruct browsers to use HTTPS for this domain for 1 year
     header Strict-Transport-Security "max-age=31536000; includeSubDomains" always
 
+    # Block external access to the Prometheus metrics endpoint.
+    # /metrics is accessible on the internal Docker network only (Prometheus scrapes backend:8000/metrics).
+    handle /metrics {
+        respond "Not found" 404
+    }
+
     # WebSocket and REST API — backend
     handle /api/* {
         reverse_proxy backend:8000

--- a/deployment-guide.md
+++ b/deployment-guide.md
@@ -116,6 +116,18 @@ A Caddy reverse proxy service is included in `docker-compose.yml`, gated behind 
 
 `COOKIE_SECURE` defaults to `true`. Local dev overrides this automatically via `docker-compose.override.yml` so cookies work over plain HTTP. In production the cookies require HTTPS; enabling the Caddy profile satisfies this.
 
+**API docs in production**
+
+`DOCS_ENABLED` defaults to `false` — Swagger UI, ReDoc, and `/openapi.json` are not served in production and return 401/404. This prevents the full API schema from being used as a reconnaissance map by unauthenticated callers.
+
+Local dev overrides this automatically via `docker-compose.override.yml` (`DOCS_ENABLED: "true"`), so developers have full access to `/docs` and `/openapi.json` without any manual steps.
+
+> **Note:** If you need docs access on a staging environment, add `DOCS_ENABLED=true` to that environment's `.env`. Never set this in production.
+
+**Prometheus `/metrics` isolation**
+
+`/metrics` is accessible on the internal Docker network only (Prometheus scrapes `backend:8000/metrics` directly). The Caddyfile blocks external requests to `/metrics` with a `404` response before they reach the backend — backend port 8000 must **not** be published to the host in production (`ports:` mapping removed or bound to `127.0.0.1`). If port 8000 is externally reachable, the Caddyfile deny is insufficient and the port mapping must be removed.
+
 **HTTP→HTTPS and HSTS**
 
 The Caddyfile redirects all HTTP (`:80`) requests to HTTPS and sets `Strict-Transport-Security` so browsers enforce HTTPS for all subsequent visits. Port 80 remains published only for Let's Encrypt HTTP-01 challenges and the redirect — no content is served over plain HTTP.
@@ -124,6 +136,7 @@ The Caddyfile redirects all HTTP (`:80`) requests to HTTPS and sets `Strict-Tran
 
 | Path pattern | Upstream |
 |---|---|
+| `/metrics` | 404 (Caddy deny — internal Docker network only) |
 | `/api/*` | `backend:8000` |
 | `/*` | `frontend:3333` |
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -18,6 +18,7 @@ services:
     command: sh -c "rm -rf /tmp/prometheus_multiproc/* 2>/dev/null; uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
     environment:
       COOKIE_SECURE: "false"
+      DOCS_ENABLED: "true"
 
   celery-worker:
     volumes:

--- a/docs/codeindex-hotspots.md
+++ b/docs/codeindex-hotspots.md
@@ -6,7 +6,7 @@ Files with blast score ≥ 5.0  (31 found)
     31.0  frontend/src/components/ui/Card.tsx  (21d / 20t)  44 loc
     29.0  backend/app/routers/system.py  (2d / 54t)  141 loc
     29.0  services/tweet-monitor/app/main.py  (2d / 54t)  266 loc
-    27.0  backend/app/main.py  (1d / 52t)  508 loc
+    27.0  backend/app/main.py  (1d / 52t)  514 loc
     27.0  backend/app/routers/futures.py  (1d / 52t)  188 loc
     27.0  backend/app/routers/scanner.py  (1d / 52t)  709 loc
     27.0  backend/app/routers/universe.py  (1d / 52t)  446 loc


### PR DESCRIPTION
Closes #369

## Summary
Automated implementation for issue #369.

## Preview
⚠️ _Preview environment failed to start (preview failed: docker compose up --build failed (see preview_build.log tail below)) — endpoint validation was skipped; see the failure comment on the issue._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #369"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #369"
```

---
*Generated by MarketHawk Dark Factory*