### PR TITLE
factory: dedupe scope-enforcement findings before filing tickets

### DIFF
--- a/.archon/commands/dark-factory-conformance.md
+++ b/.archon/commands/dark-factory-conformance.md
@@ -204,27 +204,100 @@ After excision:
 
 ### 3.6.2 — Create backlog ticket
 
-For each `[OOS]` entry (whether excision succeeded or not), create one GitHub issue:
+Before filing tickets, deduplicate OOS entries against each other and against the
+existing `scope-spillover` backlog.
+
+**Populate `OOS_ENTRIES` array from `$CONFORMANCE_DIALOGUE`** (the accumulated reviewer output
+set in Phase 3.1 step 5 and appended on each reconcile cycle):
 
 ```bash
-SPILLOVER_TITLE="<short title derived from the OOS description>"
-SPILLOVER_BODY="## Scope spillover from #${ISSUE_NUM}
+OOS_ENTRIES=()
+while IFS= read -r line; do
+  stripped="${line#- }"
+  [[ "$stripped" == \[OOS\]* ]] && OOS_ENTRIES+=("$stripped")
+done <<< "$CONFORMANCE_DIALOGUE"
+```
+
+Skip to 3.6.3 if `${#OOS_ENTRIES[@]} -eq 0`.
+
+**Step A — Fetch existing open spillover issues:**
+
+```bash
+SPILLOVER_JSON=$(gh issue list \
+  --repo omniscient/markethawk \
+  --label "$BACKLOG_LABEL" \
+  --state open \
+  --json number,title,body \
+  --limit 200 2>/dev/null || echo "[]")
+```
+
+**Step B — Build OOS JSON array and call `dedupe_oos.py` (fail-open):**
+
+```bash
+OOS_ENTRIES_JSON=$(python3 -c \
+  "import json,sys; entries=sys.argv[1:]; print(json.dumps(entries))" \
+  "${OOS_ENTRIES[@]}")
+
+DEDUPE_OUT=$(python3 dark-factory/scripts/dedupe_oos.py \
+  --oos "$OOS_ENTRIES_JSON" --spillovers "$SPILLOVER_JSON" 2>/tmp/dedupe_err.txt) \
+  && ACTION_LIST="$DEDUPE_OUT" \
+  || {
+    echo "dedupe_oos.py failed ($(cat /tmp/dedupe_err.txt)) — falling back to create-per-finding"
+    ACTION_LIST=$(echo "$OOS_ENTRIES_JSON" | python3 -c \
+      "import json,sys; print(json.dumps([{'entry':e,'action':'create','key':''} for e in json.load(sys.stdin)]))")
+  }
+```
+
+**Step C — Process actions (whether excision succeeded or not):**
+
+Use process substitution so `SPILLOVER_TICKETS` mutations survive outside the loop:
+
+```bash
+SPILLOVER_TICKETS=""
+
+while IFS='|' read -r ACTION ENTRY KEY; do
+  case "$ACTION" in
+    create)
+      SPILLOVER_TITLE="<short title derived from ENTRY>"
+      DEDUP_KEY_COMMENT="<!-- dedup-key: ${KEY} -->"
+      SPILLOVER_BODY="## Scope spillover from #${ISSUE_NUM}
 
 The dark factory noticed this pre-existing defect while implementing issue #${ISSUE_NUM} but did not fix it inline (scope enforcement).
 
-**File/area:** <file>
-**Defect:** <description from OOS entry>
+**File/area:** <file from ENTRY>
+**Defect:** <description from ENTRY>
+
+${DEDUP_KEY_COMMENT}
 
 ---
 *Automatically triaged by MarketHawk Dark Factory scope enforcement.*"
 
-SPILLOVER_NUM=$(gh issue create \
-  --repo omniscient/markethawk \
-  --title "$SPILLOVER_TITLE" \
-  --body "$SPILLOVER_BODY" \
-  --label "needs-triage,${BACKLOG_LABEL}" \
-  --json number --jq '.number')
-echo "Created spillover ticket #${SPILLOVER_NUM}"
+      SPILLOVER_URL=$(gh issue create \
+        --repo omniscient/markethawk \
+        --title "$SPILLOVER_TITLE" \
+        --body "$SPILLOVER_BODY" \
+        --label "needs-triage,${BACKLOG_LABEL}")
+      SPILLOVER_NUM=$(basename "$SPILLOVER_URL")
+      SPILLOVER_TICKETS="$SPILLOVER_TICKETS $SPILLOVER_NUM"
+      echo "scope-enforcement: created new spillover #${SPILLOVER_NUM} (key: $KEY)"
+      ;;
+    comment:*)
+      EXISTING_NUM="${ACTION#comment:}"
+      gh issue comment "$EXISTING_NUM" \
+        --repo omniscient/markethawk \
+        --body "**Scope enforcement (re-observed):** This finding was re-surfaced while implementing issue #${ISSUE_NUM}.
+
+**Entry:** ${ENTRY}
+
+No new ticket created — deduped against this issue."
+      echo "scope-enforcement: commented on existing spillover #${EXISTING_NUM} (key: $KEY)"
+      ;;
+    suppress)
+      echo "scope-enforcement: suppressed non-actionable finding (key: $KEY): $ENTRY"
+      ;;
+  esac
+done < <(echo "$ACTION_LIST" | python3 -c \
+  "import json,sys; [print(r['action']+'|'+r['entry']+'|'+r.get('key','')) for r in json.load(sys.stdin)]")
 ```
 
 Collect all created ticket numbers into `SPILLOVER_TICKETS` (space-separated list).

--- a/.archon/memory/dark-factory-ops.md
+++ b/.archon/memory/dark-factory-ops.md
@@ -33,7 +33,7 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 
 ## Scope Enforcement
 
-- [PATTERN] When an out-of-scope defect is noticed during implementation, write it to `$ARTIFACTS_DIR/out-of-scope.md` with `- <file>: <one-sentence description>` and leave the defect unfixed. The conformance gate calls `dark-factory/scripts/dedupe_oos.py` which classifies each entry as `create` (new ticket), `comment:<n>` (cross-run dup — post comment on existing `scope-spillover` issue), or `suppress` (within-run dup or ruff-reformat); only `create` entries open new issues. New issues embed `<!-- dedup-key: file|finding-type -->` for future cross-run matching. <!-- issue:#206 date:2026-06-04 updated-by:#384 date:2026-06-13 expires:2026-12-13 source:implement -->
+- [PATTERN] When an out-of-scope defect is noticed during implementation, write it to `$ARTIFACTS_DIR/out-of-scope.md` with `- <file>: <one-sentence description>` and leave the defect unfixed. The conformance gate reads this file and converts each entry into a `scope-spillover`-labelled backlog ticket automatically. <!-- issue:#206 date:2026-06-04 expires:2026-12-04 source:implement -->
 
 ## Scheduler Architecture
 

--- a/.archon/memory/dark-factory-ops.md
+++ b/.archon/memory/dark-factory-ops.md
@@ -33,7 +33,7 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 
 ## Scope Enforcement
 
-- [PATTERN] When an out-of-scope defect is noticed during implementation, write it to `$ARTIFACTS_DIR/out-of-scope.md` with `- <file>: <one-sentence description>` and leave the defect unfixed. The conformance gate reads this file and converts each entry into a `scope-spillover`-labelled backlog ticket automatically. <!-- issue:#206 date:2026-06-04 expires:2026-12-04 source:implement -->
+- [PATTERN] When an out-of-scope defect is noticed during implementation, write it to `$ARTIFACTS_DIR/out-of-scope.md` with `- <file>: <one-sentence description>` and leave the defect unfixed. The conformance gate calls `dark-factory/scripts/dedupe_oos.py` which classifies each entry as `create` (new ticket), `comment:<n>` (cross-run dup — post comment on existing `scope-spillover` issue), or `suppress` (within-run dup or ruff-reformat); only `create` entries open new issues. New issues embed `<!-- dedup-key: file|finding-type -->` for future cross-run matching. <!-- issue:#206 date:2026-06-04 updated-by:#384 date:2026-06-13 expires:2026-12-13 source:implement -->
 
 ## Scheduler Architecture
 

--- a/dark-factory/scripts/dedupe_oos.py
+++ b/dark-factory/scripts/dedupe_oos.py
@@ -1,0 +1,140 @@
+"""
+OOS entry deduplication classifier for dark-factory conformance scope enforcement.
+
+Usage:
+    python3 dedupe_oos.py --oos '<json array>' --spillovers '<json array>'
+
+Classifies each [OOS] entry as:
+  create      - no existing match; file a new ticket
+  comment:<n> - existing issue <n> has the same embedded dedup-key; post a comment
+  suppress    - ruff-reformat class or within-run duplicate; drop silently
+
+Exits 0 on success (JSON to stdout). Exits non-zero on error (message to stderr).
+Caller must handle non-zero exit as fail-open fallback (no finding silently lost).
+"""
+import argparse
+import json
+import re
+import sys
+
+SUPPRESSION_KEYWORDS = [
+    "ruff",
+    "reformat",
+    "formatter",
+    "isort",
+    "import order",
+    "import-ordering",
+    "whitespace rewrap",
+]
+
+FINDING_TYPES = {
+    "ts-type-error":     ["ts2322", "ts2345", "ts type", "typescript", "type error", "type mismatch"],
+    "missing-test":      ["missing test", "test coverage", "no test", "untested", "out-of-scope test"],
+    "seed-drift":        ["seed", "seed file", "seed drift", "default config", "default value"],
+    "unused-import":     ["unused import", "import not used", "f401"],
+    "lint-error":        ["lint", "pylint", "flake8", "mypy"],
+    "missing-migration": ["migration", "alembic", "schema change"],
+    "ts-missing-type":   ["ts2339", "ts2304", "property does not exist", "cannot find name"],
+    "ruff-reformat":     ["ruff", "reformat", "formatter", "isort", "import order", "import-ordering"],
+}
+
+
+def _normalize_slug(text, max_len=50):
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower().strip())[:max_len]
+    slug = slug.strip("-")
+    return slug if slug else "other"
+
+
+def classify_entry(entry, seen_keys, spillovers):
+    """
+    Classify one [OOS] entry. Returns dict with 'entry', 'action', 'key'.
+    Modifies seen_keys in place for within-run dedup.
+    """
+    # Parse: split on first em-dash separator, fall back to hyphen-dash
+    if " — " in entry:
+        parts = entry.split(" — ", 1)
+    elif " - " in entry:
+        parts = entry.split(" - ", 1)
+    else:
+        parts = [entry, entry]
+
+    file_or_area = parts[0]
+    if file_or_area.upper().startswith("[OOS]"):
+        file_or_area = file_or_area[5:].strip()
+    description = parts[1] if len(parts) > 1 else entry
+
+    # Step 2: Suppression check — raw keyword scan before normalization
+    desc_lower = description.lower()
+    for kw in SUPPRESSION_KEYWORDS:
+        if kw in desc_lower:
+            key = f"{file_or_area.lower()}|ruff-reformat"
+            return {"entry": entry, "action": "suppress", "key": key}
+
+    # Step 3: Finding-type extraction (first-match wins; skip ruff-reformat safety net)
+    finding_type = None
+    for type_name, keywords in FINDING_TYPES.items():
+        if type_name == "ruff-reformat":
+            continue
+        for kw in keywords:
+            if kw in desc_lower:
+                finding_type = type_name
+                break
+        if finding_type:
+            break
+    if finding_type is None:
+        finding_type = _normalize_slug(description[:50])
+
+    # Step 4: Build normalized key
+    key = f"{file_or_area.lower()}|{finding_type}"
+
+    # Step 5: Within-run dedup
+    if key in seen_keys:
+        return {"entry": entry, "action": "suppress", "key": key}
+    seen_keys.add(key)
+
+    # Step 6: Cross-run dedup — primary path via embedded dedup-key
+    for issue in sorted(spillovers, key=lambda i: i.get("number", 0)):
+        body = issue.get("body") or ""
+        m = re.search(r"<!--\s*dedup-key:\s*([^>]+?)\s*-->", body)
+        if m and m.group(1).strip() == key:
+            return {"entry": entry, "action": f"comment:{issue['number']}", "key": key}
+
+    # Best-effort fallback for keyless legacy issues (advisory; may miss)
+    for issue in sorted(spillovers, key=lambda i: i.get("number", 0)):
+        body = issue.get("body") or ""
+        if re.search(r"<!--\s*dedup-key:", body):
+            continue  # has a key but didn't match; skip fallback for keyed issues
+        fa_match = re.search(r"\*\*File/area:\*\*\s*(.+)", body)
+        if fa_match:
+            fa_norm = fa_match.group(1).strip().lower()
+            if fa_norm and fa_norm in file_or_area.lower():
+                return {"entry": entry, "action": f"comment:{issue['number']}", "key": key}
+
+    return {"entry": entry, "action": "create", "key": key}
+
+
+def classify_all(oos_entries, spillovers):
+    """Classify all OOS entries. Returns list of action dicts."""
+    seen_keys = set()
+    return [classify_entry(entry, seen_keys, spillovers) for entry in oos_entries]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="OOS entry deduplication classifier")
+    parser.add_argument("--oos", required=True, help="JSON array of OOS entry strings")
+    parser.add_argument("--spillovers", required=True,
+                        help="JSON array of existing open scope-spillover issue objects")
+    args = parser.parse_args()
+
+    oos_entries = json.loads(args.oos)
+    spillovers = json.loads(args.spillovers)
+    results = classify_all(oos_entries, spillovers)
+    print(json.dumps(results))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"dedupe_oos.py error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/dark-factory/tests/test_conformance_dedupe_step.py
+++ b/dark-factory/tests/test_conformance_dedupe_step.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+CMD = (
+    Path(__file__).resolve().parents[2]
+    / ".archon" / "commands" / "dark-factory-conformance.md"
+)
+
+
+def test_conformance_dedupe_wired():
+    """Phase 3.6.2 must invoke dedupe_oos.py."""
+    text = CMD.read_text(encoding="utf-8")
+    assert "dedupe_oos.py" in text, "Phase 3.6.2 must invoke dedupe_oos.py"
+
+
+def test_conformance_dedupe_embeds_dedup_key():
+    """New spillover issue bodies must embed a dedup-key HTML comment."""
+    text = CMD.read_text(encoding="utf-8")
+    assert "dedup-key" in text, \
+        "Spillover issue body template must include '<!-- dedup-key: ... -->'"
+
+
+def test_conformance_dedupe_fetches_spillovers():
+    """Phase 3.6.2 must fetch existing open spillover issues before calling dedupe_oos.py."""
+    text = CMD.read_text(encoding="utf-8")
+    assert "SPILLOVER_JSON" in text, \
+        "Phase 3.6.2 must fetch open spillover issues into SPILLOVER_JSON"
+
+
+def test_conformance_dedupe_action_list():
+    """Phase 3.6.2 must process an ACTION_LIST from dedupe_oos.py output."""
+    text = CMD.read_text(encoding="utf-8")
+    assert "ACTION_LIST" in text, \
+        "Phase 3.6.2 must build ACTION_LIST from dedupe_oos.py output"

--- a/dark-factory/tests/test_dedupe_oos.py
+++ b/dark-factory/tests/test_dedupe_oos.py
@@ -1,0 +1,78 @@
+"""
+Tests for dark-factory/scripts/dedupe_oos.py.
+
+classify_entry and classify_all are tested directly with synthetic inputs.
+No subprocess or gh calls needed — the script is pure Python with JSON I/O.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import dedupe_oos  # noqa: E402
+
+
+def test_suppress_ruff_reformat_class():
+    """Findings with ruff/reformat keywords are suppressed before key creation."""
+    entries = ["[OOS] backend/app/services/scanner.py — cosmetic ruff reformatting applied by formatter"]
+    results = dedupe_oos.classify_all(entries, [])
+    assert len(results) == 1
+    assert results[0]["action"] == "suppress"
+    assert results[0]["key"].endswith("|ruff-reformat")
+
+
+def test_within_run_dedup():
+    """Two entries sharing the same (file, finding-type) key: first creates, second suppresses."""
+    entries = [
+        "[OOS] frontend/src/components/Chart.tsx — TypeScript TS2322 type mismatch on line 42",
+        "[OOS] frontend/src/components/Chart.tsx — TypeScript TS2322 type error at prop assignment",
+    ]
+    results = dedupe_oos.classify_all(entries, [])
+    assert len(results) == 2
+    assert results[0]["action"] == "create"
+    assert results[1]["action"] == "suppress"
+    assert results[0]["key"] == results[1]["key"]
+
+
+def test_cross_run_dedup_via_embedded_key():
+    """Entry matching an open issue's embedded dedup-key gets comment action, not create."""
+    entries = [
+        "[OOS] frontend/src/components/Chart.tsx — TypeScript TS2322 type mismatch",
+    ]
+    spillovers = [
+        {
+            "number": 305,
+            "title": "Add frontend test coverage for Chart.tsx",
+            "body": (
+                "## Scope spillover from #250\n\n"
+                "**File/area:** frontend/src/components/Chart.tsx\n"
+                "**Defect:** TypeScript TS2322 type error\n\n"
+                "<!-- dedup-key: frontend/src/components/chart.tsx|ts-type-error -->\n\n"
+                "---\n*Automatically triaged by MarketHawk Dark Factory scope enforcement.*"
+            ),
+        }
+    ]
+    results = dedupe_oos.classify_all(entries, spillovers)
+    assert len(results) == 1
+    assert results[0]["action"] == "comment:305"
+    assert results[0]["key"] == "frontend/src/components/chart.tsx|ts-type-error"
+
+
+def test_genuinely_new_finding_returns_create():
+    """Entry with no matching key in existing issues produces create action."""
+    entries = [
+        "[OOS] backend/app/models/trade.py — missing Alembic migration for new nullable column",
+    ]
+    spillovers = [
+        {
+            "number": 99,
+            "title": "Unrelated old issue",
+            "body": (
+                "Some body\n"
+                "<!-- dedup-key: frontend/src/other.tsx|missing-test -->\n"
+            ),
+        }
+    ]
+    results = dedupe_oos.classify_all(entries, spillovers)
+    assert len(results) == 1
+    assert results[0]["action"] == "create"
+    assert results[0]["key"] == "backend/app/models/trade.py|missing-migration"

--- a/docs/codeindex-hotspots.md
+++ b/docs/codeindex-hotspots.md
@@ -1,8 +1,8 @@
 Files with blast score ≥ 5.0  (32 found)
 
-    64.0  frontend/src/api/client.ts  (20d / 88t)  78 loc
-    55.5  backend/app/routers/auth.py  (2d / 107t)  213 loc
-    41.5  frontend/src/api/scanner.ts  (31d / 21t)  809 loc
+    64.5  frontend/src/api/client.ts  (20d / 89t)  78 loc
+    56.0  backend/app/routers/auth.py  (2d / 108t)  213 loc
+    42.0  frontend/src/api/scanner.ts  (32d / 20t)  809 loc
     31.0  frontend/src/components/ui/Card.tsx  (21d / 20t)  44 loc
     29.0  backend/app/routers/system.py  (2d / 54t)  141 loc
     29.0  services/tweet-monitor/app/main.py  (2d / 54t)  266 loc


### PR DESCRIPTION
Closes omniscient/dark-factory#116

## Summary
Automated implementation for issue omniscient/dark-factory#116.

## Preview
_No preview environment — this change does not affect the running app ('No running app changes detected. Changeset consists of factory utility script (dedupe_oos.py — self-contained JSON classifier not in force_preview list), tests, workflow config, and documentation. No backend/app, migrations, docker-compose, requirements, or frontend modifications.')._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#116"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#116"
```

---
*Generated by MarketHawk Dark Factory*