### PR TITLE
fix(factory): parse archon's multi-line cost JSON in run_record (#434)

### DIFF
--- a/dark-factory/scripts/run_record.py
+++ b/dark-factory/scripts/run_record.py
@@ -111,6 +111,34 @@ def cmd_record(args) -> None:
     _post_seq(record)
 
 
+def _iter_json_documents(text: str):
+    """Yield each top-level JSON value in text (mirrors `jq -s`).
+
+    `archon workflow cost --json` emits the run as a single PRETTY-PRINTED
+    (multi-line, indent=2) object; `--quiet` suppresses its pino log lines.
+    Parsing line-by-line breaks on the indented object — every fragment is
+    invalid JSON — so decode the stream value-by-value with raw_decode and
+    resync to the next line on any non-JSON noise (e.g. a leaked pino line).
+    """
+    decoder = json.JSONDecoder()
+    i, n = 0, len(text)
+    while i < n:
+        while i < n and text[i] in " \t\r\n":
+            i += 1
+        if i >= n:
+            break
+        try:
+            obj, end = decoder.raw_decode(text, i)
+        except json.JSONDecodeError:
+            nl = text.find("\n", i)
+            if nl == -1:
+                break
+            i = nl + 1
+            continue
+        yield obj
+        i = end
+
+
 def _parse_archon_cost(path: pathlib.Path) -> list:
     """Map archon workflow cost JSON nodes to OTel field names."""
     if path is None or not path.exists():
@@ -120,17 +148,14 @@ def _parse_archon_cost(path: pathlib.Path) -> list:
         if not content:
             return []
         run_obj = None
-        for line in content.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                obj = json.loads(line)
-                if isinstance(obj, dict) and (obj.get("run_id") or obj.get("runId")):
-                    run_obj = obj
+        for obj in _iter_json_documents(content):
+            candidates = obj if isinstance(obj, list) else [obj]
+            for cand in candidates:
+                if isinstance(cand, dict) and (cand.get("run_id") or cand.get("runId")):
+                    run_obj = cand
                     break
-            except json.JSONDecodeError:
-                continue
+            if run_obj is not None:
+                break
         if run_obj is None:
             return []
 


### PR DESCRIPTION
Fixes the dark-factory cost report, which has not posted to any issue since 2026-06-12.

## Root cause
`archon workflow cost --json` emits a single **pretty-printed (multi-line)** JSON object. The line-by-line `json.loads(line)` parser added in omniscient/dark-factory#101 (`run_record.py` `_parse_archon_cost`) sees every indented line as an invalid fragment → `nodes=[]` → `post_cost_report()` silently bails at the `RUN_ROWS` empty-check. The old code used `jq -s` (slurp), which worked.

## Fix
Decode the stream value-by-value with `JSONDecoder().raw_decode` (mirrors `jq -s`). Handles the pretty-printed object, tolerates leaked pino lines, stays compatible with single-line JSONL.

## Validation
Ran the patched parser against real archon output shapes in the scheduler container:
```
pretty (real shape)    -> nodes=2  models=['opus-4-8', 'sonnet-4-6']
pino + pretty          -> nodes=2  models=['opus-4-8', 'sonnet-4-6']
jsonl single-line      -> nodes=2  models=['opus-4-8', 'sonnet-4-6']
empty                  -> nodes=0
```

`run_record.py` is read from the fresh clone, so this is effective on the next factory run — **no image rebuild required**.

Closes omniscient/dark-factory#125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
