### PR TITLE
feat(factory): auto-address advisory code-review findings (revise-advisory node)

### DIFF
--- a/.archon/commands/dark-factory-revise-advisory.md
+++ b/.archon/commands/dark-factory-revise-advisory.md
@@ -1,0 +1,148 @@
+---
+description: Auto-address advisory code-review findings — spawns a fix agent, commits, and pushes. Fail-open; never blocks "In Review".
+argument-hint: (no arguments - reads review artifacts written by dark-factory-code-review)
+---
+
+# Dark Factory — Revise Advisory
+
+**Workflow ID**: $WORKFLOW_ID
+
+---
+
+## Phase 1: LOAD
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+source "${REPO_ROOT}/dark-factory/scripts/gate_lib.sh"
+```
+
+1. Check whether `$ARTIFACTS_DIR/review_result.json` exists. If missing → exit 0 (code-review was
+   skipped or errored fail-open; nothing to revise).
+2. Read `ADVISORY_COUNT`:
+   ```bash
+   ADVISORY_COUNT=$(jq '.advisory | length' "$ARTIFACTS_DIR/review_result.json" 2>/dev/null || echo 0)
+   ```
+3. If `ADVISORY_COUNT == 0` → exit 0 (no advisory findings; fast no-op).
+4. Read `STATUS`:
+   ```bash
+   STATUS=$(jq -r '.status' "$ARTIFACTS_DIR/review_result.json" 2>/dev/null || echo "PASS")
+   ```
+5. If `STATUS != "PASS"` → exit 0 (blocked run; code-review already halted the pipeline).
+6. Determine `ISSUE_NUM` and `PR_NUM`:
+   ```bash
+   ISSUE_NUM=$(jq -r '.resolved_number' "$ARTIFACTS_DIR/issue.json" 2>/dev/null || \
+     git branch --show-current | grep -oP 'issue-\K\d+')
+   BRANCH=$(git branch --show-current)
+   PR_NUM=$(gh pr list --repo omniscient/markethawk --head "$BRANCH" --json number --jq '.[0].number // empty')
+   ```
+   If `PR_NUM` is empty → log a warning and exit 0 (fail-open; can't push comments without a PR).
+
+## Phase 2: BUILD CONTEXT
+
+1. Build a human-readable findings list from `.advisory[]` in `review_result.json`:
+   ```bash
+   FINDINGS_TEXT=$(jq -r '
+     .advisory[] |
+     "### [\(.severity | ascii_upcase)] \(.category) — \(.path)\(if .line then ":\(.line)" else "" end)\n\(.description)\n"
+   ' "$ARTIFACTS_DIR/review_result.json")
+   ```
+2. Read the diff (already written by code-review):
+   ```bash
+   DIFF_CONTENT=$(cat "$ARTIFACTS_DIR/review_diff.txt" 2>/dev/null || echo "(diff unavailable)")
+   ```
+3. Announce on the issue:
+   ```bash
+   gh issue comment "$ISSUE_NUM" --repo omniscient/markethawk \
+     --body "Addressing ${ADVISORY_COUNT} advisory finding(s) from code review..."
+   ```
+
+## Phase 3: SPAWN FIX AGENT
+
+Spawn a subagent using the Agent tool:
+
+- `description`: "Revise advisory findings: ${ADVISORY_COUNT} item(s)"
+- `model`: inherit (do not override — Sonnet is appropriate for targeted edits)
+- `prompt`:
+
+```
+You are a software engineer addressing advisory findings from a code review.
+Your task: fix each finding below by editing the relevant source files.
+
+## Advisory Findings
+
+{FINDINGS_TEXT}
+
+## Diff context (what was changed in this PR)
+
+```diff
+{DIFF_CONTENT}
+```
+
+## Instructions
+
+For each finding:
+1. Read the file at the given path.
+2. Apply the fix the finding describes. Stay minimal — fix exactly what is flagged, no refactors.
+3. Write the updated file.
+
+When done, output a brief summary of what you changed (one line per finding).
+Do NOT commit or push — the workflow handles that.
+Do NOT modify test files unless the finding explicitly targets a test file.
+```
+
+Replace `{FINDINGS_TEXT}` with `$FINDINGS_TEXT` and `{DIFF_CONTENT}` with `$DIFF_CONTENT`.
+
+Save the agent's summary output to `$ARTIFACTS_DIR/revise_summary.txt`.
+
+If the agent errors or returns empty output → log a warning and proceed to Phase 4 (the diff
+check will detect no changes and exit 0 cleanly).
+
+## Phase 4: COMMIT AND PUSH
+
+1. Check for actual changes:
+   ```bash
+   if git diff --quiet && git diff --staged --quiet; then
+     echo "revise-advisory: agent produced no file changes — skipping commit"
+     exit 0
+   fi
+   ```
+2. Stage all modified tracked files (no untracked):
+   ```bash
+   git add -u
+   ```
+3. Commit:
+   ```bash
+   git commit -m "fix(review): address ${ADVISORY_COUNT} advisory finding(s) from AI code review"
+   ```
+4. Push:
+   ```bash
+   git push origin HEAD
+   ```
+   If push fails → log error and exit 0 (fail-open; PR already exists, findings still visible).
+
+## Phase 5: REPORT
+
+Post a follow-up comment on the PR listing what was addressed:
+
+```bash
+SUMMARY=$(cat "$ARTIFACTS_DIR/revise_summary.txt" 2>/dev/null || echo "(no summary)")
+gh api "repos/omniscient/markethawk/pulls/$PR_NUM/reviews" \
+  --method POST \
+  --field body="## Advisory Findings Addressed
+
+Automatically addressed **${ADVISORY_COUNT}** advisory finding(s):
+
+${SUMMARY}
+
+---
+*Posted by MarketHawk Dark Factory*" \
+  --field event="COMMENT" || \
+  echo "revise-advisory: WARNING — posting follow-up review comment failed (continuing)"
+```
+
+Write artifact:
+```bash
+printf "STATUS: DONE\nADVISORY_FIXED: %s\n" "$ADVISORY_COUNT" > "$ARTIFACTS_DIR/revise_advisory.md"
+```
+
+Exit 0.

--- a/.archon/workflows/archon-dark-factory.yaml
+++ b/.archon/workflows/archon-dark-factory.yaml
@@ -852,6 +852,13 @@ nodes:
     when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
     idle_timeout: 600000
 
+  # Layer 4.6: Auto-address advisory findings from code review
+  - id: revise-advisory
+    command: dark-factory-revise-advisory
+    depends_on: [code-review]
+    when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
+    idle_timeout: 600000
+
   # Layer 5: Move to "In review" and post report
   - id: status-in-review
     bash: |
@@ -875,9 +882,9 @@ nodes:
       else
         echo "WARNING: Issue #$ISSUE not found on project board"
       fi
-    depends_on: [push-and-pr, push-resolve, code-review]
-    # OR-join: push-and-pr/code-review (new/continue) vs push-resolve (resolve) are
-    # mutually exclusive. Tolerate the skipped sibling; still skip if a real upstream failed.
+    depends_on: [push-and-pr, push-resolve, code-review, revise-advisory]
+    # OR-join: push-and-pr/code-review/revise-advisory (new/continue) vs push-resolve (resolve) are
+    # mutually exclusive. Tolerate skipped siblings; still skip if a real upstream failed.
     trigger_rule: none_failed_min_one_success
     when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue' || $parse-intent.output.intent == 'resolve'"
     timeout: 15000


### PR DESCRIPTION
## Summary

- Adds `revise-advisory` (Layer 4.6) to the dark factory DAG — runs after `code-review`, before `status-in-review`
- When the code reviewer posts advisory findings (medium/low) with no blockers, a Claude agent applies the fixes, commits, and posts a follow-up PR comment
- `status-in-review.depends_on` gains `revise-advisory`; `trigger_rule` unchanged (`none_failed_min_one_success` already handles skipped siblings)

## Files changed

- **`.archon/commands/dark-factory-revise-advisory.md`** (new) — 6-phase command: load → check advisory count → build context → spawn fix agent → commit & push → report
- **`.archon/workflows/archon-dark-factory.yaml`** — insert `revise-advisory` node, update `status-in-review.depends_on`

## Fail-open guarantees

Every exit path is 0 except an actual pipeline failure upstream:
- `review_result.json` missing → exit 0
- `advisory == 0` → exit 0 (fast no-op, no extra latency on clean reviews)
- `STATUS != PASS` (blocked run) → exit 0 (code-review already halted)
- Agent errors or produces no diff → exit 0
- Push fails → exit 0

## No rebuild required

`.archon/commands/` and `.archon/workflows/` are read from the fresh clone on every dispatch — takes effect immediately after merge.

Closes omniscient/dark-factory#127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
