### PR TITLE
feat(frontend): make Vite dev server allowedHosts env-driven

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,9 @@ services:
     environment:
       REACT_APP_API_URL: http://localhost:8000
       VITE_API_TARGET: http://backend:8000
+      # Extra Host-header allowlist entries for the Vite dev server (comma-separated).
+      # Set in your local .env for reverse-proxy / tunnel / Tailscale hostnames.
+      VITE_ALLOWED_HOSTS: ${VITE_ALLOWED_HOSTS:-}
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -14,6 +14,13 @@ export default defineConfig(async () => {
     plugins,
     server: {
       port: 3333,
+      // Host-header allowlist for the dev server. Defaults to localhost only;
+      // set VITE_ALLOWED_HOSTS (comma-separated) in your local .env for any
+      // reverse-proxy / tunnel / Tailscale hostnames you reach the dev server by.
+      // A leading dot (e.g. ".ts.net") matches that host and all subdomains.
+      allowedHosts: process.env.VITE_ALLOWED_HOSTS
+        ? process.env.VITE_ALLOWED_HOSTS.split(',').map((h) => h.trim()).filter(Boolean)
+        : ['localhost'],
       watch: {
         usePolling: true,
       },


### PR DESCRIPTION
## Summary

Makes the Vite dev server's `server.allowedHosts` env-driven so the dev UI is reachable by hostnames other than `localhost` (Tailscale MagicDNS, reverse proxies, tunnels) without committing any machine-specific value.

- `frontend/vite.config.ts` — `server.allowedHosts` reads `VITE_ALLOWED_HOSTS` (comma-separated), defaulting to `localhost` only. A leading dot (e.g. `.ts.net`) matches a host and all subdomains.
- `docker-compose.yml` — passes `VITE_ALLOWED_HOSTS: ${VITE_ALLOWED_HOSTS:-}` through to the `frontend` container.

Network-specific hostnames live in each developer's gitignored root `.env`, e.g. `VITE_ALLOWED_HOSTS=.tail9810f2.ts.net`.

## Verification

With `VITE_ALLOWED_HOSTS=.tail9810f2.ts.net` in `.env`:

| Host header | Result |
|---|---|
| `localhost` | 200 |
| `desktop-frank.tail9810f2.ts.net` (in tailnet) | 200 |
| `foo.sometailnet.ts.net` (other tailnet) | 403 |
| `evil.example.com` | 403 |

- `tsc --noEmit` → exit 0
- `docker compose config` resolves `VITE_ALLOWED_HOSTS` from `.env` correctly
- The 403 on an out-of-tailnet `*.ts.net` host confirms the value is sourced from `.env`, not a permissive committed default.

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)
