### PR TITLE
[security] F-DOCKER-01: socket-proxy BUILD/POST + preview compose weak creds

### DIFF
--- a/.archon/memory/dark-factory-ops.md
+++ b/.archon/memory/dark-factory-ops.md
@@ -84,9 +84,9 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 
 ## Service Dependencies
 
-- [PATTERN] The `docker-socket-proxy` service must have no `profiles:` key so it is a lifecycle superset of both `factory` and `scheduler` profiles. Consumers (`dark-factory`, `backlog-scheduler`) drop their raw `/var/run/docker.sock` volumes and instead set `DOCKER_HOST: tcp://docker-socket-proxy:2375` with `depends_on: [docker-socket-proxy]`. <!-- issue:#203 date:2026-06-05 expires:2026-12-05 source:implement -->
+- [PATTERN] Two per-consumer socket proxies replace the old shared one (issue #379): `docker-socket-proxy-scheduler` (CONTAINERS/IMAGES/POST=1, no BUILD/EXEC/NETWORKS/VOLUMES) for `backlog-scheduler`; `docker-socket-proxy-factory` (all verbs incl. EXEC=1) for `dark-factory`. Both have no `profiles:` key. Wire consumers via `DOCKER_HOST: tcp://docker-socket-proxy-<consumer>:2375` and `depends_on: [docker-socket-proxy-<consumer>]`. <!-- issue:#379 date:2026-06-14 expires:2026-12-14 source:implement -->
 
-- [PATTERN] The `docker-socket-proxy` blocks `exec` operations (HTTP 403) from inside the factory container — `docker exec` and testcontainer healthchecks both fail; verify container user via `docker inspect --format '{{.Config.User}}'` or source Dockerfile instead. <!-- evidence:curl-response issue:#287 date:2026-06-11 evidence2:docker-exec issue:#259 date:2026-06-13 expires:2026-12-13 source:implement -->
+- [INVALID: factory proxy now has EXEC=1 as of issue #379] The `docker-socket-proxy` blocks `exec` operations (HTTP 403) from inside the factory container — `docker exec` and testcontainer healthchecks both fail; verify container user via `docker inspect --format '{{.Config.User}}'` or source Dockerfile instead. <!-- evidence:curl-response issue:#287 date:2026-06-11 evidence2:docker-exec issue:#259 date:2026-06-13 expires:2026-12-13 source:implement -->
 
 ## Gate Shared Library
 

--- a/.archon/workflows/archon-dark-factory.yaml
+++ b/.archon/workflows/archon-dark-factory.yaml
@@ -180,7 +180,7 @@ nodes:
       docker compose -p "mh-preview-${ISSUE}" down -v 2>/dev/null || echo "No preview stack found"
 
       # Assert no containers survive teardown
-      STALE=$(docker ps -a --filter "name=mh-preview-${ISSUE}" --format '{{.Names}}' 2>/dev/null || true)
+      STALE=$(docker ps -a --filter "label=com.docker.compose.project=mh-preview-${ISSUE}" --format '{{.Names}}' 2>/dev/null || true)
       if [ -n "$STALE" ]; then
         echo "ERROR: Stale preview containers remain after teardown:" >&2
         echo "$STALE" >&2

--- a/.archon/workflows/archon-dark-factory.yaml
+++ b/.archon/workflows/archon-dark-factory.yaml
@@ -179,6 +179,15 @@ nodes:
       echo "Tearing down mh-preview-${ISSUE}..."
       docker compose -p "mh-preview-${ISSUE}" down -v 2>/dev/null || echo "No preview stack found"
 
+      # Assert no containers survive teardown
+      STALE=$(docker ps -a --filter "name=mh-preview-${ISSUE}" --format '{{.Names}}' 2>/dev/null || true)
+      if [ -n "$STALE" ]; then
+        echo "ERROR: Stale preview containers remain after teardown:" >&2
+        echo "$STALE" >&2
+        exit 1
+      fi
+      echo "close-preview: teardown verified — no mh-preview-${ISSUE} containers remain"
+
       # Find the PR (branch includes a slug suffix, so use search prefix match)
       PR_NUM=$(gh pr list --search "head:feat/issue-${ISSUE}-" --json number --jq '.[0].number // empty')
       if [ -z "$PR_NUM" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,9 @@ jobs:
               sys.exit(1)
           print('when: expression lint passed for all workflow file(s).')
 
+      - name: Check preview credentials not leaked to non-preview compose files
+        run: bash dark-factory/scripts/check_preview_creds.sh
+
       - name: Dependency audit
         run: |
           pip install pip-audit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,13 @@ repos:
         pass_filenames: false
         files: '\.(ts|tsx|js|jsx)$'
 
+      - id: check-preview-creds
+        name: Block preview credentials outside allowlisted compose file
+        language: system
+        entry: bash dark-factory/scripts/check_preview_creds.sh
+        pass_filenames: false
+        files: 'docker-compose.*\.yml$'
+
       - id: codeindex-blast
         name: codeindex blast-radius warning
         language: system

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,7 +31,8 @@ graph TD
     end
 
     subgraph factory["factory-network"]
-        proxy["docker-socket-proxy :2375"]
+        proxyfactory["docker-socket-proxy-factory :2375"]
+        proxyscheduler["docker-socket-proxy-scheduler :2375"]
         darkfactory["dark-factory (factory profile)"]
         scheduler["backlog-scheduler (scheduler profile)"]
     end
@@ -73,9 +74,10 @@ graph TD
     jaeger -->|OTLP| celery
     jaeger -->|OTLP| beat
 
-    proxy -->|":ro"| dockersock
-    darkfactory -->|"tcp :2375"| proxy
-    scheduler -->|"tcp :2375"| proxy
+    proxyfactory -->|":ro"| dockersock
+    proxyscheduler -->|":ro"| dockersock
+    darkfactory -->|"tcp :2375"| proxyfactory
+    scheduler -->|"tcp :2375"| proxyscheduler
 
     seqgelf -->|"GELF → HTTP"| seq
     forecastworker --> postgres

--- a/dark-factory/docker-compose.preview.yml
+++ b/dark-factory/docker-compose.preview.yml
@@ -11,7 +11,7 @@ services:
     environment:
       POSTGRES_DB: stockscanner
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: preview_password
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-preview_password}
     ports:
       - "1${ISSUE_NUM_PADDED:-00}54:5432"
     volumes:
@@ -43,14 +43,14 @@ services:
       context: ../backend
       dockerfile: Dockerfile
     environment:
-      DATABASE_URL: postgresql://postgres:preview_password@postgres:5432/stockscanner
+      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-preview_password}@postgres:5432/stockscanner
       REDIS_URL: redis://redis:6379/0
       ENVIRONMENT: development
       LOG_LEVEL: INFO
       POLYGON_API_KEY: ${POLYGON_API_KEY:-}
       # Dev-only throwaway key (>=32 chars) so the JWT_SECRET_KEY startup validator (#190)
       # is satisfied. NOT a real secret — preview stacks are ephemeral and network-isolated.
-      JWT_SECRET_KEY: preview-only-not-secret-0123456789abcdef
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY:-preview-only-not-secret-0123456789abcdef}
     ports:
       - "1${ISSUE_NUM_PADDED:-00}80:8000"
     depends_on:
@@ -86,13 +86,13 @@ services:
       dockerfile: Dockerfile
     command: celery -A app.core.celery_app:celery_app worker --loglevel=info
     environment:
-      DATABASE_URL: postgresql://postgres:preview_password@postgres:5432/stockscanner
+      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-preview_password}@postgres:5432/stockscanner
       REDIS_URL: redis://redis:6379/0
       ENVIRONMENT: development
       LOG_LEVEL: INFO
       POLYGON_API_KEY: ${POLYGON_API_KEY:-}
       # Dev-only throwaway key (>=32 chars) — see backend service note above.
-      JWT_SECRET_KEY: preview-only-not-secret-0123456789abcdef
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY:-preview-only-not-secret-0123456789abcdef}
     depends_on:
       postgres:
         condition: service_healthy
@@ -109,7 +109,7 @@ services:
     entrypoint: >
       sh -c "for f in /seed/*.sql; do
         echo \"Running $$f...\";
-        PGPASSWORD=preview_password psql -h postgres -U postgres -d stockscanner -f \"$$f\";
+        PGPASSWORD=${POSTGRES_PASSWORD:-preview_password} psql -h postgres -U postgres -d stockscanner -f \"$$f\";
       done && echo 'All seed modules loaded'"
     depends_on:
       backend:

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -716,6 +716,12 @@ fi
 
 # --- Startup: warn if stale preview containers exist (non-blocking) ---
 STALE_PREVIEW_WARN_COUNT="${STALE_PREVIEW_WARN_COUNT:-3}"
+# Validate that STALE_PREVIEW_WARN_COUNT is numeric; reset to default if not to avoid
+# integer comparison errors under set -euo pipefail.
+if ! [[ "$STALE_PREVIEW_WARN_COUNT" =~ ^[0-9]+$ ]]; then
+  echo "[$(date -u +%FT%TZ)] WARNING: STALE_PREVIEW_WARN_COUNT='${STALE_PREVIEW_WARN_COUNT}' is not a non-negative integer; resetting to default 3." >&2
+  STALE_PREVIEW_WARN_COUNT=3
+fi
 STALE_COUNT=$(docker ps -a --filter "name=mh-preview-" --format '{{.Names}}' 2>/dev/null | wc -l | tr -d ' ')
 if [ "$STALE_COUNT" -gt "$STALE_PREVIEW_WARN_COUNT" ]; then
   echo "[$(date -u +%FT%TZ)] WARNING: $STALE_COUNT stale mh-preview-* containers found (threshold: ${STALE_PREVIEW_WARN_COUNT}). Run 'docker ps -a --filter name=mh-preview-' to inspect and clean up." >&2

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -714,6 +714,13 @@ else
   echo "[$(date -u +%FT%TZ)] probe=image_ok image=${FACTORY_IMAGE}"
 fi
 
+# --- Startup: warn if stale preview containers exist (non-blocking) ---
+STALE_PREVIEW_WARN_COUNT="${STALE_PREVIEW_WARN_COUNT:-3}"
+STALE_COUNT=$(docker ps -a --filter "name=mh-preview-" --format '{{.Names}}' 2>/dev/null | wc -l | tr -d ' ')
+if [ "$STALE_COUNT" -gt "$STALE_PREVIEW_WARN_COUNT" ]; then
+  echo "[$(date -u +%FT%TZ)] WARNING: $STALE_COUNT stale mh-preview-* containers found (threshold: ${STALE_PREVIEW_WARN_COUNT}). Run 'docker ps -a --filter name=mh-preview-' to inspect and clean up." >&2
+fi
+
 # --- Main loop ---
 echo "Backlog scheduler started (poll every ${POLL_INTERVAL}s)"
 

--- a/dark-factory/scripts/check_preview_creds.sh
+++ b/dark-factory/scripts/check_preview_creds.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Guard: fail if weak preview credentials appear outside the allowlisted preview compose file.
+# Allowlisted file: dark-factory/docker-compose.preview.yml
+# Blocked literals: 'preview_password', 'preview-only-not-secret'
+set -euo pipefail
+
+ALLOWLIST="dark-factory/docker-compose.preview.yml"
+PATTERNS=("preview_password" "preview-only-not-secret")
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+
+cd "$REPO_ROOT"
+
+FAILED=0
+for pattern in "${PATTERNS[@]}"; do
+  # Search all docker-compose*.yml files for the literal string
+  while IFS= read -r match_file; do
+    # Normalise path: strip leading ./
+    norm="${match_file#./}"
+    if [ "$norm" != "$ALLOWLIST" ]; then
+      echo "ERROR: Forbidden credential literal '$pattern' found in $norm (only allowed in $ALLOWLIST)" >&2
+      FAILED=1
+    fi
+  done < <(grep -rl "$pattern" . --include="docker-compose*.yml" 2>/dev/null || true)
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "" >&2
+  echo "Weak preview credentials must not appear outside $ALLOWLIST." >&2
+  echo "Use env var fallbacks (e.g. \${POSTGRES_PASSWORD:-preview_password}) in that file," >&2
+  echo "and never copy these literals to other compose files." >&2
+  exit 1
+fi
+
+echo "check-preview-creds: OK"

--- a/dark-factory/scripts/check_preview_creds.sh
+++ b/dark-factory/scripts/check_preview_creds.sh
@@ -5,6 +5,10 @@
 set -euo pipefail
 
 ALLOWLIST="dark-factory/docker-compose.preview.yml"
+# PATTERNS lists every weak preview credential literal that must not leak outside ALLOWLIST.
+# When new preview credentials are introduced (e.g. new *_password / *_secret / *_key env-var
+# fallbacks in docker-compose.preview.yml), add their literal values here so the guard
+# catches any accidental copy-paste into other compose files.
 PATTERNS=("preview_password" "preview-only-not-secret")
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 
@@ -22,6 +26,22 @@ for pattern in "${PATTERNS[@]}"; do
     fi
   done < <(grep -rl "$pattern" . --include="docker-compose*.yml" 2>/dev/null || true)
 done
+
+# Sanity-check: if the allowlist file no longer contains ANY of the known patterns,
+# the guard can be trivially defeated by removing them from it. Warn so the bypass
+# is visible rather than silently passing.
+ALLOWLIST_HIT=0
+for pattern in "${PATTERNS[@]}"; do
+  if grep -q "$pattern" "$ALLOWLIST" 2>/dev/null; then
+    ALLOWLIST_HIT=1
+    break
+  fi
+done
+if [ "$ALLOWLIST_HIT" -eq 0 ]; then
+  echo "WARNING: None of the blocked credential literals were found in $ALLOWLIST." >&2
+  echo "The guard may have been defeated by removing them from the allowlisted file." >&2
+  echo "Verify that $ALLOWLIST still contains the expected env-var fallbacks." >&2
+fi
 
 if [ "$FAILED" -ne 0 ]; then
   echo "" >&2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -453,10 +453,31 @@ services:
       - stockscanner-network
     restart: unless-stopped
 
-  # Docker Socket Proxy — restricts Docker API access for dark-factory and backlog-scheduler
-  docker-socket-proxy:
+  # Docker Socket Proxy (scheduler) — minimal verbs for backlog-scheduler: inspect/list/pull only
+  docker-socket-proxy-scheduler:
     image: tecnativa/docker-socket-proxy:latest
-    container_name: markethawk-docker-socket-proxy
+    container_name: markethawk-docker-socket-proxy-scheduler
+    restart: unless-stopped
+    environment:
+      CONTAINERS: 1
+      IMAGES: 1
+      POST: 1
+      NETWORKS: 0
+      VOLUMES: 0
+      BUILD: 0
+      SERVICES: 0
+      EXEC: 0
+      AUTH: 0
+      SECRETS: 0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - factory-network
+
+  # Docker Socket Proxy (factory) — full verbs for dark-factory: build/exec/networks/volumes + EXEC fixes postgres-probe
+  docker-socket-proxy-factory:
+    image: tecnativa/docker-socket-proxy:latest
+    container_name: markethawk-docker-socket-proxy-factory
     restart: unless-stopped
     environment:
       CONTAINERS: 1
@@ -465,8 +486,8 @@ services:
       VOLUMES: 1
       BUILD: 1
       POST: 1
+      EXEC: 1
       SERVICES: 0
-      EXEC: 0
       AUTH: 0
       SECRETS: 0
     volumes:
@@ -485,12 +506,12 @@ services:
       - path: .archon/.env
         required: true
     environment:
-      DOCKER_HOST: tcp://docker-socket-proxy:2375
+      DOCKER_HOST: tcp://docker-socket-proxy-factory:2375
       SEQ_URL: http://seq:5341
     volumes:
       - scheduler_state:/var/lib/dark-factory
     depends_on:
-      - docker-socket-proxy
+      - docker-socket-proxy-factory
     networks:
       - factory-network
       - stockscanner-network
@@ -516,9 +537,9 @@ services:
         required: true
     environment:
       FACTORY_IMAGE: "ghcr.io/omniscient/markethawk-dark-factory:${IMAGE_TAG:-latest}"
-      DOCKER_HOST: tcp://docker-socket-proxy:2375
+      DOCKER_HOST: tcp://docker-socket-proxy-scheduler:2375
     depends_on:
-      - docker-socket-proxy
+      - docker-socket-proxy-scheduler
     # Bind-mount (.:/workspace/project:ro) is restored in docker-compose.override.yml for local dev.
     volumes:
       - scheduler_state:/var/lib/dark-factory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -453,7 +453,7 @@ services:
       - stockscanner-network
     restart: unless-stopped
 
-  # Docker Socket Proxy (scheduler) — minimal verbs for backlog-scheduler: inspect/list/pull only
+  # Docker Socket Proxy (scheduler) — allows container lifecycle ops (create/run/stop/delete) via POST+CONTAINERS for `docker compose run`; BUILD/EXEC/NETWORKS/VOLUMES are denied
   docker-socket-proxy-scheduler:
     image: tecnativa/docker-socket-proxy:latest
     container_name: markethawk-docker-socket-proxy-scheduler


### PR DESCRIPTION
Closes #379

## Summary
Automated implementation for issue #379.

## Preview
⚠️ _Preview environment failed to start (preview failed: docker compose up --build failed (see preview_build.log tail below)) — endpoint validation was skipped; see the failure comment on the issue._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #379"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #379"
```

---
*Generated by MarketHawk Dark Factory*