### PR TITLE
Scheduler dependencies_met() strands issues whose dependency is closed but off-board

### DIFF
--- a/.archon/memory/dark-factory-ops.md
+++ b/.archon/memory/dark-factory-ops.md
@@ -35,6 +35,8 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 
 - [PATTERN] When scheduler.sh defers `read_config()` until after the `SCHEDULER_SOURCE_ONLY` guard, every bash test file that sources scheduler.sh (`SCHEDULER_SOURCE_ONLY=1 source "$SCHED"`) must explicitly `export VAR=value` for all config-driven policy vars before sourcing — otherwise helper functions that reference those vars fail with `set -u` unbound-variable errors. The canonical list is in `test_scheduler.sh`'s pre-source export block. <!-- issue:#338 date:2026-06-13 expires:2026-12-13 source:implement -->
 
+- [PATTERN] In `test_scheduler.sh`, `$STUB_LOG` captures only calls to stubbed external commands (`gh`, `docker`, `set_board_status`). Scheduler functions that emit log lines via `echo` write to stdout — to assert on these in a test, capture the function's output with `_OUTPUT=$(fn_name args 2>&1) && _RET=0 || _RET=1` and grep `$_OUTPUT`, not `$STUB_LOG`. <!-- issue:#389 date:2026-06-15 expires:2026-12-15 source:implement -->
+
 ## Scheduler Architecture
 
 - [PATTERN] All `dispatch()` call sites in `scheduler.sh` must use `if dispatch ...; then ... fi` guards. A bare `dispatch "..."` under `set -e` exits the daemon on non-zero return, which triggers `restart: unless-stopped` and wipes the retry counter — the root cause of the #159 loop. <!-- issue:#160 date:2026-06-03 expires:2026-12-03 source:implement -->

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -585,12 +585,17 @@ dependencies_met() {
     if [ -z "$dep_status" ]; then
       # Dep not found on board (archived or beyond fetch window) — fall back to issue state
       local dep_state
-      dep_state=$(gh issue view "$dep_num" --repo "${OWNER}/markethawk" --json state -q '.state' 2>/dev/null || true)
+      local dep_gh_exit=0
+      dep_state=$(gh issue view "$dep_num" --repo "${OWNER}/markethawk" --json state -q '.state' 2>/dev/null) || dep_gh_exit=$?
       if [ "$dep_state" = "CLOSED" ]; then
         echo "[$(date -u +%FT%TZ)] dep_gate issue=#${issue_num} dep=#${dep_num} resolved=closed_off_board"
         continue
       fi
-      echo "[$(date -u +%FT%TZ)] dep_gate issue=#${issue_num} blocked_by=#${dep_num} dep_status=off_board"
+      if [ "$dep_gh_exit" -ne 0 ] || [ -z "$dep_state" ]; then
+        echo "[$(date -u +%FT%TZ)] dep_gate issue=#${issue_num} dep=#${dep_num} blocked_by=#${dep_num} dep_status=unknown"
+      else
+        echo "[$(date -u +%FT%TZ)] dep_gate issue=#${issue_num} dep=#${dep_num} blocked_by=#${dep_num} dep_status=off_board"
+      fi
       return 1
     fi
     if [ "$dep_status" != "Done" ]; then

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -582,7 +582,19 @@ dependencies_met() {
   while IFS= read -r dep_num; do
     local dep_status
     dep_status=$(echo "$board_items" | jq -r ".items[] | select(.content.number == $dep_num) | .status" 2>/dev/null)
+    if [ -z "$dep_status" ]; then
+      # Dep not found on board (archived or beyond fetch window) — fall back to issue state
+      local dep_state
+      dep_state=$(gh issue view "$dep_num" --repo "${OWNER}/markethawk" --json state -q '.state' 2>/dev/null || true)
+      if [ "$dep_state" = "CLOSED" ]; then
+        echo "[$(date -u +%FT%TZ)] dep_gate issue=#${issue_num} dep=#${dep_num} resolved=closed_off_board"
+        continue
+      fi
+      echo "[$(date -u +%FT%TZ)] dep_gate issue=#${issue_num} blocked_by=#${dep_num} dep_status=off_board"
+      return 1
+    fi
     if [ "$dep_status" != "Done" ]; then
+      echo "[$(date -u +%FT%TZ)] dep_gate issue=#${issue_num} blocked_by=#${dep_num} dep_status=${dep_status}"
       return 1
     fi
   done <<< "$deps"

--- a/dark-factory/tests/test_scheduler.sh
+++ b/dark-factory/tests/test_scheduler.sh
@@ -757,13 +757,13 @@ _N_DEP201_STATE=""
 # gh stub: routes by issue number; body call → _N_BODY; state call → per-dep state var
 gh() {
   echo "gh $*" >> "$STUB_LOG"
-  if echo "$*" | grep -qE "view 100"; then
+  if echo "$*" | grep -qE "view 100( |$)"; then
     printf '%s\n' "$_N_BODY"; return 0
   fi
-  if echo "$*" | grep -qE "view 201"; then
+  if echo "$*" | grep -qE "view 201( |$)"; then
     printf '%s\n' "$_N_DEP201_STATE"; return 0
   fi
-  if echo "$*" | grep -qE "view 200"; then
+  if echo "$*" | grep -qE "view 200( |$)"; then
     printf '%s\n' "$_N_DEP200_STATE"; return $_N_DEP200_GH_EXIT
   fi
   return 0

--- a/dark-factory/tests/test_scheduler.sh
+++ b/dark-factory/tests/test_scheduler.sh
@@ -742,6 +742,126 @@ dispatch() { echo "dispatch $*" >> "$STUB_LOG"; return 0; }
 export -f is_recheck_running dispatch
 
 # ==========================================
+# N: dependencies_met() — off-board fallback
+# ==========================================
+echo ""
+echo "--- N: dependencies_met ---"
+> "$STUB_LOG"
+
+# Shared stub variables for this section
+_N_BODY=""
+_N_DEP200_STATE=""
+_N_DEP200_GH_EXIT=0
+_N_DEP201_STATE=""
+
+# gh stub: routes by issue number; body call → _N_BODY; state call → per-dep state var
+gh() {
+  echo "gh $*" >> "$STUB_LOG"
+  if echo "$*" | grep -qE "view 100"; then
+    printf '%s\n' "$_N_BODY"; return 0
+  fi
+  if echo "$*" | grep -qE "view 201"; then
+    printf '%s\n' "$_N_DEP201_STATE"; return 0
+  fi
+  if echo "$*" | grep -qE "view 200"; then
+    printf '%s\n' "$_N_DEP200_STATE"; return $_N_DEP200_GH_EXIT
+  fi
+  return 0
+}
+export -f gh
+
+_BOARD_EMPTY='{"items":[]}'
+_BOARD_200_DONE='{"items":[{"content":{"number":200},"status":"Done"}]}'
+_BOARD_200_WIP='{"items":[{"content":{"number":200},"status":"In Progress"}]}'
+_BOARD_200_DONE_201_ABSENT='{"items":[{"content":{"number":200},"status":"Done"}]}'
+
+# N1: no deps in body → returns 0
+_N_BODY="No dependencies here"
+> "$STUB_LOG"
+dependencies_met "100" "$_BOARD_EMPTY" && _N_RET=0 || _N_RET=1
+assert_eq "N1: no deps → returns 0" "0" "$_N_RET"
+
+# N2: dep Done on board → returns 0, no dep_gate log
+_N_BODY="Depends on: #200"
+> "$STUB_LOG"
+dependencies_met "100" "$_BOARD_200_DONE" && _N_RET=0 || _N_RET=1
+assert_eq "N2: dep Done on board → returns 0" "0" "$_N_RET"
+assert_eq "N2: Done dep is silent (no dep_gate log)" \
+  "0" "$(grep -c 'dep_gate' "$STUB_LOG" || true)"
+
+# N3: dep non-Done on board → returns 1, logs dep_gate
+_N_BODY="Depends on: #200"
+> "$STUB_LOG"
+_N_OUTPUT=$(dependencies_met "100" "$_BOARD_200_WIP" 2>&1) && _N_RET=0 || _N_RET=1
+assert_eq "N3: non-Done dep → returns 1" "1" "$_N_RET"
+assert_eq "N3: non-Done dep → dep_gate logged" \
+  "1" "$(echo "$_N_OUTPUT" | grep -c 'dep_gate' || true)"
+
+# N4: dep off-board, gh state=CLOSED → returns 0, logs resolved=closed_off_board
+_N_BODY="Depends on: #200"
+_N_DEP200_STATE="CLOSED"
+_N_DEP200_GH_EXIT=0
+> "$STUB_LOG"
+_N_OUTPUT=$(dependencies_met "100" "$_BOARD_EMPTY" 2>&1) && _N_RET=0 || _N_RET=1
+assert_eq "N4: off-board CLOSED dep → returns 0" "0" "$_N_RET"
+assert_eq "N4: off-board CLOSED → logs resolved=closed_off_board" \
+  "1" "$(echo "$_N_OUTPUT" | grep -c 'resolved=closed_off_board' || true)"
+
+# N5: dep off-board, gh state=OPEN → returns 1, logs dep_status=off_board
+_N_BODY="Depends on: #200"
+_N_DEP200_STATE="OPEN"
+_N_DEP200_GH_EXIT=0
+> "$STUB_LOG"
+_N_OUTPUT=$(dependencies_met "100" "$_BOARD_EMPTY" 2>&1) && _N_RET=0 || _N_RET=1
+assert_eq "N5: off-board OPEN dep → returns 1" "1" "$_N_RET"
+assert_eq "N5: off-board OPEN → logs dep_status=off_board" \
+  "1" "$(echo "$_N_OUTPUT" | grep -c 'dep_status=off_board' || true)"
+
+# N6: dep off-board, gh state call fails/empty → returns 1 (safe direction)
+_N_BODY="Depends on: #200"
+_N_DEP200_STATE=""
+_N_DEP200_GH_EXIT=1
+> "$STUB_LOG"
+dependencies_met "100" "$_BOARD_EMPTY" && _N_RET=0 || _N_RET=1
+assert_eq "N6: off-board gh-failure dep → returns 1 (safe)" "1" "$_N_RET"
+
+# N7: two deps — first Done on board, second off-board OPEN → returns 1
+_N_BODY="$(printf 'Depends on: #200\nDepends on: #201')"
+_N_DEP200_STATE=""
+_N_DEP200_GH_EXIT=0
+_N_DEP201_STATE="OPEN"
+> "$STUB_LOG"
+dependencies_met "100" "$_BOARD_200_DONE_201_ABSENT" && _N_RET=0 || _N_RET=1
+assert_eq "N7: two deps, second off-board OPEN → returns 1" "1" "$_N_RET"
+
+# N8: two deps — first Done on board, second off-board CLOSED → returns 0
+_N_BODY="$(printf 'Depends on: #200\nDepends on: #201')"
+_N_DEP200_STATE=""
+_N_DEP200_GH_EXIT=0
+_N_DEP201_STATE="CLOSED"
+> "$STUB_LOG"
+dependencies_met "100" "$_BOARD_200_DONE_201_ABSENT" && _N_RET=0 || _N_RET=1
+assert_eq "N8: two deps, second off-board CLOSED → returns 0" "0" "$_N_RET"
+
+# N9: body fetch fails → returns 0 (pre-existing behaviour)
+# Override gh so body call for issue 100 returns non-zero
+gh() {
+  echo "gh $*" >> "$STUB_LOG"
+  if echo "$*" | grep -qE "view 100"; then
+    return 1
+  fi
+  return 0
+}
+export -f gh
+> "$STUB_LOG"
+dependencies_met "100" "$_BOARD_EMPTY" && _N_RET=0 || _N_RET=1
+assert_eq "N9: body fetch fails → returns 0" "0" "$_N_RET"
+
+# Restore global gh stub
+gh() { echo "gh $*" >> "$STUB_LOG"; return 0; }
+export -f gh
+
+# ==========================================
 # Cleanup
 # ==========================================
 rm -f "$STATE_FILE" "$STUB_LOG"


### PR DESCRIPTION
Closes omniscient/dark-factory#117

## Summary
Automated implementation for issue omniscient/dark-factory#117.

## Preview
_No preview environment — this change does not affect the running app ('Changeset affects scheduler infrastructure (orchestration scripts + memory) with comprehensive test coverage (9 test cases for dependencies_met fallback). No changes to main application code (backend, frontend, database migrations). Scheduler runs in separate factory container, not in preview stack. Tests validate the fix without requiring live endpoint validation.')._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#117"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#117"
```

---
*Generated by MarketHawk Dark Factory*