### PR TITLE
test: harden pre-existing flaky auth + scheduler tests (dark-factory env)

### DIFF
--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -6,11 +6,35 @@ from app.core.config import get_settings
 
 get_settings.cache_clear()
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _secure_defaults_and_clean_cookies(monkeypatch):
+    """Isolate these tests from the local-dev container's settings overrides.
+
+    docker-compose.override.yml sets COOKIE_SECURE=false / DOCS_ENABLED=true so the
+    dev stack works over plain http. pydantic Settings reads those env vars, so
+    without stripping them the default-asserting tests below would observe the dev
+    values instead of the secure code defaults (COOKIE_SECURE=True, DOCS_ENABLED=False)
+    and fail only inside the dev/factory containers.
+
+    Also reset the module-level client's cookie jar between tests: a login in one test
+    otherwise leaks its access_token into the next (when cookies are non-Secure and
+    thus echoed by the http TestClient), 401-ing against the per-test DB reset.
+    """
+    monkeypatch.delenv("COOKIE_SECURE", raising=False)
+    monkeypatch.delenv("DOCS_ENABLED", raising=False)
+    get_settings.cache_clear()
+    client.cookies.clear()
+    yield
+    get_settings.cache_clear()
+    client.cookies.clear()
 
 
 def test_auth_status_returns_bootstrapped_false_when_no_users(db):

--- a/backend/tests/core/test_docs_enabled.py
+++ b/backend/tests/core/test_docs_enabled.py
@@ -12,9 +12,15 @@ os.environ.setdefault("RATE_LIMITING_ENABLED", "false")
 
 
 @pytest.fixture(autouse=True)
-def clear_settings_cache():
+def clear_settings_cache(monkeypatch):
     from app.core.config import get_settings
 
+    # Strip the local-dev container overrides (docker-compose.override.yml sets
+    # DOCS_ENABLED=true / COOKIE_SECURE=false for http dev) so the default-asserting
+    # test sees the secure code default regardless of ambient env. Tests that need a
+    # specific value set it explicitly (monkeypatch.setenv / Settings kwarg) afterwards.
+    monkeypatch.delenv("DOCS_ENABLED", raising=False)
+    monkeypatch.delenv("COOKIE_SECURE", raising=False)
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()

--- a/dark-factory/tests/test_factory_core_breaker.py
+++ b/dark-factory/tests/test_factory_core_breaker.py
@@ -4,8 +4,6 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 from factory_core.breaker import (
     get_retry_count, increment_retry, reset_retry, trip_to_blocked,
@@ -101,3 +99,27 @@ def test_trip_to_blocked_posts_comment(tmp_path, monkeypatch):
     with patch("factory_core.board.set_board_status"):
         trip_to_blocked(42, "plan", "retry limit reached", sf)
     assert any("comment" in " ".join(c) for c in calls)
+
+
+def test_trip_to_blocked_moves_to_blocked(tmp_path, monkeypatch):
+    from factory_core.board import STATUS_BLOCKED
+
+    sf = tmp_path / "state.json"
+    monkeypatch.setattr(subprocess, "run",
+        lambda cmd, **kw: subprocess.CompletedProcess([], 0, stdout="", stderr=""))
+    with patch("factory_core.board.set_board_status") as mock_sbs:
+        trip_to_blocked(42, "implement", "test reason", sf)
+    mock_sbs.assert_called_once_with(42, STATUS_BLOCKED)
+
+
+def test_trip_to_blocked_adds_both_labels(tmp_path, monkeypatch):
+    sf = tmp_path / "state.json"
+    calls = []
+    monkeypatch.setattr(subprocess, "run",
+        lambda cmd, **kw: (calls.append(cmd),
+                           subprocess.CompletedProcess([], 0, stdout="", stderr=""))[1])
+    with patch("factory_core.board.set_board_status"):
+        trip_to_blocked(42, "plan", "retry limit reached", sf)
+    edit_cmds = [" ".join(c) for c in calls if "issue" in c and "edit" in c]
+    assert any("needs-discussion" in c for c in edit_cmds)
+    assert any("factory-regression" in c for c in edit_cmds)

--- a/dark-factory/tests/test_scheduler.sh
+++ b/dark-factory/tests/test_scheduler.sh
@@ -75,11 +75,25 @@ assert_eq "bare key independent"        "1" "$(get_retry_count "42")"
 assert_eq ":refine unaffected by bare"  "0" "$(get_retry_count "42:refine")"
 
 # ==========================================
-# B: trip_to_blocked (fails until Task 5)
+# B: trip_to_blocked (thin adapter → breaker-trip CLI)
 # ==========================================
+# scheduler.sh's trip_to_blocked is a thin adapter that delegates to
+# `factory_core/cli.py breaker-trip`. The board-move + needs-discussion/
+# factory-regression labels + comment side effects live in factory_core/breaker.py
+# and are covered by test_factory_core_breaker.py (they run in a python subprocess
+# the bash stubs can't observe). Here we verify the adapter delegates with the right
+# issue/phase and that the retry counter is reset.
 echo ""
 echo "--- B: trip_to_blocked ---"
 echo '{}' > "$STATE_FILE"; > "$STUB_LOG"
+
+# Tee python3 invocations into STUB_LOG while still running the real interpreter (so
+# the real breaker-trip resets the counter on the temp state file). Capture the real
+# path BEFORE defining the wrapper, and export both so command-substitution subshells
+# (e.g. get_retry_count) resolve them.
+export _REAL_PY3="$(command -v python3)"
+python3() { echo "python3 $*" >> "$STUB_LOG"; "$_REAL_PY3" "$@"; }
+export -f python3
 
 increment_retry "99:plan"
 increment_retry "99:plan"
@@ -87,14 +101,8 @@ increment_retry "99:plan"
 
 trip_to_blocked "99" "plan" "test reason"
 
-assert_eq "set_board_status called" \
-  "1" "$(grep -c 'set_board_status 99' "$STUB_LOG" || echo 0)"
-assert_eq "gh issue edit adds needs-discussion" \
-  "1" "$(grep -c 'issue edit 99.*needs-discussion' "$STUB_LOG" || echo 0)"
-assert_eq "gh issue comment posted" \
-  "1" "$(grep -c 'issue comment 99' "$STUB_LOG" || echo 0)"
-assert_eq "gh issue edit adds factory-regression" \
-  "1" "$(grep -c 'issue edit 99.*factory-regression' "$STUB_LOG" || echo 0)"
+assert_eq "delegates to breaker-trip CLI (issue+phase)" \
+  "1" "$(grep -c 'breaker-trip --issue 99 --phase plan' "$STUB_LOG" || echo 0)"
 assert_eq ":plan counter reset after trip" \
   "0" "$(get_retry_count "99:plan")"
 
@@ -107,6 +115,8 @@ echo '{}' > "$STATE_FILE"; > "$STUB_LOG"
 increment_retry "77"
 trip_to_blocked "77" "implement" "test"
 assert_eq "bare implement counter reset" "0" "$(get_retry_count "77")"
+
+unset -f python3
 
 # ==========================================
 # C: dispatch() exit-code capture (fails until Task 3)
@@ -617,18 +627,25 @@ assert_eq "K8: increment_retry recorded after CONFLICTING dispatch" \
 
 > "$STUB_LOG"; DISPATCHED=""
 
-# K9: P1.5-5 — trip_to_blocked called at MAX_RETRIES
+# K9: P1.5-5 — trip_to_blocked delegates to breaker-trip at MAX_RETRIES
 echo "{\"60:resolve\": $MAX_RETRIES}" > "$STATE_FILE"
 
 ISSUE=$(get_issue_number "$_ITEM_REVIEW_A")
 RETRIES=$(get_retry_count "${ISSUE}:resolve")
+
+# Tee python3 so we can observe the breaker-trip delegation (the board-move to
+# Blocked itself runs in breaker.py and is covered by test_factory_core_breaker.py).
+export _REAL_PY3="$(command -v python3)"
+python3() { echo "python3 $*" >> "$STUB_LOG"; "$_REAL_PY3" "$@"; }
+export -f python3
 if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
   trip_to_blocked "$ISSUE" "resolve" "retry limit of ${MAX_RETRIES} reached for conflict resolution"
 else
   dispatch "Deconflict issue #${ISSUE}" || true
 fi
-assert_eq "K9: set_board_status Blocked logged" \
-  "1" "$(grep -c "set_board_status 60 ${STATUS_BLOCKED}" "$STUB_LOG" || echo 0)"
+unset -f python3
+assert_eq "K9: delegates to breaker-trip CLI (resolve)" \
+  "1" "$(grep -c 'breaker-trip --issue 60 --phase resolve' "$STUB_LOG" || echo 0)"
 assert_eq "K9: no dispatch on trip" \
   "0" "$(grep -c 'dispatch' "$STUB_LOG" || true)"
 assert_eq "K9: retry counter reset to 0" \


### PR DESCRIPTION
## What

Fixes the pre-existing test failures the dark factory keeps reporting on its runs
("16 pytest + 5 bash failures, pre-existing and unrelated to this branch"). After
root-causing, **none are product bugs** — they're test-quality issues that only
surface inside the local-dev / factory container, where `docker-compose.override.yml`
sets `COOKIE_SECURE=false` / `DOCS_ENABLED=true` for http dev. All now pass in both
that env and a clean CI-like env.

## Root cause & fix

**Backend — 4 failures** (`test_auth.py`, `test_docs_enabled.py`). The real count is
5, not 16; the rest were env-specific spurious failures (e.g. `PROMETHEUS_MULTIPROC_DIR`).

- `test_cookie_secure_defaults_to_true`, `test_default_is_false`,
  `test_login_cookies_have_correct_flags` assert the **secure code defaults**
  (`COOKIE_SECURE=True`, `DOCS_ENABLED=False`) but pydantic `Settings` reads the dev
  container's env overrides, so they failed only inside the dev/factory containers.
  → autouse fixtures now strip `COOKIE_SECURE`/`DOCS_ENABLED` so the tests observe the
  code defaults regardless of ambient env.
- `test_me_returns_current_user`, `test_logout_clears_cookies` (401): the module-level
  `TestClient` never cleared cookies, so a prior login's **non-Secure** cookie leaked
  into the next test and 401'd against the per-test DB reset. A latent isolation flake,
  masked in CI (Secure cookies aren't echoed over http).
  → clear `client.cookies` between tests.

**Dark factory — 5 failures** (`test_scheduler.sh` B/K9). The assertions watched bash
stubs (`set_board_status`, `gh issue edit/comment`) that the refactored
`trip_to_blocked` no longer calls — that behavior moved into `factory_core/breaker.py`,
which runs in a python subprocess the bash stubs can't observe.

- Re-point the bash B/K9 assertions at the `breaker-trip` CLI delegation (the thin
  adapter's actual responsibility).
- Relocate the behavioral coverage (board-move to Blocked + `needs-discussion` /
  `factory-regression` labels) into `test_factory_core_breaker.py`, where
  `set_board_status`/`subprocess` are mockable. Drop a stale unused `pytest` import.

## Validation

| Check | Result |
|---|---|
| `test_scheduler.sh` (bash) | 85 passed, 0 failed (was 83 / 5) |
| `test_factory_core_breaker.py` | 14 passed (+2) |
| `test_auth.py` + `test_docs_enabled.py` | 25 passed — dev-override env **and** clean |
| Full backend suite (dev overrides on) | 951 passed, 7 skipped, **0 failed** |
| ruff check / format | clean |

All test-only changes; no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
