### PR TITLE
fix: scheduler socket-proxy needs NETWORKS/VOLUMES to dispatch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -527,8 +527,12 @@ services:
       CONTAINERS: 1
       IMAGES: 1
       POST: 1
-      NETWORKS: 0
-      VOLUMES: 0
+      # `docker compose run dark-factory` (dispatch) must look up the service's
+      # networks (factory-network, stockscanner-network) and its scheduler_state
+      # volume before creating the container — both were 0, which 403'd every
+      # dispatch after a proxy recreate. BUILD/EXEC stay 0 (run never builds/execs).
+      NETWORKS: 1
+      VOLUMES: 1
       BUILD: 0
       SERVICES: 0
       EXEC: 0


### PR DESCRIPTION
## Fix: scheduler socket-proxy needs `NETWORKS`/`VOLUMES` to dispatch

`docker-socket-proxy-scheduler` was configured with `NETWORKS: 0` / `VOLUMES: 0`, but the scheduler dispatches via `docker compose run dark-factory`, which must look up the service's networks (`factory-network`, `stockscanner-network`) and its `scheduler_state` volume before creating the container. With those denied, **every dispatch 403'd** (`Request forbidden by administrative rules`).

### Why it was latent
The running proxy container kept a working config for a long time and only surfaced when the container was **force-recreated** — the recreate applied the current compose, exposing the `0`s. The sibling `docker-socket-proxy-factory` already grants `NETWORKS: 1` / `VOLUMES: 1` for the identical `docker compose run` dispatch, so this just matches it. `BUILD`/`EXEC` stay `0` (`docker compose run` never builds or execs).

### Impact when it regressed
A ~5-minute dispatch outage during which the circuit breaker tripped **~27 tickets** to `needs-discussion`/`factory-regression` (collateral — not real ticket problems).

### Verification
After setting `NETWORKS: 1` / `VOLUMES: 1` and recreating the proxy, dispatch succeeds — real refine runs execute and `/networks` returns `200` instead of `403`. The running stack is already on this config; this commit persists it so the next recreate doesn't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
