### PR TITLE
fix(dark-factory): smoke gate must set REDIS_PASSWORD (false main-red blocking all Ready dispatch)

### DIFF
--- a/dark-factory/smoke_gate.sh
+++ b/dark-factory/smoke_gate.sh
@@ -18,7 +18,8 @@ _smoke_check_main() {
   fi
   echo "[smoke_gate] Checking backend Python import graph..."
   # Settings() is instantiated at import time and requires DATABASE_URL /
-  # POLYGON_API_KEY / JWT_SECRET_KEY (>=32 chars; preview env contract, #190).
+  # POLYGON_API_KEY / JWT_SECRET_KEY (>=32 chars) / REDIS_PASSWORD (>=16 chars,
+  # required no-default since #415 Redis requirepass; preview env contract, #190).
   # The gate verifies the import graph compiles, NOT that config is real —
   # without throwaway values the check is red in every factory container, so
   # every fix/continue/deconflict run false-latches the sentinel (#365). Same
@@ -27,6 +28,7 @@ _smoke_check_main() {
         && DATABASE_URL="postgresql://smoke:smoke@localhost:5432/smoke" \
            POLYGON_API_KEY="smoke-gate-only-not-a-real-key" \
            JWT_SECRET_KEY="smoke-gate-only-not-secret-0123456789abcdef" \
+           REDIS_PASSWORD="smoke-gate-only-not-a-real-redis-password" \
            python -c "import app.main" 2>&1); then
     echo "[smoke_gate] python import FAILED — main is red"
     return 1


### PR DESCRIPTION
## Problem

The backlog scheduler stopped dispatching **any** Ready / Blocked-retry / Deconflict work. Every poll cycle logged:

```
main_red=true
main_red_gate=skip_implement
```

Refinement (Plan/Refine) kept running, so the factory *looked* busy — but no Ready ticket had been implemented for hours. GitHub CI on `main` was fully green the whole time.

## Root cause

The factory's local **main-smoke gate** (`dark-factory/smoke_gate.sh`) runs `python -c "import app.main"` against a fresh `origin/main` clone using a minimal throwaway env. `Settings()` is instantiated at *import time* (`config.py:205`).

Since **#415** (Redis requirepass, F-NET-01), `REDIS_PASSWORD` is a **required `Settings` field with no default** (`config.py:27`, validator ≥16 chars). The smoke gate set `DATABASE_URL` / `POLYGON_API_KEY` / `JWT_SECRET_KEY` but **not `REDIS_PASSWORD`**, so the import raised:

```
pydantic_core.ValidationError: 1 validation error for Settings
REDIS_PASSWORD
  Field required [type=missing]
```

→ the gate false-latched `main-is-red` (regression #549) → scheduler paused Priority 1.5/2/3. GitHub CI never caught it because CI doesn't run this exact import-with-throwaway-vars check.

Same bug class as **#190** (missing `JWT_SECRET_KEY` broke the preview env contract).

## Fix

Add a ≥16-char throwaway `REDIS_PASSWORD` to the gate's env block, mirroring the existing `JWT_SECRET_KEY` stub. The field stays required in real deploys — only the import-graph smoke check gets a dummy value.

**Not** a default on the field — that would defeat #415's fail-closed Redis-auth control.

## Blast radius

- `ci.yml` already provides a dummy `REDIS_PASSWORD` (#370) — **CI was never broken**.
- The dark-factory smoke gate was the only harness missed.

## Verification

- Reproduced the exact `ValidationError` in a clean 3-var env; confirmed the 4-var env imports cleanly (`IMPORT OK`, no second required field).
- Rebuilt the factory image, recreated the scheduler, ran `Recheck main` through the new image → gate went **green**, sentinel cleared, #549 auto-closed.
- Scheduler resumed: `dispatched="Fix issue #302" main_red=false`.

Regression ticket: #549 (auto-closed by the green gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
