### PR TITLE
docs(docker): document root-user exception in Dockerfile.forecast

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,6 +88,15 @@ graph TD
     dbbackup -->|"failure events"| seq
 ```
 
+### Container Users
+
+| Image | Services | Runtime user | Notes |
+|---|---|---|---|
+| `markethawk-backend` | `backend`, `celery-worker`, `celery-beat`, `live-scanner`, `tweet-monitor`, `flower` | `appuser` (uid 1000) | Non-root; created in `backend/Dockerfile` |
+| `markethawk-frontend` | `frontend` | `node` | Non-root; default node image user |
+| `markethawk-dark-factory` | `dark-factory`, `backlog-scheduler` | `factory` (uid 1000) | Non-root; created in `dark-factory/Dockerfile` |
+| `markethawk-forecast` | `forecast-worker` | `root` | Exception: HuggingFace model weights (~800 MB) cached at `/root/.cache/huggingface` via `timesfm_cache` named volume; converting to non-root requires relocating the cache path (tracked as a separate follow-up) |
+
 ## Scan Execution Flow
 
 A full pre-market scan proceeds as follows:

--- a/docs/codeindex-hotspots.md
+++ b/docs/codeindex-hotspots.md
@@ -4,9 +4,9 @@ Files with blast score ≥ 5.0  (42 found)
     62.5  backend/app/routers/auth.py  (2d / 121t)  213 loc
     36.5  frontend/src/api/scanner/index.ts  (26d / 21t)  53 loc
     31.0  frontend/src/components/ui/Card.tsx  (21d / 20t)  44 loc
-    28.5  frontend/src/api/scanner/types.ts  (5d / 47t)  272 loc
+    28.5  frontend/src/api/scanner/types.ts  (5d / 47t)  271 loc
     28.5  frontend/src/components/ui/Button.tsx  (21d / 15t)  66 loc
-    28.0  backend/app/routers/scanner.py  (4d / 48t)  714 loc
+    28.0  backend/app/routers/scanner.py  (4d / 48t)  709 loc
     27.0  backend/app/routers/system.py  (2d / 50t)  141 loc
     27.0  services/tweet-monitor/app/main.py  (2d / 50t)  266 loc
     25.0  backend/app/routers/futures.py  (1d / 48t)  188 loc
@@ -22,11 +22,11 @@ Files with blast score ≥ 5.0  (42 found)
     14.0  frontend/src/components/Ticker.tsx  (6d / 16t)  80 loc
     12.5  frontend/src/api/outcomes.ts  (10d / 5t)  217 loc
     12.5  frontend/src/api/trading.ts  (9d / 7t)  244 loc
-     9.0  backend/app/main.py  (1d / 16t)  526 loc
+     9.0  backend/app/main.py  (1d / 16t)  516 loc
      9.0  backend/app/routers/auto_trading.py  (1d / 16t)  365 loc
-     9.0  backend/app/routers/universe.py  (1d / 16t)  453 loc
+     9.0  backend/app/routers/universe.py  (1d / 16t)  446 loc
      9.0  frontend/src/components/ui/MetricCard.tsx  (6d / 6t)  71 loc
-     8.5  backend/app/routers/outcomes.py  (1d / 15t)  366 loc
+     8.5  backend/app/routers/outcomes.py  (1d / 15t)  329 loc
      8.5  frontend/src/utils/url.ts  (3d / 11t)  36 loc
      8.0  frontend/src/hooks/useScorecard.ts  (5d / 6t)  98 loc
      8.0  frontend/src/pages/AutoTrading/components.tsx  (5d / 6t)  294 loc
@@ -39,6 +39,6 @@ Files with blast score ≥ 5.0  (42 found)
      6.0  frontend/src/hooks/useLiveStockData.ts  (4d / 4t)  115 loc
      5.5  frontend/src/components/QualityReportModal/GradeBadge.tsx  (3d / 5t)  35 loc
      5.5  frontend/src/utils/indicators.ts  (2d / 7t)  106 loc
-     5.0  backend/app/routers/alerts.py  (1d / 8t)  423 loc
+     5.0  backend/app/routers/alerts.py  (1d / 8t)  415 loc
      5.0  frontend/src/api/system.ts  (3d / 4t)  55 loc
      5.0  frontend/src/api/watchlist.ts  (4d / 2t)  70 loc

--- a/docs/codeindex-hotspots.md
+++ b/docs/codeindex-hotspots.md
@@ -4,9 +4,9 @@ Files with blast score ≥ 5.0  (42 found)
     62.5  backend/app/routers/auth.py  (2d / 121t)  213 loc
     36.5  frontend/src/api/scanner/index.ts  (26d / 21t)  53 loc
     31.0  frontend/src/components/ui/Card.tsx  (21d / 20t)  44 loc
-    28.5  frontend/src/api/scanner/types.ts  (5d / 47t)  271 loc
+    28.5  frontend/src/api/scanner/types.ts  (5d / 47t)  272 loc
     28.5  frontend/src/components/ui/Button.tsx  (21d / 15t)  66 loc
-    28.0  backend/app/routers/scanner.py  (4d / 48t)  709 loc
+    28.0  backend/app/routers/scanner.py  (4d / 48t)  714 loc
     27.0  backend/app/routers/system.py  (2d / 50t)  141 loc
     27.0  services/tweet-monitor/app/main.py  (2d / 50t)  266 loc
     25.0  backend/app/routers/futures.py  (1d / 48t)  188 loc
@@ -22,11 +22,11 @@ Files with blast score ≥ 5.0  (42 found)
     14.0  frontend/src/components/Ticker.tsx  (6d / 16t)  80 loc
     12.5  frontend/src/api/outcomes.ts  (10d / 5t)  217 loc
     12.5  frontend/src/api/trading.ts  (9d / 7t)  244 loc
-     9.0  backend/app/main.py  (1d / 16t)  516 loc
+     9.0  backend/app/main.py  (1d / 16t)  526 loc
      9.0  backend/app/routers/auto_trading.py  (1d / 16t)  365 loc
-     9.0  backend/app/routers/universe.py  (1d / 16t)  446 loc
+     9.0  backend/app/routers/universe.py  (1d / 16t)  453 loc
      9.0  frontend/src/components/ui/MetricCard.tsx  (6d / 6t)  71 loc
-     8.5  backend/app/routers/outcomes.py  (1d / 15t)  329 loc
+     8.5  backend/app/routers/outcomes.py  (1d / 15t)  366 loc
      8.5  frontend/src/utils/url.ts  (3d / 11t)  36 loc
      8.0  frontend/src/hooks/useScorecard.ts  (5d / 6t)  98 loc
      8.0  frontend/src/pages/AutoTrading/components.tsx  (5d / 6t)  294 loc
@@ -39,6 +39,6 @@ Files with blast score ≥ 5.0  (42 found)
      6.0  frontend/src/hooks/useLiveStockData.ts  (4d / 4t)  115 loc
      5.5  frontend/src/components/QualityReportModal/GradeBadge.tsx  (3d / 5t)  35 loc
      5.5  frontend/src/utils/indicators.ts  (2d / 7t)  106 loc
-     5.0  backend/app/routers/alerts.py  (1d / 8t)  415 loc
+     5.0  backend/app/routers/alerts.py  (1d / 8t)  423 loc
      5.0  frontend/src/api/system.ts  (3d / 4t)  55 loc
      5.0  frontend/src/api/watchlist.ts  (4d / 2t)  70 loc


### PR DESCRIPTION
Closes omniscient/dark-factory#98

## Summary
Automated implementation for issue omniscient/dark-factory#98.

## Preview
_No preview environment — this change does not affect the running app ('Both changed files are pure documentation (ARCHITECTURE.md and docs/codeindex-hotspots.md). No runtime-affecting files touched. Preview not needed.')._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#98"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#98"
```

---
*Generated by MarketHawk Dark Factory*