### PR TITLE
chore(codeindex): docs/codeindex-hotspots.md OOS line-count refreshes committed on feature branches

### DIFF
--- a/.archon/workflows/archon-dark-factory.yaml
+++ b/.archon/workflows/archon-dark-factory.yaml
@@ -232,6 +232,35 @@ nodes:
     when: "$parse-intent.output.intent == 'close'"
     timeout: 30000
 
+  - id: post-merge-update-codeindex
+    bash: |
+      if ! command -v codeindex &>/dev/null; then
+        echo "WARNING: codeindex not available — skipping post-merge hotspot update"
+        exit 0
+      fi
+      ISSUE=$(jq -r '.resolved_number' "$ARTIFACTS_DIR/issue.json")
+      echo "Refreshing codeindex hotspots on main (post-merge for issue #${ISSUE})..."
+      git fetch origin main
+      git checkout main
+      git reset --hard origin/main
+      codeindex analyze . 2>/dev/null || echo "WARNING: codeindex analyze failed"
+      codeindex symbols . --output symbolindex.json 2>/dev/null || echo "WARNING: codeindex symbols failed"
+      mkdir -p docs
+      codeindex high-blast 2>/dev/null > docs/codeindex-hotspots.md.tmp \
+        && mv docs/codeindex-hotspots.md.tmp docs/codeindex-hotspots.md \
+        || echo "WARNING: codeindex high-blast failed — hotspots file unchanged"
+      git add docs/codeindex-hotspots.md
+      if ! git diff --staged --quiet; then
+        git commit -m "chore: refresh codeindex hotspots (post-merge #${ISSUE})"
+        git push origin main \
+          || echo "WARNING: push to main failed — hotspots will be stale until next manual refresh"
+      else
+        echo "codeindex hotspots unchanged post-merge — no commit needed"
+      fi
+    depends_on: [close-preview]
+    when: "$parse-intent.output.intent == 'close'"
+    timeout: 120000
+
   - id: setup-branch
     bash: |
       ISSUE=$(jq -r '.resolved_number' "$ARTIFACTS_DIR/issue.json")
@@ -357,8 +386,10 @@ nodes:
 
   # Post-implement codeindex regeneration — refreshes the local index so the in-run MCP tools
   # (lookup_symbol / get_impact) see the final code. codeindex.json / symbolindex.json are
-  # gitignored (regenerated on demand, see #343); only docs/codeindex-hotspots.md is committed.
-  # Non-fatal: if codeindex is unavailable the run continues.
+  # gitignored (regenerated on demand, see #343). docs/codeindex-hotspots.md is generated
+  # locally for in-run use but NOT committed to the feature branch — post-merge refresh
+  # happens in the post-merge-update-codeindex node. Non-fatal: if codeindex is unavailable
+  # the run continues.
   - id: regen-codeindex
     bash: |
       if ! command -v codeindex &>/dev/null; then
@@ -367,17 +398,12 @@ nodes:
       fi
       echo "Regenerating codeindex (post-implement pass)..."
       codeindex analyze . 2>/dev/null || echo "WARNING: codeindex analyze failed"
-      codeindex symbols . --inline 2>/dev/null || echo "WARNING: codeindex symbols failed"
+      codeindex symbols . --output symbolindex.json 2>/dev/null || echo "WARNING: codeindex symbols failed"
       mkdir -p docs
-      codeindex high-blast 2>/dev/null > docs/codeindex-hotspots.md || true
-      # Commit only the small human-readable hotspots doc; the JSON indexes are gitignored.
-      git add docs/codeindex-hotspots.md 2>/dev/null || true
-      if ! git diff --staged --quiet 2>/dev/null; then
-        git commit -m "chore: update codeindex hotspots (post-implement)"
-        echo "codeindex hotspots committed"
-      else
-        echo "codeindex hotspots unchanged — no commit needed"
-      fi
+      codeindex high-blast 2>/dev/null > docs/codeindex-hotspots.md.tmp \
+        && mv docs/codeindex-hotspots.md.tmp docs/codeindex-hotspots.md \
+        || echo "WARNING: codeindex high-blast failed — hotspots file unchanged"
+      echo "codeindex hotspots generated locally (not committed — post-merge refresh via post-merge-update-codeindex)"
     depends_on: [implement]
     when: "$parse-intent.output.intent == 'new' || $parse-intent.output.intent == 'continue'"
     timeout: 120000

--- a/docs/codeindex-hotspots.md
+++ b/docs/codeindex-hotspots.md
@@ -4,9 +4,9 @@ Files with blast score ≥ 5.0  (42 found)
     62.5  backend/app/routers/auth.py  (2d / 121t)  213 loc
     36.5  frontend/src/api/scanner/index.ts  (26d / 21t)  53 loc
     31.0  frontend/src/components/ui/Card.tsx  (21d / 20t)  44 loc
-    28.5  frontend/src/api/scanner/types.ts  (5d / 47t)  272 loc
+    28.5  frontend/src/api/scanner/types.ts  (5d / 47t)  271 loc
     28.5  frontend/src/components/ui/Button.tsx  (21d / 15t)  66 loc
-    28.0  backend/app/routers/scanner.py  (4d / 48t)  714 loc
+    28.0  backend/app/routers/scanner.py  (4d / 48t)  709 loc
     27.0  backend/app/routers/system.py  (2d / 50t)  141 loc
     27.0  services/tweet-monitor/app/main.py  (2d / 50t)  266 loc
     25.0  backend/app/routers/futures.py  (1d / 48t)  188 loc
@@ -22,11 +22,11 @@ Files with blast score ≥ 5.0  (42 found)
     14.0  frontend/src/components/Ticker.tsx  (6d / 16t)  80 loc
     12.5  frontend/src/api/outcomes.ts  (10d / 5t)  217 loc
     12.5  frontend/src/api/trading.ts  (9d / 7t)  244 loc
-     9.0  backend/app/main.py  (1d / 16t)  526 loc
+     9.0  backend/app/main.py  (1d / 16t)  516 loc
      9.0  backend/app/routers/auto_trading.py  (1d / 16t)  365 loc
-     9.0  backend/app/routers/universe.py  (1d / 16t)  453 loc
+     9.0  backend/app/routers/universe.py  (1d / 16t)  446 loc
      9.0  frontend/src/components/ui/MetricCard.tsx  (6d / 6t)  71 loc
-     8.5  backend/app/routers/outcomes.py  (1d / 15t)  366 loc
+     8.5  backend/app/routers/outcomes.py  (1d / 15t)  329 loc
      8.5  frontend/src/utils/url.ts  (3d / 11t)  36 loc
      8.0  frontend/src/hooks/useScorecard.ts  (5d / 6t)  98 loc
      8.0  frontend/src/pages/AutoTrading/components.tsx  (5d / 6t)  294 loc
@@ -39,6 +39,6 @@ Files with blast score ≥ 5.0  (42 found)
      6.0  frontend/src/hooks/useLiveStockData.ts  (4d / 4t)  115 loc
      5.5  frontend/src/components/QualityReportModal/GradeBadge.tsx  (3d / 5t)  35 loc
      5.5  frontend/src/utils/indicators.ts  (2d / 7t)  106 loc
-     5.0  backend/app/routers/alerts.py  (1d / 8t)  423 loc
+     5.0  backend/app/routers/alerts.py  (1d / 8t)  415 loc
      5.0  frontend/src/api/system.ts  (3d / 4t)  55 loc
      5.0  frontend/src/api/watchlist.ts  (4d / 2t)  70 loc

--- a/docs/codeindex-hotspots.md
+++ b/docs/codeindex-hotspots.md
@@ -4,9 +4,9 @@ Files with blast score ≥ 5.0  (42 found)
     62.5  backend/app/routers/auth.py  (2d / 121t)  213 loc
     36.5  frontend/src/api/scanner/index.ts  (26d / 21t)  53 loc
     31.0  frontend/src/components/ui/Card.tsx  (21d / 20t)  44 loc
-    28.5  frontend/src/api/scanner/types.ts  (5d / 47t)  271 loc
+    28.5  frontend/src/api/scanner/types.ts  (5d / 47t)  272 loc
     28.5  frontend/src/components/ui/Button.tsx  (21d / 15t)  66 loc
-    28.0  backend/app/routers/scanner.py  (4d / 48t)  709 loc
+    28.0  backend/app/routers/scanner.py  (4d / 48t)  714 loc
     27.0  backend/app/routers/system.py  (2d / 50t)  141 loc
     27.0  services/tweet-monitor/app/main.py  (2d / 50t)  266 loc
     25.0  backend/app/routers/futures.py  (1d / 48t)  188 loc
@@ -22,11 +22,11 @@ Files with blast score ≥ 5.0  (42 found)
     14.0  frontend/src/components/Ticker.tsx  (6d / 16t)  80 loc
     12.5  frontend/src/api/outcomes.ts  (10d / 5t)  217 loc
     12.5  frontend/src/api/trading.ts  (9d / 7t)  244 loc
-     9.0  backend/app/main.py  (1d / 16t)  516 loc
+     9.0  backend/app/main.py  (1d / 16t)  526 loc
      9.0  backend/app/routers/auto_trading.py  (1d / 16t)  365 loc
-     9.0  backend/app/routers/universe.py  (1d / 16t)  446 loc
+     9.0  backend/app/routers/universe.py  (1d / 16t)  453 loc
      9.0  frontend/src/components/ui/MetricCard.tsx  (6d / 6t)  71 loc
-     8.5  backend/app/routers/outcomes.py  (1d / 15t)  329 loc
+     8.5  backend/app/routers/outcomes.py  (1d / 15t)  366 loc
      8.5  frontend/src/utils/url.ts  (3d / 11t)  36 loc
      8.0  frontend/src/hooks/useScorecard.ts  (5d / 6t)  98 loc
      8.0  frontend/src/pages/AutoTrading/components.tsx  (5d / 6t)  294 loc
@@ -39,6 +39,6 @@ Files with blast score ≥ 5.0  (42 found)
      6.0  frontend/src/hooks/useLiveStockData.ts  (4d / 4t)  115 loc
      5.5  frontend/src/components/QualityReportModal/GradeBadge.tsx  (3d / 5t)  35 loc
      5.5  frontend/src/utils/indicators.ts  (2d / 7t)  106 loc
-     5.0  backend/app/routers/alerts.py  (1d / 8t)  415 loc
+     5.0  backend/app/routers/alerts.py  (1d / 8t)  423 loc
      5.0  frontend/src/api/system.ts  (3d / 4t)  55 loc
      5.0  frontend/src/api/watchlist.ts  (4d / 2t)  70 loc


### PR DESCRIPTION
Closes omniscient/dark-factory#134

## Summary
Automated implementation for issue omniscient/dark-factory#134.

## Preview
_No preview environment — this change does not affect the running app ('Changeset contains only workflow config (.archon/workflows/) and documentation (docs/codeindex-hotspots.md) — no runtime-affecting changes to backend, frontend, migrations, or dependencies.')._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#134"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#134"
```


## Blast radius

```
Impact: yaml
Blast Score: 10.0  (10 direct · 0 transitive)  [HIGH]

Direct dependents (10)
  backend/tests/api/test_metrics.py
  dark-factory/scripts/check_workflow_dag.py
  dark-factory/scripts/check_workflow_when.py
  dark-factory/scripts/gate_blast_radius.py
  dark-factory/tests/test_bench_suite.py
  dark-factory/tests/test_blast_radius.py
  dark-factory/tests/test_config_code_review.py
  dark-factory/tests/test_workflow_code_review.py
  dark-factory/tests/test_workflow_or_join.py
  dark-factory/tests/test_workflow_when.py

Risk: HIGH — affects 10/601 files (1.7% of codebase)
```
---
*Generated by MarketHawk Dark Factory*