### PR TITLE
docs(#548): epic autopilot + system notifications design specs

### DIFF
--- a/docs/superpowers/specs/2026-06-20-epic-autopilot-design.md
+++ b/docs/superpowers/specs/2026-06-20-epic-autopilot-design.md
@@ -1,0 +1,172 @@
+# Epic Autopilot — bounded self-unlock for a starved scheduler
+
+**Status:** design
+**Date:** 2026-06-20
+**Epic:** #548 (Dark Factory platform — maintenance, telemetry)
+**Depends on:** System Notifications Enabler (`2026-06-20-system-notifications-enabler-design.md`)
+**Build constraint:** This modifies the scheduler/factory itself (a "factory self-edit"),
+so it must be **human-implemented**, never auto-refined/implemented by the factory.
+
+## Problem
+
+The backlog scheduler dispatches nothing when the only Ready items are epics
+(never dispatched, by design) and every refined child sits behind a human-review
+gate (`spec-pending-review` / `plan-pending-review`). Observed 2026-06-20: 5 Ready
+epics, 53 opted-in backlog specs all `spec-pending-review`, factory idle for hours
+with free slots — every cycle `skip=nothing_to_do`. Unblocking required a human to
+review a ticket and advance it (we did this for #402 by hand).
+
+We want the scheduler to **self-unlock** when starved: review the safest refined
+children of *in-progress* epics with a strong model and advance them autonomously,
+within hard guardrails, with full transparency and escalation.
+
+## Decision
+
+A new **Priority 6: Epic Autopilot** runs at the tail of the poll loop, **only when
+starved**, backed by a testable Python module. It reviews **one** candidate per cycle
+with **Opus 4.8** and, on a low-risk verdict, adds `direct-to-pr` so the existing
+grace-timer machinery carries the ticket spec→plan→implement→PR.
+
+### Control flow (`scheduler.sh`)
+
+```sh
+# After Priority 5, at the loop tail:
+if [ -z "$DISPATCHED" ] && [ "$MAIN_IS_RED" = "false" ] && [ "$EPIC_AUTOPILOT_ENABLED" = "true" ]; then
+  python3 "$FACTORY_CORE_CLI" epic-autopilot --once
+fi
+```
+
+`DISPATCHED` empty ⇒ no priority dispatched this cycle (and the capacity guard already
+`continue`d if at capacity), so the autopilot only ever fills genuine idle time and
+never runs while main is red. The scheduler logs the module's structured outcome:
+`autopilot=advanced issue=#N` / `autopilot=hold issue=#N reason=…` /
+`autopilot=no_candidates` / `autopilot=daily_cap_reached`.
+
+### Module (`dark-factory/scripts/factory_core/epic_autopilot.py`)
+
+Thin-adapter pattern (like `breaker.py` / `board.py`), invoked via `cli.py epic-autopilot`.
+
+**Stage A — structural eligibility** (all must hold):
+- OPEN `subIssue` of an **in-progress** epic (GraphQL `subIssues`)
+- board status `spec-pending-review` or `plan-pending-review`
+- not already `direct-to-pr`, `no-autopilot`, `needs-discussion`, or `epic`
+- **below the dispatch ceiling** (size S, or M without a `dispatch_ceiling` keyword) —
+  above-ceiling can't reach a PR autonomously, so skipping avoids wasted Opus calls
+- no cached HOLD verdict for the current spec hash
+
+**Stage B — hard exclusions** (any match ⇒ drop before Opus sees it; **fail-closed**):
+- **Factory self-edits** — target paths under `dark-factory/`, `.archon/`, `scheduler.sh`,
+  `factory_core/`, refinement skills
+- **Automated trading** — live order/trading path (`app/services/trading*`,
+  `app/tasks/trading.py`, IBKR order methods) or `trading` label + order keywords
+- **AuthN/AuthZ** — `app/core/auth*`, `app/routers/auth*`, JWT/login/session/RBAC
+  keywords. **Plain `security` label is allowed** (normal security fixes are fine);
+  only auth-specific changes are excluded.
+
+Detection reads the **declared target files** in the generated spec/plan plus
+title/body keywords. If the spec does not clearly declare its file scope, the sensitive
+categories (trading/auth) are treated as **possibly matched → excluded**. Size,
+migrations, and blast-radius are **soft** inputs to Opus (not hard blocks), except
+where `dispatch_ceiling` already parks them.
+
+**Candidate pick:** one eligible candidate per cycle (oldest / highest `priority:` first).
+
+**Context for the reviewer:** ticket #/title/body/labels/size, parent epic title, the
+full generated spec (and plan if present), declared target files, and — *best-effort,
+when codeindex data is available to the scheduler* — their blast scores. Blast scores
+are a soft input; if absent, Opus judges from the spec/plan text alone.
+
+**Reviewer call:** `claude -p --model claude-opus-4-8` (mirrors the existing
+`classify_comments` `claude -p` pattern). Structured JSON output:
+```json
+{ "decision": "ADVANCE|HOLD", "risk": "low|medium|high",
+  "confidence": 0.0-1.0, "reasons": [...], "concerns": [...] }
+```
+The prompt asks Opus to weigh spec completeness, test coverage, reversibility, blast
+radius, and empty-branch/no-op risk; to re-check trading/auth/factory-self as a
+redundant catch; and to **default to HOLD when uncertain**.
+
+**Decision rule (belt-and-suspenders):** ADVANCE only if
+`decision == ADVANCE` **and** `risk == low` **and** `confidence >= confidence_floor`.
+Anything else, or any parse error, → **HOLD** (fail-closed, mirroring
+`classify_comments`→SKIP and `code_review.fail_open`).
+
+**Actions:**
+- **ADVANCE** → add `direct-to-pr`; post a verdict comment (reasons + concerns,
+  footer `Posted by MarketHawk Epic Autopilot`); send the advance notification.
+  *No new dispatch logic* — the existing P4/P5 grace-timer path carries it onward.
+  (Uses the `direct-to-pr` grace path, **not** a manual remove-label-then-board-move,
+  which avoids the re-plan race seen when advancing #402 by hand.)
+- **HOLD** → post a one-time "parked by autopilot" comment; cache the verdict.
+
+**Idempotency / cost:** verdict cache on the `scheduler_state` volume keyed by
+`issue → {spec_hash, verdict}`. HOLD is not re-reviewed until the spec is regenerated
+(hash changes); ADVANCE is terminal (label present → no longer a candidate). ≤1 Opus
+call per cycle; ≤1 per ticket per spec revision.
+
+**Pacing & backstop:** one advance per starved cycle (advancing fills a slot → next
+cycle isn't starved → autopilot sleeps). A **daily cap** (`daily_cap`, default 5) hard-
+limits autonomous advances per UTC day, tracked in the state file, reset at midnight.
+
+### Notifications (via the System Notifications Enabler endpoint)
+
+The module POSTs to `http://backend:8000/api/alerts/system` (scheduler is on
+`stockscanner-network`) with `X-Internal-Token`. All three go to **email + browser
+push**. Notification failure is fail-soft (logged, never blocks autopilot):
+
+1. **Advancing** *(info, per advance)* — "🤖 Autopilot advancing #N «title» — risk=low:
+   `<reason>`."
+2. **Daily cap reached** *(warning)* — "⚠️ Autopilot hit its daily cap (N); autonomous
+   advancement paused until UTC reset — review the backlog."
+3. **Starved but stuck** *(warning, throttled 1×/day via `dedupe_key`)* — factory idle
+   **and** zero eligible candidates: "⚠️ Factory idle and autopilot has nothing safe to
+   advance — human input needed."
+
+### Config (new `epic_autopilot:` section in `.claude/skills/refinement/config.yaml`)
+
+```yaml
+epic_autopilot:
+  enabled: false              # kill-switch — ship OFF, enable after validation. env: EPIC_AUTOPILOT_ENABLED
+  model: claude-opus-4-8
+  daily_cap: 5                # max autonomous advances / UTC day
+  confidence_floor: 0.7       # min Opus confidence to ADVANCE
+  opt_out_label: no-autopilot
+  hard_exclude_paths:         # factory-self / trading / auth — fail-closed
+    - "dark-factory/"
+    - ".archon/"
+    - "app/services/trading"
+    - "app/tasks/trading.py"
+    - "app/core/auth"
+    - "app/routers/auth"
+```
+Loaded via the existing `read_config` knob pattern (env overrides logged).
+
+## Guardrails summary
+
+Starved-only trigger · hard-rule envelope (fail-closed) · Opus low-risk + confidence
+threshold · `no-autopilot` opt-out · daily cap · kill-switch (ships OFF) · full
+reversibility (remove `direct-to-pr`) · every action commented + notified · the
+autopilot excludes edits to itself.
+
+## Validation
+
+- **Python unit tests** (alongside `test_breaker`/`test_board`, fully mocked — no live
+  API): eligibility filter; each hard-exclusion category incl. fail-closed on undeclared
+  scope and `security`-passes-through; decision rule (ADVANCE only on
+  `ADVANCE`+`low`+`≥floor`); malformed Opus output → HOLD; verdict-cache invalidation by
+  `spec_hash`; daily-cap enforcement + UTC reset; notification payload shape.
+- **Scheduler bash test** (`SCHEDULER_SOURCE_ONLY`): P6 guard fires only when
+  `DISPATCHED` empty + main not red + enabled.
+- **Manual:** enable; watch it advance exactly one low-risk ticket end-to-end to a PR;
+  verify ticket comment + `direct-to-pr` label + cache entry + advance email/push;
+  force `daily_cap` and confirm the cap notification; empty the candidate pool and
+  confirm the stuck notification.
+
+## Accepted trade-offs
+
+- One advance per cycle (throughput traded for caution + self-pacing).
+- Opus per review is costly, but bounded by starved-only + daily cap + verdict cache.
+- Reviews from spec/plan text (not a full agent reading the codebase) — cheaper and
+  sufficient given the hard-rule envelope; a full-agent reviewer (factory intent) is a
+  possible future upgrade.
+- Human-implemented (factory self-edit) — cannot be dogfooded through the pipeline.

--- a/docs/superpowers/specs/2026-06-20-system-notifications-enabler-design.md
+++ b/docs/superpowers/specs/2026-06-20-system-notifications-enabler-design.md
@@ -1,0 +1,105 @@
+# System Notifications Enabler — generic email/push for non-scanner events
+
+**Status:** design
+**Date:** 2026-06-20
+**Epic:** #548 (Dark Factory platform — maintenance, telemetry)
+**Consumed by:** Epic Autopilot (`2026-06-20-epic-autopilot-design.md`)
+
+## Problem
+
+MarketHawk already has multi-channel notification delivery — `NotificationDispatcher`
+in `app/services/alert_service.py` sends **email** (SMTP via `smtplib`) and **browser
+push** (VAPID via `pywebpush`), plus `google_chat` and `webhook`. But it is wired
+**only** to the scanner path: `dispatch(rule: AlertRule, event: ScannerEvent, db)`.
+The delivery helpers (`_send_email`, `_send_browser_push`) take a `ScannerEvent` and
+build scanner-specific subject/body.
+
+The one generic entry point, `POST /api/alerts/infrastructure`, merely **logs the
+payload to Seq** (`receive_infrastructure_alert`) — it does not deliver anything.
+
+So there is no way for the app — or an external component like the backlog scheduler —
+to say "email/push me this system message." The Epic Autopilot feature needs exactly
+that, and so will future system events (main-red, circuit-breaker trips, preview
+failures).
+
+## Decision
+
+Add a small **generic system-notification path** that reuses the existing SMTP/VAPID
+delivery, decoupled from `AlertRule`/`ScannerEvent`.
+
+### Components
+
+1. **Refactor delivery helpers to a generic core** (`app/services/alert_service.py`):
+   - Extract `_send_email(to, subject, body)` and
+     `_send_browser_push(title, body, url=None)` as generic functions.
+   - The existing scanner-specific senders become thin wrappers that build the
+     scanner subject/body, then call the generic core. No behavior change on the
+     scanner path.
+
+2. **`app/services/system_notifier.py`** — new module:
+   ```python
+   def notify_system(
+       title: str,
+       body: str,
+       severity: str = "info",        # info | warning | critical
+       dedupe_key: str | None = None,
+       channels: list[str] | None = None,  # default: ["email", "browser_push"]
+   ) -> dict:  # {channel: "sent"|"skipped"|"failed:<reason>"}
+   ```
+   - Email → `OPS_ALERT_EMAIL` (new optional Settings field). If unset: skip email,
+     log a warning (never raise).
+   - Browser push → all stored `PushSubscription` rows.
+   - **Severity** prefixes the subject (`[WARNING] …`) and sets push urgency.
+   - **Dedupe/throttle:** if `dedupe_key` is given, suppress re-sends of the same key
+     within a short cooldown (default 60 min). `AlertDeliveryLog` is scanner-rule-scoped
+     (`rule_id` FK) and is **not** reused directly; the store is decided in the plan —
+     a small dedicated table or persisted state so the cooldown survives restarts
+     (mirroring the `is_on_cooldown` *pattern*, not the table).
+   - **Fail-soft:** each channel is attempted independently; a failure is logged to Seq
+     and recorded in `AlertDeliveryLog`, never raised to the caller.
+
+3. **`POST /api/alerts/system`** (in `app/routers/alerts.py`):
+   - Body: `{title, body, severity?, dedupe_key?, channels?}` → calls `notify_system`
+     → returns the per-channel delivery summary.
+   - **Auth:** server-to-server only. Require a shared-secret header
+     `X-Internal-Token` matching `INTERNAL_API_TOKEN` (new Settings field). Reject with
+     401 if absent/mismatched. This avoids coupling to the evolving user-auth model
+     (#373) while preventing an open spam endpoint. If `INTERNAL_API_TOKEN` is unset,
+     the endpoint is disabled (503) — fail-closed.
+
+### Config (new Settings fields)
+
+| Field | Default | Purpose |
+|---|---|---|
+| `OPS_ALERT_EMAIL` | `""` (optional) | recipient for system emails; unset → email skipped |
+| `INTERNAL_API_TOKEN` | `""` (required to enable the endpoint) | shared secret for `/api/alerts/system` |
+
+`SMTP_*` and `VAPID_*` already exist. **Preview env contract:** these new fields are
+optional/empty-default, so they do not break the smoke gate or preview boot
+(cf. #190 / REDIS_PASSWORD lesson — no new *required-no-default* field).
+
+## Non-goals
+
+- Per-user notification routing or preferences (single ops recipient for now).
+- Templated digests / batching.
+- Retry queues or guaranteed delivery (fail-soft, best-effort).
+
+## Validation
+
+- **Unit tests** (mock `smtplib.SMTP` and `pywebpush`):
+  - `notify_system` sends to email + push; returns per-channel summary.
+  - `OPS_ALERT_EMAIL` unset → email skipped, push still attempted, no raise.
+  - One channel failing does not prevent the other; both logged.
+  - `dedupe_key` cooldown suppresses the second identical send.
+- **Endpoint tests:** valid `X-Internal-Token` → 200 + summary; missing/wrong → 401;
+  `INTERNAL_API_TOKEN` unset → 503.
+- **Manual:** `curl -H "X-Internal-Token: $TOK" -d '{"title":"test","body":"hi","severity":"warning"}'
+  http://localhost:8000/api/alerts/system` → email + browser push received.
+- **Migration:** none (no schema change; `AlertDeliveryLog` reused).
+
+## Accepted trade-offs
+
+- Single ops recipient (`OPS_ALERT_EMAIL`) rather than per-user — simplest thing that
+  serves the autopilot use case; multi-recipient routing can come later.
+- Shared-secret auth rather than full JWT — appropriate for server-to-server and
+  decoupled from the in-flight authz epic (#373).


### PR DESCRIPTION
## Two design specs for epic omniscient/dark-factory#133 (Dark Factory maintenance)

Brainstormed with the user. Both follow the house spec style.

### `2026-06-20-system-notifications-enabler-design.md` (size S, backend)
A generic `notify_system(title, body, severity, dedupe_key)` + `POST /api/alerts/system`
that reuses the existing SMTP (email) and VAPID (browser push) delivery in
`alert_service.py`, decoupled from the scanner `AlertRule`/`ScannerEvent` path. Today the
only generic entry point (`/api/alerts/infrastructure`) merely logs to Seq. Adds optional
`OPS_ALERT_EMAIL` + shared-secret `INTERNAL_API_TOKEN` (both empty-default — no
required-no-default field, so the smoke gate/preview stay green). Reusable beyond autopilot.

### `2026-06-20-epic-autopilot-design.md` (size M, scheduler — depends on the above)
A new starved-only scheduler step that reviews the refined, below-ceiling children of
**in-progress epics** with **Opus 4.8** and advances the low-risk ones via `direct-to-pr`.
Defense-in-depth: deterministic hard-rule envelope (excludes factory self-edits,
automated-trading, authN/authZ — fail-closed) → Opus low-risk + confidence gate → reversible
`direct-to-pr`. Bounded by starved-only trigger, daily cap, verdict cache, kill-switch
(ships OFF). Emails/pushes you on each advance, on hitting the cap, and when it's idle but
has nothing safe to advance. **Human-built** (it's itself a factory self-edit).

Filed as sub-issues under omniscient/dark-factory#133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
