### PR TITLE
feat(backtest): 5-scanner x strategy comparison run (#302)

### DIFF
--- a/backend/docs/backtest/comparison-2026-05-31.md
+++ b/backend/docs/backtest/comparison-2026-05-31.md
@@ -1,0 +1,78 @@
+---
+universe_id: 7
+universe_name: Active, 100M+ caps
+ticker_count: 3893
+start_date: 2025-06-01
+end_date: 2026-05-31
+max_hold_sessions: 10
+strategies:
+  backtest-tight-2pct-2to1: {entry: market, stop_pct: 2.0, rr: 2.0, sessions: [regular]}
+  backtest-loose-4pct-1.5to1: {entry: market, stop_pct: 4.0, rr: 1.5, sessions: [regular]}
+  backtest-pullback-limit-2pct-2to1: {entry: limit, limit_offset_pct: -0.5, stop_pct: 2.0, rr: 2.0, sessions: [regular, pre]}}
+generated_at: 2026-06-20T03:07:38Z
+harness_issue: "301"
+---
+
+> **Note — `pre_market_volume_spike`**: this scanner fires on intraday pre-market minute bars.
+> Where those are absent in the replay window the harness uses stored `ScannerEvent` rows only.
+> Interpret its row against `trade_count`; a low count indicates limited historical data coverage.
+
+## Expectancy (R)
+
+| Scanner | tight-2pct-2to1 | loose-4pct-1.5to1 | pullback-limit |
+|---------|---|---|---|
+| trend_pullback | N/A ⚠* | N/A ⚠* | N/A ⚠* |
+| oversold_bounce | -1.000 ⚠* | 1.500 ⚠* | N/A ⚠* |
+| pocket_pivot | -0.087 | -0.121 | -0.097 |
+| pre_market_volume_spike | 0.500 ⚠* | 0.250 ⚠* | N/A ⚠* |
+| liquidity_hunt | 0.714 ⚠* | 1.143 ⚠* | 2.000 ⚠* |
+
+## Profit Factor
+
+| Scanner | tight-2pct-2to1 | loose-4pct-1.5to1 | pullback-limit |
+|---------|---|---|---|
+| trend_pullback | N/A ⚠* | N/A ⚠* | N/A ⚠* |
+| oversold_bounce | 0.00 ⚠* | inf ⚠* | N/A ⚠* |
+| pocket_pivot | 0.86 | 0.77 | 0.85 |
+| pre_market_volume_spike | 2.00 ⚠* | 1.50 ⚠* | N/A ⚠* |
+| liquidity_hunt | 2.67 ⚠* | 9.00 ⚠* | inf ⚠* |
+
+## Win Rate (%)
+
+| Scanner | tight-2pct-2to1 | loose-4pct-1.5to1 | pullback-limit |
+|---------|---|---|---|
+| trend_pullback | N/A ⚠* | N/A ⚠* | N/A ⚠* |
+| oversold_bounce | 0.0% ⚠* | 100.0% ⚠* | N/A ⚠* |
+| pocket_pivot | 29.6% | 34.8% | 29.1% |
+| pre_market_volume_spike | 50.0% ⚠* | 50.0% ⚠* | N/A ⚠* |
+| liquidity_hunt | 57.1% ⚠* | 85.7% ⚠* | 100.0% ⚠* |
+
+## Max Drawdown (%)
+
+| Scanner | tight-2pct-2to1 | loose-4pct-1.5to1 | pullback-limit |
+|---------|---|---|---|
+| trend_pullback | N/A ⚠* | N/A ⚠* | N/A ⚠* |
+| oversold_bounce | 1.00 ⚠* | 0.00 ⚠* | N/A ⚠* |
+| pocket_pivot | 694.99 | 763.35 | 53.19 |
+| pre_market_volume_spike | 1.00 ⚠* | 1.00 ⚠* | N/A ⚠* |
+| liquidity_hunt | 2.00 ⚠* | 1.00 ⚠* | 0.00 ⚠* |
+
+## Trade Count
+
+| Scanner | tight-2pct-2to1 | loose-4pct-1.5to1 | pullback-limit |
+|---------|---|---|---|
+| trend_pullback | 0 ⚠* | 0 ⚠* | 0 ⚠* |
+| oversold_bounce | 1 ⚠* | 1 ⚠* | 0 ⚠* |
+| pocket_pivot | 5015 | 5015 | 361 |
+| pre_market_volume_spike | 2 ⚠* | 2 ⚠* | 0 ⚠* |
+| liquidity_hunt | 7 ⚠* | 7 ⚠* | 1 ⚠* |
+
+⚠ Cells with fewer than 20 trades are marked with *.
+
+## Findings
+
+No combos with positive expectancy and ≥ 20 trades.
+
+Best combo: N/A
+
+Scanners negative across all strategies: trend_pullback, pocket_pivot

--- a/backend/scripts/run_backtest_comparison.py
+++ b/backend/scripts/run_backtest_comparison.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""
+Backtest comparison run: 5 scanners × 3 strategy profiles.
+
+Usage (inside the backend container):
+  python scripts/run_backtest_comparison.py [--start YYYY-MM-DD] [--end YYYY-MM-DD]
+                                             [--universe-id N] [--max-hold N]
+
+Output:
+  backend/docs/backtest/comparison-{end_date}.md
+  (mounted read-only in dev; run without override: docker-compose -f docker-compose.yml exec backend ...)
+"""
+
+import argparse
+import calendar
+import sys
+import time
+import uuid as _uuid
+from datetime import date
+from pathlib import Path
+
+# Module-level import so tests can patch scripts.run_backtest_comparison.run_backtest
+from app.tasks.backtest import run_backtest  # noqa: E402
+
+SCANNERS = [
+    "trend_pullback",
+    "oversold_bounce",
+    "pocket_pivot",
+    "pre_market_volume_spike",
+    "liquidity_hunt",
+]
+
+STRATEGY_DEFINITIONS = [
+    {
+        "name": "backtest-tight-2pct-2to1",
+        "entry_type": "market",
+        "stop_pct": 2.0,
+        "risk_reward_ratio": 2.0,
+        "limit_offset_pct": 0.0,
+        "allowed_sessions": ["regular"],
+    },
+    {
+        "name": "backtest-loose-4pct-1.5to1",
+        "entry_type": "market",
+        "stop_pct": 4.0,
+        "risk_reward_ratio": 1.5,
+        "limit_offset_pct": 0.0,
+        "allowed_sessions": ["regular"],
+    },
+    {
+        "name": "backtest-pullback-limit-2pct-2to1",
+        "entry_type": "limit",
+        "stop_pct": 2.0,
+        "risk_reward_ratio": 2.0,
+        "limit_offset_pct": -0.5,
+        "allowed_sessions": ["regular", "pre"],
+    },
+]
+
+POLL_INTERVAL_SECONDS = 5
+TIMEOUT_SECONDS = 30 * 60  # 30 minutes
+LOW_SAMPLE_THRESHOLD = 20
+
+
+def _today() -> date:
+    return date.today()
+
+
+def _default_date_range() -> tuple[date, date]:
+    """Return (start, end) for trailing 12 months ending at last completed month."""
+    today = _today()
+    first_this_month = today.replace(day=1)
+    if first_this_month.month == 1:
+        prior_month = first_this_month.replace(year=first_this_month.year - 1, month=12)
+    else:
+        prior_month = first_this_month.replace(month=first_this_month.month - 1)
+    end = prior_month.replace(
+        day=calendar.monthrange(prior_month.year, prior_month.month)[1]
+    )
+    start = today.replace(year=today.year - 1, day=1)
+    return start, end
+
+
+def _parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Run 5×3 backtest comparison and write a Markdown report."
+    )
+    parser.add_argument(
+        "--start",
+        type=date.fromisoformat,
+        default=None,
+        help="Start date YYYY-MM-DD (default: 12 months ago, first of month)",
+    )
+    parser.add_argument(
+        "--end",
+        type=date.fromisoformat,
+        default=None,
+        help="End date YYYY-MM-DD (default: last day of prior month)",
+    )
+    parser.add_argument(
+        "--universe-id",
+        type=int,
+        default=1,
+        dest="universe_id",
+        help="StockUniverse id (default: 1)",
+    )
+    parser.add_argument(
+        "--max-hold",
+        type=int,
+        default=10,
+        dest="max_hold",
+        help="Max hold sessions per trade (default: 10)",
+    )
+    return parser.parse_args(argv)
+
+
+def _seed_strategies(db) -> list[int]:
+    """Get-or-create the 3 backtest TradingStrategy rows. Returns list of IDs in definition order."""
+    from app.models.trading_strategy import TradingStrategy
+
+    ids = []
+    for defn in STRATEGY_DEFINITIONS:
+        row = (
+            db.query(TradingStrategy)
+            .filter(TradingStrategy.name == defn["name"])
+            .first()
+        )
+        if row is None:
+            row = TradingStrategy(
+                name=defn["name"],
+                entry_type=defn["entry_type"],
+                stop_pct=defn["stop_pct"],
+                risk_reward_ratio=defn["risk_reward_ratio"],
+                limit_offset_pct=defn["limit_offset_pct"],
+                allowed_sessions=defn["allowed_sessions"],
+                paper_mode=True,
+                requires_approval=False,
+                risk_per_trade_pct=1.0,
+                direction="long_only",
+                max_trades_per_day=99,
+                max_concurrent_positions=99,
+            )
+            db.add(row)
+            db.flush()  # populate row.id before moving to next strategy
+        ids.append(row.id)
+    return ids
+
+
+def _parse_run_uuids(run_uuids: list) -> list:
+    """Convert any mix of str/UUID to UUID objects.
+
+    BacktestRun.uuid is UUID(as_uuid=True); Postgres requires uuid.UUID objects
+    (not strings) in .in_() queries.
+    """
+    return [_uuid.UUID(str(u)) for u in run_uuids]
+
+
+def _enqueue_runs(
+    db,
+    strategy_ids: list[int],
+    universe_id: int,
+    start_date: date,
+    end_date: date,
+    max_hold_sessions: int,
+) -> list:
+    """Create 15 BacktestRun rows (5 scanners × 3 strategies) and dispatch Celery tasks."""
+    from app.models.backtest_run import BacktestRun
+    from app.utils.time import utc_now
+
+    runs = []
+    for scanner_type in SCANNERS:
+        for strategy_id in strategy_ids:
+            run = BacktestRun(
+                uuid=_uuid.uuid4(),
+                scanner_type=scanner_type,
+                strategy_id=strategy_id,
+                universe_id=universe_id,
+                start_date=start_date,
+                end_date=end_date,
+                max_hold_sessions=max_hold_sessions,
+                status="queued",
+                created_at=utc_now(),
+            )
+            db.add(run)
+            db.flush()  # obtain run.id before dispatching
+            db.refresh(run)
+
+            async_result = run_backtest.delay(
+                run_id=run.id,
+                scanner_type=scanner_type,
+                strategy_id=strategy_id,
+                universe_id=universe_id,
+                start_date_iso=start_date.isoformat(),
+                end_date_iso=end_date.isoformat(),
+                max_hold_sessions=max_hold_sessions,
+            )
+            run.celery_task_id = async_result.id
+            runs.append(run)
+
+    db.commit()
+    return runs
+
+
+def _poll_until_done(db, run_uuids: list, timeout: int = TIMEOUT_SECONDS) -> list:
+    """Poll BacktestRun.status until all reach 'completed'.
+
+    Calls sys.exit(1) if any run fails or the timeout is exceeded.
+    """
+    from app.models.backtest_run import BacktestRun
+
+    uuid_objs = _parse_run_uuids(
+        run_uuids
+    )  # str → UUID for Postgres UUID(as_uuid=True)
+    deadline = time.monotonic() + timeout
+    total = len(run_uuids)
+
+    while True:
+        db.expire_all()
+        runs = db.query(BacktestRun).filter(BacktestRun.uuid.in_(uuid_objs)).all()
+        failed = [r for r in runs if r.status == "failed"]
+        if failed:
+            for r in failed:
+                print(
+                    f"FAILED: {r.scanner_type} — {r.error_message}",
+                    file=sys.stderr,
+                )
+            sys.exit(1)
+
+        done = [r for r in runs if r.status == "completed"]
+        print(f"Progress: {len(done)}/{total} completed", flush=True)
+        if len(done) == total:
+            return runs
+
+        if time.monotonic() > deadline:
+            print(
+                f"TIMEOUT: {len(done)}/{total} completed after {timeout}s",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+def _resolve_universe(db, universe_id: int) -> tuple[str, int]:
+    """Return (name, ticker_count) for the given universe. Exits on not found."""
+    from app.models.stock_universe import StockUniverse
+    from app.models.stock_universe_ticker import StockUniverseTicker
+
+    universe = db.query(StockUniverse).filter(StockUniverse.id == universe_id).first()
+    if universe is None:
+        print(f"ERROR: StockUniverse id={universe_id} not found", file=sys.stderr)
+        sys.exit(1)
+    count = (
+        db.query(StockUniverseTicker)
+        .filter(StockUniverseTicker.universe_id == universe_id)
+        .count()
+    )
+    return universe.name, count
+
+
+def _render_markdown(
+    stats: dict,
+    universe_id: int,
+    universe_name: str,
+    ticker_count: int,
+    start_date: date,
+    end_date: date,
+    max_hold_sessions: int,
+) -> str:
+    """Render the full comparison Markdown document."""
+    from datetime import datetime, timezone
+
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    strategy_slugs = [d["name"] for d in STRATEGY_DEFINITIONS]
+    short_slugs = ["tight-2pct-2to1", "loose-4pct-1.5to1", "pullback-limit"]
+
+    lines: list[str] = []
+
+    # YAML frontmatter
+    lines += [
+        "---",
+        f"universe_id: {universe_id}",
+        f"universe_name: {universe_name}",
+        f"ticker_count: {ticker_count}",
+        f"start_date: {start_date}",
+        f"end_date: {end_date}",
+        f"max_hold_sessions: {max_hold_sessions}",
+        "strategies:",
+        f"  {strategy_slugs[0]}: {{entry: market, stop_pct: 2.0, rr: 2.0, sessions: [regular]}}",
+        f"  {strategy_slugs[1]}: {{entry: market, stop_pct: 4.0, rr: 1.5, sessions: [regular]}}",
+        (
+            f"  {strategy_slugs[2]}: {{entry: limit, limit_offset_pct: -0.5,"
+            " stop_pct: 2.0, rr: 2.0, sessions: [regular, pre]}}"
+        ),
+        f"generated_at: {generated_at}",
+        'harness_issue: "301"',
+        "---",
+        "",
+        (
+            "> **Note — `pre_market_volume_spike`**: this scanner fires on intraday"
+            " pre-market minute bars."
+        ),
+        (
+            "> Where those are absent in the replay window the harness uses stored"
+            " `ScannerEvent` rows only."
+        ),
+        "> Interpret its row against `trade_count`; a low count indicates limited"
+        " historical data coverage.",
+        "",
+    ]
+
+    header_row = "| Scanner | " + " | ".join(short_slugs) + " |"
+    sep_row = "|---------|" + "|".join(["---"] * len(short_slugs)) + "|"
+
+    def _cell(metric_key: str, fmt_str: str, scanner: str, slug: str) -> str:
+        s = stats.get((scanner, slug), {})
+        v = s.get(metric_key)
+        if v is None:
+            cell = "N/A"
+        else:
+            cell = format(v, fmt_str)
+        trades = s.get("total_trades") or 0
+        if trades < LOW_SAMPLE_THRESHOLD:
+            cell += " ⚠*"
+        return cell
+
+    def _metric_table(metric_key: str, fmt_str: str, heading: str) -> list[str]:
+        rows = [f"## {heading}", "", header_row, sep_row]
+        for scanner in SCANNERS:
+            cells = [
+                _cell(metric_key, fmt_str, scanner, slug) for slug in strategy_slugs
+            ]
+            rows.append(f"| {scanner} | " + " | ".join(cells) + " |")
+        rows.append("")
+        return rows
+
+    lines += _metric_table("expectancy_r", ".3f", "Expectancy (R)")
+    lines += _metric_table("profit_factor", ".2f", "Profit Factor")
+    lines += _metric_table("win_rate", ".1%", "Win Rate (%)")
+    lines += _metric_table("max_drawdown_r", ".2f", "Max Drawdown (%)")
+
+    # Trade count table — flag low-sample cells; count displayed raw
+    lines += ["## Trade Count", "", header_row, sep_row]
+    for scanner in SCANNERS:
+        cells = []
+        for slug in strategy_slugs:
+            s = stats.get((scanner, slug), {})
+            trades = s.get("total_trades")
+            if trades is None:
+                cells.append("N/A")
+            elif trades < LOW_SAMPLE_THRESHOLD:
+                cells.append(f"{trades} ⚠*")
+            else:
+                cells.append(str(trades))
+        lines.append(f"| {scanner} | " + " | ".join(cells) + " |")
+    lines += ["", "⚠ Cells with fewer than 20 trades are marked with *.", ""]
+
+    # Findings
+    lines += ["## Findings", ""]
+    positives = []
+    best: tuple | None = None
+    best_exp: float | None = None
+
+    for scanner in SCANNERS:
+        for slug in strategy_slugs:
+            s = stats.get((scanner, slug), {})
+            exp = s.get("expectancy_r")
+            trades = s.get("total_trades") or 0
+            if exp is not None and exp > 0 and trades >= LOW_SAMPLE_THRESHOLD:
+                positives.append(
+                    f"- **{scanner}** / `{slug}` —"
+                    f" expectancy_r={exp:.3f} R ({trades} trades)"
+                )
+                if best_exp is None or exp > best_exp:
+                    best_exp = exp
+                    best = (scanner, slug, exp, trades)
+
+    if positives:
+        lines.append(
+            "Combos with positive expectancy (expectancy_r > 0, trade_count ≥ 20):"
+        )
+        lines += positives
+    else:
+        lines.append("No combos with positive expectancy and ≥ 20 trades.")
+
+    lines.append("")
+    if best:
+        s, slug, exp, trades = best
+        lines.append(
+            f"Best combo: **{s}** / `{slug}`"
+            f" (expectancy_r = {exp:.2f} R, {trades} trades)"
+        )
+    else:
+        lines.append("Best combo: N/A")
+
+    all_negative = [
+        scanner
+        for scanner in SCANNERS
+        if all(
+            (stats.get((scanner, slug), {}).get("expectancy_r") or 0) <= 0
+            for slug in strategy_slugs
+        )
+    ]
+    lines.append("")
+    if all_negative:
+        lines.append(
+            f"Scanners negative across all strategies: {', '.join(all_negative)}"
+        )
+    else:
+        lines.append("Scanners negative across all strategies: none")
+
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    args = _parse_args()
+
+    if args.start and args.end:
+        start_date, end_date = args.start, args.end
+    else:
+        start_date, end_date = _default_date_range()
+
+    from app.core.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        print("Seeding strategies...")
+        strategy_ids = _seed_strategies(db)
+        print(f"  Strategy IDs: {strategy_ids}")
+
+        universe_name, ticker_count = _resolve_universe(db, args.universe_id)
+        print(f"Universe: {universe_name} ({ticker_count} tickers)")
+        print(f"Date range: {start_date} → {end_date}")
+        print("Enqueueing 15 backtest runs (5 scanners × 3 strategies)...")
+
+        runs = _enqueue_runs(
+            db=db,
+            strategy_ids=strategy_ids,
+            universe_id=args.universe_id,
+            start_date=start_date,
+            end_date=end_date,
+            max_hold_sessions=args.max_hold,
+        )
+        run_uuids = [str(r.uuid) for r in runs]
+        print(f"Enqueued {len(run_uuids)} runs. Polling (timeout=30 min)...")
+
+        completed_runs = _poll_until_done(db=db, run_uuids=run_uuids)
+
+        id_to_slug = {
+            sid: defn["name"] for sid, defn in zip(strategy_ids, STRATEGY_DEFINITIONS)
+        }
+        stats: dict = {}
+        for run in completed_runs:
+            slug = id_to_slug.get(run.strategy_id)
+            if slug:
+                stats[(run.scanner_type, slug)] = {
+                    "total_trades": run.total_trades,
+                    "win_rate": run.win_rate,
+                    "profit_factor": run.profit_factor,
+                    "expectancy_r": run.expectancy_r,
+                    "max_drawdown_r": run.max_drawdown_r,
+                }
+
+        md = _render_markdown(
+            stats=stats,
+            universe_id=args.universe_id,
+            universe_name=universe_name,
+            ticker_count=ticker_count,
+            start_date=start_date,
+            end_date=end_date,
+            max_hold_sessions=args.max_hold,
+        )
+
+        # Output at backend/docs/backtest/ (= /app/docs/backtest/ in container)
+        out_dir = Path(__file__).parent.parent / "docs" / "backtest"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"comparison-{end_date}.md"
+        out_path.write_text(md, encoding="utf-8")
+        print(f"\nWritten: {out_path}")
+
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/scripts/test_run_backtest_comparison.py
+++ b/backend/tests/scripts/test_run_backtest_comparison.py
@@ -1,0 +1,379 @@
+"""Unit tests for run_backtest_comparison.py helpers."""
+
+import uuid as _uuid_mod
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Date-range helpers
+# ---------------------------------------------------------------------------
+
+
+def test_default_date_range_mid_year():
+    # Today=2026-06-15 → start=2025-06-01, end=2026-05-31
+    with patch(
+        "scripts.run_backtest_comparison._today", return_value=date(2026, 6, 15)
+    ):
+        from scripts.run_backtest_comparison import _default_date_range
+
+        start, end = _default_date_range()
+    assert start == date(2025, 6, 1)
+    assert end == date(2026, 5, 31)
+
+
+def test_default_date_range_january_wraps_year():
+    # Today=2026-01-10 → start=2025-01-01, end=2025-12-31
+    with patch(
+        "scripts.run_backtest_comparison._today", return_value=date(2026, 1, 10)
+    ):
+        from scripts.run_backtest_comparison import _default_date_range
+
+        start, end = _default_date_range()
+    assert start == date(2025, 1, 1)
+    assert end == date(2025, 12, 31)
+
+
+# ---------------------------------------------------------------------------
+# CLI arg parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_args_defaults():
+    from scripts.run_backtest_comparison import _parse_args
+
+    args = _parse_args([])
+    assert args.universe_id == 1
+    assert args.max_hold == 10
+    assert args.start is None
+    assert args.end is None
+
+
+def test_parse_args_overrides():
+    from scripts.run_backtest_comparison import _parse_args
+
+    args = _parse_args(
+        [
+            "--start",
+            "2025-01-01",
+            "--end",
+            "2025-12-31",
+            "--universe-id",
+            "3",
+            "--max-hold",
+            "20",
+        ]
+    )
+    assert args.start == date(2025, 1, 1)
+    assert args.end == date(2025, 12, 31)
+    assert args.universe_id == 3
+    assert args.max_hold == 20
+
+
+# ---------------------------------------------------------------------------
+# Strategy seed
+# ---------------------------------------------------------------------------
+
+
+def _make_db_not_found():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    return db
+
+
+def _stub_strategy(name: str, id_: int):
+    s = MagicMock()
+    s.id = id_
+    s.name = name
+    return s
+
+
+def test_seed_strategies_creates_all_three_when_absent():
+    from scripts.run_backtest_comparison import _seed_strategies
+
+    db = _make_db_not_found()
+    ids = _seed_strategies(db)
+    assert len(ids) == 3
+    assert db.add.call_count == 3
+    assert db.flush.call_count == 3
+
+
+def test_seed_strategies_idempotent_when_rows_exist():
+    from scripts.run_backtest_comparison import STRATEGY_DEFINITIONS, _seed_strategies
+
+    db = MagicMock()
+    stubs = [
+        _stub_strategy(d["name"], i + 10) for i, d in enumerate(STRATEGY_DEFINITIONS)
+    ]
+    db.query.return_value.filter.return_value.first.side_effect = stubs
+    ids = _seed_strategies(db)
+    assert ids == [10, 11, 12]
+    db.add.assert_not_called()
+
+
+def test_seed_strategies_returns_three_ids():
+    from scripts.run_backtest_comparison import STRATEGY_DEFINITIONS, _seed_strategies
+
+    # Use stubs so row.id is a real int (MagicMock db.flush() doesn't populate ORM ids)
+    db = MagicMock()
+    stubs = [
+        _stub_strategy(d["name"], i + 1) for i, d in enumerate(STRATEGY_DEFINITIONS)
+    ]
+    db.query.return_value.filter.return_value.first.side_effect = stubs
+    ids = _seed_strategies(db)
+    assert len(ids) == 3
+    assert all(isinstance(i, int) for i in ids)
+
+
+# ---------------------------------------------------------------------------
+# UUID conversion (Postgres UUID(as_uuid=True) requires UUID objects, not strings)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_run_uuids_converts_strings():
+    from scripts.run_backtest_comparison import _parse_run_uuids
+
+    uuid_str = "12345678-1234-5678-1234-567812345678"
+    result = _parse_run_uuids([uuid_str])
+    assert result == [_uuid_mod.UUID(uuid_str)]
+    assert all(isinstance(u, _uuid_mod.UUID) for u in result)
+
+
+def test_parse_run_uuids_accepts_uuid_objects():
+    from scripts.run_backtest_comparison import _parse_run_uuids
+
+    uid = _uuid_mod.uuid4()
+    result = _parse_run_uuids([uid])
+    assert result == [uid]
+
+
+# ---------------------------------------------------------------------------
+# Enqueue + poll
+# ---------------------------------------------------------------------------
+
+
+def test_enqueue_runs_creates_15_rows():
+    from scripts.run_backtest_comparison import SCANNERS, _enqueue_runs
+
+    db = MagicMock()
+    created_runs = []
+
+    def capturing_add(obj):
+        obj.id = None
+        created_runs.append(obj)
+
+    def fake_flush():
+        for run in created_runs:
+            if run.id is None:
+                run.id = len(created_runs)
+
+    db.add.side_effect = capturing_add
+    db.flush.side_effect = fake_flush
+    db.refresh.side_effect = lambda obj: None
+
+    with patch("scripts.run_backtest_comparison.run_backtest") as mock_task:
+        mock_task.delay.return_value.id = "celery-id"
+        runs = _enqueue_runs(
+            db=db,
+            strategy_ids=[1, 2, 3],
+            universe_id=1,
+            start_date=date(2025, 6, 1),
+            end_date=date(2026, 5, 31),
+            max_hold_sessions=10,
+        )
+
+    assert len(runs) == 15  # 5 scanners × 3 strategies
+    dispatched_scanners = [
+        c.kwargs["scanner_type"] for c in mock_task.delay.call_args_list
+    ]
+    for scanner in SCANNERS:
+        assert dispatched_scanners.count(scanner) == 3
+
+
+def test_poll_returns_when_all_completed():
+    from scripts.run_backtest_comparison import _poll_until_done
+
+    db = MagicMock()
+    runs = [MagicMock(uuid=_uuid_mod.uuid4(), status="completed") for _ in range(15)]
+    db.query.return_value.filter.return_value.all.return_value = runs
+
+    run_uuids = [str(r.uuid) for r in runs]
+    result = _poll_until_done(db=db, run_uuids=run_uuids, timeout=30)
+    assert len(result) == 15
+
+
+def test_poll_exits_on_failed_run():
+    from scripts.run_backtest_comparison import _poll_until_done
+
+    db = MagicMock()
+    runs = [MagicMock(uuid=_uuid_mod.uuid4(), status="completed") for _ in range(14)]
+    failed = MagicMock(
+        uuid=_uuid_mod.uuid4(),
+        status="failed",
+        scanner_type="trend_pullback",
+        error_message="crash",
+    )
+    runs.append(failed)
+    db.query.return_value.filter.return_value.all.return_value = runs
+
+    with pytest.raises(SystemExit):
+        _poll_until_done(db=db, run_uuids=[str(r.uuid) for r in runs], timeout=30)
+
+
+def test_poll_exits_on_timeout():
+    from scripts.run_backtest_comparison import _poll_until_done
+
+    db = MagicMock()
+    stuck = [MagicMock(uuid=_uuid_mod.uuid4(), status="running")]
+    db.query.return_value.filter.return_value.all.return_value = stuck
+
+    with patch("time.sleep"), patch("time.monotonic", side_effect=[0.0, 3601.0]):
+        with pytest.raises(SystemExit):
+            _poll_until_done(db=db, run_uuids=[str(stuck[0].uuid)], timeout=1)
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+
+def _full_stats(expectancy_r=0.3, total_trades=30):
+    from scripts.run_backtest_comparison import SCANNERS, STRATEGY_DEFINITIONS
+
+    stats = {}
+    for scanner in SCANNERS:
+        for defn in STRATEGY_DEFINITIONS:
+            stats[(scanner, defn["name"])] = {
+                "total_trades": total_trades,
+                "win_rate": 0.55,
+                "profit_factor": 1.8,
+                "expectancy_r": expectancy_r,
+                "max_drawdown_r": -2.5,
+            }
+    return stats
+
+
+def test_render_markdown_contains_all_section_headers():
+    from scripts.run_backtest_comparison import _render_markdown
+
+    md = _render_markdown(
+        stats=_full_stats(),
+        universe_id=1,
+        universe_name="Main Liquid Universe",
+        ticker_count=50,
+        start_date=date(2025, 6, 1),
+        end_date=date(2026, 5, 31),
+        max_hold_sessions=10,
+    )
+    assert "## Expectancy (R)" in md
+    assert "## Profit Factor" in md
+    assert "## Win Rate (%)" in md
+    assert "## Max Drawdown (%)" in md
+    assert "## Trade Count" in md
+    assert "## Findings" in md
+    assert "universe_id:" in md  # YAML frontmatter present
+    assert "generated_at:" in md
+
+
+def test_render_markdown_low_sample_flag():
+    from scripts.run_backtest_comparison import _render_markdown
+
+    md = _render_markdown(
+        stats=_full_stats(total_trades=5),  # below LOW_SAMPLE_THRESHOLD (20)
+        universe_id=1,
+        universe_name="Test",
+        ticker_count=10,
+        start_date=date(2025, 6, 1),
+        end_date=date(2026, 5, 31),
+        max_hold_sessions=10,
+    )
+    assert "⚠*" in md
+
+
+def test_render_markdown_no_low_sample_flag_above_threshold():
+    from scripts.run_backtest_comparison import _render_markdown
+
+    md = _render_markdown(
+        stats=_full_stats(total_trades=25),  # above threshold
+        universe_id=1,
+        universe_name="Test",
+        ticker_count=10,
+        start_date=date(2025, 6, 1),
+        end_date=date(2026, 5, 31),
+        max_hold_sessions=10,
+    )
+    assert "⚠*" not in md
+
+
+def test_render_markdown_findings_positive_expectancy():
+    from scripts.run_backtest_comparison import (
+        SCANNERS,
+        STRATEGY_DEFINITIONS,
+        _render_markdown,
+    )
+
+    stats = {}
+    for scanner in SCANNERS:
+        for defn in STRATEGY_DEFINITIONS:
+            if (
+                scanner == "trend_pullback"
+                and defn["name"] == "backtest-tight-2pct-2to1"
+            ):
+                stats[(scanner, defn["name"])] = {
+                    "total_trades": 30,
+                    "win_rate": 0.6,
+                    "profit_factor": 2.0,
+                    "expectancy_r": 0.5,
+                    "max_drawdown_r": -1.0,
+                }
+            else:
+                stats[(scanner, defn["name"])] = {
+                    "total_trades": 30,
+                    "win_rate": 0.4,
+                    "profit_factor": 0.8,
+                    "expectancy_r": -0.2,
+                    "max_drawdown_r": -3.0,
+                }
+    md = _render_markdown(
+        stats=stats,
+        universe_id=1,
+        universe_name="Test",
+        ticker_count=50,
+        start_date=date(2025, 6, 1),
+        end_date=date(2026, 5, 31),
+        max_hold_sessions=10,
+    )
+    findings_section = md.split("## Findings")[1]
+    assert "trend_pullback" in findings_section
+    assert "backtest-tight-2pct-2to1" in findings_section
+
+
+def test_render_markdown_findings_none_positive():
+    from scripts.run_backtest_comparison import _render_markdown
+
+    md = _render_markdown(
+        stats=_full_stats(expectancy_r=-0.1),
+        universe_id=1,
+        universe_name="Test",
+        ticker_count=10,
+        start_date=date(2025, 6, 1),
+        end_date=date(2026, 5, 31),
+        max_hold_sessions=10,
+    )
+    assert "No combos with positive expectancy" in md
+
+
+def test_render_markdown_pre_market_note_present():
+    from scripts.run_backtest_comparison import _render_markdown
+
+    md = _render_markdown(
+        stats=_full_stats(),
+        universe_id=1,
+        universe_name="Test",
+        ticker_count=10,
+        start_date=date(2025, 6, 1),
+        end_date=date(2026, 5, 31),
+        max_hold_sessions=10,
+    )
+    assert "pre_market_volume_spike" in md.split("## Expectancy")[0]  # note in preamble


### PR DESCRIPTION
﻿## Summary

Promotes already-complete work stranded by repeated session-limit circuit-breaker trips on issue #302.

- The original factory run `77cba2b` (2026-06-20T03:00:15Z) finished successfully: it implemented the comparison script, tests, and the strategy seeder — but 6 subsequent factory retries all exhausted the Claude-Max quota at session start (zero work done each time), which tripped the scheduler circuit-breaker and left the branch with no PR.
- This rescue branch cherry-picks exactly those two real-work commits (`77cba2b`, `0dbb12a`) onto current `origin/main`, discarding the spurious `eval: record factory failure` and unrelated ARCHITECTURE.md/Dockerfile/entrypoint.sh revert commits that accumulated on the feature branch.
- Dependency #301 (backtest harness) is already merged on main.

**Deliverables included:**

| File | Description |
|------|-------------|
| `backend/scripts/run_backtest_comparison.py` | CLI runner: seeds 3 strategy profiles, enqueues 15 backtest runs (5 scanners x 3 strategies), polls to completion, renders Markdown report |
| `backend/tests/scripts/test_run_backtest_comparison.py` | 19 unit tests (all MagicMock, no DB required); 19/19 pass |
| `backend/docs/backtest/comparison-2026-05-31.md` | 5x3 comparison report over universe 7, 2025-06-01 to 2026-05-31 |

**Test results (run in backend container against throwaway DB `test_302_rescue`):**
`
19 passed in 0.21s
`

**Diff stat vs origin/main:**
`
backend/docs/backtest/comparison-2026-05-31.md     |  78 ++++
backend/scripts/run_backtest_comparison.py         | 486 +++++++++++++++++++++
backend/tests/scripts/__init__.py                  |   0
backend/tests/scripts/test_run_backtest_comparison.py | 379 ++++++++++++++++
4 files changed, 943 insertions(+)
`

Closes #302

Generated with [Claude Code](https://claude.com/claude-code)