### PR TITLE
feat(scheduler): epic autopilot — bounded self-unlock with Opus review (#571)

### DIFF
--- a/.claude/skills/refinement/config.yaml
+++ b/.claude/skills/refinement/config.yaml
@@ -67,3 +67,22 @@ dispatch_ceiling:
   # M tickets lose the plan-pending-review grace-window auto-advance. S is unaffected.
   # See docs/superpowers/specs/2026-06-12-size-type-aware-dispatch-ceiling-design.md
   # Revisit: 2026-09-12
+
+epic_autopilot:
+  enabled: false              # kill-switch — ship OFF. env: EPIC_AUTOPILOT_ENABLED overrides
+  model: claude-opus-4-8      # reviewer model. env: EPIC_AUTOPILOT_MODEL overrides
+  daily_cap: 5                # max autonomous advances / UTC day. env: EPIC_AUTOPILOT_DAILY_CAP overrides
+  confidence_floor: 0.7       # min Opus confidence to ADVANCE. env: EPIC_AUTOPILOT_CONFIDENCE_FLOOR overrides
+  opt_out_label: no-autopilot # per-ticket veto label. env: EPIC_AUTOPILOT_OPT_OUT_LABEL overrides
+  hard_exclude_paths:         # spec target paths matching any of these → excluded before Opus (fail-closed)
+    - "dark-factory/"
+    - ".archon/"
+    - "scheduler.sh"
+    - "factory_core/"
+    - "app/services/trading"
+    - "app/tasks/trading.py"
+    - "app/core/auth"
+    - "app/routers/auth"
+  # When starved (a poll dispatched nothing) and main is green, review the refined, below-ceiling
+  # children of in-progress epics with Opus and advance the low-risk ones via direct-to-pr.
+  # See docs/superpowers/specs/2026-06-20-epic-autopilot-design.md

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -1099,6 +1099,16 @@ To proceed:
     fi
   done < <(echo "$BACKLOG" | jq -c '.[]')
 
+  # --- Priority 6: Epic Autopilot (starved self-unlock, #571) ---
+  # Runs ONLY when this cycle dispatched nothing (starved), main is green, and it is
+  # enabled. Reviews the refined, below-ceiling children of in-progress epics with Opus
+  # and advances the low-risk ones via direct-to-pr. Fail-soft: never abort the loop.
+  if [ -z "$DISPATCHED" ] && [ "$MAIN_IS_RED" = "false" ] && [ "${EPIC_AUTOPILOT_ENABLED:-false}" = "true" ]; then
+    AP_OUT=$(python3 "$FACTORY_CORE_CLI" epic-autopilot --once 2>&1) || true
+    echo "[$(date -u +%FT%TZ)] ${AP_OUT}"
+    case "$AP_OUT" in *"autopilot=advanced"*) DISPATCHED="$AP_OUT" ;; esac
+  fi
+
   # --- Log cycle summary ---
   BUDGET=$(gh api rate_limit --jq '.resources.graphql | "\(.used)/\(.limit)"' 2>/dev/null) || BUDGET="?"
   if [ -n "$DISPATCHED" ]; then

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -79,6 +79,11 @@ read_config() {
   _set_cfg DISPATCH_CEILING_ENABLED   '.dispatch_ceiling.enabled'
   _set_cfg ABOVE_CEILING_LABEL        '.dispatch_ceiling.label'
   _set_cfg ABOVE_CEILING_KEYWORDS     '.dispatch_ceiling.keywords'
+  _set_cfg EPIC_AUTOPILOT_ENABLED          '.epic_autopilot.enabled'
+  _set_cfg EPIC_AUTOPILOT_MODEL            '.epic_autopilot.model'
+  _set_cfg EPIC_AUTOPILOT_DAILY_CAP        '.epic_autopilot.daily_cap'
+  _set_cfg EPIC_AUTOPILOT_CONFIDENCE_FLOOR '.epic_autopilot.confidence_floor'
+  _set_cfg EPIC_AUTOPILOT_OPT_OUT_LABEL    '.epic_autopilot.opt_out_label'
 
   echo "[config] loaded from ${cfg}"
 }

--- a/dark-factory/scripts/factory_core/cli.py
+++ b/dark-factory/scripts/factory_core/cli.py
@@ -72,6 +72,11 @@ def _run_record(args):
     run_record.main()
 
 
+def _epic_autopilot(args):
+    from factory_core.epic_autopilot import main_once
+    main_once()
+
+
 def main():
     parser = argparse.ArgumentParser(prog="factory-core")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -108,6 +113,10 @@ def main():
     rr = sub.add_parser("run-record")
     rr.add_argument("run_record_args", nargs=argparse.REMAINDER)
     rr.set_defaults(func=_run_record)
+
+    ea = sub.add_parser("epic-autopilot")
+    ea.add_argument("--once", action="store_true")
+    ea.set_defaults(func=_epic_autopilot)
 
     parsed = parser.parse_args()
     parsed.func(parsed)

--- a/dark-factory/scripts/factory_core/epic_autopilot.py
+++ b/dark-factory/scripts/factory_core/epic_autopilot.py
@@ -7,6 +7,7 @@ docs/superpowers/specs/2026-06-20-epic-autopilot-design.md.
 
 The pure functions below take/return plain data so they unit-test with no IO.
 """
+import json
 import re
 
 _GATED_STATUSES = {"spec-pending-review", "plan-pending-review"}
@@ -59,3 +60,41 @@ def hard_excluded(c: dict, exclude_paths: list):
             if ex in p:
                 return True, ex
     return False, ""
+
+
+# ── Verdict parsing + decision rule ─────────────────────────────────────────
+
+_HOLD = {"decision": "HOLD", "risk": "high", "confidence": 0.0,
+         "reasons": ["unparseable"], "concerns": []}
+
+
+def parse_verdict(text: str) -> dict:
+    """Parse Opus's JSON verdict. Fail-closed to HOLD on any error/ambiguity."""
+    if not text or not text.strip():
+        return dict(_HOLD)
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end <= start:
+        return dict(_HOLD)
+    try:
+        v = json.loads(text[start:end + 1])
+    except Exception:
+        return dict(_HOLD)
+    if not isinstance(v, dict) or v.get("decision") not in ("ADVANCE", "HOLD"):
+        return dict(_HOLD)
+    v.setdefault("risk", "high")
+    v.setdefault("confidence", 0.0)
+    v.setdefault("reasons", [])
+    v.setdefault("concerns", [])
+    try:
+        v["confidence"] = float(v["confidence"])
+    except Exception:
+        return dict(_HOLD)
+    return v
+
+
+def should_advance(verdict: dict, confidence_floor: float) -> bool:
+    """ADVANCE only on decision=ADVANCE AND risk=low AND confidence>=floor."""
+    return (verdict.get("decision") == "ADVANCE"
+            and verdict.get("risk") == "low"
+            and float(verdict.get("confidence", 0.0)) >= confidence_floor)

--- a/dark-factory/scripts/factory_core/epic_autopilot.py
+++ b/dark-factory/scripts/factory_core/epic_autopilot.py
@@ -130,3 +130,77 @@ def cached_verdict(state: dict, issue: int, spec_hash_: str):
 
 def record_verdict(state: dict, issue: int, spec_hash_: str, verdict: str) -> None:
     state.setdefault("verdicts", {})[str(issue)] = {"spec_hash": spec_hash_, "verdict": verdict}
+
+
+# ── Orchestrator (pure control flow; all IO injected via `io`) ──────────────
+
+def build_review_prompt(c: dict) -> str:
+    return f"""You are a cautious senior engineer deciding whether a refined ticket is safe to
+implement and merge AUTONOMOUSLY (adding the direct-to-pr label means it flows
+spec->plan->implement->PR with NO further human gate before the PR opens).
+
+Reply with ONLY a JSON object:
+{{"decision":"ADVANCE|HOLD","risk":"low|medium|high","confidence":0.0-1.0,
+  "reasons":[...],"concerns":[...]}}
+
+ADVANCE only if the work is genuinely low-risk: small, well-scoped, reversible, good test
+coverage in the spec/plan, low blast radius, and NOT touching automated trading,
+authentication/authorization, or the factory/scheduler itself. If the spec is vague, an
+empty-branch/no-op risk, or you are unsure -- choose HOLD.
+
+Ticket #{c['number']}: {c['title']}
+Labels: {', '.join(c.get('labels', []))}   Size: {c.get('size')}
+Declared target files: {', '.join(c.get('target_paths') or []) or '(none declared)'}
+
+--- SPEC/PLAN ---
+{(c.get('spec_text') or '')[:8000]}
+"""
+
+
+def run_once(cfg: dict, io, state: dict, today: str) -> dict:
+    """One starved-cycle pass. Returns {outcome, issue, reason}. Never raises for IO
+    that the injected `io` swallows; pure-logic errors propagate to the caller."""
+    if daily_remaining(state, cfg["daily_cap"], today) <= 0:
+        io.notify("Epic autopilot — daily cap reached",
+                  f"Hit the daily cap of {cfg['daily_cap']} autonomous advances; paused until UTC reset. Review the backlog.",
+                  "warning", "autopilot-cap")
+        return {"outcome": "daily_cap_reached", "issue": None, "reason": "cap"}
+
+    candidates = []
+    for cand in io.fetch_candidates():
+        ok, _ = is_eligible(cand, cfg["opt_out_label"], cfg["ceiling_keywords"])
+        if not ok:
+            continue
+        excluded, _ = hard_excluded(cand, cfg["exclude_paths"])
+        if excluded:
+            continue
+        if cached_verdict(state, cand["number"], spec_hash(cand.get("spec_text", ""))) == "HOLD":
+            continue
+        candidates.append(cand)
+
+    if not candidates:
+        io.notify("Epic autopilot — idle, nothing safe to advance",
+                  "The factory is starved and the autopilot has no eligible low-risk ticket to advance. Human input needed.",
+                  "warning", "autopilot-stuck")
+        return {"outcome": "no_candidates", "issue": None, "reason": "empty"}
+
+    cand = candidates[0]
+    verdict = parse_verdict(io.review(build_review_prompt(cand), cfg["model"]))
+    h = spec_hash(cand.get("spec_text", ""))
+    if should_advance(verdict, cfg["confidence_floor"]):
+        io.advance(cand["number"])
+        reason = "; ".join(verdict.get("reasons", [])) or "low-risk"
+        io.comment(cand["number"],
+                   f"\U0001f916 **Epic Autopilot** — advancing (risk={verdict['risk']}, conf={verdict['confidence']}). "
+                   f"Reason: {reason}\n\n---\n*Posted by MarketHawk Epic Autopilot*")
+        io.notify(f"Autopilot advancing #{cand['number']}",
+                  f"{cand['title']} — risk=low: {reason}", "info", None)
+        record_advance(state, today)
+        record_verdict(state, cand["number"], h, "ADVANCE")
+        return {"outcome": "advanced", "issue": cand["number"], "reason": reason}
+
+    concerns = "; ".join(verdict.get("concerns", [])) or "not low-risk / low confidence"
+    io.comment(cand["number"],
+               f"\U0001f916 **Epic Autopilot** — parked (HOLD). {concerns}\n\n---\n*Posted by MarketHawk Epic Autopilot*")
+    record_verdict(state, cand["number"], h, "HOLD")
+    return {"outcome": "hold", "issue": cand["number"], "reason": concerns}

--- a/dark-factory/scripts/factory_core/epic_autopilot.py
+++ b/dark-factory/scripts/factory_core/epic_autopilot.py
@@ -1,0 +1,61 @@
+"""Epic Autopilot — starved-only self-unlock reviewer (pure core + injected IO).
+
+When the backlog scheduler is starved (a poll dispatched nothing) and main is green,
+review the refined, below-ceiling children of in-progress epics with Opus 4.8 and
+advance the low-risk ones via the `direct-to-pr` label. See
+docs/superpowers/specs/2026-06-20-epic-autopilot-design.md.
+
+The pure functions below take/return plain data so they unit-test with no IO.
+"""
+import re
+
+_GATED_STATUSES = {"spec-pending-review", "plan-pending-review"}
+_PATH_RE = re.compile(r"[A-Za-z0-9_./-]+\.(?:py|ts|tsx|sh|ya?ml|md|sql)")
+
+
+def extract_target_paths(text: str) -> list:
+    """Best-effort: pull code-path-like tokens from a spec/plan/body."""
+    if not text:
+        return []
+    seen, out = set(), []
+    for m in _PATH_RE.findall(text):
+        if m not in seen:
+            seen.add(m)
+            out.append(m)
+    return out
+
+
+def _size(c: dict):
+    for label in c.get("labels", []):
+        if label.lower().startswith("size:"):
+            return label.split(":", 1)[1].strip().upper()
+    s = c.get("size")
+    return s.upper() if s else None
+
+
+def is_eligible(c: dict, opt_out_label: str, ceiling_keywords: str):
+    """Stage A — structural eligibility. Returns (ok: bool, reason: str)."""
+    labels = [label.lower() for label in c.get("labels", [])]
+    if c.get("status") not in _GATED_STATUSES:
+        return False, f"status={c.get('status')}"
+    for blk in ("direct-to-pr", opt_out_label, "needs-discussion", "epic"):
+        if blk.lower() in labels:
+            return False, f"label:{blk}"
+    size = _size(c) or ""
+    if size in ("L", "XL"):
+        return False, f"above-ceiling:size={size}"
+    if size == "M" and re.search(ceiling_keywords, c.get("title", ""), re.I):
+        return False, "above-ceiling:M+keyword"
+    return True, ""
+
+
+def hard_excluded(c: dict, exclude_paths: list):
+    """Stage B — categorical exclusions (fail-closed). Returns (excluded: bool, reason: str)."""
+    paths = c.get("target_paths") or []
+    if not paths:
+        return True, "undeclared-scope"  # fail-closed: undeclared scope might be trading/auth
+    for p in paths:
+        for ex in exclude_paths:
+            if ex in p:
+                return True, ex
+    return False, ""

--- a/dark-factory/scripts/factory_core/epic_autopilot.py
+++ b/dark-factory/scripts/factory_core/epic_autopilot.py
@@ -204,3 +204,188 @@ def run_once(cfg: dict, io, state: dict, today: str) -> dict:
                f"\U0001f916 **Epic Autopilot** — parked (HOLD). {concerns}\n\n---\n*Posted by MarketHawk Epic Autopilot*")
     record_verdict(state, cand["number"], h, "HOLD")
     return {"outcome": "hold", "issue": cand["number"], "reason": concerns}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Live IO (exercised in manual validation, not unit tests — all gh/claude/HTTP)
+# ─────────────────────────────────────────────────────────────────────────────
+import os  # noqa: E402
+import subprocess  # noqa: E402
+import urllib.request  # noqa: E402
+
+OWNER = "omniscient/markethawk"
+PROJECT_ID = "PVT_kwHOAAFds84BWh4w"
+_GATING_LABELS = ("plan-pending-review", "spec-pending-review")  # plan takes precedence
+_DEFAULT_EXCLUDE = ["dark-factory/", ".archon/", "scheduler.sh", "factory_core/",
+                    "app/services/trading", "app/tasks/trading.py", "app/core/auth", "app/routers/auth"]
+_CONFIG_PATHS = ["/workspace/project/.claude/skills/refinement/config.yaml",
+                 "/opt/refinement-skills/config.yaml"]
+
+
+def _gh_json(args: list):
+    """Run a gh command and parse JSON stdout; return None on failure."""
+    try:
+        p = subprocess.run(["gh"] + args, capture_output=True, text=True, timeout=60)
+        if p.returncode != 0 or not p.stdout.strip():
+            return None
+        return json.loads(p.stdout)
+    except Exception:
+        return None
+
+
+def _load_exclude_paths() -> list:
+    """Read epic_autopilot.hard_exclude_paths from config.yaml (via yq); fall back to defaults."""
+    for cfg in _CONFIG_PATHS:
+        if not os.path.exists(cfg):
+            continue
+        try:
+            p = subprocess.run(["yq", ".epic_autopilot.hard_exclude_paths[]", cfg],
+                               capture_output=True, text=True, timeout=15)
+            paths = [ln.strip().strip('"') for ln in p.stdout.splitlines() if ln.strip()]
+            if paths:
+                return paths
+        except Exception:
+            pass
+    return list(_DEFAULT_EXCLUDE)
+
+
+def _in_progress_epics() -> list:
+    """Issue numbers of epics whose board Status is 'In progress'."""
+    q = ('query { node(id: "%s") { ... on ProjectV2 { items(first:100) { nodes { '
+         'fieldValueByName(name:"Status"){ ... on ProjectV2ItemFieldSingleSelectValue { name } } '
+         'content { ... on Issue { number labels(first:20){nodes{name}} } } } } } } }') % PROJECT_ID
+    data = _gh_json(["api", "graphql", "-f", "query=" + q])
+    if not data:
+        return []
+    out = []
+    for n in data.get("data", {}).get("node", {}).get("items", {}).get("nodes", []):
+        content = n.get("content") or {}
+        status = (n.get("fieldValueByName") or {}).get("name")
+        labels = [x["name"] for x in (content.get("labels") or {}).get("nodes", [])]
+        if content.get("number") and status == "In progress" and "epic" in labels:
+            out.append(content["number"])
+    return out
+
+
+def _sub_issue_numbers(epic: int) -> list:
+    q = ('query { repository(owner:"omniscient", name:"markethawk") { issue(number:%d) { '
+         'subIssues(first:50) { nodes { number state labels(first:20){nodes{name}} } } } } }') % epic
+    data = _gh_json(["api", "graphql", "-f", "query=" + q])
+    if not data:
+        return []
+    out = []
+    for s in data.get("data", {}).get("repository", {}).get("issue", {}).get("subIssues", {}).get("nodes", []):
+        labels = [x["name"].lower() for x in (s.get("labels") or {}).get("nodes", [])]
+        if s.get("state") == "OPEN" and any(g in labels for g in _GATING_LABELS):
+            out.append(s["number"])
+    return out
+
+
+def _fetch_spec_doc(comment_body: str) -> str:
+    """Best-effort: pull the linked spec/plan markdown file (path + ref) from a comment."""
+    m = re.search(r"/blob/([^/]+)/(\S+?\.md)", comment_body or "")
+    if not m:
+        return ""
+    ref, path = m.group(1), m.group(2)
+    data = _gh_json(["api", f"repos/{OWNER}/contents/{path}", "-f", f"ref={ref}", "--jq", ".content"])
+    if isinstance(data, str):
+        try:
+            import base64
+            return base64.b64decode(data).decode("utf-8", "replace")
+        except Exception:
+            return ""
+    return ""
+
+
+def _build_candidate(num: int) -> dict:
+    info = _gh_json(["issue", "view", str(num), "--repo", OWNER, "--json", "title,body,labels,comments"])
+    if not info:
+        return {}
+    labels = [x["name"] for x in info.get("labels", [])]
+    low = [x.lower() for x in labels]
+    status = next((g for g in _GATING_LABELS if g in low), "")
+    gen = ""
+    for cm in info.get("comments", []):
+        if "Spec Generated" in cm.get("body", "") or "Plan Generated" in cm.get("body", ""):
+            gen = cm["body"]
+    spec_text = "\n\n".join(filter(None, [info.get("body", ""), gen, _fetch_spec_doc(gen)]))
+    return {"number": num, "title": info.get("title", ""), "body": info.get("body", ""),
+            "labels": labels, "size": None, "status": status, "spec_text": spec_text,
+            "target_paths": extract_target_paths(spec_text)}
+
+
+class LiveIO:
+    """Real adapters: gh GraphQL/REST + claude -p + the /api/v1/alerts/system notify endpoint."""
+
+    def __init__(self, model: str):
+        self.model = model
+
+    def fetch_candidates(self) -> list:
+        cands = []
+        for epic in _in_progress_epics():
+            for num in _sub_issue_numbers(epic):
+                cand = _build_candidate(num)
+                if cand:
+                    cands.append(cand)
+        # oldest issue number first (rough proxy for priority/age)
+        return sorted(cands, key=lambda x: x["number"])
+
+    def review(self, prompt: str, model: str) -> str:
+        try:
+            p = subprocess.run(["claude", "-p", "--model", model], input=prompt,
+                               capture_output=True, text=True, timeout=300)
+            return p.stdout if p.returncode == 0 else ""
+        except Exception:
+            return ""
+
+    def advance(self, issue: int) -> None:
+        subprocess.run(["gh", "issue", "edit", str(issue), "--repo", OWNER,
+                        "--add-label", "direct-to-pr"], check=False)
+
+    def comment(self, issue: int, body: str) -> None:
+        subprocess.run(["gh", "issue", "comment", str(issue), "--repo", OWNER, "--body", body], check=False)
+
+    def notify(self, title: str, body: str, severity: str, dedupe_key) -> None:
+        token = os.environ.get("INTERNAL_API_TOKEN", "")
+        if not token:
+            return
+        payload = {"title": title, "body": body, "severity": severity}
+        if dedupe_key:
+            payload["dedupe_key"] = dedupe_key
+        try:
+            req = urllib.request.Request(
+                "http://backend:8000/api/v1/alerts/system",
+                data=json.dumps(payload).encode(),
+                headers={"Content-Type": "application/json", "X-Internal-Token": token},
+                method="POST")
+            urllib.request.urlopen(req, timeout=10)
+        except Exception:
+            pass  # fail-soft
+
+
+def main_once() -> int:
+    from datetime import datetime, timezone
+    state_dir = os.environ.get("SCHEDULER_STATE_DIR", "/var/lib/dark-factory")
+    path = os.path.join(state_dir, "autopilot-state.json")
+    try:
+        with open(path) as f:
+            state = json.load(f)
+    except Exception:
+        state = {}
+    today = datetime.now(timezone.utc).date().isoformat()
+    cfg = dict(
+        exclude_paths=_load_exclude_paths(),
+        opt_out_label=os.environ.get("EPIC_AUTOPILOT_OPT_OUT_LABEL", "no-autopilot"),
+        ceiling_keywords=os.environ.get("ABOVE_CEILING_KEYWORDS",
+                                        "migration|migrate|performance|perf|architectur|refactor"),
+        confidence_floor=float(os.environ.get("EPIC_AUTOPILOT_CONFIDENCE_FLOOR", "0.7")),
+        daily_cap=int(os.environ.get("EPIC_AUTOPILOT_DAILY_CAP", "5")),
+        model=os.environ.get("EPIC_AUTOPILOT_MODEL", "claude-opus-4-8"))
+    out = run_once(cfg, LiveIO(cfg["model"]), state, today)
+    try:
+        with open(path, "w") as f:
+            json.dump(state, f)
+    except Exception:
+        pass
+    print(f"autopilot={out['outcome']} issue=#{out['issue']}")
+    return 0

--- a/dark-factory/scripts/factory_core/epic_autopilot.py
+++ b/dark-factory/scripts/factory_core/epic_autopilot.py
@@ -7,6 +7,7 @@ docs/superpowers/specs/2026-06-20-epic-autopilot-design.md.
 
 The pure functions below take/return plain data so they unit-test with no IO.
 """
+import hashlib
 import json
 import re
 
@@ -98,3 +99,34 @@ def should_advance(verdict: dict, confidence_floor: float) -> bool:
     return (verdict.get("decision") == "ADVANCE"
             and verdict.get("risk") == "low"
             and float(verdict.get("confidence", 0.0)) >= confidence_floor)
+
+
+# ── Daily cap + verdict cache (state is a plain dict; orchestrator persists JSON) ──
+
+def spec_hash(spec_text: str) -> str:
+    return hashlib.sha256((spec_text or "").encode("utf-8")).hexdigest()[:16]
+
+
+def daily_remaining(state: dict, cap: int, today: str) -> int:
+    d = state.get("daily") or {}
+    used = d.get("count", 0) if d.get("date") == today else 0
+    return max(0, cap - used)
+
+
+def record_advance(state: dict, today: str) -> None:
+    d = state.get("daily") or {}
+    if d.get("date") != today:
+        d = {"date": today, "count": 0}
+    d["count"] = d.get("count", 0) + 1
+    state["daily"] = d
+
+
+def cached_verdict(state: dict, issue: int, spec_hash_: str):
+    entry = (state.get("verdicts") or {}).get(str(issue))
+    if entry and entry.get("spec_hash") == spec_hash_:
+        return entry.get("verdict")
+    return None
+
+
+def record_verdict(state: dict, issue: int, spec_hash_: str, verdict: str) -> None:
+    state.setdefault("verdicts", {})[str(issue)] = {"spec_hash": spec_hash_, "verdict": verdict}

--- a/dark-factory/tests/test_epic_autopilot.py
+++ b/dark-factory/tests/test_epic_autopilot.py
@@ -88,3 +88,35 @@ def test_security_label_not_excluded():
         c(labels=["security", "ready-for-agent"], target_paths=["backend/app/services/redaction.py"]),
         ["app/core/auth", "app/services/trading"])
     assert not ex
+
+
+# ── Task 3: verdict parsing + decision rule ─────────────────────────────────
+
+def test_parse_clean_json():
+    v = ap.parse_verdict('{"decision":"ADVANCE","risk":"low","confidence":0.9,"reasons":["ok"],"concerns":[]}')
+    assert v["decision"] == "ADVANCE" and v["confidence"] == 0.9
+
+
+def test_parse_json_in_fence():
+    v = ap.parse_verdict('blah\n```json\n{"decision":"HOLD","risk":"medium","confidence":0.5,"reasons":[],"concerns":["x"]}\n```\n')
+    assert v["decision"] == "HOLD"
+
+
+def test_parse_garbage_fails_closed():
+    v = ap.parse_verdict("the model rambled with no json")
+    assert v["decision"] == "HOLD" and v["risk"] == "high"
+
+
+def test_parse_empty_fails_closed():
+    assert ap.parse_verdict("")["decision"] == "HOLD"
+
+
+def test_parse_bad_decision_value_fails_closed():
+    assert ap.parse_verdict('{"decision":"MAYBE","risk":"low","confidence":1.0}')["decision"] == "HOLD"
+
+
+def test_should_advance_only_on_low_and_floor():
+    assert ap.should_advance({"decision": "ADVANCE", "risk": "low", "confidence": 0.8}, 0.7)
+    assert not ap.should_advance({"decision": "ADVANCE", "risk": "medium", "confidence": 0.9}, 0.7)
+    assert not ap.should_advance({"decision": "ADVANCE", "risk": "low", "confidence": 0.6}, 0.7)
+    assert not ap.should_advance({"decision": "HOLD", "risk": "low", "confidence": 0.99}, 0.7)

--- a/dark-factory/tests/test_epic_autopilot.py
+++ b/dark-factory/tests/test_epic_autopilot.py
@@ -142,3 +142,77 @@ def test_verdict_cache_roundtrip_and_hash_invalidation():
     assert ap.cached_verdict(st, 402, h1) == "HOLD"
     # regenerated spec → different hash → cache miss (re-review)
     assert ap.cached_verdict(st, 402, ap.spec_hash("spec A v2")) is None
+
+
+# ── Task 5: orchestrator with injected IO ───────────────────────────────────
+
+class FakeIO:
+    def __init__(self, candidates, review_text):
+        self._cands = candidates
+        self._review = review_text
+        self.advanced = []
+        self.comments = []
+        self.notes = []
+
+    def fetch_candidates(self):
+        return self._cands
+
+    def review(self, prompt, model):
+        return self._review
+
+    def advance(self, issue):
+        self.advanced.append(issue)
+
+    def comment(self, issue, body):
+        self.comments.append((issue, body))
+
+    def notify(self, title, body, severity, dedupe_key):
+        self.notes.append((severity, dedupe_key))
+
+
+CFG = dict(exclude_paths=["app/core/auth", "dark-factory/"], opt_out_label="no-autopilot",
+           ceiling_keywords=CEIL, confidence_floor=0.7, daily_cap=5, model="claude-opus-4-8")
+
+
+def test_run_advances_low_risk():
+    io = FakeIO([c(number=402)], '{"decision":"ADVANCE","risk":"low","confidence":0.9,"reasons":["safe"],"concerns":[]}')
+    st = {}
+    out = ap.run_once(CFG, io, st, "2026-06-20")
+    assert out["outcome"] == "advanced" and out["issue"] == 402
+    assert io.advanced == [402]
+    assert any(sev == "info" for sev, _ in io.notes)          # advance notice
+    assert ap.daily_remaining(st, 5, "2026-06-20") == 4
+
+
+def test_run_holds_medium_risk():
+    io = FakeIO([c(number=402)], '{"decision":"ADVANCE","risk":"medium","confidence":0.9,"reasons":[],"concerns":["risky"]}')
+    st = {}
+    out = ap.run_once(CFG, io, st, "2026-06-20")
+    assert out["outcome"] == "hold" and io.advanced == []
+    assert ap.cached_verdict(st, 402, ap.spec_hash(c(number=402)["spec_text"])) == "HOLD"
+
+
+def test_run_no_candidates_notifies_stuck():
+    io = FakeIO([c(number=402, labels=["no-autopilot", "ready-for-agent"])], "x")
+    out = ap.run_once(CFG, io, {}, "2026-06-20")
+    assert out["outcome"] == "no_candidates"
+    assert any(sev == "warning" and key == "autopilot-stuck" for sev, key in io.notes)
+
+
+def test_run_daily_cap_reached_notifies():
+    io = FakeIO([c(number=402)], "x")
+    st = {"daily": {"date": "2026-06-20", "count": 5}}
+    out = ap.run_once(CFG, io, st, "2026-06-20")
+    assert out["outcome"] == "daily_cap_reached"
+    assert io.advanced == []
+    assert any(key == "autopilot-cap" for _, key in io.notes)
+
+
+def test_run_skips_cached_hold():
+    cand = c(number=402)
+    st = {}
+    ap.record_verdict(st, 402, ap.spec_hash(cand["spec_text"]), "HOLD")
+    io = FakeIO([cand], '{"decision":"ADVANCE","risk":"low","confidence":0.9}')
+    out = ap.run_once(CFG, io, st, "2026-06-20")
+    assert out["outcome"] == "no_candidates"   # only candidate is cache-suppressed
+    assert io.advanced == []

--- a/dark-factory/tests/test_epic_autopilot.py
+++ b/dark-factory/tests/test_epic_autopilot.py
@@ -1,0 +1,90 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+from factory_core import epic_autopilot as ap  # noqa: E402
+
+CEIL = "migration|migrate|performance|perf|architectur|refactor"
+
+
+def c(**kw):
+    base = dict(
+        number=1, title="t", body="b", labels=["ready-for-agent"], size="S",
+        status="spec-pending-review", spec_text="touches backend/app/services/foo.py",
+        target_paths=["backend/app/services/foo.py"],
+    )
+    base.update(kw)
+    return base
+
+
+# ── Task 2: eligibility + hard-rule exclusions ──────────────────────────────
+
+def test_eligible_happy():
+    ok, why = ap.is_eligible(c(), "no-autopilot", CEIL)
+    assert ok, why
+
+
+def test_ineligible_opt_out():
+    ok, _ = ap.is_eligible(c(labels=["ready-for-agent", "no-autopilot"]), "no-autopilot", CEIL)
+    assert not ok
+
+
+def test_ineligible_already_direct_to_pr():
+    ok, _ = ap.is_eligible(c(labels=["direct-to-pr"]), "no-autopilot", CEIL)
+    assert not ok
+
+
+def test_ineligible_wrong_status():
+    ok, _ = ap.is_eligible(c(status="Ready"), "no-autopilot", CEIL)
+    assert not ok
+
+
+def test_ineligible_above_ceiling_size_l():
+    ok, _ = ap.is_eligible(c(size="L"), "no-autopilot", CEIL)
+    assert not ok
+
+
+def test_ineligible_m_with_ceiling_keyword():
+    ok, _ = ap.is_eligible(c(size="M", title="perf refactor of scanner"), "no-autopilot", CEIL)
+    assert not ok
+
+
+def test_eligible_m_without_keyword():
+    ok, why = ap.is_eligible(c(size="M", title="add data quality preflight"), "no-autopilot", CEIL)
+    assert ok, why
+
+
+def test_size_from_label_prefix():
+    # size carried as a label "size: L" rather than the size field
+    ok, _ = ap.is_eligible(c(size=None, labels=["ready-for-agent", "size: L"]), "no-autopilot", CEIL)
+    assert not ok
+
+
+def test_extract_paths():
+    paths = ap.extract_target_paths("Modifies `backend/app/services/x.py` and dark-factory/seed/y.sql")
+    assert "backend/app/services/x.py" in paths
+    assert "dark-factory/seed/y.sql" in paths
+
+
+def test_hard_exclude_factory_self():
+    ex, why = ap.hard_excluded(c(target_paths=["dark-factory/scheduler.sh"]),
+                               ["dark-factory/", "app/core/auth"])
+    assert ex and "dark-factory/" in why
+
+
+def test_hard_exclude_auth():
+    ex, _ = ap.hard_excluded(c(target_paths=["backend/app/core/auth/jwt.py"]),
+                             ["app/core/auth"])
+    assert ex
+
+
+def test_hard_exclude_undeclared_scope_fails_closed():
+    ex, why = ap.hard_excluded(c(target_paths=[]), ["app/core/auth"])
+    assert ex and why == "undeclared-scope"
+
+
+def test_security_label_not_excluded():
+    ex, _ = ap.hard_excluded(
+        c(labels=["security", "ready-for-agent"], target_paths=["backend/app/services/redaction.py"]),
+        ["app/core/auth", "app/services/trading"])
+    assert not ex

--- a/dark-factory/tests/test_epic_autopilot.py
+++ b/dark-factory/tests/test_epic_autopilot.py
@@ -120,3 +120,25 @@ def test_should_advance_only_on_low_and_floor():
     assert not ap.should_advance({"decision": "ADVANCE", "risk": "medium", "confidence": 0.9}, 0.7)
     assert not ap.should_advance({"decision": "ADVANCE", "risk": "low", "confidence": 0.6}, 0.7)
     assert not ap.should_advance({"decision": "HOLD", "risk": "low", "confidence": 0.99}, 0.7)
+
+
+# ── Task 4: daily cap + verdict cache ───────────────────────────────────────
+
+def test_daily_cap_counts_and_resets():
+    st = {}
+    assert ap.daily_remaining(st, 5, "2026-06-20") == 5
+    ap.record_advance(st, "2026-06-20")
+    ap.record_advance(st, "2026-06-20")
+    assert ap.daily_remaining(st, 5, "2026-06-20") == 3
+    # next UTC day resets the counter
+    assert ap.daily_remaining(st, 5, "2026-06-21") == 5
+
+
+def test_verdict_cache_roundtrip_and_hash_invalidation():
+    st = {}
+    h1 = ap.spec_hash("spec A")
+    assert ap.cached_verdict(st, 402, h1) is None
+    ap.record_verdict(st, 402, h1, "HOLD")
+    assert ap.cached_verdict(st, 402, h1) == "HOLD"
+    # regenerated spec → different hash → cache miss (re-review)
+    assert ap.cached_verdict(st, 402, ap.spec_hash("spec A v2")) is None

--- a/dark-factory/tests/test_epic_autopilot_config.sh
+++ b/dark-factory/tests/test_epic_autopilot_config.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Verifies the epic_autopilot config section + scheduler.sh read_config wiring.
+# Run (needs yq): bash dark-factory/tests/test_epic_autopilot_config.sh
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+cfg="$HERE/../../.claude/skills/refinement/config.yaml"
+sched="$HERE/../scheduler.sh"
+
+val=$(yq '.epic_autopilot.enabled' "$cfg")
+[ "$val" = "false" ] || { echo "FAIL: epic_autopilot.enabled should default false, got '$val'"; exit 1; }
+
+cap=$(yq '.epic_autopilot.daily_cap' "$cfg")
+[ "$cap" = "5" ] || { echo "FAIL: epic_autopilot.daily_cap should be 5, got '$cap'"; exit 1; }
+
+model=$(yq '.epic_autopilot.model' "$cfg")
+[ "$model" = "claude-opus-4-8" ] || { echo "FAIL: epic_autopilot.model should be claude-opus-4-8, got '$model'"; exit 1; }
+
+floor=$(yq '.epic_autopilot.confidence_floor' "$cfg")
+[ "$floor" = "0.7" ] || { echo "FAIL: epic_autopilot.confidence_floor should be 0.7, got '$floor'"; exit 1; }
+
+# scheduler.sh read_config wires the knobs
+grep -qE 'EPIC_AUTOPILOT_ENABLED[[:space:]]+.\.epic_autopilot\.enabled.' "$sched" \
+  || { echo "FAIL: scheduler.sh read_config missing EPIC_AUTOPILOT_ENABLED wiring"; exit 1; }
+grep -qE 'EPIC_AUTOPILOT_DAILY_CAP[[:space:]]+.\.epic_autopilot\.daily_cap.' "$sched" \
+  || { echo "FAIL: scheduler.sh read_config missing EPIC_AUTOPILOT_DAILY_CAP wiring"; exit 1; }
+
+echo "PASS"

--- a/dark-factory/tests/test_scheduler_autopilot_guard.sh
+++ b/dark-factory/tests/test_scheduler_autopilot_guard.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Verifies the scheduler.sh Priority-6 autopilot hook exists and is correctly guarded.
+# Run: bash dark-factory/tests/test_scheduler_autopilot_guard.sh
+set -euo pipefail
+sched="$(cd "$(dirname "$0")" && pwd)/../scheduler.sh"
+
+grep -q 'epic-autopilot --once' "$sched" \
+  || { echo "FAIL: scheduler.sh does not call the epic-autopilot CLI"; exit 1; }
+grep -q 'EPIC_AUTOPILOT_ENABLED' "$sched" \
+  || { echo "FAIL: scheduler.sh autopilot block missing the enabled kill-switch"; exit 1; }
+
+# The Priority-6 block must be gated by DISPATCHED-empty (starved) AND main-green.
+block="$(awk '/Priority 6: Epic Autopilot/{f=1} f{print} f&&/^  fi$/{exit}' "$sched")"
+echo "$block" | grep -q 'z "\$DISPATCHED"' \
+  || { echo "FAIL: autopilot not guarded by DISPATCHED-empty (starved)"; exit 1; }
+echo "$block" | grep -q 'MAIN_IS_RED.*false' \
+  || { echo "FAIL: autopilot not guarded by main-green"; exit 1; }
+
+echo "PASS"

--- a/docs/superpowers/plans/2026-06-20-epic-autopilot.md
+++ b/docs/superpowers/plans/2026-06-20-epic-autopilot.md
@@ -1,0 +1,753 @@
+# Epic Autopilot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Build constraint:** This modifies the scheduler/factory itself (a "factory self-edit"). It must be implemented by a HUMAN, never dispatched through the dark factory.
+
+**Goal:** When the backlog scheduler is starved, review the refined, below-ceiling children of in-progress epics with Opus 4.8 and advance the low-risk ones via `direct-to-pr`, with email/push notifications and hard guardrails.
+
+**Architecture:** A pure, dependency-injected Python core in `dark-factory/scripts/factory_core/epic_autopilot.py` (eligibility, hard-rule exclusions, verdict parsing, decision rule, daily cap, verdict cache — all unit-testable with no IO). A thin orchestrator wires GraphQL fetch, the `claude -p` Opus call, and gh/notify actions through injected callables. Exposed via `cli.py epic-autopilot --once` and called from a guarded **Priority 6** step in `scheduler.sh` that only runs when a poll dispatched nothing.
+
+**Tech Stack:** Python 3.12 (stdlib only — argparse, json, subprocess, datetime, hashlib), bash (`scheduler.sh`), `gh` CLI, `claude -p`.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-epic-autopilot-design.md`
+**Depends on:** `2026-06-20-system-notifications-enabler.md` (provides `POST /api/v1/alerts/system`).
+
+## Global Constraints
+
+- **Ships disabled:** `epic_autopilot.enabled: false` in config; the scheduler hook is a no-op until enabled. Decision threshold: ADVANCE only on `decision==ADVANCE AND risk==low AND confidence>=confidence_floor` (default 0.7).
+- **Fail-closed everywhere:** unparseable Opus output → HOLD; undeclared file scope → excluded; any exception in the autopilot step must never crash the scheduler loop (the `scheduler.sh` call is guarded with `|| true` semantics).
+- **Hard exclusions (deterministic, before Opus):** factory self-edits (`dark-factory/`, `.archon/`, `scheduler.sh`, `factory_core/`), automated-trading (`app/services/trading`, `app/tasks/trading.py`), authN/authZ (`app/core/auth`, `app/routers/auth`). Plain `security` label is allowed.
+- **Pacing:** ≤1 advance per cycle; daily cap (default 5, UTC reset); verdict cache keyed by `(issue, spec_hash)`.
+- Notifications POST to `http://backend:8000/api/v1/alerts/system` with header `X-Internal-Token: $INTERNAL_API_TOKEN`.
+- Tests live in `dark-factory/tests/`; run with `python -m pytest dark-factory/tests/test_epic_autopilot.py -v`. No live `gh`/`claude`/HTTP in tests (inject fakes).
+
+---
+
+### Task 1: Config knobs (config.yaml + scheduler.sh)
+
+**Files:**
+- Modify: `.claude/skills/refinement/config.yaml` (add `epic_autopilot:` section)
+- Modify: `dark-factory/scheduler.sh` (`read_config` block ~lines 68-83; add a guarded Priority-6 call is Task 6)
+- Test: `dark-factory/tests/test_epic_autopilot_config.sh`
+
+**Interfaces:**
+- Produces env vars (via `read_config`): `EPIC_AUTOPILOT_ENABLED`, `EPIC_AUTOPILOT_MODEL`, `EPIC_AUTOPILOT_DAILY_CAP`, `EPIC_AUTOPILOT_CONFIDENCE_FLOOR`, `EPIC_AUTOPILOT_OPT_OUT_LABEL`.
+
+- [ ] **Step 1: Write the failing test**
+```bash
+# dark-factory/tests/test_epic_autopilot_config.sh
+#!/usr/bin/env bash
+set -euo pipefail
+export SCHEDULER_SOURCE_ONLY=1
+source "$(dirname "$0")/../scheduler.sh"
+cfg="$(dirname "$0")/../../.claude/skills/refinement/config.yaml"
+val=$(yq '.epic_autopilot.enabled' "$cfg")
+[ "$val" = "false" ] || { echo "FAIL: epic_autopilot.enabled should default false, got '$val'"; exit 1; }
+cap=$(yq '.epic_autopilot.daily_cap' "$cfg")
+[ "$cap" = "5" ] || { echo "FAIL: daily_cap should be 5, got '$cap'"; exit 1; }
+echo "PASS"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bash dark-factory/tests/test_epic_autopilot_config.sh`
+Expected: FAIL (`null` for `.epic_autopilot.enabled`)
+
+- [ ] **Step 3: Add the config section**
+
+Append to `.claude/skills/refinement/config.yaml`:
+```yaml
+epic_autopilot:
+  enabled: false              # kill-switch — ship OFF. env: EPIC_AUTOPILOT_ENABLED
+  model: claude-opus-4-8
+  daily_cap: 5                # max autonomous advances / UTC day
+  confidence_floor: 0.7       # min Opus confidence to ADVANCE
+  opt_out_label: no-autopilot
+  hard_exclude_paths:
+    - "dark-factory/"
+    - ".archon/"
+    - "scheduler.sh"
+    - "factory_core/"
+    - "app/services/trading"
+    - "app/tasks/trading.py"
+    - "app/core/auth"
+    - "app/routers/auth"
+```
+
+- [ ] **Step 4: Wire the knobs in `read_config`**
+
+In `dark-factory/scheduler.sh`, inside `read_config()` after the existing `_set_cfg` calls (~line 81), add:
+```sh
+  _set_cfg EPIC_AUTOPILOT_ENABLED          '.epic_autopilot.enabled'
+  _set_cfg EPIC_AUTOPILOT_MODEL            '.epic_autopilot.model'
+  _set_cfg EPIC_AUTOPILOT_DAILY_CAP        '.epic_autopilot.daily_cap'
+  _set_cfg EPIC_AUTOPILOT_CONFIDENCE_FLOOR '.epic_autopilot.confidence_floor'
+  _set_cfg EPIC_AUTOPILOT_OPT_OUT_LABEL    '.epic_autopilot.opt_out_label'
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `bash dark-factory/tests/test_epic_autopilot_config.sh`
+Expected: `PASS`
+
+- [ ] **Step 6: Commit**
+```bash
+git add .claude/skills/refinement/config.yaml dark-factory/scheduler.sh dark-factory/tests/test_epic_autopilot_config.sh
+git commit -m "feat(autopilot): config section + scheduler read_config knobs (ships disabled)"
+```
+
+---
+
+### Task 2: Eligibility + hard-rule exclusions (pure)
+
+**Files:**
+- Create: `dark-factory/scripts/factory_core/epic_autopilot.py`
+- Test: `dark-factory/tests/test_epic_autopilot.py`
+
+**Interfaces:**
+- Produces:
+  - `Candidate` = a dict `{number:int, title:str, body:str, labels:list[str], size:str|None, status:str, spec_text:str, target_paths:list[str]}`
+  - `is_eligible(c: dict, opt_out_label: str, ceiling_keywords: str) -> tuple[bool, str]`
+  - `extract_target_paths(text: str) -> list[str]`
+  - `hard_excluded(c: dict, exclude_paths: list[str]) -> tuple[bool, str]`
+
+- [ ] **Step 1: Write failing tests**
+```python
+# dark-factory/tests/test_epic_autopilot.py
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+from factory_core import epic_autopilot as ap
+
+CEIL = "migration|migrate|performance|perf|architectur|refactor"
+
+def c(**kw):
+    base = dict(number=1, title="t", body="b", labels=["ready-for-agent"], size="S",
+                status="spec-pending-review", spec_text="touches backend/app/services/foo.py",
+                target_paths=["backend/app/services/foo.py"])
+    base.update(kw); return base
+
+def test_eligible_happy():
+    ok, why = ap.is_eligible(c(), "no-autopilot", CEIL)
+    assert ok, why
+
+def test_ineligible_opt_out():
+    ok, _ = ap.is_eligible(c(labels=["ready-for-agent", "no-autopilot"]), "no-autopilot", CEIL)
+    assert not ok
+
+def test_ineligible_already_direct_to_pr():
+    ok, _ = ap.is_eligible(c(labels=["direct-to-pr"]), "no-autopilot", CEIL)
+    assert not ok
+
+def test_ineligible_wrong_status():
+    ok, _ = ap.is_eligible(c(status="Ready"), "no-autopilot", CEIL)
+    assert not ok
+
+def test_ineligible_above_ceiling_size_l():
+    ok, _ = ap.is_eligible(c(size="L"), "no-autopilot", CEIL)
+    assert not ok
+
+def test_ineligible_m_with_ceiling_keyword():
+    ok, _ = ap.is_eligible(c(size="M", title="perf refactor of scanner"), "no-autopilot", CEIL)
+    assert not ok
+
+def test_eligible_m_without_keyword():
+    ok, why = ap.is_eligible(c(size="M", title="add data quality preflight"), "no-autopilot", CEIL)
+    assert ok, why
+
+def test_extract_paths():
+    paths = ap.extract_target_paths("Modifies `backend/app/services/x.py` and dark-factory/seed/y.sql")
+    assert "backend/app/services/x.py" in paths
+    assert "dark-factory/seed/y.sql" in paths
+
+def test_hard_exclude_factory_self():
+    ex, why = ap.hard_excluded(c(target_paths=["dark-factory/scheduler.sh"]),
+                               ["dark-factory/", "app/core/auth"])
+    assert ex and "dark-factory/" in why
+
+def test_hard_exclude_auth():
+    ex, _ = ap.hard_excluded(c(target_paths=["backend/app/core/auth/jwt.py"]),
+                             ["app/core/auth"])
+    assert ex
+
+def test_hard_exclude_undeclared_scope_fails_closed():
+    ex, why = ap.hard_excluded(c(target_paths=[]), ["app/core/auth"])
+    assert ex and why == "undeclared-scope"
+
+def test_security_label_not_excluded():
+    ex, _ = ap.hard_excluded(c(labels=["security", "ready-for-agent"],
+                               target_paths=["backend/app/services/redaction.py"]),
+                             ["app/core/auth", "app/services/trading"])
+    assert not ex
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest dark-factory/tests/test_epic_autopilot.py -v`
+Expected: FAIL (`ModuleNotFoundError` / functions missing)
+
+- [ ] **Step 3: Implement eligibility + exclusions**
+```python
+# dark-factory/scripts/factory_core/epic_autopilot.py
+"""Epic Autopilot — starved-only self-unlock reviewer (pure core + injected IO)."""
+import re
+
+_GATED_STATUSES = {"spec-pending-review", "plan-pending-review"}
+_PATH_RE = re.compile(r"[A-Za-z0-9_./-]+\.(?:py|ts|tsx|sh|ya?ml|md|sql)")
+
+
+def extract_target_paths(text: str) -> list[str]:
+    """Best-effort: pull code-path-like tokens from a spec/plan/body."""
+    if not text:
+        return []
+    seen, out = set(), []
+    for m in _PATH_RE.findall(text):
+        if m not in seen:
+            seen.add(m); out.append(m)
+    return out
+
+
+def _size(c: dict) -> str | None:
+    for l in c.get("labels", []):
+        if l.lower().startswith("size:"):
+            return l.split(":", 1)[1].strip().upper()
+    return c.get("size")
+
+
+def is_eligible(c: dict, opt_out_label: str, ceiling_keywords: str) -> tuple[bool, str]:
+    labels = [l.lower() for l in c.get("labels", [])]
+    if c.get("status") not in _GATED_STATUSES:
+        return False, f"status={c.get('status')}"
+    for blk in ("direct-to-pr", opt_out_label, "needs-discussion", "epic"):
+        if blk.lower() in labels:
+            return False, f"label:{blk}"
+    size = (_size(c) or "").upper()
+    if size in ("L", "XL"):
+        return False, f"above-ceiling:size={size}"
+    if size == "M" and re.search(ceiling_keywords, c.get("title", ""), re.I):
+        return False, "above-ceiling:M+keyword"
+    return True, ""
+
+
+def hard_excluded(c: dict, exclude_paths: list[str]) -> tuple[bool, str]:
+    paths = c.get("target_paths") or []
+    if not paths:
+        return True, "undeclared-scope"   # fail-closed
+    for p in paths:
+        for ex in exclude_paths:
+            if ex in p:
+                return True, ex
+    return False, ""
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python -m pytest dark-factory/tests/test_epic_autopilot.py -v`
+Expected: PASS (all eligibility/exclusion tests)
+
+- [ ] **Step 5: Commit**
+```bash
+git add dark-factory/scripts/factory_core/epic_autopilot.py dark-factory/tests/test_epic_autopilot.py
+git commit -m "feat(autopilot): eligibility + hard-rule exclusions (pure, fail-closed)"
+```
+
+---
+
+### Task 3: Verdict parsing + decision rule (pure)
+
+**Files:**
+- Modify: `dark-factory/scripts/factory_core/epic_autopilot.py`
+- Test: `dark-factory/tests/test_epic_autopilot.py` (append)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  - `parse_verdict(text: str) -> dict` — returns `{"decision","risk","confidence","reasons","concerns"}`; on any error returns the HOLD sentinel `{"decision":"HOLD","risk":"high","confidence":0.0,"reasons":["unparseable"],"concerns":[]}`.
+  - `should_advance(verdict: dict, confidence_floor: float) -> bool`
+
+- [ ] **Step 1: Append failing tests**
+```python
+def test_parse_clean_json():
+    v = ap.parse_verdict('{"decision":"ADVANCE","risk":"low","confidence":0.9,"reasons":["ok"],"concerns":[]}')
+    assert v["decision"] == "ADVANCE" and v["confidence"] == 0.9
+
+def test_parse_json_in_fence():
+    v = ap.parse_verdict('blah\n```json\n{"decision":"HOLD","risk":"medium","confidence":0.5,"reasons":[],"concerns":["x"]}\n```\n')
+    assert v["decision"] == "HOLD"
+
+def test_parse_garbage_fails_closed():
+    v = ap.parse_verdict("the model rambled with no json")
+    assert v["decision"] == "HOLD" and v["risk"] == "high"
+
+def test_parse_empty_fails_closed():
+    assert ap.parse_verdict("")["decision"] == "HOLD"
+
+def test_should_advance_only_on_low_and_floor():
+    assert ap.should_advance({"decision":"ADVANCE","risk":"low","confidence":0.8}, 0.7)
+    assert not ap.should_advance({"decision":"ADVANCE","risk":"medium","confidence":0.9}, 0.7)
+    assert not ap.should_advance({"decision":"ADVANCE","risk":"low","confidence":0.6}, 0.7)
+    assert not ap.should_advance({"decision":"HOLD","risk":"low","confidence":0.99}, 0.7)
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest dark-factory/tests/test_epic_autopilot.py -k "parse or advance" -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement**
+```python
+import json
+
+_HOLD = {"decision": "HOLD", "risk": "high", "confidence": 0.0,
+         "reasons": ["unparseable"], "concerns": []}
+
+
+def parse_verdict(text: str) -> dict:
+    if not text or not text.strip():
+        return dict(_HOLD)
+    # find the first {...} block (tolerates ```json fences / surrounding prose)
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end <= start:
+        return dict(_HOLD)
+    try:
+        v = json.loads(text[start:end + 1])
+    except Exception:
+        return dict(_HOLD)
+    if not isinstance(v, dict) or v.get("decision") not in ("ADVANCE", "HOLD"):
+        return dict(_HOLD)
+    v.setdefault("risk", "high")
+    v.setdefault("confidence", 0.0)
+    v.setdefault("reasons", [])
+    v.setdefault("concerns", [])
+    try:
+        v["confidence"] = float(v["confidence"])
+    except Exception:
+        return dict(_HOLD)
+    return v
+
+
+def should_advance(verdict: dict, confidence_floor: float) -> bool:
+    return (verdict.get("decision") == "ADVANCE"
+            and verdict.get("risk") == "low"
+            and float(verdict.get("confidence", 0.0)) >= confidence_floor)
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python -m pytest dark-factory/tests/test_epic_autopilot.py -k "parse or advance" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+```bash
+git add dark-factory/scripts/factory_core/epic_autopilot.py dark-factory/tests/test_epic_autopilot.py
+git commit -m "feat(autopilot): verdict parsing + decision rule (fail-closed to HOLD)"
+```
+
+---
+
+### Task 4: Daily cap + verdict cache (state file)
+
+**Files:**
+- Modify: `dark-factory/scripts/factory_core/epic_autopilot.py`
+- Test: `dark-factory/tests/test_epic_autopilot.py` (append)
+
+**Interfaces:**
+- Produces (all take/return a plain `state` dict so they're pure; the orchestrator loads/saves JSON):
+  - `daily_remaining(state: dict, cap: int, today: str) -> int`
+  - `record_advance(state: dict, today: str) -> None`
+  - `cached_verdict(state: dict, issue: int, spec_hash: str) -> str | None`
+  - `record_verdict(state: dict, issue: int, spec_hash: str, verdict: str) -> None`
+  - `spec_hash(spec_text: str) -> str`
+
+- [ ] **Step 1: Append failing tests**
+```python
+def test_daily_cap_counts_and_resets():
+    st = {}
+    assert ap.daily_remaining(st, 5, "2026-06-20") == 5
+    ap.record_advance(st, "2026-06-20"); ap.record_advance(st, "2026-06-20")
+    assert ap.daily_remaining(st, 5, "2026-06-20") == 3
+    # next UTC day resets
+    assert ap.daily_remaining(st, 5, "2026-06-21") == 5
+
+def test_verdict_cache_roundtrip_and_hash_invalidation():
+    st = {}
+    h1 = ap.spec_hash("spec A")
+    assert ap.cached_verdict(st, 402, h1) is None
+    ap.record_verdict(st, 402, h1, "HOLD")
+    assert ap.cached_verdict(st, 402, h1) == "HOLD"
+    # regenerated spec → different hash → cache miss (re-review)
+    assert ap.cached_verdict(st, 402, ap.spec_hash("spec A v2")) is None
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest dark-factory/tests/test_epic_autopilot.py -k "daily or cache" -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement**
+```python
+import hashlib
+
+
+def spec_hash(spec_text: str) -> str:
+    return hashlib.sha256((spec_text or "").encode("utf-8")).hexdigest()[:16]
+
+
+def daily_remaining(state: dict, cap: int, today: str) -> int:
+    d = state.get("daily") or {}
+    used = d.get("count", 0) if d.get("date") == today else 0
+    return max(0, cap - used)
+
+
+def record_advance(state: dict, today: str) -> None:
+    d = state.get("daily") or {}
+    if d.get("date") != today:
+        d = {"date": today, "count": 0}
+    d["count"] = d.get("count", 0) + 1
+    state["daily"] = d
+
+
+def cached_verdict(state: dict, issue: int, spec_hash_: str) -> str | None:
+    entry = (state.get("verdicts") or {}).get(str(issue))
+    if entry and entry.get("spec_hash") == spec_hash_:
+        return entry.get("verdict")
+    return None
+
+
+def record_verdict(state: dict, issue: int, spec_hash_: str, verdict: str) -> None:
+    state.setdefault("verdicts", {})[str(issue)] = {"spec_hash": spec_hash_, "verdict": verdict}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python -m pytest dark-factory/tests/test_epic_autopilot.py -k "daily or cache" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+```bash
+git add dark-factory/scripts/factory_core/epic_autopilot.py dark-factory/tests/test_epic_autopilot.py
+git commit -m "feat(autopilot): daily cap + spec-hash verdict cache (pure)"
+```
+
+---
+
+### Task 5: Orchestrator with injected IO
+
+**Files:**
+- Modify: `dark-factory/scripts/factory_core/epic_autopilot.py`
+- Test: `dark-factory/tests/test_epic_autopilot.py` (append)
+
+**Interfaces:**
+- Produces: `run_once(cfg, io, state, today) -> dict` where:
+  - `cfg` = `{exclude_paths, opt_out_label, ceiling_keywords, confidence_floor, daily_cap, model}`
+  - `io` = an object/namespace with injected callables: `fetch_candidates() -> list[dict]`, `review(prompt, model) -> str`, `advance(issue) -> None` (adds `direct-to-pr`), `comment(issue, body) -> None`, `notify(title, body, severity, dedupe_key) -> None`
+  - returns `{"outcome": "advanced|hold|no_candidates|daily_cap_reached", "issue": int|None, "reason": str}`
+- The orchestrator: enforce daily cap → fetch → filter (eligible & not hard-excluded & not cache-HOLD) → if none, notify "stuck" (throttled) + return `no_candidates` → pick first → build prompt → review → parse → decide → ADVANCE: advance+comment+notify+record; HOLD: comment+cache.
+
+- [ ] **Step 1: Append failing tests (fakes, no real IO)**
+```python
+class FakeIO:
+    def __init__(self, candidates, review_text):
+        self._cands = candidates; self._review = review_text
+        self.advanced = []; self.comments = []; self.notes = []
+    def fetch_candidates(self): return self._cands
+    def review(self, prompt, model): return self._review
+    def advance(self, issue): self.advanced.append(issue)
+    def comment(self, issue, body): self.comments.append((issue, body))
+    def notify(self, title, body, severity, dedupe_key): self.notes.append((severity, dedupe_key))
+
+CFG = dict(exclude_paths=["app/core/auth", "dark-factory/"], opt_out_label="no-autopilot",
+           ceiling_keywords=CEIL, confidence_floor=0.7, daily_cap=5, model="claude-opus-4-8")
+
+def test_run_advances_low_risk():
+    io = FakeIO([c(number=402)], '{"decision":"ADVANCE","risk":"low","confidence":0.9,"reasons":["safe"],"concerns":[]}')
+    st = {}
+    out = ap.run_once(CFG, io, st, "2026-06-20")
+    assert out["outcome"] == "advanced" and out["issue"] == 402
+    assert io.advanced == [402]
+    assert any(sev == "info" for sev, _ in io.notes)          # advance notice
+    assert ap.daily_remaining(st, 5, "2026-06-20") == 4
+
+def test_run_holds_medium_risk():
+    io = FakeIO([c(number=402)], '{"decision":"ADVANCE","risk":"medium","confidence":0.9,"reasons":[],"concerns":["risky"]}')
+    st = {}
+    out = ap.run_once(CFG, io, st, "2026-06-20")
+    assert out["outcome"] == "hold" and io.advanced == []
+    assert ap.cached_verdict(st, 402, ap.spec_hash(c(number=402)["spec_text"])) == "HOLD"
+
+def test_run_no_candidates_notifies_stuck():
+    io = FakeIO([c(number=402, labels=["no-autopilot", "ready-for-agent"])], "x")
+    out = ap.run_once(CFG, io, {}, "2026-06-20")
+    assert out["outcome"] == "no_candidates"
+    assert any(sev == "warning" and key == "autopilot-stuck" for sev, key in io.notes)
+
+def test_run_daily_cap_reached_notifies():
+    io = FakeIO([c(number=402)], "x")
+    st = {"daily": {"date": "2026-06-20", "count": 5}}
+    out = ap.run_once(CFG, io, st, "2026-06-20")
+    assert out["outcome"] == "daily_cap_reached"
+    assert io.advanced == []
+    assert any(key == "autopilot-cap" for _, key in io.notes)
+
+def test_run_skips_cached_hold():
+    cand = c(number=402)
+    st = {}; ap.record_verdict(st, 402, ap.spec_hash(cand["spec_text"]), "HOLD")
+    io = FakeIO([cand], '{"decision":"ADVANCE","risk":"low","confidence":0.9}')
+    out = ap.run_once(CFG, io, st, "2026-06-20")
+    assert out["outcome"] == "no_candidates"   # the only candidate is cache-suppressed
+    assert io.advanced == []
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest dark-factory/tests/test_epic_autopilot.py -k "run_" -v`
+Expected: FAIL
+
+- [ ] **Step 3: Implement the orchestrator + prompt builder**
+```python
+def build_review_prompt(c: dict) -> str:
+    return f"""You are a cautious senior engineer deciding whether a refined ticket is safe to
+implement and merge AUTONOMOUSLY (adding the direct-to-pr label means it flows
+spec→plan→implement→PR with NO further human gate before the PR opens).
+
+Reply with ONLY a JSON object:
+{{"decision":"ADVANCE|HOLD","risk":"low|medium|high","confidence":0.0-1.0,
+  "reasons":[...],"concerns":[...]}}
+
+ADVANCE only if the work is genuinely low-risk: small, well-scoped, reversible, good test
+coverage in the spec/plan, low blast radius, and NOT touching automated trading,
+authentication/authorization, or the factory/scheduler itself. If the spec is vague, an
+empty-branch/no-op risk, or you are unsure — choose HOLD.
+
+Ticket #{c['number']}: {c['title']}
+Labels: {', '.join(c.get('labels', []))}   Size: {c.get('size')}
+Declared target files: {', '.join(c.get('target_paths') or []) or '(none declared)'}
+
+--- SPEC/PLAN ---
+{c.get('spec_text', '')[:8000]}
+"""
+
+
+def run_once(cfg: dict, io, state: dict, today: str) -> dict:
+    if daily_remaining(state, cfg["daily_cap"], today) <= 0:
+        io.notify("Epic autopilot — daily cap reached",
+                  f"Hit the daily cap of {cfg['daily_cap']} autonomous advances; paused until UTC reset. Review the backlog.",
+                  "warning", "autopilot-cap")
+        return {"outcome": "daily_cap_reached", "issue": None, "reason": "cap"}
+
+    candidates = []
+    for cand in io.fetch_candidates():
+        ok, _ = is_eligible(cand, cfg["opt_out_label"], cfg["ceiling_keywords"])
+        if not ok:
+            continue
+        ex, _ = hard_excluded(cand, cfg["exclude_paths"])
+        if ex:
+            continue
+        if cached_verdict(state, cand["number"], spec_hash(cand.get("spec_text", ""))) == "HOLD":
+            continue
+        candidates.append(cand)
+
+    if not candidates:
+        io.notify("Epic autopilot — idle, nothing safe to advance",
+                  "The factory is starved and the autopilot has no eligible low-risk ticket to advance. Human input needed.",
+                  "warning", "autopilot-stuck")
+        return {"outcome": "no_candidates", "issue": None, "reason": "empty"}
+
+    cand = candidates[0]
+    verdict = parse_verdict(io.review(build_review_prompt(cand), cfg["model"]))
+    h = spec_hash(cand.get("spec_text", ""))
+    if should_advance(verdict, cfg["confidence_floor"]):
+        io.advance(cand["number"])
+        reason = "; ".join(verdict.get("reasons", [])) or "low-risk"
+        io.comment(cand["number"],
+                   f"🤖 **Epic Autopilot** — advancing (risk={verdict['risk']}, conf={verdict['confidence']}). "
+                   f"Reason: {reason}\n\n---\n*Posted by MarketHawk Epic Autopilot*")
+        io.notify(f"Autopilot advancing #{cand['number']}",
+                  f"{cand['title']} — risk=low: {reason}", "info", None)
+        record_advance(state, today)
+        record_verdict(state, cand["number"], h, "ADVANCE")
+        return {"outcome": "advanced", "issue": cand["number"], "reason": reason}
+
+    concerns = "; ".join(verdict.get("concerns", [])) or "not low-risk / low confidence"
+    io.comment(cand["number"],
+               f"🤖 **Epic Autopilot** — parked (HOLD). {concerns}\n\n---\n*Posted by MarketHawk Epic Autopilot*")
+    record_verdict(state, cand["number"], h, "HOLD")
+    return {"outcome": "hold", "issue": cand["number"], "reason": concerns}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python -m pytest dark-factory/tests/test_epic_autopilot.py -v`
+Expected: PASS (full suite)
+
+- [ ] **Step 5: Commit**
+```bash
+git add dark-factory/scripts/factory_core/epic_autopilot.py dark-factory/tests/test_epic_autopilot.py
+git commit -m "feat(autopilot): orchestrator (advance/hold/stuck/cap) with injected IO"
+```
+
+---
+
+### Task 6: Real IO adapter, CLI subcommand, scheduler hook
+
+**Files:**
+- Modify: `dark-factory/scripts/factory_core/epic_autopilot.py` (add real `LiveIO` + `main_once()`)
+- Modify: `dark-factory/scripts/factory_core/cli.py` (subcommand `epic-autopilot`)
+- Modify: `dark-factory/scheduler.sh` (Priority-6 guarded call)
+- Test: `dark-factory/tests/test_scheduler_autopilot_guard.sh`
+
+**Interfaces:**
+- Consumes: `run_once`, all pure helpers.
+- Produces: `cli.py epic-autopilot --once` prints one structured line (`autopilot=<outcome> issue=#N`); `scheduler.sh` Priority 6 calls it only when starved.
+
+- [ ] **Step 1: Write the failing scheduler-guard test**
+```bash
+# dark-factory/tests/test_scheduler_autopilot_guard.sh
+#!/usr/bin/env bash
+set -euo pipefail
+# The Priority-6 block must be gated on DISPATCHED empty + main green + enabled.
+grep -q 'EPIC_AUTOPILOT_ENABLED' "$(dirname "$0")/../scheduler.sh" || { echo "FAIL: no autopilot hook"; exit 1; }
+# Must reference the cli subcommand and the starved guard
+grep -qE 'epic-autopilot' "$(dirname "$0")/../scheduler.sh" || { echo "FAIL: cli call missing"; exit 1; }
+grep -qE '\[ -z "\$DISPATCHED" \].*EPIC_AUTOPILOT_ENABLED|EPIC_AUTOPILOT_ENABLED.*-z "\$DISPATCHED"' "$(dirname "$0")/../scheduler.sh" \
+  || grep -A3 'EPIC_AUTOPILOT_ENABLED' "$(dirname "$0")/../scheduler.sh" | grep -q 'DISPATCHED' \
+  || { echo "FAIL: not guarded by DISPATCHED-empty"; exit 1; }
+echo "PASS"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bash dark-factory/tests/test_scheduler_autopilot_guard.sh`
+Expected: FAIL
+
+- [ ] **Step 3: Add `LiveIO` + `main_once()` to `epic_autopilot.py`**
+```python
+import os, subprocess, urllib.request
+
+OWNER = "omniscient/markethawk"
+
+
+class LiveIO:
+    """Real adapters: gh GraphQL/REST + claude -p + the /system notify endpoint."""
+    def __init__(self, model: str):
+        self.model = model
+
+    def fetch_candidates(self) -> list[dict]:
+        # GraphQL: in-progress epics -> subIssues; map gated children to candidate dicts.
+        # (Implementation mirrors fetch_board_items in scheduler.sh; for each gated child,
+        #  pull its spec text from the latest "Spec/Plan Generated" comment and the issue body.)
+        return _gh_fetch_candidates()
+
+    def review(self, prompt: str, model: str) -> str:
+        p = subprocess.run(["claude", "-p", "--model", model], input=prompt,
+                           capture_output=True, text=True, timeout=300)
+        return p.stdout if p.returncode == 0 else ""
+
+    def advance(self, issue: int) -> None:
+        subprocess.run(["gh", "issue", "edit", str(issue), "--repo", OWNER,
+                        "--add-label", "direct-to-pr"], check=False)
+
+    def comment(self, issue: int, body: str) -> None:
+        subprocess.run(["gh", "issue", "comment", str(issue), "--repo", OWNER,
+                        "--body", body], check=False)
+
+    def notify(self, title: str, body: str, severity: str, dedupe_key) -> None:
+        token = os.environ.get("INTERNAL_API_TOKEN", "")
+        if not token:
+            return
+        payload = {"title": title, "body": body, "severity": severity}
+        if dedupe_key:
+            payload["dedupe_key"] = dedupe_key
+        req = urllib.request.Request(
+            "http://backend:8000/api/v1/alerts/system",
+            data=__import__("json").dumps(payload).encode(),
+            headers={"Content-Type": "application/json", "X-Internal-Token": token},
+            method="POST")
+        try:
+            urllib.request.urlopen(req, timeout=10)
+        except Exception:
+            pass  # fail-soft
+
+
+def main_once() -> int:
+    import json
+    state_dir = os.environ.get("SCHEDULER_STATE_DIR", "/var/lib/dark-factory")
+    path = os.path.join(state_dir, "autopilot-state.json")
+    state = json.load(open(path)) if os.path.exists(path) else {}
+    from datetime import datetime, timezone
+    today = datetime.now(timezone.utc).date().isoformat()
+    cfg = dict(
+        exclude_paths=_load_exclude_paths(),
+        opt_out_label=os.environ.get("EPIC_AUTOPILOT_OPT_OUT_LABEL", "no-autopilot"),
+        ceiling_keywords=os.environ.get("ABOVE_CEILING_KEYWORDS",
+            "migration|migrate|performance|perf|architectur|refactor"),
+        confidence_floor=float(os.environ.get("EPIC_AUTOPILOT_CONFIDENCE_FLOOR", "0.7")),
+        daily_cap=int(os.environ.get("EPIC_AUTOPILOT_DAILY_CAP", "5")),
+        model=os.environ.get("EPIC_AUTOPILOT_MODEL", "claude-opus-4-8"))
+    out = run_once(cfg, LiveIO(cfg["model"]), state, today)
+    json.dump(state, open(path, "w"))
+    print(f"autopilot={out['outcome']} issue=#{out['issue']}")
+    return 0
+```
+(Add stub helpers `_gh_fetch_candidates()` and `_load_exclude_paths()` — the latter reads `hard_exclude_paths` from config.yaml via `yq` or a small parser; `_gh_fetch_candidates()` does the GraphQL walk. These touch live `gh`, so they're exercised only in the manual validation step, not unit tests.)
+
+- [ ] **Step 4: Add the CLI subcommand**
+
+In `dark-factory/scripts/factory_core/cli.py`, add a handler and register it in `main()`:
+```python
+def _epic_autopilot(args):
+    from factory_core.epic_autopilot import main_once
+    return main_once()
+```
+```python
+    ea = sub.add_parser("epic-autopilot")
+    ea.add_argument("--once", action="store_true")
+    ea.set_defaults(func=_epic_autopilot)
+```
+
+- [ ] **Step 5: Add the Priority-6 hook in `scheduler.sh`**
+
+After Priority 5 (the Backlog loop ends ~line 1095) and before the cycle-summary log (~line 1097), add:
+```sh
+  # --- Priority 6: Epic Autopilot (starved self-unlock, #571) ---
+  # Runs ONLY when this cycle dispatched nothing, main is green, and it is enabled.
+  # Fail-soft: never let it abort the loop.
+  if [ -z "$DISPATCHED" ] && [ "$MAIN_IS_RED" = "false" ] && [ "${EPIC_AUTOPILOT_ENABLED:-false}" = "true" ]; then
+    AP_OUT=$(python3 "$FACTORY_CORE_CLI" epic-autopilot --once 2>&1) || true
+    echo "[$(date -u +%FT%TZ)] ${AP_OUT}"
+    case "$AP_OUT" in *"autopilot=advanced"*) DISPATCHED="$AP_OUT" ;; esac
+  fi
+```
+
+- [ ] **Step 6: Run the guard test + full python suite**
+
+Run: `bash dark-factory/tests/test_scheduler_autopilot_guard.sh && python -m pytest dark-factory/tests/test_epic_autopilot.py -v`
+Expected: `PASS` + green suite
+
+- [ ] **Step 7: Manual validation (with the image rebuilt)**
+
+Per project memory: scheduler.sh + factory_core are baked into the factory image, so rebuild + recreate before this runs live.
+```bash
+docker compose --profile factory build dark-factory
+docker compose --profile scheduler up -d --force-recreate --no-build backlog-scheduler
+# Temporarily enable in .archon/.env (EPIC_AUTOPILOT_ENABLED=true) + ensure INTERNAL_API_TOKEN is set
+# Watch one starved cycle advance a single low-risk ticket:
+docker logs -f backlog-scheduler | grep autopilot
+```
+Expected: `autopilot=advanced issue=#N`, the ticket gains `direct-to-pr` + an autopilot comment, and an advance email/push arrives. Force the cap and the empty-pool path to confirm the `autopilot-cap` / `autopilot-stuck` notifications.
+
+- [ ] **Step 8: Commit**
+```bash
+git add dark-factory/scripts/factory_core/epic_autopilot.py dark-factory/scripts/factory_core/cli.py dark-factory/scheduler.sh dark-factory/tests/test_scheduler_autopilot_guard.sh
+git commit -m "feat(autopilot): live IO adapter, CLI subcommand, scheduler Priority-6 hook"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** starved-only trigger (Task 6 guard) ✓; Stage A eligibility + ceiling (Task 2) ✓; Stage B hard exclusions + fail-closed undeclared scope + security-passes (Task 2) ✓; Opus reviewer + structured verdict + decision rule + fail-closed (Task 3) ✓; ADVANCE/HOLD actions + comment + notify (Task 5) ✓; daily cap + verdict cache (Task 4) ✓; three notifications incl. throttled stuck via dedupe_key (Task 5) ✓; config + kill-switch (Task 1) ✓; CLI + hook + baked-image rebuild note (Task 6) ✓.
+- **Placeholders:** the only deferred-to-implementation pieces are `_gh_fetch_candidates()` and `_load_exclude_paths()` (live-`gh`/config IO) — explicitly flagged as manual-validation-only, not unit-tested, with their contracts stated (return candidate dicts / exclude-path list). All pure logic is fully coded + tested.
+- **Type consistency:** the `Candidate` dict keys (`number/title/body/labels/size/status/spec_text/target_paths`) are identical across Tasks 2/5; `run_once(cfg, io, state, today)` and the `io` callable set match between the Task 5 definition, the FakeIO test, and the Task 6 `LiveIO`; `spec_hash`/`cached_verdict`/`record_verdict` signatures consistent across Tasks 4/5.
+- **Cross-plan dependency:** Task 5/6 `notify` targets `POST /api/v1/alerts/system` from the System Notifications Enabler plan — implement that plan first (or the notify calls fail-soft to no-ops until it exists).

--- a/docs/superpowers/plans/2026-06-20-system-notifications-enabler.md
+++ b/docs/superpowers/plans/2026-06-20-system-notifications-enabler.md
@@ -1,0 +1,466 @@
+# System Notifications Enabler Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a generic `notify_system()` + `POST /api/v1/alerts/system` endpoint that delivers email + browser-push for non-scanner events, reusing the existing SMTP/VAPID delivery.
+
+**Architecture:** Extract the scanner-coupled browser-push loop into a generic payload sender (email's `_send_email(to, subject, body)` is already generic). Add a thin `system_notifier.notify_system()` that fans out to email + push with per-channel fail-soft and an in-process dedupe cooldown. Expose it via a token-guarded endpoint that is exempt from the JWT/CSRF middleware (server-to-server).
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0 (sync), `smtplib` (SMTP), `pywebpush` (VAPID), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-system-notifications-enabler-design.md`
+
+## Global Constraints
+
+- No new **required-no-default** Settings field — both new fields default to `""` (the smoke gate runs `python -c "import app.main"` with only 3 env vars; a required field breaks it, cf. REDIS_PASSWORD).
+- Endpoint auth is a shared secret `X-Internal-Token` (NOT JWT) — decoupled from the in-flight authz epic #373.
+- `notify_system` must be **fail-soft**: a channel error is logged + recorded in the return value, never raised.
+- Router prefix is `/api/v1/alerts` (full path `/api/v1/alerts/system`).
+- Tests mock `smtplib`/`pywebpush` — no live SMTP/push in CI.
+
+---
+
+### Task 1: Config fields
+
+**Files:**
+- Modify: `backend/app/core/config.py` (Settings class, near SMTP fields ~line 110 and JWT ~line 57)
+- Test: `backend/tests/core/test_config_system_notify.py`
+
+**Interfaces:**
+- Produces: `settings.OPS_ALERT_EMAIL: str` (default `""`), `settings.INTERNAL_API_TOKEN: str` (default `""`)
+
+- [ ] **Step 1: Write the failing test**
+```python
+# backend/tests/core/test_config_system_notify.py
+from app.core.config import Settings
+
+def test_system_notify_fields_default_empty(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://smoke:smoke@localhost:5432/smoke")
+    monkeypatch.setenv("POLYGON_API_KEY", "x")
+    monkeypatch.setenv("JWT_SECRET_KEY", "smoke-gate-only-not-secret-0123456789abcdef")
+    monkeypatch.setenv("REDIS_PASSWORD", "smoke-gate-only-not-a-real-redis-password")
+    s = Settings()
+    assert s.OPS_ALERT_EMAIL == ""
+    assert s.INTERNAL_API_TOKEN == ""
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest backend/tests/core/test_config_system_notify.py -v`
+Expected: FAIL (`AttributeError: 'Settings' object has no attribute 'OPS_ALERT_EMAIL'`)
+
+- [ ] **Step 3: Add the fields**
+
+In `backend/app/core/config.py`, add after `SMTP_FROM_EMAIL` (~line 110):
+```python
+    # System notifications (generic non-scanner alerts). Both optional/empty-default —
+    # NEVER make these required-no-default (would break the smoke gate, cf. REDIS_PASSWORD).
+    OPS_ALERT_EMAIL: str = ""
+    INTERNAL_API_TOKEN: str = Field(default="", repr=False)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest backend/tests/core/test_config_system_notify.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Verify smoke-gate import still passes**
+
+Run: `docker exec stockscanner-api sh -c 'cd /app && env -i PATH=/usr/local/bin:/usr/bin:/bin HOME=/root DATABASE_URL=postgresql://smoke:smoke@localhost:5432/smoke POLYGON_API_KEY=x JWT_SECRET_KEY=smoke-gate-only-not-secret-0123456789abcdef REDIS_PASSWORD=smoke-gate-only-not-a-real-redis-password python -c "import app.main; print(\"OK\")"'`
+Expected: `OK`
+
+- [ ] **Step 6: Commit**
+```bash
+git add backend/app/core/config.py backend/tests/core/test_config_system_notify.py
+git commit -m "feat(config): add OPS_ALERT_EMAIL + INTERNAL_API_TOKEN (optional, empty-default)"
+```
+
+---
+
+### Task 2: Extract a generic browser-push sender
+
+**Files:**
+- Modify: `backend/app/services/alert_service.py:177-226` (`_send_browser_push`)
+- Test: `backend/tests/services/test_push_generic.py`
+
+**Interfaces:**
+- Produces: `NotificationDispatcher._push_to_subscriptions(payload: dict, db: Session) -> int` (returns # delivered; raises `RuntimeError` only if ALL deliveries fail)
+- `_send_browser_push(event, db)` becomes a thin wrapper that builds the scanner payload then calls `_push_to_subscriptions`.
+
+- [ ] **Step 1: Write the failing test**
+```python
+# backend/tests/services/test_push_generic.py
+from unittest.mock import MagicMock, patch
+from app.services.alert_service import NotificationDispatcher
+
+@patch("app.services.alert_service.settings")
+def test_push_to_subscriptions_sends_to_all(mock_settings):
+    mock_settings.VAPID_PRIVATE_KEY = "k"; mock_settings.VAPID_PUBLIC_KEY = "p"
+    mock_settings.VAPID_CLAIMS_EMAIL = "mailto:a@b.c"
+    db = MagicMock()
+    sub = MagicMock(endpoint="e", p256dh="x", auth="y", id=1)
+    db.query.return_value.all.return_value = [sub]
+    with patch("pywebpush.webpush") as wp:
+        count = NotificationDispatcher._push_to_subscriptions(
+            {"title": "T", "body": "B", "severity": "warning", "url": "/"}, db)
+    assert count == 1
+    wp.assert_called_once()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest backend/tests/services/test_push_generic.py -v`
+Expected: FAIL (`AttributeError: ... has no attribute '_push_to_subscriptions'`)
+
+- [ ] **Step 3: Refactor — add the generic sender, rewire the scanner wrapper**
+
+In `backend/app/services/alert_service.py`, replace the body of `_send_browser_push` (lines 177-226). Move the VAPID check + subscription loop into a new generic method that takes a pre-built `payload`:
+```python
+    @staticmethod
+    def _push_to_subscriptions(payload: dict, db: Session) -> int:
+        """Web-push `payload` (a dict with title/body/...) to all stored subscriptions.
+        Returns the number delivered. Raises RuntimeError only if ALL deliveries fail."""
+        try:
+            from pywebpush import webpush  # noqa: F401
+        except ImportError:
+            raise RuntimeError("pywebpush is not installed. Add it to requirements.txt and rebuild.")
+        if not settings.VAPID_PRIVATE_KEY or not settings.VAPID_PUBLIC_KEY:
+            raise ValueError("VAPID_PRIVATE_KEY and VAPID_PUBLIC_KEY must be set to send browser push.")
+        subscriptions = db.query(PushSubscription).all()
+        if not subscriptions:
+            logger.debug("No push subscriptions registered — skipping browser push.")
+            return 0
+        data = json.dumps(payload)
+        vapid_claims = {"sub": settings.VAPID_CLAIMS_EMAIL}
+        failed = 0
+        for sub in subscriptions:
+            try:
+                webpush(
+                    subscription_info={"endpoint": sub.endpoint,
+                                       "keys": {"p256dh": sub.p256dh, "auth": sub.auth}},
+                    data=data, vapid_private_key=settings.VAPID_PRIVATE_KEY, vapid_claims=vapid_claims)
+            except Exception as exc:
+                failed += 1
+                if "410" in str(exc) or "404" in str(exc):
+                    logger.info(f"Removing expired push subscription id={sub.id}"); db.delete(sub)
+                else:
+                    logger.warning(f"Push failed for subscription {sub.id}: {exc}")
+        if failed == len(subscriptions):
+            raise RuntimeError(f"All {failed} push deliveries failed.")
+        return len(subscriptions) - failed
+
+    @staticmethod
+    def _send_browser_push(event: ScannerEvent, db: Session) -> None:
+        """Scanner-event browser push (thin wrapper over the generic sender)."""
+        NotificationDispatcher._push_to_subscriptions(
+            NotificationDispatcher._build_push_payload(event), db)
+```
+(`webpush` is imported lazily inside `_push_to_subscriptions`; the test patches `pywebpush.webpush`.)
+
+- [ ] **Step 4: Run tests to verify pass (new + existing alert tests)**
+
+Run: `pytest backend/tests/services/test_push_generic.py backend/tests/services/ -k "push or alert" -v`
+Expected: PASS (new test passes; existing scanner-push tests unaffected)
+
+- [ ] **Step 5: Commit**
+```bash
+git add backend/app/services/alert_service.py backend/tests/services/test_push_generic.py
+git commit -m "refactor(alerts): extract generic _push_to_subscriptions from scanner push"
+```
+
+---
+
+### Task 3: `notify_system()`
+
+**Files:**
+- Create: `backend/app/services/system_notifier.py`
+- Test: `backend/tests/services/test_system_notifier.py`
+
+**Interfaces:**
+- Consumes: `NotificationDispatcher._send_email(to, subject, body)`, `NotificationDispatcher._push_to_subscriptions(payload, db)` (Task 2), `settings.OPS_ALERT_EMAIL`
+- Produces: `notify_system(title, body, severity="info", dedupe_key=None, channels=None, db=None, cooldown_seconds=3600, _now=None) -> dict[str, str]` (per-channel: `"sent"|"sent:<n>"|"skipped"|"suppressed"|"unknown_channel"|"failed:<reason>"`)
+
+- [ ] **Step 1: Write the failing tests**
+```python
+# backend/tests/services/test_system_notifier.py
+from unittest.mock import patch
+import app.services.system_notifier as sn
+
+def _patch(email_ok=True, ops="ops@x.com"):
+    return patch.multiple("app.services.system_notifier",
+        settings=type("S", (), {"OPS_ALERT_EMAIL": ops})())
+
+@patch("app.services.system_notifier.NotificationDispatcher")
+def test_email_and_push(mock_disp):
+    with patch.object(sn.settings, "OPS_ALERT_EMAIL", "ops@x.com"):
+        mock_disp._push_to_subscriptions.return_value = 2
+        r = sn.notify_system("T", "B", severity="warning", db=object())
+    assert r["email"] == "sent"
+    assert r["browser_push"] == "sent:2"
+    mock_disp._send_email.assert_called_once()
+
+@patch("app.services.system_notifier.NotificationDispatcher")
+def test_email_skipped_when_ops_unset(mock_disp):
+    with patch.object(sn.settings, "OPS_ALERT_EMAIL", ""):
+        mock_disp._push_to_subscriptions.return_value = 0
+        r = sn.notify_system("T", "B", db=object())
+    assert r["email"] == "skipped"
+    mock_disp._send_email.assert_not_called()
+
+@patch("app.services.system_notifier.NotificationDispatcher")
+def test_channel_failure_is_soft(mock_disp):
+    with patch.object(sn.settings, "OPS_ALERT_EMAIL", "ops@x.com"):
+        mock_disp._send_email.side_effect = RuntimeError("smtp down")
+        mock_disp._push_to_subscriptions.return_value = 1
+        r = sn.notify_system("T", "B", db=object())
+    assert r["email"].startswith("failed:")
+    assert r["browser_push"] == "sent:1"
+
+@patch("app.services.system_notifier.NotificationDispatcher")
+def test_dedupe_suppresses_within_cooldown(mock_disp):
+    with patch.object(sn.settings, "OPS_ALERT_EMAIL", "ops@x.com"):
+        mock_disp._push_to_subscriptions.return_value = 0
+        first = sn.notify_system("T", "B", dedupe_key="k1", db=object(), cooldown_seconds=100, _now=1000.0)
+        second = sn.notify_system("T", "B", dedupe_key="k1", db=object(), cooldown_seconds=100, _now=1050.0)
+        third = sn.notify_system("T", "B", dedupe_key="k1", db=object(), cooldown_seconds=100, _now=1200.0)
+    assert first["email"] == "sent"
+    assert second == {"email": "suppressed", "browser_push": "suppressed"}
+    assert third["email"] == "sent"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest backend/tests/services/test_system_notifier.py -v`
+Expected: FAIL (`ModuleNotFoundError: app.services.system_notifier`)
+
+- [ ] **Step 3: Implement `system_notifier.py`**
+```python
+# backend/app/services/system_notifier.py
+"""Generic system notifications (non-scanner) reusing the alert delivery channels."""
+import logging
+import time
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.services.alert_service import NotificationDispatcher
+
+logger = logging.getLogger(__name__)
+
+# In-process dedupe cache: dedupe_key -> last-sent monotonic timestamp.
+# Best-effort (per-process, resets on restart) — acceptable for fail-soft alerts.
+_dedupe_cache: dict[str, float] = {}
+
+_SEV_COLOR = {"info": "#3b82f6", "warning": "#f59e0b", "critical": "#ef4444"}
+
+
+def _html(title: str, body: str, severity: str) -> str:
+    color = _SEV_COLOR.get(severity, "#3b82f6")
+    return (
+        '<html><body style="font-family:sans-serif;background:#111827;color:#f3f4f6;padding:24px">'
+        f'<h2 style="color:{color}">{title}</h2><p>{body}</p></body></html>'
+    )
+
+
+def notify_system(
+    title: str,
+    body: str,
+    severity: str = "info",
+    dedupe_key: Optional[str] = None,
+    channels: Optional[list[str]] = None,
+    db: Optional[Session] = None,
+    cooldown_seconds: int = 3600,
+    _now: Optional[float] = None,
+) -> dict:
+    """Fan out a system notification to email + browser push. Never raises."""
+    channels = channels if channels is not None else ["email", "browser_push"]
+    now = _now if _now is not None else time.monotonic()
+
+    if dedupe_key is not None:
+        last = _dedupe_cache.get(dedupe_key)
+        if last is not None and (now - last) < cooldown_seconds:
+            return {ch: "suppressed" for ch in channels}
+        _dedupe_cache[dedupe_key] = now
+
+    subject = title if severity == "info" else f"[{severity.upper()}] {title}"
+    result: dict[str, str] = {}
+    for ch in channels:
+        try:
+            if ch == "email":
+                if settings.OPS_ALERT_EMAIL:
+                    NotificationDispatcher._send_email(settings.OPS_ALERT_EMAIL, subject, _html(title, body, severity))
+                    result[ch] = "sent"
+                else:
+                    result[ch] = "skipped"
+            elif ch == "browser_push":
+                if db is not None:
+                    count = NotificationDispatcher._push_to_subscriptions(
+                        {"title": title, "body": body, "severity": severity, "url": "/"}, db)
+                    result[ch] = f"sent:{count}"
+                else:
+                    result[ch] = "skipped"
+            else:
+                result[ch] = "unknown_channel"
+        except Exception as exc:  # fail-soft per channel
+            logger.error("system notification channel=%s failed: %s", ch, exc)
+            result[ch] = f"failed:{exc}"
+    return result
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest backend/tests/services/test_system_notifier.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+```bash
+git add backend/app/services/system_notifier.py backend/tests/services/test_system_notifier.py
+git commit -m "feat(notifications): add notify_system() generic email/push dispatcher"
+```
+
+---
+
+### Task 4: `POST /api/v1/alerts/system` endpoint + middleware exemption
+
+**Files:**
+- Modify: `backend/app/routers/alerts.py` (add import + endpoint)
+- Modify: `backend/app/main.py:52` (CSRF_EXEMPT_PREFIXES) and `backend/app/main.py:280-286` (`_base_exempt`)
+- Test: `backend/tests/routers/test_alerts_system.py`
+
+**Interfaces:**
+- Consumes: `notify_system(...)` (Task 3), `settings.INTERNAL_API_TOKEN`
+- Produces: `POST /api/v1/alerts/system` — `{title, body, severity?, dedupe_key?, channels?}` + header `X-Internal-Token` → `{"status":"dispatched","channels":{...}}`. 503 if token unset, 401 if mismatch, 422 if title/body missing.
+
+- [ ] **Step 1: Write the failing tests**
+```python
+# backend/tests/routers/test_alerts_system.py
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from app.main import create_app
+
+def _client():
+    return TestClient(create_app())
+
+def test_503_when_token_unset():
+    with patch("app.routers.alerts.settings") as s:
+        s.INTERNAL_API_TOKEN = ""
+        r = _client().post("/api/v1/alerts/system", json={"title": "t", "body": "b"})
+    assert r.status_code == 503
+
+def test_401_on_bad_token():
+    with patch("app.routers.alerts.settings") as s:
+        s.INTERNAL_API_TOKEN = "secret"
+        r = _client().post("/api/v1/alerts/system", json={"title": "t", "body": "b"},
+                           headers={"X-Internal-Token": "wrong"})
+    assert r.status_code == 401
+
+def test_200_dispatches():
+    with patch("app.routers.alerts.settings") as s, \
+         patch("app.routers.alerts.notify_system") as ns:
+        s.INTERNAL_API_TOKEN = "secret"
+        ns.return_value = {"email": "sent", "browser_push": "sent:0"}
+        r = _client().post("/api/v1/alerts/system",
+                           json={"title": "t", "body": "b", "severity": "warning"},
+                           headers={"X-Internal-Token": "secret"})
+    assert r.status_code == 200
+    assert r.json()["channels"]["email"] == "sent"
+
+def test_422_missing_fields():
+    with patch("app.routers.alerts.settings") as s:
+        s.INTERNAL_API_TOKEN = "secret"
+        r = _client().post("/api/v1/alerts/system", json={"title": "t"},
+                           headers={"X-Internal-Token": "secret"})
+    assert r.status_code == 422
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest backend/tests/routers/test_alerts_system.py -v`
+Expected: FAIL (404 — endpoint missing, and/or 401 from AuthMiddleware because path not exempt)
+
+- [ ] **Step 3: Add the middleware exemptions**
+
+In `backend/app/main.py`, line 52:
+```python
+CSRF_EXEMPT_PREFIXES = ("/api/auth/", "/api/v1/alerts/infrastructure", "/api/v1/alerts/system")
+```
+And in `_base_exempt` (lines 280-286), add the path:
+```python
+    _base_exempt = (
+        "/api/auth/",
+        "/api/health",
+        "/api/ready",
+        "/metrics",
+        "/api/v1/alerts/infrastructure",
+        "/api/v1/alerts/system",
+    )
+```
+
+- [ ] **Step 4: Add the endpoint**
+
+In `backend/app/routers/alerts.py`, add imports near the top:
+```python
+from fastapi import Header
+from app.core.config import settings
+from app.services.system_notifier import notify_system
+```
+And add the endpoint (place after `receive_infrastructure_alert`):
+```python
+@router.post("/system", status_code=200)
+def send_system_notification(
+    payload: Dict[str, Any],
+    db: Session = Depends(get_db),
+    x_internal_token: str | None = Header(default=None, alias="X-Internal-Token"),
+) -> Dict[str, Any]:
+    """Generic system notification (email + browser push). Server-to-server only."""
+    if not settings.INTERNAL_API_TOKEN:
+        raise HTTPException(status_code=503, detail="system notifications disabled (INTERNAL_API_TOKEN unset)")
+    if x_internal_token != settings.INTERNAL_API_TOKEN:
+        raise HTTPException(status_code=401, detail="invalid internal token")
+    title = payload.get("title")
+    body = payload.get("body")
+    if not title or not body:
+        raise HTTPException(status_code=422, detail="title and body are required")
+    channels = notify_system(
+        title=title, body=body,
+        severity=payload.get("severity", "info"),
+        dedupe_key=payload.get("dedupe_key"),
+        channels=payload.get("channels"),
+        db=db,
+    )
+    return {"status": "dispatched", "channels": channels}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest backend/tests/routers/test_alerts_system.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 6: Validate live (per project rule — curl the new endpoint)**
+
+Confirm reload, set a token, and exercise it:
+```bash
+docker-compose logs backend --tail=10
+docker exec stockscanner-api sh -c 'INTERNAL_API_TOKEN=test-token python - <<PY
+# quick in-container check that the route exists and token logic works
+PY'
+curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:8000/api/v1/alerts/system \
+  -H "Content-Type: application/json" -d '{"title":"t","body":"b"}'   # 503 if token unset
+```
+Expected: `503` when `INTERNAL_API_TOKEN` is unset (fail-closed), confirming the route is mounted and not behind JWT.
+
+- [ ] **Step 7: Commit**
+```bash
+git add backend/app/routers/alerts.py backend/app/main.py backend/tests/routers/test_alerts_system.py
+git commit -m "feat(api): POST /api/v1/alerts/system (token-guarded, middleware-exempt)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** generic delivery (Task 2/3) ✓; endpoint + token auth + 503/401 (Task 4) ✓; optional empty-default config (Task 1) ✓; fail-soft + dedupe (Task 3) ✓; email reuse of `_send_email` ✓. Google-chat/webhook channels are out of scope (not needed by autopilot) — consistent with the spec's non-goals.
+- **Placeholders:** none — every step has concrete code/commands.
+- **Type consistency:** `_push_to_subscriptions(payload, db) -> int` used identically in Task 2 and Task 3; `notify_system(...)` signature matches between Task 3 definition and Task 4 call.
+- **Note for executor:** run pytest via the project recipe (throwaway `TEST_DATABASE_URL` in `stockscanner-db`, `COVERAGE_FILE=/tmp/.coverage`, `--no-cov`) — see project memory "Backend local test recipe".


### PR DESCRIPTION
Closes omniscient/dark-factory#135. Implements `docs/superpowers/specs/2026-06-20-epic-autopilot-design.md` per `docs/superpowers/plans/2026-06-20-epic-autopilot.md`.

## What this does
When a scheduler poll dispatches nothing (**starved**) and main is green, a new **Priority 6** step reviews the refined, below-ceiling children of **in-progress epics** with **Opus 4.8** and advances the low-risk ones via `direct-to-pr` — automating the manual unlock we did for omniscient/dark-factory#121.

Defense-in-depth: deterministic **hard-rule envelope** (excludes factory self-edits, automated-trading, authN/authZ; **fail-closed** on undeclared scope) → Opus low-risk + confidence gate (`ADVANCE` only on `ADVANCE`+`low`+`conf≥0.7`) → reversible `direct-to-pr`. Bounded by starved-only trigger, daily cap (UTC reset), spec-hash verdict cache, and a kill-switch.

## Ships disabled
`epic_autopilot.enabled: false` in config.yaml — the scheduler hook is a no-op until enabled. No behavior change on merge.

## Notifications (fail-soft)
Advancing / daily-cap-reached / starved-but-stuck → email + browser push via `POST /api/v1/alerts/system`. That endpoint is **#570** (not yet built); the notify calls are fail-soft no-ops until it exists, so this works end-to-end without it.

## Structure
- Pure, unit-tested core in `factory_core/epic_autopilot.py` (eligibility, hard-rule exclusions, verdict parsing, decision rule, daily cap, verdict cache, orchestrator) — **26 tests, fully mocked**.
- Live IO adapter (`LiveIO`/`main_once`) for gh GraphQL + `claude -p` + notify (exercised in manual validation).
- `cli.py epic-autopilot --once` + the guarded `scheduler.sh` Priority-6 hook.

## Tests
- `dark-factory/tests/test_epic_autopilot.py` — 26 pass
- `dark-factory/tests/test_epic_autopilot_config.sh`, `test_scheduler_autopilot_guard.sh` — pass
- `test_scheduler.sh` — 88 pass (no regression)

## Build constraint
This is a **factory self-edit** — built by a human, never dispatched through the factory. After merge, **rebuild the factory image + recreate the scheduler** (scheduler.sh/factory_core are baked), then set `EPIC_AUTOPILOT_ENABLED=true` (and `INTERNAL_API_TOKEN`) to test it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
