### PR TITLE
ci: pg_isready healthcheck uses the test role (log hygiene)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           POSTGRES_PASSWORD: test
           POSTGRES_DB: markethawk_test
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U test -d markethawk_test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
@@ -151,7 +151,7 @@ jobs:
           POSTGRES_PASSWORD: test
           POSTGRES_DB: markethawk_test
         options: >-
-          --health-cmd pg_isready
+          --health-cmd "pg_isready -U test -d markethawk_test"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5


### PR DESCRIPTION
The CI Postgres service runs `pg_isready` with no `-U`, so the healthcheck (running as the container's root) defaults to role `root` and Postgres logs `FATAL: role "root" does not exist` on every probe. The healthcheck still passes and tests connect fine as `test` — this is pure log noise.

Point the healthcheck at the configured role/db (`pg_isready -U test -d markethawk_test`) in both jobs (`test` + the migration-check job) to silence it. No behavior change.

(The separate `locale: not found` warnings come from the musl-based `postgres:15-alpine` image having no locale data — cosmetic, left as-is.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)