### PR TITLE
fix(scheduler): recognize Epic Autopilot comments as bot (stop re-refine churn)

### DIFF
--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -402,7 +402,7 @@ has_new_comment_after_report() {
   # posts pipeline-status comments — none are feedback, so re-running the spec on them
   # loops the pipeline (issue #124: cost report -> spurious second spec). Match on
   # footer/marker, NOT author: every comment is authored by the same PAT account.
-  local bot_re="Posted by MarketHawk Refinement Pipeline|Posted by MarketHawk Backlog Scheduler|Posted by MarketHawk Dark Factory|Updated by MarketHawk Dark Factory|dark-factory-cost-report"
+  local bot_re="Posted by MarketHawk Refinement Pipeline|Posted by MarketHawk Backlog Scheduler|Posted by MarketHawk Dark Factory|Updated by MarketHawk Dark Factory|dark-factory-cost-report|Posted by MarketHawk Epic Autopilot"
 
   local has_human
   has_human=$(echo "$comments" | jq --arg marker "$report_marker" --arg bot "$bot_re" '

--- a/dark-factory/tests/test_has_new_comment_after_report.sh
+++ b/dark-factory/tests/test_has_new_comment_after_report.sh
@@ -91,6 +91,18 @@ ${COST_FOOTER}" \
   "Looks good but rename the helper.")
 assert_eq "human comment after cost report IS feedback" "yes" "$(has_new_comment_after_report 124 "$REPORT_MARKER")"
 
+# Scenario C2 — Epic Autopilot HOLD comment after spec is NOT human feedback => "no".
+# Regression: the autopilot footer must be in bot_re, else its HOLD comment is mistaken
+# for human feedback and re-triggers refinement (churn loop on in-progress-epic children).
+MOCK_COMMENTS=$(mock_comments \
+  "## Refinement Pipeline — Spec Generated
+---
+${SPEC_FOOTER}" \
+  "🤖 **Epic Autopilot** — parked (HOLD). Too risky to autonomously advance.
+---
+*Posted by MarketHawk Epic Autopilot*")
+assert_eq "Epic Autopilot HOLD comment after spec is NOT human feedback" "no" "$(has_new_comment_after_report 124 "$REPORT_MARKER")"
+
 # Scenario D — spec only, nothing after => "no".
 MOCK_COMMENTS=$(mock_comments \
   "## Refinement Pipeline — Spec Generated


### PR DESCRIPTION
**Bug:** the epic autopilot (#571) posts HOLD/advance comments footed `Posted by MarketHawk Epic Autopilot`, but that footer was missing from `has_new_comment_after_report`'s `bot_re`. So a HOLD comment was read as *human feedback* → the scheduler stripped `spec-pending-review` and re-ran refinement, churning in-progress-epic children (the omniscient/markethawk#491 Data Quality cluster omniscient/markethawk#492-498) through the pipeline in a loop (bounded by the 3-retry breaker).

**Fix:** add `Posted by MarketHawk Epic Autopilot` to `bot_re` + a regression test (`test_has_new_comment_after_report.sh`, 6/6 pass). Baked file → needs an image rebuild + recreate.

Found while testing omniscient/dark-factory#135 live. 🤖 Generated with [Claude Code](https://claude.com/claude-code)