### PR TITLE
feat(notifications): generic system-notification path (email/push) for non-scanner events (#570)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -109,6 +109,11 @@ class Settings(BaseSettings):
     SMTP_PASSWORD: str = Field(default="", repr=False)
     SMTP_FROM_EMAIL: str = "MarketHawk Alerts <noreply@example.com>"
 
+    # System notifications (generic non-scanner alerts). Both optional/empty-default —
+    # NEVER make these required-no-default (would break the smoke gate, cf. REDIS_PASSWORD).
+    OPS_ALERT_EMAIL: str = ""
+    INTERNAL_API_TOKEN: str = Field(default="", repr=False)
+
     # ── Web Push / VAPID (Browser Push Notifications) ─────────────────────
     # Generate a key pair once with: python -c "from py_vapid import Vapid; v=Vapid(); v.generate_keys(); print('PRIV:', v.private_pem().decode()); print('PUB:', v.public_key)"
     # Or use the /api/alerts/push/generate-keys endpoint on first run.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -49,7 +49,7 @@ from app.services.websocket_manager import websocket_manager
 # CSRF header check — module-level so it is importable by the test suite without
 # triggering the full create_app() factory. Pure ASGI (not BaseHTTPMiddleware) to
 # avoid the chunked-gzip termination bug described at the AuthMiddleware comment below.
-CSRF_EXEMPT_PREFIXES = ("/api/auth/", "/api/v1/alerts/infrastructure")
+CSRF_EXEMPT_PREFIXES = ("/api/auth/", "/api/v1/alerts/infrastructure", "/api/v1/alerts/system")
 CSRF_MUTATING_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
 
@@ -283,6 +283,7 @@ def create_app() -> FastAPI:
         "/api/ready",
         "/metrics",
         "/api/v1/alerts/infrastructure",
+        "/api/v1/alerts/system",
     )
     _doc_prefixes = ("/docs", "/redoc", "/openapi.json")
     EXEMPT_PREFIXES = _base_exempt + (_doc_prefixes if settings.DOCS_ENABLED else ())

--- a/backend/app/routers/alerts.py
+++ b/backend/app/routers/alerts.py
@@ -8,15 +8,17 @@ from datetime import date, datetime
 from typing import Any, Dict, List
 
 import pydantic
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.core.database import get_db
 from app.models.alert_delivery_log import AlertDeliveryLog
 from app.models.alert_rule import AlertRule
 from app.models.push_subscription import PushSubscription
 from app.models.scanner_event import ScannerEvent
 from app.schemas.alerts import ChannelConfig
+from app.services.system_notifier import notify_system
 from app.utils.db import get_or_404
 from app.utils.time import utc_now
 
@@ -420,3 +422,36 @@ def receive_infrastructure_alert(payload: Dict[str, Any]) -> Dict[str, str]:
         json.dumps(payload),
     )
     return {"status": "received"}
+
+
+@router.post("/system", status_code=200)
+def send_system_notification(
+    payload: Dict[str, Any],
+    db: Session = Depends(get_db),
+    x_internal_token: str = Header(default=None, alias="X-Internal-Token"),
+) -> Dict[str, Any]:
+    """Generic system notification (email + browser push). Server-to-server only.
+
+    Guarded by a shared secret (INTERNAL_API_TOKEN) rather than user JWT — this path
+    is exempt from the auth/CSRF middleware (see main.py). 503 if the token is unset
+    (fail-closed), 401 on mismatch.
+    """
+    if not settings.INTERNAL_API_TOKEN:
+        raise HTTPException(
+            status_code=503, detail="system notifications disabled (INTERNAL_API_TOKEN unset)"
+        )
+    if x_internal_token != settings.INTERNAL_API_TOKEN:
+        raise HTTPException(status_code=401, detail="invalid internal token")
+    title = payload.get("title")
+    body = payload.get("body")
+    if not title or not body:
+        raise HTTPException(status_code=422, detail="title and body are required")
+    channels = notify_system(
+        title=title,
+        body=body,
+        severity=payload.get("severity", "info"),
+        dedupe_key=payload.get("dedupe_key"),
+        channels=payload.get("channels"),
+        db=db,
+    )
+    return {"status": "dispatched", "channels": channels}

--- a/backend/app/services/alert_service.py
+++ b/backend/app/services/alert_service.py
@@ -174,10 +174,14 @@ class NotificationDispatcher:
     # ── Browser Push ──────────────────────────────────────────────────────────
 
     @staticmethod
-    def _send_browser_push(event: ScannerEvent, db: Session) -> None:
-        """Send a native browser push notification to all stored subscriptions."""
+    def _push_to_subscriptions(payload: dict, db: Session) -> int:
+        """Web-push a pre-built `payload` dict to all stored subscriptions.
+
+        Generic core shared by scanner-event push and system notifications.
+        Returns the number delivered. Raises RuntimeError only if ALL deliveries fail.
+        """
         try:
-            from pywebpush import WebPushException, webpush  # noqa: F401
+            from pywebpush import webpush  # noqa: F401
         except ImportError:
             raise RuntimeError(
                 "pywebpush is not installed. "
@@ -192,9 +196,9 @@ class NotificationDispatcher:
         subscriptions = db.query(PushSubscription).all()
         if not subscriptions:
             logger.debug("No push subscriptions registered — skipping browser push.")
-            return
+            return 0
 
-        data = json.dumps(NotificationDispatcher._build_push_payload(event))
+        data = json.dumps(payload)
         vapid_claims = {"sub": settings.VAPID_CLAIMS_EMAIL}
         # Key is stored as raw base64url (43 chars, no PEM headers) — py_vapid from_string
         # only supports this format; PEM is not recognized in this version.
@@ -222,8 +226,16 @@ class NotificationDispatcher:
                 else:
                     logger.warning(f"Push failed for subscription {sub.id}: {exc}")
 
-        if failed == len(subscriptions) and subscriptions:
+        if failed == len(subscriptions):
             raise RuntimeError(f"All {failed} push deliveries failed.")
+        return len(subscriptions) - failed
+
+    @staticmethod
+    def _send_browser_push(event: ScannerEvent, db: Session) -> None:
+        """Scanner-event browser push (thin wrapper over the generic sender)."""
+        NotificationDispatcher._push_to_subscriptions(
+            NotificationDispatcher._build_push_payload(event), db
+        )
 
     # ── Email ─────────────────────────────────────────────────────────────────
 

--- a/backend/app/services/system_notifier.py
+++ b/backend/app/services/system_notifier.py
@@ -1,0 +1,77 @@
+"""Generic system notifications (non-scanner) reusing the alert delivery channels."""
+import logging
+import time
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.services.alert_service import NotificationDispatcher
+
+logger = logging.getLogger(__name__)
+
+# In-process dedupe cache: dedupe_key -> last-sent monotonic timestamp.
+# Best-effort (per-process, resets on restart) — acceptable for fail-soft alerts.
+_dedupe_cache: dict = {}
+
+_SEV_COLOR = {"info": "#3b82f6", "warning": "#f59e0b", "critical": "#ef4444"}
+
+
+def _html(title: str, body: str, severity: str) -> str:
+    color = _SEV_COLOR.get(severity, "#3b82f6")
+    return (
+        '<html><body style="font-family:sans-serif;background:#111827;color:#f3f4f6;padding:24px">'
+        f'<h2 style="color:{color}">{title}</h2><p>{body}</p></body></html>'
+    )
+
+
+def notify_system(
+    title: str,
+    body: str,
+    severity: str = "info",
+    dedupe_key: Optional[str] = None,
+    channels: Optional[list] = None,
+    db: Optional[Session] = None,
+    cooldown_seconds: int = 3600,
+    _now: Optional[float] = None,
+) -> dict:
+    """Fan out a system notification to email + browser push. Never raises.
+
+    Returns a per-channel status dict:
+    "sent" | "sent:<n>" | "skipped" | "suppressed" | "unknown_channel" | "failed:<reason>".
+    """
+    channels = channels if channels is not None else ["email", "browser_push"]
+    now = _now if _now is not None else time.monotonic()
+
+    if dedupe_key is not None:
+        last = _dedupe_cache.get(dedupe_key)
+        if last is not None and (now - last) < cooldown_seconds:
+            return {ch: "suppressed" for ch in channels}
+        _dedupe_cache[dedupe_key] = now
+
+    subject = title if severity == "info" else f"[{severity.upper()}] {title}"
+    result: dict = {}
+    for ch in channels:
+        try:
+            if ch == "email":
+                if settings.OPS_ALERT_EMAIL:
+                    NotificationDispatcher._send_email(
+                        settings.OPS_ALERT_EMAIL, subject, _html(title, body, severity)
+                    )
+                    result[ch] = "sent"
+                else:
+                    result[ch] = "skipped"
+            elif ch == "browser_push":
+                if db is not None:
+                    count = NotificationDispatcher._push_to_subscriptions(
+                        {"title": title, "body": body, "severity": severity, "url": "/"}, db
+                    )
+                    result[ch] = f"sent:{count}"
+                else:
+                    result[ch] = "skipped"
+            else:
+                result[ch] = "unknown_channel"
+        except Exception as exc:  # fail-soft per channel
+            logger.error("system notification channel=%s failed: %s", ch, exc)
+            result[ch] = f"failed:{exc}"
+    return result

--- a/backend/tests/api/test_alerts_system.py
+++ b/backend/tests/api/test_alerts_system.py
@@ -1,0 +1,53 @@
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+
+def _client():
+    return TestClient(create_app())
+
+
+def test_503_when_token_unset():
+    with patch("app.routers.alerts.settings") as s:
+        s.INTERNAL_API_TOKEN = ""
+        r = _client().post("/api/v1/alerts/system", json={"title": "t", "body": "b"})
+    assert r.status_code == 503
+
+
+def test_401_on_bad_token():
+    with patch("app.routers.alerts.settings") as s:
+        s.INTERNAL_API_TOKEN = "secret"
+        r = _client().post(
+            "/api/v1/alerts/system",
+            json={"title": "t", "body": "b"},
+            headers={"X-Internal-Token": "wrong"},
+        )
+    assert r.status_code == 401
+
+
+def test_200_dispatches():
+    with patch("app.routers.alerts.settings") as s, patch(
+        "app.routers.alerts.notify_system"
+    ) as ns:
+        s.INTERNAL_API_TOKEN = "secret"
+        ns.return_value = {"email": "sent", "browser_push": "sent:0"}
+        r = _client().post(
+            "/api/v1/alerts/system",
+            json={"title": "t", "body": "b", "severity": "warning"},
+            headers={"X-Internal-Token": "secret"},
+        )
+    assert r.status_code == 200
+    assert r.json()["channels"]["email"] == "sent"
+
+
+def test_422_missing_fields():
+    with patch("app.routers.alerts.settings") as s:
+        s.INTERNAL_API_TOKEN = "secret"
+        r = _client().post(
+            "/api/v1/alerts/system",
+            json={"title": "t"},
+            headers={"X-Internal-Token": "secret"},
+        )
+    assert r.status_code == 422

--- a/backend/tests/core/test_config_system_notify.py
+++ b/backend/tests/core/test_config_system_notify.py
@@ -1,0 +1,11 @@
+from app.core.config import Settings
+
+
+def test_system_notify_fields_default_empty(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://smoke:smoke@localhost:5432/smoke")
+    monkeypatch.setenv("POLYGON_API_KEY", "x")
+    monkeypatch.setenv("JWT_SECRET_KEY", "smoke-gate-only-not-secret-0123456789abcdef")
+    monkeypatch.setenv("REDIS_PASSWORD", "smoke-gate-only-not-a-real-redis-password")
+    s = Settings()
+    assert s.OPS_ALERT_EMAIL == ""
+    assert s.INTERNAL_API_TOKEN == ""

--- a/backend/tests/services/test_push_generic.py
+++ b/backend/tests/services/test_push_generic.py
@@ -1,0 +1,29 @@
+from unittest.mock import MagicMock, patch
+
+from app.services.alert_service import NotificationDispatcher
+
+
+@patch("app.services.alert_service.settings")
+def test_push_to_subscriptions_sends_to_all(mock_settings):
+    mock_settings.VAPID_PRIVATE_KEY = "k"
+    mock_settings.VAPID_PUBLIC_KEY = "p"
+    mock_settings.VAPID_CLAIMS_EMAIL = "mailto:a@b.c"
+    db = MagicMock()
+    sub = MagicMock(endpoint="e", p256dh="x", auth="y", id=1)
+    db.query.return_value.all.return_value = [sub]
+    with patch("pywebpush.webpush") as wp:
+        count = NotificationDispatcher._push_to_subscriptions(
+            {"title": "T", "body": "B", "severity": "warning", "url": "/"}, db
+        )
+    assert count == 1
+    wp.assert_called_once()
+
+
+@patch("app.services.alert_service.settings")
+def test_push_no_subscriptions_returns_zero(mock_settings):
+    mock_settings.VAPID_PRIVATE_KEY = "k"
+    mock_settings.VAPID_PUBLIC_KEY = "p"
+    db = MagicMock()
+    db.query.return_value.all.return_value = []
+    count = NotificationDispatcher._push_to_subscriptions({"title": "T", "body": "B"}, db)
+    assert count == 0

--- a/backend/tests/services/test_system_notifier.py
+++ b/backend/tests/services/test_system_notifier.py
@@ -1,0 +1,44 @@
+from unittest.mock import patch
+
+import app.services.system_notifier as sn
+
+
+@patch("app.services.system_notifier.NotificationDispatcher")
+def test_email_and_push(mock_disp):
+    with patch.object(sn.settings, "OPS_ALERT_EMAIL", "ops@x.com"):
+        mock_disp._push_to_subscriptions.return_value = 2
+        r = sn.notify_system("T", "B", severity="warning", db=object())
+    assert r["email"] == "sent"
+    assert r["browser_push"] == "sent:2"
+    mock_disp._send_email.assert_called_once()
+
+
+@patch("app.services.system_notifier.NotificationDispatcher")
+def test_email_skipped_when_ops_unset(mock_disp):
+    with patch.object(sn.settings, "OPS_ALERT_EMAIL", ""):
+        mock_disp._push_to_subscriptions.return_value = 0
+        r = sn.notify_system("T", "B", db=object())
+    assert r["email"] == "skipped"
+    mock_disp._send_email.assert_not_called()
+
+
+@patch("app.services.system_notifier.NotificationDispatcher")
+def test_channel_failure_is_soft(mock_disp):
+    with patch.object(sn.settings, "OPS_ALERT_EMAIL", "ops@x.com"):
+        mock_disp._send_email.side_effect = RuntimeError("smtp down")
+        mock_disp._push_to_subscriptions.return_value = 1
+        r = sn.notify_system("T", "B", db=object())
+    assert r["email"].startswith("failed:")
+    assert r["browser_push"] == "sent:1"
+
+
+@patch("app.services.system_notifier.NotificationDispatcher")
+def test_dedupe_suppresses_within_cooldown(mock_disp):
+    with patch.object(sn.settings, "OPS_ALERT_EMAIL", "ops@x.com"):
+        mock_disp._push_to_subscriptions.return_value = 0
+        first = sn.notify_system("T", "B", dedupe_key="k1", db=object(), cooldown_seconds=100, _now=1000.0)
+        second = sn.notify_system("T", "B", dedupe_key="k1", db=object(), cooldown_seconds=100, _now=1050.0)
+        third = sn.notify_system("T", "B", dedupe_key="k1", db=object(), cooldown_seconds=100, _now=1200.0)
+    assert first["email"] == "sent"
+    assert second == {"email": "suppressed", "browser_push": "suppressed"}
+    assert third["email"] == "sent"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,6 +154,9 @@ services:
       OTEL_SERVICE_NAME: markethawk-backend
       # JWT auth secret — required by Settings validator (>=32 chars), sourced from .env
       JWT_SECRET_KEY: ${JWT_SECRET_KEY}
+      # System notifications (#570) — shared secret for POST /api/v1/alerts/system + ops recipient
+      INTERNAL_API_TOKEN: ${INTERNAL_API_TOKEN:-}
+      OPS_ALERT_EMAIL: ${OPS_ALERT_EMAIL:-}
     ports:
       - "127.0.0.1:8000:8000"
     depends_on:


### PR DESCRIPTION
Closes omniscient/markethawk#570. Implements `docs/superpowers/specs/2026-06-20-system-notifications-enabler-design.md` per its plan — the notifications enabler that the epic autopilot (#571) consumes.

## What this adds
A generic system-notification path that reuses the existing SMTP (email) + VAPID (browser push) delivery in `alert_service.py`, decoupled from the scanner `AlertRule`/`ScannerEvent` path (today the only generic entry point, `/api/v1/alerts/infrastructure`, just logs to Seq).

- **`_push_to_subscriptions(payload, db)`** — extracted generic core of the browser-push loop; `_send_browser_push(event, db)` is now a thin wrapper (no behaviour change on the scanner path).
- **`system_notifier.notify_system(title, body, severity, dedupe_key, channels, db)`** — fans out to email (`OPS_ALERT_EMAIL`) + push; per-channel **fail-soft** (logged, never raises); in-process dedupe cooldown.
- **`POST /api/v1/alerts/system`** — `{title, body, severity?, dedupe_key?, channels?}` guarded by an `X-Internal-Token` header (`INTERNAL_API_TOKEN`). **503** if the token is unset (fail-closed), **401** on mismatch, **422** on missing fields. Added to the auth + CSRF middleware exemptions (server-to-server, decoupled from the omniscient/markethawk#373 user-auth model).
- **Config:** new optional, empty-default `OPS_ALERT_EMAIL` + `INTERNAL_API_TOKEN` — deliberately not required-no-default, so the smoke gate / preview stay green (cf. the REDIS_PASSWORD lesson).

## Ships inert
With `INTERNAL_API_TOKEN` unset the endpoint returns 503, so nothing changes until you generate a token and set it in both the backend env and the scheduler's `.archon/.env`. Then the autopilot's advance/cap/stuck notifications start delivering (they're fail-soft no-ops until then).

## Tests (11, all green locally)
- `test_config_system_notify.py` (1) — optional empty-default fields; smoke import still passes
- `test_push_generic.py` (2) — generic sender delivers / returns 0 with no subs
- `test_system_notifier.py` (4) — email+push, OPS unset skip, per-channel fail-soft, dedupe cooldown
- `test_alerts_system.py` (4) — 503 / 401 / 200 / 422 (run against a throwaway DB)

Post-merge: update local `main` so the backend bind-mount serves the new code, then a quick `curl … /api/v1/alerts/system` confirms 503 (token unset) live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
