### PR TITLE
feat(autopilot): broaden reach — drain backlog, start next epic (closes #590)

### DIFF
--- a/.claude/skills/refinement/config.yaml
+++ b/.claude/skills/refinement/config.yaml
@@ -73,6 +73,10 @@ epic_autopilot:
   model: claude-opus-4-8      # reviewer model. env: EPIC_AUTOPILOT_MODEL overrides
   daily_cap: 5                # max autonomous advances / UTC day. env: EPIC_AUTOPILOT_DAILY_CAP overrides
   confidence_floor: 0.7       # min Opus confidence to ADVANCE. env: EPIC_AUTOPILOT_CONFIDENCE_FLOOR overrides
+  hold_ttl_hours: 24          # re-review a cached HOLD after this many hours. env EPIC_AUTOPILOT_HOLD_TTL_HOURS
+  size_ceiling: XL            # drop only at/above this size (L/M now eligible). env EPIC_AUTOPILOT_SIZE_CEILING
+  start_epics: true           # when no gated child is advanceable, promote the next Ready epic. env EPIC_AUTOPILOT_START_EPICS
+  sensitive_keywords: "trading|ibkr|live order|notional|authentication|authorization|authn|authz|jwt|oauth|rbac|/auth"
   opt_out_label: no-autopilot # per-ticket veto label. env: EPIC_AUTOPILOT_OPT_OUT_LABEL overrides
   hard_exclude_paths:         # spec target paths matching any of these → excluded before Opus (fail-closed)
     - "dark-factory/"

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -84,6 +84,10 @@ read_config() {
   _set_cfg EPIC_AUTOPILOT_DAILY_CAP        '.epic_autopilot.daily_cap'
   _set_cfg EPIC_AUTOPILOT_CONFIDENCE_FLOOR '.epic_autopilot.confidence_floor'
   _set_cfg EPIC_AUTOPILOT_OPT_OUT_LABEL    '.epic_autopilot.opt_out_label'
+  _set_cfg EPIC_AUTOPILOT_HOLD_TTL_HOURS    '.epic_autopilot.hold_ttl_hours'
+  _set_cfg EPIC_AUTOPILOT_SIZE_CEILING      '.epic_autopilot.size_ceiling'
+  _set_cfg EPIC_AUTOPILOT_START_EPICS       '.epic_autopilot.start_epics'
+  _set_cfg EPIC_AUTOPILOT_SENSITIVE_KEYWORDS '.epic_autopilot.sensitive_keywords'
 
   echo "[config] loaded from ${cfg}"
 }
@@ -233,7 +237,7 @@ has_direct_to_pr_label() {
 # --- Dispatch ceiling classification (#339) ---
 # Returns "S", "M", "L", or "" from the item's labels
 get_size_label() {
-  echo "$1" | jq -r '.labels[]?' 2>/dev/null | grep -oi 'size: [SML]' | awk '{print $2}' | head -1
+  echo "$1" | jq -r '.labels[]?' 2>/dev/null | grep -oiE 'size: ?(xl|[sml])' | awk '{print toupper($NF)}' | head -1
 }
 
 # True (returns 0) if item is above the dispatch ceiling: size L always, or size M
@@ -244,7 +248,7 @@ is_above_ceiling() {
   title=$(echo "$item" | jq -r '.content.title // ""' 2>/dev/null)
   size=$(get_size_label "$item")
   case "$size" in
-    L) return 0 ;;
+    XL) return 0 ;;
     M) echo "$title" | grep -qiE "${ABOVE_CEILING_KEYWORDS}" && return 0 || return 1 ;;
     *) return 1 ;;
   esac
@@ -259,7 +263,7 @@ has_above_ceiling_label() {
 is_below_ceiling() {
   local size
   size=$(get_size_label "$1")
-  case "$size" in S|"") return 0 ;; *) return 1 ;; esac
+  case "$size" in S|L|"") return 0 ;; *) return 1 ;; esac
 }
 
 # Returns minutes elapsed since the last comment matching $marker_re on the given issue.
@@ -1106,7 +1110,7 @@ To proceed:
   if [ -z "$DISPATCHED" ] && [ "$MAIN_IS_RED" = "false" ] && [ "${EPIC_AUTOPILOT_ENABLED:-false}" = "true" ]; then
     AP_OUT=$(python3 "$FACTORY_CORE_CLI" epic-autopilot --once 2>&1) || true
     echo "[$(date -u +%FT%TZ)] ${AP_OUT}"
-    case "$AP_OUT" in *"autopilot=advanced"*) DISPATCHED="$AP_OUT" ;; esac
+    case "$AP_OUT" in *"autopilot=advanced"*|*"autopilot=epic_started"*) DISPATCHED="$AP_OUT" ;; esac
   fi
 
   # --- Log cycle summary ---

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -971,7 +971,7 @@ This issue was left in **In progress** with no running factory container — the
 "## Scheduler — Above Dispatch Ceiling
 
 This ticket has been classified as **above the autonomous dispatch ceiling** \
-(size: L, or size: M with a perf/architectural/migration title keyword).
+(size: XL, or size: M with a perf/architectural/migration title keyword).
 
 Spec and plan are complete. **A human must pair on implementation.**
 

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -240,7 +240,7 @@ get_size_label() {
   echo "$1" | jq -r '.labels[]?' 2>/dev/null | grep -oiE 'size: ?(xl|[sml])' | awk '{print toupper($NF)}' | head -1
 }
 
-# True (returns 0) if item is above the dispatch ceiling: size L always, or size M
+# True (returns 0) if item is above the dispatch ceiling: size XL always, or size M
 # when the title matches an ABOVE_CEILING_KEYWORDS pattern (escalation only — the
 # keyword heuristic never demotes).
 is_above_ceiling() {
@@ -259,7 +259,7 @@ has_above_ceiling_label() {
   echo "$1" | jq -r '.labels[]?' 2>/dev/null | grep -qi "^${ABOVE_CEILING_LABEL}$"
 }
 
-# True if item is S-size or has no size label (unlabelled is treated as S per spec)
+# True if item is S- or L-size, or has no size label (unlabelled is treated as S per spec)
 is_below_ceiling() {
   local size
   size=$(get_size_label "$1")

--- a/dark-factory/scripts/factory_core/epic_autopilot.py
+++ b/dark-factory/scripts/factory_core/epic_autopilot.py
@@ -35,7 +35,15 @@ def _size(c: dict):
     return s.upper() if s else None
 
 
-def is_eligible(c: dict, opt_out_label: str, ceiling_keywords: str):
+_SIZE_ORDER = {"S": 0, "M": 1, "L": 2, "XL": 3}
+
+
+def _size_rank(s: str) -> int:
+    """Rank a size token; unknown/blank ranks below S so it is never above ceiling."""
+    return _SIZE_ORDER.get((s or "").upper(), -1)
+
+
+def is_eligible(c: dict, opt_out_label: str, size_ceiling: str = "XL"):
     """Stage A — structural eligibility. Returns (ok: bool, reason: str)."""
     labels = [label.lower() for label in c.get("labels", [])]
     if c.get("status") not in _GATED_STATUSES:
@@ -44,10 +52,8 @@ def is_eligible(c: dict, opt_out_label: str, ceiling_keywords: str):
         if blk.lower() in labels:
             return False, f"label:{blk}"
     size = _size(c) or ""
-    if size in ("L", "XL"):
-        return False, f"above-ceiling:size={size}"
-    if size == "M" and re.search(ceiling_keywords, c.get("title", ""), re.I):
-        return False, "above-ceiling:M+keyword"
+    if _size_rank(size) >= _size_rank(size_ceiling):
+        return False, f"above-ceiling:size={size or '?'}"
     return True, ""
 
 
@@ -178,7 +184,7 @@ def run_once(cfg: dict, io, state: dict, today: str) -> dict:
 
     candidates = []
     for cand in io.fetch_candidates():
-        ok, _ = is_eligible(cand, cfg["opt_out_label"], cfg["ceiling_keywords"])
+        ok, _ = is_eligible(cand, cfg["opt_out_label"], cfg.get("size_ceiling", "XL"))
         if not ok:
             continue
         excluded, _ = hard_excluded(cand, cfg["exclude_paths"])

--- a/dark-factory/scripts/factory_core/epic_autopilot.py
+++ b/dark-factory/scripts/factory_core/epic_autopilot.py
@@ -51,15 +51,25 @@ def is_eligible(c: dict, opt_out_label: str, ceiling_keywords: str):
     return True, ""
 
 
-def hard_excluded(c: dict, exclude_paths: list):
-    """Stage B — categorical exclusions (fail-closed). Returns (excluded: bool, reason: str)."""
+def hard_excluded(c: dict, exclude_paths: list, sensitive_keywords: str = ""):
+    """Stage B — categorical exclusions. Returns (excluded: bool, reason: str).
+
+    Trading/auth keywords in title/body hard-drop (fail-closed) even when scope is
+    undeclared. A declared path matching an exclude prefix hard-drops. No declared
+    paths is NOT a drop anymore — flag scope_undeclared so Opus is warned and leans HOLD.
+    """
+    if sensitive_keywords:
+        text = f"{c.get('title', '')} {c.get('body', '')}".lower()
+        if re.search(sensitive_keywords, text):
+            return True, "sensitive-keyword"
     paths = c.get("target_paths") or []
-    if not paths:
-        return True, "undeclared-scope"  # fail-closed: undeclared scope might be trading/auth
     for p in paths:
         for ex in exclude_paths:
             if ex in p:
                 return True, ex
+    if not paths:
+        c["scope_undeclared"] = True
+        return False, "undeclared-scope"
     return False, ""
 
 

--- a/dark-factory/scripts/factory_core/epic_autopilot.py
+++ b/dark-factory/scripts/factory_core/epic_autopilot.py
@@ -137,15 +137,28 @@ def record_advance(state: dict, today: str) -> None:
     state["daily"] = d
 
 
-def cached_verdict(state: dict, issue: int, spec_hash_: str):
+def _age_hours(ts_iso: str, now_iso: str) -> float:
+    from datetime import datetime
+    try:
+        return (datetime.fromisoformat(now_iso) - datetime.fromisoformat(ts_iso)).total_seconds() / 3600.0
+    except Exception:
+        return 0.0
+
+
+def cached_verdict(state: dict, issue: int, spec_hash_: str, now_iso=None, ttl_hours=None):
     entry = (state.get("verdicts") or {}).get(str(issue))
-    if entry and entry.get("spec_hash") == spec_hash_:
-        return entry.get("verdict")
-    return None
+    if not entry or entry.get("spec_hash") != spec_hash_:
+        return None
+    if ttl_hours and now_iso and entry.get("ts") and _age_hours(entry["ts"], now_iso) >= ttl_hours:
+        return None
+    return entry.get("verdict")
 
 
-def record_verdict(state: dict, issue: int, spec_hash_: str, verdict: str) -> None:
-    state.setdefault("verdicts", {})[str(issue)] = {"spec_hash": spec_hash_, "verdict": verdict}
+def record_verdict(state: dict, issue: int, spec_hash_: str, verdict: str, now_iso=None) -> None:
+    entry = {"spec_hash": spec_hash_, "verdict": verdict}
+    if now_iso:
+        entry["ts"] = now_iso
+    state.setdefault("verdicts", {})[str(issue)] = entry
 
 
 # ── Orchestrator (pure control flow; all IO injected via `io`) ──────────────

--- a/dark-factory/scripts/factory_core/epic_autopilot.py
+++ b/dark-factory/scripts/factory_core/epic_autopilot.py
@@ -191,6 +191,9 @@ def pick_next_epic(epics: list, exclude_pattern: str = _EPIC_EXCLUDE_RE):
 # ── Orchestrator (pure control flow; all IO injected via `io`) ──────────────
 
 def build_review_prompt(c: dict) -> str:
+    scope = ", ".join(c.get("target_paths") or []) or "(none declared)"
+    warn = ("\nNOTE: file scope is UNDECLARED — treat trading/auth/factory-self risk as "
+            "possible and lean HOLD unless the spec is clearly safe." if c.get("scope_undeclared") else "")
     return f"""You are a cautious senior engineer deciding whether a refined ticket is safe to
 implement and merge AUTONOMOUSLY (adding the direct-to-pr label means it flows
 spec->plan->implement->PR with NO further human gate before the PR opens).
@@ -206,16 +209,15 @@ empty-branch/no-op risk, or you are unsure -- choose HOLD.
 
 Ticket #{c['number']}: {c['title']}
 Labels: {', '.join(c.get('labels', []))}   Size: {c.get('size')}
-Declared target files: {', '.join(c.get('target_paths') or []) or '(none declared)'}
+Declared target files: {scope}{warn}
 
 --- SPEC/PLAN ---
 {(c.get('spec_text') or '')[:8000]}
 """
 
 
-def run_once(cfg: dict, io, state: dict, today: str) -> dict:
-    """One starved-cycle pass. Returns {outcome, issue, reason}. Never raises for IO
-    that the injected `io` swallows; pure-logic errors propagate to the caller."""
+def run_once(cfg: dict, io, state: dict, today: str, now_iso=None) -> dict:
+    """One starved-cycle pass. Returns {outcome, issue, reason}."""
     if daily_remaining(state, cfg["daily_cap"], today) <= 0:
         io.notify("Epic autopilot — daily cap reached",
                   f"Hit the daily cap of {cfg['daily_cap']} autonomous advances; paused until UTC reset. Review the backlog.",
@@ -227,14 +229,26 @@ def run_once(cfg: dict, io, state: dict, today: str) -> dict:
         ok, _ = is_eligible(cand, cfg["opt_out_label"], cfg.get("size_ceiling", "XL"))
         if not ok:
             continue
-        excluded, _ = hard_excluded(cand, cfg["exclude_paths"])
+        excluded, _ = hard_excluded(cand, cfg["exclude_paths"], cfg.get("sensitive_keywords", ""))
         if excluded:
             continue
-        if cached_verdict(state, cand["number"], spec_hash(cand.get("spec_text", ""))) == "HOLD":
+        if cached_verdict(state, cand["number"], spec_hash(cand.get("spec_text", "")),
+                          now_iso, cfg.get("hold_ttl_hours")) == "HOLD":
             continue
         candidates.append(cand)
 
     if not candidates:
+        if cfg.get("start_epics") and hasattr(io, "fetch_ready_epics"):
+            epic_num = pick_next_epic(io.fetch_ready_epics())
+            if epic_num is not None:
+                io.promote_epic(epic_num)
+                io.comment(epic_num,
+                           "\U0001f916 **Epic Autopilot** — starting epic: promoted to In progress and "
+                           "marked its open children ready-for-agent.\n\n---\n*Posted by MarketHawk Epic Autopilot*")
+                io.notify(f"Autopilot starting epic #{epic_num}",
+                          "Promoted to In progress; children marked ready-for-agent.", "info", None)
+                record_advance(state, today)
+                return {"outcome": "epic_started", "issue": epic_num, "reason": "promote"}
         io.notify("Epic autopilot — idle, nothing safe to advance",
                   "The factory is starved and the autopilot has no eligible low-risk ticket to advance. Human input needed.",
                   "warning", "autopilot-stuck")
@@ -252,13 +266,13 @@ def run_once(cfg: dict, io, state: dict, today: str) -> dict:
         io.notify(f"Autopilot advancing #{cand['number']}",
                   f"{cand['title']} — risk=low: {reason}", "info", None)
         record_advance(state, today)
-        record_verdict(state, cand["number"], h, "ADVANCE")
+        record_verdict(state, cand["number"], h, "ADVANCE", now_iso)
         return {"outcome": "advanced", "issue": cand["number"], "reason": reason}
 
     concerns = "; ".join(verdict.get("concerns", [])) or "not low-risk / low confidence"
     io.comment(cand["number"],
                f"\U0001f916 **Epic Autopilot** — parked (HOLD). {concerns}\n\n---\n*Posted by MarketHawk Epic Autopilot*")
-    record_verdict(state, cand["number"], h, "HOLD")
+    record_verdict(state, cand["number"], h, "HOLD", now_iso)
     return {"outcome": "hold", "issue": cand["number"], "reason": concerns}
 
 

--- a/dark-factory/scripts/factory_core/epic_autopilot.py
+++ b/dark-factory/scripts/factory_core/epic_autopilot.py
@@ -319,6 +319,38 @@ def _load_exclude_paths() -> list:
     return list(_DEFAULT_EXCLUDE)
 
 
+def _ready_epics() -> list:
+    """Ready-column epics as [{number, title, labels, board_order}], board order preserved."""
+    q = ('query { node(id: "%s") { ... on ProjectV2 { items(first:100) { nodes { '
+         'fieldValueByName(name:"Status"){ ... on ProjectV2ItemFieldSingleSelectValue { name } } '
+         'content { ... on Issue { number title labels(first:20){nodes{name}} } } } } } } }') % PROJECT_ID
+    data = _gh_json(["api", "graphql", "-f", "query=" + q])
+    if not data:
+        return []
+    out, order = [], 0
+    for n in data.get("data", {}).get("node", {}).get("items", {}).get("nodes", []):
+        content = n.get("content") or {}
+        status = (n.get("fieldValueByName") or {}).get("name")
+        labels = [x["name"] for x in (content.get("labels") or {}).get("nodes", [])]
+        if content.get("number") and status == "Ready" and "epic" in labels:
+            out.append({"number": content["number"], "title": content.get("title", ""),
+                        "labels": labels, "board_order": order})
+        order += 1
+    return out
+
+
+def _open_child_numbers(epic: int) -> list:
+    """All OPEN sub-issue numbers of an epic (any label)."""
+    q = ('query { repository(owner:"omniscient", name:"markethawk") { issue(number:%d) { '
+         'subIssues(first:50) { nodes { number state } } } } }') % epic
+    data = _gh_json(["api", "graphql", "-f", "query=" + q])
+    if not data:
+        return []
+    return [s["number"] for s in
+            data.get("data", {}).get("repository", {}).get("issue", {}).get("subIssues", {}).get("nodes", [])
+            if s.get("state") == "OPEN"]
+
+
 def _in_progress_epics() -> list:
     """Issue numbers of epics whose board Status is 'In progress'."""
     q = ('query { node(id: "%s") { ... on ProjectV2 { items(first:100) { nodes { '
@@ -415,6 +447,16 @@ class LiveIO:
     def comment(self, issue: int, body: str) -> None:
         subprocess.run(["gh", "issue", "comment", str(issue), "--repo", OWNER, "--body", body], check=False)
 
+    def fetch_ready_epics(self) -> list:
+        return _ready_epics()
+
+    def promote_epic(self, epic: int) -> None:
+        from factory_core.board import set_board_status
+        set_board_status(epic, "In progress")
+        for child in _open_child_numbers(epic):
+            subprocess.run(["gh", "issue", "edit", str(child), "--repo", OWNER,
+                            "--add-label", "ready-for-agent"], check=False)
+
     def notify(self, title: str, body: str, severity: str, dedupe_key) -> None:
         token = os.environ.get("INTERNAL_API_TOKEN", "")
         if not token:
@@ -446,12 +488,17 @@ def main_once() -> int:
     cfg = dict(
         exclude_paths=_load_exclude_paths(),
         opt_out_label=os.environ.get("EPIC_AUTOPILOT_OPT_OUT_LABEL", "no-autopilot"),
-        ceiling_keywords=os.environ.get("ABOVE_CEILING_KEYWORDS",
-                                        "migration|migrate|performance|perf|architectur|refactor"),
+        size_ceiling=os.environ.get("EPIC_AUTOPILOT_SIZE_CEILING", "XL"),
+        sensitive_keywords=os.environ.get(
+            "EPIC_AUTOPILOT_SENSITIVE_KEYWORDS",
+            r"trading|ibkr|live order|notional|authentication|authorization|authn|authz|jwt|oauth|rbac|/auth"),
+        hold_ttl_hours=float(os.environ.get("EPIC_AUTOPILOT_HOLD_TTL_HOURS", "24")),
+        start_epics=os.environ.get("EPIC_AUTOPILOT_START_EPICS", "true").lower() == "true",
         confidence_floor=float(os.environ.get("EPIC_AUTOPILOT_CONFIDENCE_FLOOR", "0.7")),
         daily_cap=int(os.environ.get("EPIC_AUTOPILOT_DAILY_CAP", "5")),
         model=os.environ.get("EPIC_AUTOPILOT_MODEL", "claude-opus-4-8"))
-    out = run_once(cfg, LiveIO(cfg["model"]), state, today)
+    now_iso = datetime.now(timezone.utc).isoformat()
+    out = run_once(cfg, LiveIO(cfg["model"]), state, today, now_iso)
     try:
         with open(path, "w") as f:
             json.dump(state, f)

--- a/dark-factory/scripts/factory_core/epic_autopilot.py
+++ b/dark-factory/scripts/factory_core/epic_autopilot.py
@@ -451,8 +451,8 @@ class LiveIO:
         return _ready_epics()
 
     def promote_epic(self, epic: int) -> None:
-        from factory_core.board import set_board_status
-        set_board_status(epic, "In progress")
+        from factory_core.board import set_board_status, STATUS_IN_PROGRESS
+        set_board_status(epic, STATUS_IN_PROGRESS)
         for child in _open_child_numbers(epic):
             subprocess.run(["gh", "issue", "edit", str(child), "--repo", OWNER,
                             "--add-label", "ready-for-agent"], check=False)

--- a/dark-factory/scripts/factory_core/epic_autopilot.py
+++ b/dark-factory/scripts/factory_core/epic_autopilot.py
@@ -161,6 +161,33 @@ def record_verdict(state: dict, issue: int, spec_hash_: str, verdict: str, now_i
     state.setdefault("verdicts", {})[str(issue)] = entry
 
 
+# ── Epic selector (pure; used by epic-starter workflow) ──────────────────────
+
+_EPIC_EXCLUDE_RE = r"security|auth|authz|authn|trading|ibkr|dark.?factory|scheduler|factory.self"
+
+
+def _priority_rank(labels: list) -> int:
+    low = [label.lower() for label in labels]
+    if any("must-have" in label for label in low):
+        return 0
+    if any("should-have" in label for label in low):
+        return 1
+    return 2
+
+
+def _epic_excluded(e: dict, pattern: str) -> bool:
+    hay = (e.get("title", "") + " " + " ".join(e.get("labels", []))).lower()
+    return bool(re.search(pattern, hay))
+
+
+def pick_next_epic(epics: list, exclude_pattern: str = _EPIC_EXCLUDE_RE):
+    """Highest-priority unstarted epic, skipping hard-excluded categories. None if none."""
+    elig = [e for e in epics if not _epic_excluded(e, exclude_pattern)]
+    elig.sort(key=lambda e: (_priority_rank(e.get("labels", [])),
+                             e.get("board_order", 10 ** 9), e["number"]))
+    return elig[0]["number"] if elig else None
+
+
 # ── Orchestrator (pure control flow; all IO injected via `io`) ──────────────
 
 def build_review_prompt(c: dict) -> str:

--- a/dark-factory/tests/test_epic_autopilot.py
+++ b/dark-factory/tests/test_epic_autopilot.py
@@ -78,9 +78,18 @@ def test_hard_exclude_auth():
     assert ex
 
 
-def test_hard_exclude_undeclared_scope_fails_closed():
-    ex, why = ap.hard_excluded(c(target_paths=[]), ["app/core/auth"])
-    assert ex and why == "undeclared-scope"
+def test_undeclared_scope_is_soft_and_flags():
+    cand = c(target_paths=[])
+    ex, why = ap.hard_excluded(cand, ["app/core/auth"])
+    assert not ex and why == "undeclared-scope"
+    assert cand.get("scope_undeclared") is True
+
+
+def test_sensitive_keyword_hard_drops_even_without_paths():
+    cand = c(title="Live IBKR order path kill switch", body="", target_paths=[])
+    ex, why = ap.hard_excluded(cand, ["app/core/auth"],
+                               sensitive_keywords=r"trading|ibkr|order|jwt|/auth")
+    assert ex and why == "sensitive-keyword"
 
 
 def test_security_label_not_excluded():

--- a/dark-factory/tests/test_epic_autopilot.py
+++ b/dark-factory/tests/test_epic_autopilot.py
@@ -241,3 +241,32 @@ def test_cached_verdict_backward_compatible_without_timestamps():
     h = ap.spec_hash("spec A")
     ap.record_verdict(st, 402, h, "HOLD")  # no now_iso
     assert ap.cached_verdict(st, 402, h) == "HOLD"  # no ttl args → unconditional
+
+
+# ── Task 4: pick_next_epic selector ─────────────────────────────────────────
+
+def _e(number, title="epic", labels=None, board_order=0):
+    return {"number": number, "title": title, "labels": labels or [], "board_order": board_order}
+
+
+def test_pick_next_epic_skips_security_and_orders_by_priority():
+    epics = [
+        _e(373, "Authorization model", labels=["epic", "security", "should-have"], board_order=0),
+        _e(450, "LLM narrative", labels=["epic", "should-have"], board_order=2),
+        _e(483, "Signal replay engine", labels=["epic", "must-have"], board_order=1),
+    ]
+    assert ap.pick_next_epic(epics) == 483  # must-have, security #373 skipped
+
+
+def test_pick_next_epic_board_order_tiebreak():
+    epics = [
+        _e(449, labels=["epic", "must-have"], board_order=5),
+        _e(448, labels=["epic", "must-have"], board_order=3),
+    ]
+    assert ap.pick_next_epic(epics) == 448  # same priority → lower board_order wins
+
+
+def test_pick_next_epic_none_when_all_excluded():
+    epics = [_e(373, "auth", labels=["epic", "security"]),
+             _e(601, "trading kill switch", labels=["epic"])]
+    assert ap.pick_next_epic(epics) is None

--- a/dark-factory/tests/test_epic_autopilot.py
+++ b/dark-factory/tests/test_epic_autopilot.py
@@ -270,3 +270,34 @@ def test_pick_next_epic_none_when_all_excluded():
     epics = [_e(373, "auth", labels=["epic", "security"]),
              _e(601, "trading kill switch", labels=["epic"])]
     assert ap.pick_next_epic(epics) is None
+
+
+class FakeEpicIO(FakeIO):
+    def __init__(self, candidates, review_text, ready_epics):
+        super().__init__(candidates, review_text)
+        self._epics = ready_epics
+        self.promoted = []
+
+    def fetch_ready_epics(self):
+        return self._epics
+
+    def promote_epic(self, n):
+        self.promoted.append(n)
+
+
+def test_run_starts_epic_when_no_child_candidates():
+    io = FakeEpicIO([], "x", [_e(483, labels=["epic", "must-have"])])
+    cfg = dict(CFG, start_epics=True)
+    out = ap.run_once(cfg, io, {}, "2026-06-20", now_iso="2026-06-20T00:00:00+00:00")
+    assert out["outcome"] == "epic_started" and out["issue"] == 483
+    assert io.promoted == [483]
+    assert any(sev == "info" for sev, _ in io.notes)
+
+
+def test_run_stuck_when_no_children_and_no_eligible_epic():
+    io = FakeEpicIO([], "x", [_e(373, "auth", labels=["epic", "security"])])
+    cfg = dict(CFG, start_epics=True)
+    out = ap.run_once(cfg, io, {}, "2026-06-20")
+    assert out["outcome"] == "no_candidates"
+    assert io.promoted == []
+    assert any(key == "autopilot-stuck" for _, key in io.notes)

--- a/dark-factory/tests/test_epic_autopilot.py
+++ b/dark-factory/tests/test_epic_autopilot.py
@@ -20,43 +20,42 @@ def c(**kw):
 # ── Task 2: eligibility + hard-rule exclusions ──────────────────────────────
 
 def test_eligible_happy():
-    ok, why = ap.is_eligible(c(), "no-autopilot", CEIL)
+    ok, why = ap.is_eligible(c(), "no-autopilot")
     assert ok, why
 
 
 def test_ineligible_opt_out():
-    ok, _ = ap.is_eligible(c(labels=["ready-for-agent", "no-autopilot"]), "no-autopilot", CEIL)
+    ok, _ = ap.is_eligible(c(labels=["ready-for-agent", "no-autopilot"]), "no-autopilot")
     assert not ok
 
 
 def test_ineligible_already_direct_to_pr():
-    ok, _ = ap.is_eligible(c(labels=["direct-to-pr"]), "no-autopilot", CEIL)
+    ok, _ = ap.is_eligible(c(labels=["direct-to-pr"]), "no-autopilot")
     assert not ok
 
 
 def test_ineligible_wrong_status():
-    ok, _ = ap.is_eligible(c(status="Ready"), "no-autopilot", CEIL)
+    ok, _ = ap.is_eligible(c(status="Ready"), "no-autopilot")
     assert not ok
 
 
-def test_ineligible_above_ceiling_size_l():
-    ok, _ = ap.is_eligible(c(size="L"), "no-autopilot", CEIL)
-    assert not ok
-
-
-def test_ineligible_m_with_ceiling_keyword():
-    ok, _ = ap.is_eligible(c(size="M", title="perf refactor of scanner"), "no-autopilot", CEIL)
-    assert not ok
-
-
-def test_eligible_m_without_keyword():
-    ok, why = ap.is_eligible(c(size="M", title="add data quality preflight"), "no-autopilot", CEIL)
+def test_size_l_now_eligible():
+    ok, why = ap.is_eligible(c(size="L"), "no-autopilot")
     assert ok, why
 
 
-def test_size_from_label_prefix():
-    # size carried as a label "size: L" rather than the size field
-    ok, _ = ap.is_eligible(c(size=None, labels=["ready-for-agent", "size: L"]), "no-autopilot", CEIL)
+def test_size_m_with_keyword_now_eligible():
+    ok, why = ap.is_eligible(c(size="M", title="perf refactor of scanner"), "no-autopilot")
+    assert ok, why
+
+
+def test_size_xl_dropped():
+    ok, why = ap.is_eligible(c(size="XL"), "no-autopilot")
+    assert not ok and "above-ceiling" in why
+
+
+def test_size_xl_from_label_prefix():
+    ok, _ = ap.is_eligible(c(size=None, labels=["ready-for-agent", "size: XL"]), "no-autopilot")
     assert not ok
 
 

--- a/dark-factory/tests/test_epic_autopilot.py
+++ b/dark-factory/tests/test_epic_autopilot.py
@@ -224,3 +224,20 @@ def test_run_skips_cached_hold():
     out = ap.run_once(CFG, io, st, "2026-06-20")
     assert out["outcome"] == "no_candidates"   # only candidate is cache-suppressed
     assert io.advanced == []
+
+
+def test_hold_ttl_expires_and_reenables_review():
+    st = {}
+    h = ap.spec_hash("spec A")
+    ap.record_verdict(st, 402, h, "HOLD", now_iso="2026-06-20T00:00:00+00:00")
+    # within TTL → still cached
+    assert ap.cached_verdict(st, 402, h, "2026-06-20T10:00:00+00:00", 24) == "HOLD"
+    # past TTL → cache miss (re-review)
+    assert ap.cached_verdict(st, 402, h, "2026-06-21T01:00:00+00:00", 24) is None
+
+
+def test_cached_verdict_backward_compatible_without_timestamps():
+    st = {}
+    h = ap.spec_hash("spec A")
+    ap.record_verdict(st, 402, h, "HOLD")  # no now_iso
+    assert ap.cached_verdict(st, 402, h) == "HOLD"  # no ttl args → unconditional

--- a/dark-factory/tests/test_scheduler_ceiling.sh
+++ b/dark-factory/tests/test_scheduler_ceiling.sh
@@ -19,8 +19,8 @@ echo "$block" | grep -qE '^[[:space:]]*L\)[[:space:]]*return 0' \
 grep -qE 'S\|L\|""\)' <(awk '/^is_below_ceiling\(\)/{f=1} f{print} f&&/^}/{exit}' "$sched") \
   || { echo "FAIL: is_below_ceiling does not include L"; exit 1; }
 
-# Priority-6 must map epic_started → DISPATCHED
-grep -q 'autopilot=epic_started' "$sched" \
-  || { echo "FAIL: scheduler does not map epic_started to DISPATCHED"; exit 1; }
+# Priority-6 must map epic_started → DISPATCHED on the same line
+grep -qE 'autopilot=epic_started.*DISPATCHED|DISPATCHED.*autopilot=epic_started' "$sched" \
+  || { echo "FAIL: scheduler does not map epic_started to DISPATCHED on the same line"; exit 1; }
 
 echo "PASS"

--- a/dark-factory/tests/test_scheduler_ceiling.sh
+++ b/dark-factory/tests/test_scheduler_ceiling.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Verifies scheduler.sh raised the dispatch ceiling to L and maps the epic_started outcome.
+# Run: bash dark-factory/tests/test_scheduler_ceiling.sh
+set -euo pipefail
+sched="$(cd "$(dirname "$0")" && pwd)/../scheduler.sh"
+
+# get_size_label must recognise XL (not just S/M/L)
+grep -qE 'XL|xl' <(awk '/^get_size_label\(\)/{f=1} f{print} f&&/^}/{exit}' "$sched") \
+  || { echo "FAIL: get_size_label does not recognise XL"; exit 1; }
+
+# is_above_ceiling must park XL (not L)
+block="$(awk '/^is_above_ceiling\(\)/{f=1} f{print} f&&/^}/{exit}' "$sched")"
+echo "$block" | grep -qE 'XL\)' \
+  || { echo "FAIL: is_above_ceiling does not special-case XL"; exit 1; }
+echo "$block" | grep -qE '^[[:space:]]*L\)[[:space:]]*return 0' \
+  && { echo "FAIL: is_above_ceiling still parks L unconditionally"; exit 1; }
+
+# is_below_ceiling must treat L as below ceiling (timer-advance applies to S and L)
+grep -qE 'S\|L\|""\)' <(awk '/^is_below_ceiling\(\)/{f=1} f{print} f&&/^}/{exit}' "$sched") \
+  || { echo "FAIL: is_below_ceiling does not include L"; exit 1; }
+
+# Priority-6 must map epic_started → DISPATCHED
+grep -q 'autopilot=epic_started' "$sched" \
+  || { echo "FAIL: scheduler does not map epic_started to DISPATCHED"; exit 1; }
+
+echo "PASS"

--- a/docs/superpowers/plans/2026-06-21-epic-autopilot-broaden-reach.md
+++ b/docs/superpowers/plans/2026-06-21-epic-autopilot-broaden-reach.md
@@ -1,0 +1,815 @@
+# Epic Autopilot — Broaden Reach Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Epic Autopilot actually advance work — stop accidental over-drops, advance size-L children, and start the next epic when its child pool is dry.
+
+**Architecture:** Extends the existing pure-core + injected-IO module `dark-factory/scripts/factory_core/epic_autopilot.py` (three behaviour changes), raises the global factory dispatch ceiling in `scheduler.sh`, and adds an epic-starter stage. All pure logic stays unit-tested with no IO; the scheduler change is grep-tested; live adapters are exercised in manual validation.
+
+**Tech Stack:** Python 3 (stdlib only), POSIX sh (`scheduler.sh`), `gh` CLI + GraphQL, `yq`, pytest, `claude -p` (Opus 4.8 reviewer).
+
+## Global Constraints
+
+- **Factory self-edit → human-implemented only.** Never auto-refine/implement this.
+- **Baked files.** `epic_autopilot.py`, `cli.py`, `scheduler.sh` are baked into `markethawk-dark-factory:latest`. Changes deploy only after `docker compose build backlog-scheduler && docker compose up -d --force-recreate backlog-scheduler` (Task 8).
+- **Fail-closed safety preserved.** Trading/auth keyword hits and declared exclude-path matches remain hard drops; Opus parse errors → HOLD; Opus defaults to HOLD when uncertain.
+- **Backward-compatible signatures.** New parameters on existing pure functions are optional with defaults so the current test-suite calls keep compiling.
+- **Run python tests:** `cd dark-factory && python -m pytest tests/test_epic_autopilot.py -v` (pure functions, no DB/network).
+- **Run scheduler test:** `bash dark-factory/tests/test_scheduler_ceiling.sh`.
+
+## File Structure
+
+- `dark-factory/scripts/factory_core/epic_autopilot.py` — MODIFY. `hard_excluded`, `is_eligible`, `cached_verdict`/`record_verdict`, `build_review_prompt`, `run_once`, new `pick_next_epic`/`_priority_rank`/`_epic_excluded`/`_size_rank`/`_age_hours`; new `LiveIO.fetch_ready_epics`/`promote_epic`; `main_once` cfg assembly + outcome print.
+- `dark-factory/tests/test_epic_autopilot.py` — MODIFY. Update ceiling/undeclared-scope tests; add TTL, keyword, `pick_next_epic`, and epic-starter tests.
+- `dark-factory/scheduler.sh` — MODIFY. Raise dispatch ceiling (`get_size_label`, `is_above_ceiling`, `is_below_ceiling`), map `epic_started` → `DISPATCHED`, add `_set_cfg` for new knobs.
+- `dark-factory/tests/test_scheduler_ceiling.sh` — CREATE. Grep-assert the ceiling + epic_started wiring.
+- `.claude/skills/refinement/config.yaml` — MODIFY. New `epic_autopilot` knobs + ceiling comment.
+
+---
+
+### Task 1: Soft over-drops in `hard_excluded`
+
+Undeclared scope stops being a hard drop; it flags the candidate so Opus is warned. A new `sensitive_keywords` pattern hard-drops trading/auth by title/body keyword even when scope is undeclared.
+
+**Files:**
+- Modify: `dark-factory/scripts/factory_core/epic_autopilot.py` (`hard_excluded`, ~lines 54-63)
+- Test: `dark-factory/tests/test_epic_autopilot.py`
+
+**Interfaces:**
+- Produces: `hard_excluded(c: dict, exclude_paths: list, sensitive_keywords: str = "") -> (bool, str)`. Sets `c["scope_undeclared"] = True` when no paths are declared. Reasons: `"sensitive-keyword"`, an exclude-path string, `"undeclared-scope"` (now non-excluding), or `""`.
+
+- [ ] **Step 1: Replace the two undeclared-scope tests with the new contract**
+
+In `tests/test_epic_autopilot.py`, replace `test_hard_exclude_undeclared_scope_fails_closed` with:
+
+```python
+def test_undeclared_scope_is_soft_and_flags():
+    cand = c(target_paths=[])
+    ex, why = ap.hard_excluded(cand, ["app/core/auth"])
+    assert not ex and why == "undeclared-scope"
+    assert cand.get("scope_undeclared") is True
+
+
+def test_sensitive_keyword_hard_drops_even_without_paths():
+    cand = c(title="Live IBKR order path kill switch", body="", target_paths=[])
+    ex, why = ap.hard_excluded(cand, ["app/core/auth"],
+                               sensitive_keywords=r"trading|ibkr|order|jwt|/auth")
+    assert ex and why == "sensitive-keyword"
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cd dark-factory && python -m pytest tests/test_epic_autopilot.py -k "undeclared or sensitive" -v`
+Expected: FAIL (`test_undeclared_scope_is_soft_and_flags` asserts `not ex` but current code returns `ex=True`; `sensitive_keywords` is an unexpected kwarg).
+
+- [ ] **Step 3: Rewrite `hard_excluded`**
+
+Replace the function body (currently lines ~54-63) with:
+
+```python
+def hard_excluded(c: dict, exclude_paths: list, sensitive_keywords: str = ""):
+    """Stage B — categorical exclusions. Returns (excluded: bool, reason: str).
+
+    Trading/auth keywords in title/body hard-drop (fail-closed) even when scope is
+    undeclared. A declared path matching an exclude prefix hard-drops. No declared
+    paths is NOT a drop anymore — flag scope_undeclared so Opus is warned and leans HOLD.
+    """
+    if sensitive_keywords:
+        text = f"{c.get('title', '')} {c.get('body', '')}".lower()
+        if re.search(sensitive_keywords, text):
+            return True, "sensitive-keyword"
+    paths = c.get("target_paths") or []
+    for p in paths:
+        for ex in exclude_paths:
+            if ex in p:
+                return True, ex
+    if not paths:
+        c["scope_undeclared"] = True
+        return False, "undeclared-scope"
+    return False, ""
+```
+
+- [ ] **Step 4: Run the hard_excluded tests to verify they pass**
+
+Run: `cd dark-factory && python -m pytest tests/test_epic_autopilot.py -k "exclude or undeclared or sensitive or security" -v`
+Expected: PASS (incl. the still-valid `test_hard_exclude_factory_self`, `test_hard_exclude_auth`, `test_security_label_not_excluded`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dark-factory/scripts/factory_core/epic_autopilot.py dark-factory/tests/test_epic_autopilot.py
+git commit -m "feat(autopilot): undeclared-scope becomes a soft Opus concern; keyword fail-closed for trading/auth"
+```
+
+---
+
+### Task 2: Size ceiling → XL-only in `is_eligible`
+
+`is_eligible` should drop only `XL`; `L` and `M` become eligible (Opus weighs blast radius). Replaces the `(L, XL)` drop and the `M`+keyword drop.
+
+**Files:**
+- Modify: `dark-factory/scripts/factory_core/epic_autopilot.py` (`is_eligible`, ~lines 38-51; add `_size_rank`)
+- Test: `dark-factory/tests/test_epic_autopilot.py`
+
+**Interfaces:**
+- Produces: `is_eligible(c: dict, opt_out_label: str, size_ceiling: str = "XL") -> (bool, str)`. Drops when the candidate size rank ≥ the `size_ceiling` rank. `_size_rank(s: str) -> int` maps S<M<L<XL (unknown/blank rank −1, i.e. below S).
+
+- [ ] **Step 1: Update the ceiling tests to the new contract**
+
+In `tests/test_epic_autopilot.py`, the helper passes `CEIL` as the third arg to `is_eligible` in several tests. Replace the affected tests (`test_eligible_happy`, `test_ineligible_opt_out`, `test_ineligible_already_direct_to_pr`, `test_ineligible_wrong_status`, `test_ineligible_above_ceiling_size_l`, `test_ineligible_m_with_ceiling_keyword`, `test_eligible_m_without_keyword`, `test_size_from_label_prefix`) with:
+
+```python
+def test_eligible_happy():
+    ok, why = ap.is_eligible(c(), "no-autopilot")
+    assert ok, why
+
+
+def test_ineligible_opt_out():
+    ok, _ = ap.is_eligible(c(labels=["ready-for-agent", "no-autopilot"]), "no-autopilot")
+    assert not ok
+
+
+def test_ineligible_already_direct_to_pr():
+    ok, _ = ap.is_eligible(c(labels=["direct-to-pr"]), "no-autopilot")
+    assert not ok
+
+
+def test_ineligible_wrong_status():
+    ok, _ = ap.is_eligible(c(status="Ready"), "no-autopilot")
+    assert not ok
+
+
+def test_size_l_now_eligible():
+    ok, why = ap.is_eligible(c(size="L"), "no-autopilot")
+    assert ok, why
+
+
+def test_size_m_with_keyword_now_eligible():
+    ok, why = ap.is_eligible(c(size="M", title="perf refactor of scanner"), "no-autopilot")
+    assert ok, why
+
+
+def test_size_xl_dropped():
+    ok, why = ap.is_eligible(c(size="XL"), "no-autopilot")
+    assert not ok and "above-ceiling" in why
+
+
+def test_size_xl_from_label_prefix():
+    ok, _ = ap.is_eligible(c(size=None, labels=["ready-for-agent", "size: XL"]), "no-autopilot")
+    assert not ok
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `cd dark-factory && python -m pytest tests/test_epic_autopilot.py -k "eligib or size" -v`
+Expected: FAIL (`size="L"` currently drops; `XL` currently slips through because the old code only special-cases L; `is_eligible` still expects a third positional `ceiling_keywords`).
+
+- [ ] **Step 3: Rewrite `is_eligible` + add `_size_rank`**
+
+Replace `is_eligible` (lines ~38-51) and add the rank helper just above it:
+
+```python
+_SIZE_ORDER = {"S": 0, "M": 1, "L": 2, "XL": 3}
+
+
+def _size_rank(s: str) -> int:
+    """Rank a size token; unknown/blank ranks below S so it is never above ceiling."""
+    return _SIZE_ORDER.get((s or "").upper(), -1)
+
+
+def is_eligible(c: dict, opt_out_label: str, size_ceiling: str = "XL"):
+    """Stage A — structural eligibility. Returns (ok: bool, reason: str)."""
+    labels = [label.lower() for label in c.get("labels", [])]
+    if c.get("status") not in _GATED_STATUSES:
+        return False, f"status={c.get('status')}"
+    for blk in ("direct-to-pr", opt_out_label, "needs-discussion", "epic"):
+        if blk.lower() in labels:
+            return False, f"label:{blk}"
+    size = _size(c) or ""
+    if _size_rank(size) >= _size_rank(size_ceiling):
+        return False, f"above-ceiling:size={size or '?'}"
+    return True, ""
+```
+
+Note: `_size(c)` already reads a `size:`-prefixed label; it upper-cases the suffix so `"size: XL"` → `"XL"`.
+
+- [ ] **Step 4: Run to verify passes**
+
+Run: `cd dark-factory && python -m pytest tests/test_epic_autopilot.py -k "eligib or size" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dark-factory/scripts/factory_core/epic_autopilot.py dark-factory/tests/test_epic_autopilot.py
+git commit -m "feat(autopilot): raise size ceiling to XL-only (L/M now eligible)"
+```
+
+---
+
+### Task 3: HOLD verdict TTL
+
+A cached `HOLD` expires after `hold_ttl_hours` so a one-off HOLD isn't permanent; ADVANCE stays terminal via the label. Backward-compatible: no timestamp args ⇒ old behaviour.
+
+**Files:**
+- Modify: `dark-factory/scripts/factory_core/epic_autopilot.py` (`cached_verdict`, `record_verdict`, ~lines 124-132; add `_age_hours`)
+- Test: `dark-factory/tests/test_epic_autopilot.py`
+
+**Interfaces:**
+- Produces: `record_verdict(state, issue, spec_hash_, verdict, now_iso: str | None = None)` (stamps `ts` when `now_iso` given). `cached_verdict(state, issue, spec_hash_, now_iso: str | None = None, ttl_hours: float | None = None)` (returns `None` if expired). `_age_hours(ts_iso, now_iso) -> float`.
+
+- [ ] **Step 1: Add the TTL tests**
+
+Append to `tests/test_epic_autopilot.py`:
+
+```python
+def test_hold_ttl_expires_and_reenables_review():
+    st = {}
+    h = ap.spec_hash("spec A")
+    ap.record_verdict(st, 402, h, "HOLD", now_iso="2026-06-20T00:00:00+00:00")
+    # within TTL → still cached
+    assert ap.cached_verdict(st, 402, h, "2026-06-20T10:00:00+00:00", 24) == "HOLD"
+    # past TTL → cache miss (re-review)
+    assert ap.cached_verdict(st, 402, h, "2026-06-21T01:00:00+00:00", 24) is None
+
+
+def test_cached_verdict_backward_compatible_without_timestamps():
+    st = {}
+    h = ap.spec_hash("spec A")
+    ap.record_verdict(st, 402, h, "HOLD")  # no now_iso
+    assert ap.cached_verdict(st, 402, h) == "HOLD"  # no ttl args → unconditional
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd dark-factory && python -m pytest tests/test_epic_autopilot.py -k "ttl or backward_compatible" -v`
+Expected: FAIL (`record_verdict`/`cached_verdict` reject the extra args).
+
+- [ ] **Step 3: Implement the TTL**
+
+Add `_age_hours` near the top imports area, and replace `cached_verdict`/`record_verdict`:
+
+```python
+def _age_hours(ts_iso: str, now_iso: str) -> float:
+    from datetime import datetime
+    try:
+        return (datetime.fromisoformat(now_iso) - datetime.fromisoformat(ts_iso)).total_seconds() / 3600.0
+    except Exception:
+        return 0.0
+
+
+def cached_verdict(state: dict, issue: int, spec_hash_: str, now_iso=None, ttl_hours=None):
+    entry = (state.get("verdicts") or {}).get(str(issue))
+    if not entry or entry.get("spec_hash") != spec_hash_:
+        return None
+    if ttl_hours and now_iso and entry.get("ts") and _age_hours(entry["ts"], now_iso) >= ttl_hours:
+        return None
+    return entry.get("verdict")
+
+
+def record_verdict(state: dict, issue: int, spec_hash_: str, verdict: str, now_iso=None) -> None:
+    entry = {"spec_hash": spec_hash_, "verdict": verdict}
+    if now_iso:
+        entry["ts"] = now_iso
+    state.setdefault("verdicts", {})[str(issue)] = entry
+```
+
+- [ ] **Step 4: Run to verify passes (incl. the legacy cache tests)**
+
+Run: `cd dark-factory && python -m pytest tests/test_epic_autopilot.py -k "ttl or verdict or cache or hold" -v`
+Expected: PASS (`test_verdict_cache_roundtrip_and_hash_invalidation`, `test_run_skips_cached_hold` still green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dark-factory/scripts/factory_core/epic_autopilot.py dark-factory/tests/test_epic_autopilot.py
+git commit -m "feat(autopilot): expire cached HOLD verdicts after a TTL"
+```
+
+---
+
+### Task 4: `pick_next_epic` selector
+
+Pure selector for the epic-starter: choose the highest-priority unstarted epic, skipping hard-excluded categories (security/auth/trading/factory-self).
+
+**Files:**
+- Modify: `dark-factory/scripts/factory_core/epic_autopilot.py` (add functions near the pure-core block)
+- Test: `dark-factory/tests/test_epic_autopilot.py`
+
+**Interfaces:**
+- Produces: `pick_next_epic(epics: list, exclude_pattern: str = _EPIC_EXCLUDE_RE) -> int | None`. `epics` items: `{number:int, title:str, labels:list[str], board_order:int}`. Orders by `_priority_rank(labels)` (must-have<should-have<other), then `board_order`, then `number`. Skips any epic whose title/labels match `exclude_pattern`.
+
+- [ ] **Step 1: Add the selector tests**
+
+Append to `tests/test_epic_autopilot.py`:
+
+```python
+def _e(number, title="epic", labels=None, board_order=0):
+    return {"number": number, "title": title, "labels": labels or [], "board_order": board_order}
+
+
+def test_pick_next_epic_skips_security_and_orders_by_priority():
+    epics = [
+        _e(373, "Authorization model", labels=["epic", "security", "should-have"], board_order=0),
+        _e(450, "LLM narrative", labels=["epic", "should-have"], board_order=2),
+        _e(483, "Signal replay engine", labels=["epic", "must-have"], board_order=1),
+    ]
+    assert ap.pick_next_epic(epics) == 483  # must-have, security #373 skipped
+
+
+def test_pick_next_epic_board_order_tiebreak():
+    epics = [
+        _e(449, labels=["epic", "must-have"], board_order=5),
+        _e(448, labels=["epic", "must-have"], board_order=3),
+    ]
+    assert ap.pick_next_epic(epics) == 448  # same priority → lower board_order wins
+
+
+def test_pick_next_epic_none_when_all_excluded():
+    epics = [_e(373, "auth", labels=["epic", "security"]),
+             _e(601, "trading kill switch", labels=["epic"])]
+    assert ap.pick_next_epic(epics) is None
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd dark-factory && python -m pytest tests/test_epic_autopilot.py -k "pick_next_epic" -v`
+Expected: FAIL (`AttributeError: module ... has no attribute 'pick_next_epic'`).
+
+- [ ] **Step 3: Implement the selector**
+
+Add to `epic_autopilot.py` after the verdict-cache helpers:
+
+```python
+_EPIC_EXCLUDE_RE = r"security|auth|authz|authn|trading|ibkr|dark.?factory|scheduler|factory.self"
+
+
+def _priority_rank(labels: list) -> int:
+    low = [label.lower() for label in labels]
+    if any("must-have" in label for label in low):
+        return 0
+    if any("should-have" in label for label in low):
+        return 1
+    return 2
+
+
+def _epic_excluded(e: dict, pattern: str) -> bool:
+    hay = (e.get("title", "") + " " + " ".join(e.get("labels", []))).lower()
+    return bool(re.search(pattern, hay))
+
+
+def pick_next_epic(epics: list, exclude_pattern: str = _EPIC_EXCLUDE_RE):
+    """Highest-priority unstarted epic, skipping hard-excluded categories. None if none."""
+    elig = [e for e in epics if not _epic_excluded(e, exclude_pattern)]
+    elig.sort(key=lambda e: (_priority_rank(e.get("labels", [])),
+                             e.get("board_order", 10 ** 9), e["number"]))
+    return elig[0]["number"] if elig else None
+```
+
+- [ ] **Step 4: Run to verify passes**
+
+Run: `cd dark-factory && python -m pytest tests/test_epic_autopilot.py -k "pick_next_epic" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dark-factory/scripts/factory_core/epic_autopilot.py dark-factory/tests/test_epic_autopilot.py
+git commit -m "feat(autopilot): pick_next_epic selector (priority order, skip sensitive epics)"
+```
+
+---
+
+### Task 5: Orchestrator epic-starter + wired config
+
+`run_once` threads timestamps into the cache, uses the new eligibility/exclusion signatures, warns Opus on undeclared scope, and — when the child pool is empty and `start_epics` is on — promotes the next epic. New outcome `epic_started`.
+
+**Files:**
+- Modify: `dark-factory/scripts/factory_core/epic_autopilot.py` (`build_review_prompt`, `run_once`)
+- Test: `dark-factory/tests/test_epic_autopilot.py`
+
+**Interfaces:**
+- Consumes: `is_eligible(..., size_ceiling)`, `hard_excluded(..., sensitive_keywords)`, `cached_verdict(..., now_iso, ttl_hours)`, `record_verdict(..., now_iso)`, `pick_next_epic(...)`.
+- Produces: `run_once(cfg, io, state, today, now_iso=None) -> {"outcome", "issue", "reason"}` where outcome ∈ {advanced, hold, epic_started, no_candidates, daily_cap_reached}. Epic-starter requires `cfg.get("start_epics")` truthy and `io.fetch_ready_epics()` / `io.promote_epic(n)`. `cfg` keys read with defaults: `size_ceiling="XL"`, `sensitive_keywords=""`, `hold_ttl_hours=None`, `start_epics=False`.
+
+- [ ] **Step 1: Add the epic-starter orchestrator test**
+
+Append to `tests/test_epic_autopilot.py`:
+
+```python
+class FakeEpicIO(FakeIO):
+    def __init__(self, candidates, review_text, ready_epics):
+        super().__init__(candidates, review_text)
+        self._epics = ready_epics
+        self.promoted = []
+
+    def fetch_ready_epics(self):
+        return self._epics
+
+    def promote_epic(self, n):
+        self.promoted.append(n)
+
+
+def test_run_starts_epic_when_no_child_candidates():
+    io = FakeEpicIO([], "x", [_e(483, labels=["epic", "must-have"])])
+    cfg = dict(CFG, start_epics=True)
+    out = ap.run_once(cfg, io, {}, "2026-06-20", now_iso="2026-06-20T00:00:00+00:00")
+    assert out["outcome"] == "epic_started" and out["issue"] == 483
+    assert io.promoted == [483]
+    assert any(sev == "info" for sev, _ in io.notes)
+
+
+def test_run_stuck_when_no_children_and_no_eligible_epic():
+    io = FakeEpicIO([], "x", [_e(373, "auth", labels=["epic", "security"])])
+    cfg = dict(CFG, start_epics=True)
+    out = ap.run_once(cfg, io, {}, "2026-06-20")
+    assert out["outcome"] == "no_candidates"
+    assert io.promoted == []
+    assert any(key == "autopilot-stuck" for _, key in io.notes)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd dark-factory && python -m pytest tests/test_epic_autopilot.py -k "starts_epic or stuck_when" -v`
+Expected: FAIL (`run_once` has no epic-starter branch).
+
+- [ ] **Step 3: Update `build_review_prompt` and `run_once`**
+
+In `build_review_prompt`, surface the undeclared-scope flag so Opus is warned. Replace the whole function with:
+
+```python
+def build_review_prompt(c: dict) -> str:
+    scope = ", ".join(c.get("target_paths") or []) or "(none declared)"
+    warn = ("\nNOTE: file scope is UNDECLARED — treat trading/auth/factory-self risk as "
+            "possible and lean HOLD unless the spec is clearly safe." if c.get("scope_undeclared") else "")
+    return f"""You are a cautious senior engineer deciding whether a refined ticket is safe to
+implement and merge AUTONOMOUSLY (adding the direct-to-pr label means it flows
+spec->plan->implement->PR with NO further human gate before the PR opens).
+
+Reply with ONLY a JSON object:
+{{"decision":"ADVANCE|HOLD","risk":"low|medium|high","confidence":0.0-1.0,
+  "reasons":[...],"concerns":[...]}}
+
+ADVANCE only if the work is genuinely low-risk: small, well-scoped, reversible, good test
+coverage in the spec/plan, low blast radius, and NOT touching automated trading,
+authentication/authorization, or the factory/scheduler itself. If the spec is vague, an
+empty-branch/no-op risk, or you are unsure -- choose HOLD.
+
+Ticket #{c['number']}: {c['title']}
+Labels: {', '.join(c.get('labels', []))}   Size: {c.get('size')}
+Declared target files: {scope}{warn}
+
+--- SPEC/PLAN ---
+{(c.get('spec_text') or '')[:8000]}
+"""
+```
+
+Then replace `run_once` with the version below (changes: `now_iso` param; new signatures; epic-starter branch):
+
+```python
+def run_once(cfg: dict, io, state: dict, today: str, now_iso=None) -> dict:
+    """One starved-cycle pass. Returns {outcome, issue, reason}."""
+    if daily_remaining(state, cfg["daily_cap"], today) <= 0:
+        io.notify("Epic autopilot — daily cap reached",
+                  f"Hit the daily cap of {cfg['daily_cap']} autonomous advances; paused until UTC reset. Review the backlog.",
+                  "warning", "autopilot-cap")
+        return {"outcome": "daily_cap_reached", "issue": None, "reason": "cap"}
+
+    candidates = []
+    for cand in io.fetch_candidates():
+        ok, _ = is_eligible(cand, cfg["opt_out_label"], cfg.get("size_ceiling", "XL"))
+        if not ok:
+            continue
+        excluded, _ = hard_excluded(cand, cfg["exclude_paths"], cfg.get("sensitive_keywords", ""))
+        if excluded:
+            continue
+        if cached_verdict(state, cand["number"], spec_hash(cand.get("spec_text", "")),
+                          now_iso, cfg.get("hold_ttl_hours")) == "HOLD":
+            continue
+        candidates.append(cand)
+
+    if not candidates:
+        if cfg.get("start_epics") and hasattr(io, "fetch_ready_epics"):
+            epic_num = pick_next_epic(io.fetch_ready_epics())
+            if epic_num is not None:
+                io.promote_epic(epic_num)
+                io.comment(epic_num,
+                           "\U0001f916 **Epic Autopilot** — starting epic: promoted to In progress and "
+                           "marked its open children ready-for-agent.\n\n---\n*Posted by MarketHawk Epic Autopilot*")
+                io.notify(f"Autopilot starting epic #{epic_num}",
+                          "Promoted to In progress; children marked ready-for-agent.", "info", None)
+                record_advance(state, today)
+                return {"outcome": "epic_started", "issue": epic_num, "reason": "promote"}
+        io.notify("Epic autopilot — idle, nothing safe to advance",
+                  "The factory is starved and the autopilot has no eligible low-risk ticket to advance. Human input needed.",
+                  "warning", "autopilot-stuck")
+        return {"outcome": "no_candidates", "issue": None, "reason": "empty"}
+
+    cand = candidates[0]
+    verdict = parse_verdict(io.review(build_review_prompt(cand), cfg["model"]))
+    h = spec_hash(cand.get("spec_text", ""))
+    if should_advance(verdict, cfg["confidence_floor"]):
+        io.advance(cand["number"])
+        reason = "; ".join(verdict.get("reasons", [])) or "low-risk"
+        io.comment(cand["number"],
+                   f"\U0001f916 **Epic Autopilot** — advancing (risk={verdict['risk']}, conf={verdict['confidence']}). "
+                   f"Reason: {reason}\n\n---\n*Posted by MarketHawk Epic Autopilot*")
+        io.notify(f"Autopilot advancing #{cand['number']}",
+                  f"{cand['title']} — risk=low: {reason}", "info", None)
+        record_advance(state, today)
+        record_verdict(state, cand["number"], h, "ADVANCE", now_iso)
+        return {"outcome": "advanced", "issue": cand["number"], "reason": reason}
+
+    concerns = "; ".join(verdict.get("concerns", [])) or "not low-risk / low confidence"
+    io.comment(cand["number"],
+               f"\U0001f916 **Epic Autopilot** — parked (HOLD). {concerns}\n\n---\n*Posted by MarketHawk Epic Autopilot*")
+    record_verdict(state, cand["number"], h, "HOLD", now_iso)
+    return {"outcome": "hold", "issue": cand["number"], "reason": concerns}
+```
+
+- [ ] **Step 4: Run the full orchestrator suite**
+
+Run: `cd dark-factory && python -m pytest tests/test_epic_autopilot.py -v`
+Expected: PASS (all tasks 1-5, incl. legacy `test_run_advances_low_risk`, `test_run_holds_medium_risk`, `test_run_no_candidates_notifies_stuck`, `test_run_daily_cap_reached_notifies`, `test_run_skips_cached_hold`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dark-factory/scripts/factory_core/epic_autopilot.py dark-factory/tests/test_epic_autopilot.py
+git commit -m "feat(autopilot): epic-starter branch + undeclared-scope reviewer warning + TTL threading"
+```
+
+---
+
+### Task 6: Live adapters, cfg assembly, and config knobs
+
+Wire the new behaviour to the real world: GraphQL adapters to fetch Ready epics and promote one, cfg assembly from env/config in `main_once`, the new outcome line, and the `config.yaml` knobs. IO-heavy — exercised in manual validation (Task 8), no new unit tests (mirrors the existing "LiveIO not unit-tested" note).
+
+**Files:**
+- Modify: `dark-factory/scripts/factory_core/epic_autopilot.py` (`LiveIO`, `main_once`)
+- Modify: `.claude/skills/refinement/config.yaml` (`epic_autopilot` section)
+
+**Interfaces:**
+- Consumes: `factory_core.board.set_board_status` (existing), `_in_progress_epics`-style GraphQL, `_sub_issue_numbers` pattern.
+- Produces: `LiveIO.fetch_ready_epics() -> list[dict]`, `LiveIO.promote_epic(n: int) -> None`.
+
+- [ ] **Step 1: Add `fetch_ready_epics` + `promote_epic` to `LiveIO`**
+
+Add a `_ready_epics()` module helper near `_in_progress_epics` (it reuses the same project query, filtering Status == "Ready" + `epic` label, and reads the `priority:` label + board order):
+
+```python
+def _ready_epics() -> list:
+    """Ready-column epics as [{number, title, labels, board_order}], board order preserved."""
+    q = ('query { node(id: "%s") { ... on ProjectV2 { items(first:100) { nodes { '
+         'fieldValueByName(name:"Status"){ ... on ProjectV2ItemFieldSingleSelectValue { name } } '
+         'content { ... on Issue { number title labels(first:20){nodes{name}} } } } } } } }') % PROJECT_ID
+    data = _gh_json(["api", "graphql", "-f", "query=" + q])
+    if not data:
+        return []
+    out, order = [], 0
+    for n in data.get("data", {}).get("node", {}).get("items", {}).get("nodes", []):
+        content = n.get("content") or {}
+        status = (n.get("fieldValueByName") or {}).get("name")
+        labels = [x["name"] for x in (content.get("labels") or {}).get("nodes", [])]
+        if content.get("number") and status == "Ready" and "epic" in labels:
+            out.append({"number": content["number"], "title": content.get("title", ""),
+                        "labels": labels, "board_order": order})
+        order += 1
+    return out
+
+
+def _open_child_numbers(epic: int) -> list:
+    """All OPEN sub-issue numbers of an epic (any label)."""
+    q = ('query { repository(owner:"omniscient", name:"markethawk") { issue(number:%d) { '
+         'subIssues(first:50) { nodes { number state } } } } }') % epic
+    data = _gh_json(["api", "graphql", "-f", "query=" + q])
+    if not data:
+        return []
+    return [s["number"] for s in
+            data.get("data", {}).get("repository", {}).get("issue", {}).get("subIssues", {}).get("nodes", [])
+            if s.get("state") == "OPEN"]
+```
+
+Then add these two methods to the `LiveIO` class:
+
+```python
+    def fetch_ready_epics(self) -> list:
+        return _ready_epics()
+
+    def promote_epic(self, epic: int) -> None:
+        from factory_core.board import set_board_status
+        set_board_status(epic, "In progress")
+        for child in _open_child_numbers(epic):
+            subprocess.run(["gh", "issue", "edit", str(child), "--repo", OWNER,
+                            "--add-label", "ready-for-agent"], check=False)
+```
+
+- [ ] **Step 2: Assemble new cfg keys + outcome line in `main_once`**
+
+In `main_once`, extend the `cfg = dict(...)` with the new knobs and update the final print:
+
+```python
+    cfg = dict(
+        exclude_paths=_load_exclude_paths(),
+        opt_out_label=os.environ.get("EPIC_AUTOPILOT_OPT_OUT_LABEL", "no-autopilot"),
+        size_ceiling=os.environ.get("EPIC_AUTOPILOT_SIZE_CEILING", "XL"),
+        sensitive_keywords=os.environ.get(
+            "EPIC_AUTOPILOT_SENSITIVE_KEYWORDS",
+            r"trading|ibkr|live order|notional|authentication|authorization|authn|authz|jwt|oauth|rbac|/auth"),
+        hold_ttl_hours=float(os.environ.get("EPIC_AUTOPILOT_HOLD_TTL_HOURS", "24")),
+        start_epics=os.environ.get("EPIC_AUTOPILOT_START_EPICS", "true").lower() == "true",
+        confidence_floor=float(os.environ.get("EPIC_AUTOPILOT_CONFIDENCE_FLOOR", "0.7")),
+        daily_cap=int(os.environ.get("EPIC_AUTOPILOT_DAILY_CAP", "5")),
+        model=os.environ.get("EPIC_AUTOPILOT_MODEL", "claude-opus-4-8"))
+    now_iso = datetime.now(timezone.utc).isoformat()
+    out = run_once(cfg, LiveIO(cfg["model"]), state, today, now_iso)
+```
+
+(`from datetime import datetime, timezone` is already imported at the top of `main_once`.) Leave the final `print(f"autopilot={out['outcome']} issue=#{out['issue']}")` as-is — it already emits `autopilot=epic_started issue=#N`.
+
+- [ ] **Step 3: Add the config knobs**
+
+In `.claude/skills/refinement/config.yaml`, under `epic_autopilot:`, add after `confidence_floor`:
+
+```yaml
+  hold_ttl_hours: 24          # re-review a cached HOLD after this many hours. env EPIC_AUTOPILOT_HOLD_TTL_HOURS
+  size_ceiling: XL            # drop only at/above this size (L/M now eligible). env EPIC_AUTOPILOT_SIZE_CEILING
+  start_epics: true           # when no gated child is advanceable, promote the next Ready epic. env EPIC_AUTOPILOT_START_EPICS
+  sensitive_keywords: "trading|ibkr|live order|notional|authentication|authorization|authn|authz|jwt|oauth|rbac|/auth"
+```
+
+- [ ] **Step 4: Byte-compile sanity check (no live calls)**
+
+Run: `cd dark-factory && python -c "import sys; sys.path.insert(0,'scripts'); import factory_core.epic_autopilot as ap; print(hasattr(ap.LiveIO,'fetch_ready_epics'), hasattr(ap.LiveIO,'promote_epic'))"`
+Expected: `True True`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dark-factory/scripts/factory_core/epic_autopilot.py .claude/skills/refinement/config.yaml
+git commit -m "feat(autopilot): live Ready-epic adapters + cfg knobs (TTL, ceiling, epic-starter)"
+```
+
+---
+
+### Task 7: Raise the global dispatch ceiling + map `epic_started`
+
+Raise the factory's implement-side ceiling so `L` is below ceiling (only `XL` parks; `M`+keyword still escalates), recognise the `size: XL` label (currently unmatched), map the new `epic_started` outcome to a non-empty `DISPATCHED`, and export the new autopilot knobs.
+
+**Files:**
+- Modify: `dark-factory/scheduler.sh` (`get_size_label` ~236, `is_above_ceiling` ~242-251, `is_below_ceiling` ~259-263, Priority-6 `case` ~1109, `_set_cfg` block ~82-84)
+- Create: `dark-factory/tests/test_scheduler_ceiling.sh`
+
+- [ ] **Step 1: Write the grep-based scheduler test**
+
+Create `dark-factory/tests/test_scheduler_ceiling.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Verifies scheduler.sh raised the dispatch ceiling to L and maps the epic_started outcome.
+# Run: bash dark-factory/tests/test_scheduler_ceiling.sh
+set -euo pipefail
+sched="$(cd "$(dirname "$0")" && pwd)/../scheduler.sh"
+
+# get_size_label must recognise XL (not just S/M/L)
+grep -qE 'XL|xl' <(awk '/^get_size_label\(\)/{f=1} f{print} f&&/^}/{exit}' "$sched") \
+  || { echo "FAIL: get_size_label does not recognise XL"; exit 1; }
+
+# is_above_ceiling must park XL (not L)
+block="$(awk '/^is_above_ceiling\(\)/{f=1} f{print} f&&/^}/{exit}' "$sched")"
+echo "$block" | grep -qE 'XL\)' \
+  || { echo "FAIL: is_above_ceiling does not special-case XL"; exit 1; }
+echo "$block" | grep -qE '^[[:space:]]*L\)[[:space:]]*return 0' \
+  && { echo "FAIL: is_above_ceiling still parks L unconditionally"; exit 1; }
+
+# is_below_ceiling must treat L as below ceiling (timer-advance applies to S and L)
+grep -qE 'S\|L\|""\)' <(awk '/^is_below_ceiling\(\)/{f=1} f{print} f&&/^}/{exit}' "$sched") \
+  || { echo "FAIL: is_below_ceiling does not include L"; exit 1; }
+
+# Priority-6 must map epic_started → DISPATCHED
+grep -q 'autopilot=epic_started' "$sched" \
+  || { echo "FAIL: scheduler does not map epic_started to DISPATCHED"; exit 1; }
+
+echo "PASS"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bash dark-factory/tests/test_scheduler_ceiling.sh`
+Expected: FAIL at the first assertion (`get_size_label` only matches `[SML]`).
+
+- [ ] **Step 3: Edit `get_size_label` to recognise XL**
+
+Replace line ~236:
+
+```sh
+  echo "$1" | jq -r '.labels[]?' 2>/dev/null | grep -oiE 'size: ?(xl|[sml])' | awk '{print toupper($NF)}' | head -1
+```
+
+- [ ] **Step 4: Edit `is_above_ceiling` — park XL, not L**
+
+Replace the `case "$size"` block (~246-250):
+
+```sh
+  case "$size" in
+    XL) return 0 ;;
+    M) echo "$title" | grep -qiE "${ABOVE_CEILING_KEYWORDS}" && return 0 || return 1 ;;
+    *) return 1 ;;
+  esac
+```
+
+- [ ] **Step 5: Edit `is_below_ceiling` — include L**
+
+Replace line ~262:
+
+```sh
+  case "$size" in S|L|"") return 0 ;; *) return 1 ;; esac
+```
+
+- [ ] **Step 6: Map `epic_started` in the Priority-6 case**
+
+Replace line ~1109:
+
+```sh
+    case "$AP_OUT" in *"autopilot=advanced"*|*"autopilot=epic_started"*) DISPATCHED="$AP_OUT" ;; esac
+```
+
+- [ ] **Step 7: Export the new autopilot knobs**
+
+After the existing `_set_cfg EPIC_AUTOPILOT_DAILY_CAP ...` line (~84), add:
+
+```sh
+  _set_cfg EPIC_AUTOPILOT_HOLD_TTL_HOURS    '.epic_autopilot.hold_ttl_hours'
+  _set_cfg EPIC_AUTOPILOT_SIZE_CEILING      '.epic_autopilot.size_ceiling'
+  _set_cfg EPIC_AUTOPILOT_START_EPICS       '.epic_autopilot.start_epics'
+  _set_cfg EPIC_AUTOPILOT_SENSITIVE_KEYWORDS '.epic_autopilot.sensitive_keywords'
+```
+
+- [ ] **Step 8: Run both scheduler tests to verify pass**
+
+Run: `bash dark-factory/tests/test_scheduler_ceiling.sh && bash dark-factory/tests/test_scheduler_autopilot_guard.sh`
+Expected: `PASS` (both). The guard test still passes — the Priority-6 trigger guards are unchanged.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add dark-factory/scheduler.sh dark-factory/tests/test_scheduler_ceiling.sh
+git commit -m "feat(scheduler): raise dispatch ceiling to L (XL-only park), map epic_started, export autopilot knobs"
+```
+
+---
+
+### Task 8: Deploy + manual validation
+
+Rebuild the baked scheduler image, force-recreate, and validate on the live factory. Not a code task — a release gate.
+
+**Files:** none (operational).
+
+- [ ] **Step 1: Full python + bash test sweep**
+
+Run: `cd dark-factory && python -m pytest tests/test_epic_autopilot.py -v && bash tests/test_scheduler_ceiling.sh && bash tests/test_scheduler_autopilot_guard.sh`
+Expected: all green.
+
+- [ ] **Step 2: Rebuild + recreate the baked scheduler**
+
+```bash
+docker compose build backlog-scheduler
+docker compose up -d --force-recreate backlog-scheduler
+```
+
+- [ ] **Step 3: Confirm the image carries the change**
+
+Run: `docker exec backlog-scheduler grep -c 'autopilot=epic_started' /opt/dark-factory/scheduler.sh` (adjust path to the baked location)
+Expected: ≥ 1. Also `docker exec backlog-scheduler python3 -c "import sys;sys.path.insert(0,'<factory_core scripts path>');import factory_core.epic_autopilot as ap;print(ap.pick_next_epic([]))"` → `None`.
+
+- [ ] **Step 4: Watch a live cycle**
+
+Run: `docker logs backlog-scheduler --tail 40 -f | grep autopilot`
+Expected (within a couple of cycles): an `autopilot=advanced issue=#…` for a now-eligible size-L data-quality child (e.g. #492/#494/#495), or — if the gated-child pool is dry — `autopilot=epic_started issue=#…` promoting the highest-priority non-security Ready epic (skipping #373). Confirm the matching GitHub comment + email/push notification.
+
+- [ ] **Step 5: Push the branch + open the PR**
+
+```bash
+git push -u origin docs/autopilot-reach-and-main-red-autofix-specs
+gh pr create --repo omniscient/markethawk --base main \
+  --title "feat(autopilot): broaden reach (drain backlog, start next epic) — closes #590" \
+  --body "Implements docs/superpowers/specs/2026-06-21-epic-autopilot-broaden-reach-design.md. Closes #590."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Soft over-drops (undeclared-scope → soft + keyword fail-closed) → Task 1. ✅
+- HOLD-TTL → Task 3. ✅
+- Size ceiling → L (autopilot) → Task 2; (factory global #339) → Task 7. ✅
+- Broaden candidate source + epic-starter (promote & delegate, priority order, skip security) → Tasks 4-6. ✅
+- Daily cap covers starts+advances → Task 5 (`record_advance` on the epic_started path). ✅
+- Config knobs → Task 6; scheduler export → Task 7. ✅
+- Unchanged safety (starved-only, main-green, Opus gate, opt-out, kill-switch, reversibility, notify) → trigger untouched (Task 7 guard test), Opus path intact (Task 5). ✅
+- Validation (unit, scheduler, manual) → Tasks 1-5 (unit), 7 (scheduler), 8 (manual). ✅
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. (One operational path is environment-specific: Task 8 Step 3's baked `scheduler.sh` / `factory_core` paths inside the container — resolve them against the running image, e.g. `docker exec backlog-scheduler sh -c 'command -v scheduler.sh || find / -name scheduler.sh 2>/dev/null'`.)
+
+**Type consistency:** `is_eligible(c, opt_out_label, size_ceiling="XL")`, `hard_excluded(c, exclude_paths, sensitive_keywords="")`, `cached_verdict(state, issue, spec_hash_, now_iso=None, ttl_hours=None)`, `record_verdict(..., now_iso=None)`, `pick_next_epic(epics, exclude_pattern=...)`, `run_once(cfg, io, state, today, now_iso=None)` — names/arities match across the orchestrator call sites in Task 5 and the LiveIO/cfg wiring in Task 6. Outcome string `epic_started` matches the scheduler `case` in Task 7.

--- a/docs/superpowers/plans/2026-06-21-epic-autopilot-broaden-reach.md
+++ b/docs/superpowers/plans/2026-06-21-epic-autopilot-broaden-reach.md
@@ -597,8 +597,8 @@ Then add these two methods to the `LiveIO` class:
         return _ready_epics()
 
     def promote_epic(self, epic: int) -> None:
-        from factory_core.board import set_board_status
-        set_board_status(epic, "In progress")
+        from factory_core.board import set_board_status, STATUS_IN_PROGRESS
+        set_board_status(epic, STATUS_IN_PROGRESS)  # option-id, NOT the name "In progress"
         for child in _open_child_numbers(epic):
             subprocess.run(["gh", "issue", "edit", str(child), "--repo", OWNER,
                             "--add-label", "ready-for-agent"], check=False)

--- a/docs/superpowers/specs/2026-06-19-authorization-model-design.md
+++ b/docs/superpowers/specs/2026-06-19-authorization-model-design.md
@@ -1,0 +1,234 @@
+# Authorization Model — Design Spec
+
+**Date:** 2026-06-19
+**Status:** Approved (brainstorm complete) — pending implementation-plan + epic breakdown
+**Source finding:** F-AUTHZ-01 (Defensive Security Review 2026-06-12), tracked as #373
+**Supersedes:** #373 as a single ticket — #373 is promoted to an epic; this spec is its design pass.
+**Standard:** OWASP A01:2021 Broken Access Control · CWE-639 (IDOR) / CWE-862 (Missing Authorization)
+
+---
+
+## 1. Problem
+
+MarketHawk authenticates but does not **authorize**. A valid JWT cookie grants full access to
+every record and every action, including arming live IBKR trades. The schema cannot express
+ownership — no data table carries a `user_id` — so adding a second user silently shares all
+trade journals, watchlists, strategies, and scanner configs (horizontal privilege escalation by
+construction).
+
+**What already exists** (authentication foundation is in place):
+- `users` table: `id` (UUID), `username`, `password_hash`, `created_at`, `is_active`. **No role.**
+- JWT-in-cookie auth (`{sub, exp}`, HS256), `get_current_user` / `ws_get_current_user`
+  dependencies, refresh-token rotation, an ASGI `AuthMiddleware` that validates the signature on
+  all non-exempt routes.
+- Registration is **bootstrap-only** (blocks after the first user).
+
+**What is missing** (pure authorization gap):
+- No `role` on `User`; no role/scope claim used for decisions.
+- `get_current_user` is wired into only **6 endpoints** today (logout, `/me`, the WebSockets) — every
+  other endpoint authenticates via middleware but **never extracts the user**.
+- No `user_id` on any data table; no per-user query scoping anywhere.
+
+## 2. Goal & end-state decisions
+
+The end-state is **real multi-user**, reached in phases. Decisions locked during brainstorming:
+
+| Dimension | Decision |
+|---|---|
+| Tenancy shape | **Flat multi-user, one workspace.** `user_id` only — **no** org/tenant entity, no `org_id`. |
+| Trading-account boundary | **Shared IBKR account/desk.** Per-user (BYO) broker accounts are a **separate later epic** — out of scope here. |
+| Work-product ownership | Universes, scanner configs, strategies, backtests are **personal, private by default.** |
+| Roles | **`admin` / `member`** (two fixed roles). |
+| Provisioning | **Invite links/tokens.** Admin issues a one-time, expiring invite; invitee completes signup; defaults to `member`. |
+| Enforcement | **Hybrid (Approach C):** explicit `require_admin` for the small role surface + centralized, can't-forget data scoping for the large data surface, rolled out router-by-router with a two-user test per router. |
+
+### Explicitly out of scope
+- Per-user (BYO) IBKR broker accounts / per-user positions isolation — **later epic**.
+- Organizations / tenants / workspaces — not building an `org_id`.
+- Cross-user admin analytics/views — deferred (the mechanism allows it via `unscoped()`).
+- Granular capability flags — fixed two-role model only.
+
+## 3. Resource classification
+
+Every table falls into one of three buckets.
+
+### ① Personal — gets `user_id` FK (NOT NULL, indexed); queries scoped to owner
+`Trade` (+ `TradeExecution` via parent), `JournalEntry`, `Tag`, `ActiveWatchlist`,
+`AlertRule` (+ `AlertDeliveryLog` via parent), `PushSubscription`, `NewsPreference`,
+`StockUniverse`, `ScannerConfig`, `TradingStrategy`, `AutoTradeOrder`,
+`BacktestRun` (+ `BacktestTrade` via parent).
+
+Child rows (`TradeExecution`, `AlertDeliveryLog`, `BacktestTrade`) inherit ownership through their
+parent FK and do **not** get their own `user_id` column.
+
+### ② Global / shared reference — NO `user_id`; everyone reads; admin-only writes where applicable
+`StockAggregate`, `FuturesAggregate`, `FuturesContract`, `FuturesRollover`, `StockMetric`,
+`StockSplit`, `TickerReference`, `MarketHoliday`, `NewsArticle`, `RegimeModel`, `SystemConfig`,
+all outcome/signal-analysis models (`Scanner*Outcome*`, `SignalAnalysisRun`, `SignalCluster`,
+`SignalReview`), `TweetSignal`.
+
+### ③ Attributed-but-global — gets `user_id` for "who ran it" + per-user rate-limiting; results stay globally readable
+`ScannerRun` — carries `user_id` for attribution and per-user rate-limiting, but the `ScannerEvent`s
+it produces are **global** market facts (see edge case 1).
+
+(`BacktestRun` is **fully personal** — bucket ①: it carries `user_id` and both the run and its
+`BacktestTrade` results are scoped to the owner. It is listed only under ①.)
+
+### Confirmed edge cases
+1. **`ScannerEvent`** → **global** market fact (outcome ML already aggregates across all events).
+2. **`MonitoredAccount`** (Twitter/X handles the backend polls) → **admin-managed global ingestion
+   config**, not personal — the poller produces `TweetSignal`s consumed by everyone.
+3. **`NewsPreference`** → **personal** (each user tracks their own tickers).
+
+## 4. Role & capability model
+
+Two roles. **Authorization decisions read `current_user.role` from the DB**, never the JWT claim —
+so demoting/deactivating a user takes effect immediately rather than waiting for token expiry. The
+`role` claim is added to the JWT **only** so the frontend can render role-aware UI.
+
+- **`admin`** — everything `member` can do, plus: arm/approve live trades, toggle `paper_mode`,
+  destructive/global mutations, system config writes, and user management. Bootstrap (first) user is
+  `admin`.
+- **`member`** — own personal data + full app use + all global reads. **Cannot** arm/approve live
+  trades, write system config, perform destructive global mutations, or manage users.
+
+### Admin-only endpoints (`require_admin`)
+
+| Capability | Endpoints |
+|---|---|
+| Live trading (shared account) | `POST /trading/orders/{id}/approve` · `/reject` · `/cancel` · `GET /trading/account` · `PATCH /trading/config` (paper_mode) |
+| Destructive / global mutations | `DELETE /universe/aggregates` · `POST /system/apply-split-adjustments` · `PATCH /system/config` · `POST /alerts/push/generate-keys` |
+| User management (new) | `GET /users` · `POST /users/invite` · `DELETE /users/invite/{id}` · `PATCH /users/{id}` (role/active) · `DELETE /users/{id}` |
+
+`GET /system/config` and other `GET /system/*` stay readable by members (app settings, not secrets).
+`GET /trading/account` is **admin-only** (shared-account financials).
+
+### Approval workflow this creates
+A member builds a strategy → it generates an `AutoTradeOrder` they own → only an **admin** can
+approve/arm it on the shared IBKR account. This dovetails with the existing `requires_approval`
+flag and with #368 (notional cap + kill switch) on that same path.
+
+## 5. Enforcement architecture (Approach C)
+
+1. **`OwnedModel` mixin** — adds `user_id: Mapped[uuid.UUID]` FK to `users.id`, `nullable=False`,
+   indexed. The ~13 personal parent models inherit it.
+
+2. **`current_user` wired everywhere** — add `Depends(get_current_user)` at the **router level** for
+   all authenticated routers so every handler has the user object; layer `require_admin` on the
+   admin endpoints in §4. (`require_admin` depends on `get_current_user` and checks
+   `current_user.role`.)
+
+3. **`scoped(model, user)` query helper** — the canonical read path for owned data:
+   `select(model).where(model.user_id == user.id)`. Creates set `user_id = user.id`. Update/delete
+   fetch **through** `scoped()` first; touching another user's row returns **404** (not 403 — do not
+   reveal existence).
+
+4. **`with_loader_criteria` safety net** — a request-scoped SQLAlchemy filter, driven by a
+   `contextvar` the auth dependency sets, that auto-injects `user_id == current_user.id` on every
+   owned-model SELECT. Belt-and-suspenders: a handler that forgets `scoped()` still cannot leak.
+   - **Escape hatch** — `unscoped()` context (admin cross-user reads, background tasks) disables the
+     criteria explicitly.
+
+### Background workers (critical edge)
+The safety net is **request-scoped and inert in Celery** (no request user). Tasks that create owned
+rows — e.g. an alert-rule evaluation spawning an `AutoTradeOrder` — must set `user_id` **explicitly**
+from the parent resource's owner (`strategy.user_id`). Per-task `user_id`-stamping is a checklist
+item in each affected rollout slice.
+
+## 6. Provisioning & invite flow
+
+- `POST /users/invite {role}` (admin) → generate a random token; store only its **hash** + expiry +
+  issuing admin + role; return the one-time link/token in plaintext to the admin to hand off.
+- `GET /auth/invite/{token}` → validate (unused, unexpired) and show the signup form.
+- `POST /auth/invite/{token}/accept {username, password}` → create the user with the invited role,
+  mark the token `used` (one-time), and log them in (issue JWT).
+- The existing bootstrap `/register` stays **first-user-only** (becomes `admin`); all subsequent
+  users arrive via invites. Open registration stays blocked.
+- Admin can revoke an unused invite (`DELETE /users/invite/{id}`).
+
+### `invite_tokens` table
+`id`, `token_hash`, `created_by` (admin user_id FK), `role` (granted role), `expires_at`,
+`used_at` (nullable), `used_by` (nullable user_id FK).
+
+## 7. Migration & backfill strategy
+
+Per personal table, the safe three-step pattern (additive, restartable, idempotent):
+1. Add `user_id` **nullable** (+ FK + index).
+2. **Backfill** every existing row to the bootstrap admin's id (all current data belongs to the
+   single existing user); child tables backfill from their parent.
+3. Alter to **NOT NULL**.
+
+Plus: add `User.role` with `server_default='member'`, then set the existing first user to `admin`.
+New `invite_tokens` table is a plain create.
+
+### Safety guards
+- **Fresh DB** (zero rows): backfill no-ops; NOT NULL trivially satisfied.
+- **Existing data but no user**: migration **fails loudly** rather than inventing an owner.
+- **Idempotent / restartable** (consistent with the orphaned-preview-schema idempotency rule).
+- The backend **entrypoint runs `alembic check`, not `upgrade`** — deploy requires a deliberate
+  `alembic upgrade head` step (flag in the epic). Validate against a throwaway DB before merge.
+
+## 8. Frontend
+
+- **Invite acceptance page** — public route `/invite/:token` → set username/password form.
+- **User management UI** (admin-only) — list users, generate invite link, revoke invite, change
+  role, deactivate.
+- **Role-aware gating** — read `role` from `/auth/me`; hide/disable admin-only actions (approve
+  order, paper_mode toggle, system config, purge aggregates, user mgmt) for members; handle `403`
+  gracefully if a member calls one anyway.
+- **No other UI change** — the backend scopes data automatically, so existing pages show "my" data.
+  Cross-user admin views are deferred.
+- `tsc --noEmit` must stay green.
+
+## 9. Verification
+
+The point of the finding is to **prove the IDOR hole is closed**.
+
+- **Two-user isolation suite** — per personal resource: A creates a row → B gets `404` on
+  read/update/delete and B's list excludes it. Regression gate, run per resource-group.
+- **Role-gating suite** — `member` gets `403` on every admin-only endpoint; `admin` succeeds.
+- **Invite suite** — create/accept/expire/reuse/revoke; first-user bootstrap still works; open
+  registration still blocked.
+- **Safety-net test** — a deliberately un-`scoped()` query still returns only the caller's rows.
+- **Worker test** — alert-rule task stamps the correct `user_id` on a generated `AutoTradeOrder`.
+- **Migration test** — throwaway DB seeded with single-user data → assert backfill correctness.
+- **Re-run the security review** to confirm F-AUTHZ-01 closed ("verified against code", per #372 DoD).
+
+## 10. Epic phasing → sub-issue slices
+
+Each slice is independently grabbable, vertically sliced, and carries its own tests.
+
+### Phase 1 — Identity & roles (closes the dangerous gap first)
+- **S1** — `User.role` + migration + `require_admin` + gate all admin-only endpoints + wire
+  `current_user` at router level. *Tracer bullet: a member can no longer arm trades or change
+  config. Highest security value, smallest blast radius.*
+- **S2** — Invite provisioning: `invite_tokens` table, admin invite/revoke endpoints, accept flow,
+  frontend invite page + user-management UI.
+
+### Phase 2 — Per-user ownership (mechanical bulk)
+- **S3** — Enforcement scaffolding: `OwnedModel` mixin, `scoped()`, `with_loader_criteria` safety net
+  + `unscoped()` escape, contextvar wiring, **proven end-to-end on Watchlist** with a two-user test.
+  *Tracer bullet for the scoping mechanism.*
+- **S4** — Journals / trades / tags scoping (+ migration + two-user test).
+- **S5** — Alerts (rules / delivery / push subs) scoping.
+- **S6** — Universes scoping.
+- **S7** — Scanner configs + runs scoping.
+- **S8** — Strategies + auto-trade orders scoping (+ Celery `user_id` stamping).
+- **S9** — Backtests + news preferences scoping.
+
+### Phase 3 — Closeout
+- **S10** — Full isolation + role-gating regression suite, throwaway-DB migration validation, **ADR**
+  documenting the authz model (`docs/adr/`), re-run security review, update `CONTEXT.md`, close epic.
+
+Phase 1 alone closes the privilege-gating half of F-AUTHZ-01; Phase 2 closes the data-isolation half.
+
+## 11. Risks & mitigations
+- **Forgotten scoping filter (IDOR)** → the `with_loader_criteria` safety net + mandatory two-user
+  test per slice.
+- **Over-broad global filter breaking admin/worker paths** → explicit `unscoped()` escape; workers
+  never rely on request scoping and stamp `user_id` from the parent resource.
+- **NOT NULL migration on populated tables** → three-step additive pattern + fail-loud guard +
+  throwaway-DB validation.
+- **Stale role in JWT after demotion** → authz reads DB `current_user.role`, never the claim.
+- **Deploy forgets `alembic upgrade head`** (entrypoint is `alembic check` only) → called out in the
+  epic and each migration slice.

--- a/docs/superpowers/specs/2026-06-21-epic-autopilot-broaden-reach-design.md
+++ b/docs/superpowers/specs/2026-06-21-epic-autopilot-broaden-reach-design.md
@@ -1,0 +1,163 @@
+# Epic Autopilot — broaden reach (drain the backlog, start the next epic)
+
+**Status:** design
+**Date:** 2026-06-21
+**Epic:** #548 (Dark Factory platform — maintenance, telemetry)
+**Builds on:** `2026-06-20-epic-autopilot-design.md` (the starved-only self-unlock reviewer)
+**Sibling spec:** `2026-06-21-main-red-autofix-design.md` (separate feature; implement A first)
+**Build constraint:** Modifies the scheduler/factory itself (a "factory self-edit"), so it
+must be **human-implemented**, never auto-refined/implemented by the factory. Edits to
+`scheduler.sh` / `factory_core/` are **baked** — they need
+`docker compose build backlog-scheduler` + `up --force-recreate` to take effect.
+
+## Problem
+
+Epic Autopilot shipped (#571) but in practice advances nothing. Observed 2026-06-21:
+`backlog=87 refined=4 in_progress=4 in_review=1`, free slots everywhere, yet every cycle
+logs `autopilot=no_candidates`. Tracing the funnel against the live board:
+
+1. **Candidate source is too narrow.** `fetch_candidates()` only returns OPEN sub-issues of
+   *in-progress* epics that carry a `spec-pending-review` / `plan-pending-review` label. It
+   cannot see Backlog, Ready, or Refined work. The 6 "Ready" items are all **epics**
+   (#373, #483, #438, #448, #449, #450), which nobody dispatches — so there is committed,
+   prioritised work sitting idle that autopilot structurally cannot reach.
+2. **Within its pool, every candidate is dropped** by one of: size-L above-ceiling
+   (the meaty data-quality children #492/#494/#495/#499/#500), `needs-discussion`,
+   trading/auth hard-exclude (correct), factory-self hard-exclude (correct),
+   **undeclared-scope fail-closed** (over-aggressive), or a permanent cached `HOLD`.
+
+Three of those drops are *accidental* (size-L, undeclared-scope, stale-HOLD); the rest are
+intentional safety. We want autopilot to (a) stop the accidental drops, (b) advance size-L
+children, and (c) when its existing pool is dry, **start the next epic** itself.
+
+## Decision
+
+Three changes to the existing module + scheduler + factory ceiling. The starved-only
+trigger, main-green-only guard, Opus low-risk+confidence gate, `no-autopilot` opt-out,
+daily cap, kill-switch, reversibility, and comment+notify-every-action invariants are all
+**unchanged**.
+
+### 1. Soft over-drops (Stage B, `epic_autopilot.py`)
+
+- **Undeclared scope is no longer a hard drop.** Today `hard_excluded()` returns
+  `(True, "undeclared-scope")` whenever `extract_target_paths()` finds no path-like tokens.
+  Change: undeclared scope passes through to Opus as an explicit **concern** in the review
+  prompt ("declared file scope: none — treat trading/auth/factory risk as possible"). The
+  fail-closed hard-drop is retained **only** when trading/auth keywords actually appear in
+  the title/body (`trading|order|ibkr|auth|login|jwt|session|rbac|token`), or when a
+  declared path matches `exclude_paths`. Opus still defaults to HOLD when uncertain, so the
+  envelope holds; we just stop discarding safe-but-pathless specs before review.
+- **Cached HOLD gets a TTL.** `record_verdict()` stamps a `ts`; `cached_verdict()` returns
+  the cached HOLD only if `now - ts < hold_ttl_hours` (default 24h) **and** the spec hash
+  still matches. After the TTL, the ticket is re-reviewed (spec may have been edited, or the
+  earlier HOLD was a one-off). ADVANCE remains terminal (label present ⇒ not a candidate).
+
+### 2. Size ceiling → L (autopilot + factory)
+
+- **Autopilot:** `is_eligible()` currently drops `size in (L, XL)`. Change to drop `XL` only
+  (L becomes eligible). The M+keyword ceiling check is removed for autopilot — Opus weighs
+  blast radius directly.
+- **Factory implement ceiling (#339, global):** raise the dispatch ceiling so **L is below
+  ceiling**. `is_above_ceiling()` in `scheduler.sh` classifies `size: L` as above-ceiling
+  today; the change makes only `XL` (and M-with-keyword, if we keep that) above-ceiling, via
+  the `.dispatch_ceiling.*` config. This is a **global** behaviour change: it affects the
+  Priority-2 park gate (`scheduler.sh:957`) and the timer-based advance (`:341`) for **all**
+  tickets, human-created included — not just autopilot's. Called out explicitly as an
+  accepted factory-self change.
+
+### 3. Broaden candidate source + epic-starter (`epic_autopilot.py`)
+
+`fetch_candidates()` keeps returning gated children of in-progress epics (advance those
+first — finish what's started). When that pool yields no candidate, a new
+**`pick_next_epic()`** stage runs:
+
+- Enumerate epics whose board Status is **Ready** (unstarted).
+- **Skip hard-excluded epics**: security/auth/trading/factory-self by label or title
+  keyword (e.g. #373 security is skipped; the next eligible epic is chosen).
+- **Order by priority:** `priority:` label (`must-have` before `should-have`), then board
+  order / issue age as a tiebreak.
+- **Promote & delegate** the chosen epic (one per starved cycle):
+  - move its board Status `Ready → In progress`,
+  - add `ready-for-agent` to its OPEN children (so the normal Priority-5 refiner picks them
+    up), and
+  - post a comment + notification ("🤖 Epic Autopilot — starting epic #N «title»").
+- Autopilot then **sleeps**: promoting fills the pipeline, so the next cycle isn't starved.
+  No Opus review is needed to *start* an epic (promotion is fully reversible — demote +
+  remove labels); Opus review still gates each **child** advance as today.
+
+### Control flow (`scheduler.sh`, Priority 6)
+
+Unchanged trigger — still `[ -z "$DISPATCHED" ] && [ "$MAIN_IS_RED" = "false" ] &&
+[ "$EPIC_AUTOPILOT_ENABLED" = "true" ]`. The module now has two internal outcomes beyond
+today's: `autopilot=epic_started epic=#N`. The scheduler maps `advanced`/`epic_started` to a
+non-empty `DISPATCHED`.
+
+## Module shape (`dark-factory/scripts/factory_core/epic_autopilot.py`)
+
+Pure-core + injected-IO pattern is preserved. New/changed pure functions (all unit-tested,
+no IO):
+
+- `hard_excluded(c, exclude_paths)` → drop only on keyword/path match; undeclared scope
+  returns `(False, "undeclared-scope")` and sets a `scope_undeclared` flag on the candidate.
+- `is_eligible(...)` → `XL` ceiling only.
+- `cached_verdict(state, issue, hash, now, ttl)` / `record_verdict(..., now)` → TTL-aware.
+- `pick_next_epic(epics)` → pure selector: takes `[{number, title, labels, priority,
+  board_order, status}]`, returns the chosen epic number or `None` (skips hard-excluded,
+  orders by priority then board_order).
+- `run_once(cfg, io, state, today, now)` → after the child-candidate pass yields nothing,
+  call `io.fetch_ready_epics()` → `pick_next_epic()` → `io.promote_epic(n)` →
+  comment/notify/record. New outcome dict `{"outcome": "epic_started", "issue": n}`.
+
+New `LiveIO` adapters: `fetch_ready_epics()` (GraphQL: board items Status=Ready + `epic`
+label + priority label + order), `promote_epic(n)` (set Status field → In progress; add
+`ready-for-agent` to OPEN children via the existing sub-issue query).
+
+## Config (`.claude/skills/refinement/config.yaml`, `epic_autopilot:` section)
+
+```yaml
+epic_autopilot:
+  enabled: false                 # unchanged kill-switch (env EPIC_AUTOPILOT_ENABLED overrides)
+  model: claude-opus-4-8
+  daily_cap: 5                   # caps advances AND epic-starts combined per UTC day
+  confidence_floor: 0.7
+  hold_ttl_hours: 24             # NEW — re-review a cached HOLD after this long
+  size_ceiling: XL               # NEW — drop only at/above this size (was effectively L)
+  start_epics: true              # NEW — enable the epic-starter stage
+  opt_out_label: no-autopilot
+  hard_exclude_paths: [ ... ]    # unchanged
+dispatch_ceiling:                # GLOBAL factory ceiling (#339) — raise to allow L
+  enabled: true
+  # size L is now below ceiling; only XL (and M+keyword, if retained) park
+```
+
+## Error handling / safety
+
+- Fail-closed unchanged: parse errors → HOLD; trading/auth keyword hits → hard drop;
+  declared exclude-path hits → hard drop.
+- Epic promotion is reversible (demote Status + remove `ready-for-agent`); it triggers no
+  code change and no PR by itself.
+- Daily cap covers advances **and** epic-starts so the combined autonomous rate is bounded.
+- Notifications fail-soft (logged, never block).
+
+## Validation
+
+- **Python unit tests** (mocked, alongside `test_epic_autopilot.py`): undeclared-scope now
+  passes through + sets the concern flag; trading/auth keyword still hard-drops;
+  HOLD-TTL expiry re-enables review; `size: L` eligible, `XL` dropped; `pick_next_epic`
+  ordering + hard-exclude skip (security epic skipped, next chosen); `epic_started` outcome
+  shape; daily-cap counts starts + advances.
+- **Scheduler bash test** (`SCHEDULER_SOURCE_ONLY`): `is_above_ceiling` treats L as below
+  ceiling under the new config; Priority-6 maps `epic_started` to a non-empty DISPATCHED.
+- **Manual:** enable on the live scheduler (env already `true`); confirm it advances a size-L
+  data-quality child end-to-end; empty the gated-child pool and confirm it promotes the
+  highest-priority non-security Ready epic (skipping #373) and marks its children
+  `ready-for-agent`; confirm comment + notification on both paths; force the daily cap.
+
+## Accepted trade-offs
+
+- Raising the **global** dispatch ceiling to L means human-created L tickets also dispatch
+  autonomously — a deliberate throughput-for-oversight trade.
+- Softening undeclared-scope leans harder on Opus's judgement (mitigated by the keyword
+  fail-closed backstop + default-HOLD).
+- Epic-starter advances board state without a heavyweight review; justified because
+  promotion is fully reversible and every child still passes the Opus gate before any PR.

--- a/docs/superpowers/specs/2026-06-21-main-red-autofix-design.md
+++ b/docs/superpowers/specs/2026-06-21-main-red-autofix-design.md
@@ -1,0 +1,159 @@
+# Main-Red Auto-Fix — autonomous pipeline recovery
+
+**Status:** design
+**Date:** 2026-06-21
+**Epic:** #548 (Dark Factory platform — maintenance, telemetry)
+**Sibling spec:** `2026-06-21-epic-autopilot-broaden-reach-design.md` (implement that first)
+**Build constraint:** Factory self-edit → **human-implemented** only. New module +
+`scheduler.sh` priority are **baked**; need `docker compose build backlog-scheduler` +
+`up --force-recreate` to deploy.
+
+## Problem
+
+When the smoke gate trips, `smoke_gate.sh` writes a `main-is-red` sentinel (and a
+`main-is-red-issue` regression ticket) which pauses all implementation dispatch
+(`scheduler.sh:865`, Priorities 1.5/2/3 gated). Recovery today is either the throttled
+"Recheck main" run (which only clears the sentinel if main *self-heals*) or a human fixing
+the break. In this repo red main is most often caused by the **pipeline itself** —
+smoke-gate env gaps, migrations not-up-to-date, compose/CI regressions — and it can block
+the whole factory for hours.
+
+We want a bounded autonomous agent that, when main is red, **diagnoses → fixes →
+verifies-green → merges**, and escalates to a human when it can't.
+
+## Decision
+
+A new **Main-Red Auto-Fix** path, separate from Epic Autopilot (different action model: it
+edits code and merges to main). A new scheduler priority fires when the sentinel is set; a
+new module (`factory_core/main_red_fixer.py`, pure-core + injected-IO) drives one bounded
+fix attempt per cycle. Ships **OFF** behind its own kill-switch.
+
+### Trigger & dedupe (`scheduler.sh`)
+
+A new block at the **top of the loop** (highest priority — nothing matters more than green
+main), guarded by `MAIN_IS_RED == true` and `MAIN_RED_AUTOFIX_ENABLED == true`:
+
+```sh
+if [ "$MAIN_IS_RED" = "true" ] && [ "${MAIN_RED_AUTOFIX_ENABLED:-false}" = "true" ]; then
+  if ! fix_container_running; then          # reuse the recheck dedupe pattern (:170)
+    dispatch "Fix main" && DISPATCHED="Fix main"
+  fi
+fi
+```
+
+One attempt at a time (dedupe on a running "Fix main" container), one per cycle. The
+existing "Recheck main" self-clear path is **left intact** as a fallback for self-healing
+breaks.
+
+### Diagnosis input
+
+The fixer reads:
+- `${SMOKE_STATE_DIR}/main-is-red-issue` → the regression ticket number, and that ticket's
+  body/comments (what `smoke_gate.sh` recorded).
+- Reproduces locally via the smoke gate's own checks (`tsc`, python import) and, when
+  available, the failing GitHub CI logs for `main`.
+
+### Scope (hard envelope)
+
+**Allowed:** smoke-gate scripts, alembic migrations, `docker-compose*.yml`, `.github/`
+workflows, env contracts (`.env*` templates / preview compose), and app code
+(`backend/`, `frontend/`).
+
+**Blocked (escalate immediately, never attempt):** `scheduler.sh`, `factory_core/`, the
+autopilot/fixer modules themselves — the control loop must not rewrite its own brain. If
+diagnosis concludes the root cause lives in the protected zone, the fixer posts the
+diagnosis to the regression ticket, notifies a human, and stops (counts as a terminal
+escalation, not a retry).
+
+### Fix loop (verify-green-then-merge)
+
+1. Branch from `main` (`fix/main-red-<issue>`).
+2. Apply the fix (a `claude -p` coding agent constrained to the allowed scope).
+3. Push → open a **ready** (non-draft) PR linking the regression ticket, with the diagnosis
+   in the body.
+4. **Wait for the branch's full CI to pass.** Poll the PR checks (bounded wait).
+5. **CI green → merge** (squash). The existing green-recheck then clears the `main-is-red`
+   sentinel and closes the regression ticket — no new sentinel logic needed.
+6. **CI red →** treat as a failed attempt (see bounding).
+
+It **never** merges a red or unverified branch.
+
+### Bounding & escalation
+
+- **Attempt cap** `max_attempts` (default **3**) per red event, tracked in a state file
+  keyed by the regression-issue number. An attempt = one fix→push→CI cycle.
+- On cap reached (or a protected-zone root cause): stop, **leave the last PR open**, post a
+  summary to the regression ticket, and send an escalation notification. No further attempts
+  until the sentinel clears and a new red event opens a new issue number.
+- Per-attempt timeouts on the coding agent and the CI wait (fail → counts as an attempt).
+
+### Notifications (`/api/v1/alerts/system`, fail-soft)
+
+1. **Red detected / fixing** *(warning)* — "🛠️ Main is red (#issue) — auto-fix attempt N/3 in progress."
+2. **Recovered** *(info)* — "✅ Main-red auto-fix merged PR #P — main is green again."
+3. **Escalation** *(warning)* — cap reached or protected-zone cause; "human needed."
+
+## Module shape (`dark-factory/scripts/factory_core/main_red_fixer.py`)
+
+Pure-core + injected-IO, mirroring `epic_autopilot.py`:
+
+- **Pure:** `classify_scope(target_paths, allowed, blocked)` → allowed | protected | unknown;
+  `should_escalate(attempts, cap, scope_verdict)`; attempt-state read/record with cap +
+  per-issue keying; PR-checks → green/red/pending reducer.
+- **LiveIO:** `read_regression(issue)`, `reproduce()` (run smoke checks), `apply_fix(prompt)`
+  (`claude -p` constrained agent), `open_pr(branch)`, `poll_ci(pr)`, `merge(pr)`,
+  `comment()`, `notify()`.
+- `run_once(cfg, io, state)` → one bounded attempt; returns
+  `{outcome: fixing|merged|escalated|noop, issue, pr}`.
+
+## Config (`.claude/skills/refinement/config.yaml`, new `main_red_autofix:` section)
+
+```yaml
+main_red_autofix:
+  enabled: false                 # kill-switch — ships OFF (env MAIN_RED_AUTOFIX_ENABLED)
+  model: claude-opus-4-8
+  max_attempts: 3                # fix→CI cycles per red event
+  ci_wait_minutes: 20            # bounded wait for branch CI
+  allowed_paths: [ "backend/", "frontend/", "alembic/", "dark-factory/smoke_gate.sh",
+                   "docker-compose", ".github/", ".env" ]
+  blocked_paths: [ "dark-factory/scheduler.sh", "dark-factory/scripts/factory_core/",
+                   "dark-factory/entrypoint.sh" ]
+```
+
+## Known limitations (call out in implementation)
+
+- **Baked-file fixes don't self-deploy.** A fix to `smoke_gate.sh` (a baked file) lands in
+  git and goes green in CI, but the *running* scheduler/gate keeps the old baked copy until a
+  human rebuilds the image + force-recreates. The fixer notes this in the recovered
+  notification when its diff touches baked paths.
+- The fixer reproduces with the smoke gate's lightweight checks (`tsc` + python import); a
+  red caused by something the smoke gate doesn't run (e.g. a full integration suite) is
+  diagnosed from CI logs only.
+
+## Error handling / safety summary
+
+Red-only trigger · highest priority · one attempt/cycle with container dedupe · allowed/
+blocked path envelope (protected zone → immediate escalation) · verify-green-before-merge
+(never lands red) · attempt cap + escalate · separate kill-switch (ships OFF) · every action
+commented on the regression ticket + notified · existing recheck self-clear left intact.
+
+## Validation
+
+- **Python unit tests** (mocked): `classify_scope` (allowed/protected/unknown);
+  protected-zone cause → escalate without attempting; attempt-cap enforcement + per-issue
+  keying; CI-checks reducer (green/red/pending); never-merge-on-red; outcome shapes;
+  notification payloads.
+- **Scheduler bash test** (`SCHEDULER_SOURCE_ONLY`): the "Fix main" block fires only when
+  `MAIN_IS_RED=true` + enabled + no fix container running; does not fire when green.
+- **Manual (staging):** induce a red main with an app-code break (tsc/import) → confirm
+  branch → PR → CI green → merge → sentinel cleared + ticket closed + recovered notification.
+  Induce a protected-zone cause → confirm immediate escalation, no PR. Force `max_attempts`
+  → confirm escalation notification + PR left open.
+
+## Accepted trade-offs
+
+- Auto-merging to main is gated on branch-CI-green, so it cannot make main *worse*, but it
+  does bypass human pre-merge review for pipeline fixes — bounded by the attempt cap + scope
+  envelope + kill-switch.
+- Cannot fix breaks rooted in its own brain (by design) — those escalate.
+- Baked-file fixes need a human rebuild to deploy (noted above).


### PR DESCRIPTION
## Epic Autopilot — broaden reach (closes omniscient/dark-factory#136)

Makes the dark-factory Epic Autopilot actually advance work instead of logging `autopilot=no_candidates` every cycle while the backlog sits idle.

**Spec:** `docs/superpowers/specs/2026-06-21-epic-autopilot-broaden-reach-design.md`
**Plan:** `docs/superpowers/plans/2026-06-21-epic-autopilot-broaden-reach.md`

### What changed
1. **Soft over-drops** (`hard_excluded`) — undeclared file scope is now a soft Opus concern (with a `scope_undeclared` warning injected into the review prompt) instead of a hard drop; trading/auth keyword hits in title/body still hard-drop (fail-closed).
2. **Size ceiling → XL-only** — `is_eligible` drops only `XL` (L/M now eligible), **and** the global factory dispatch ceiling (#339) in `scheduler.sh` so size-L is below ceiling (only XL parks; M+keyword still escalates). `get_size_label` now recognises `size: XL` (it previously never matched XL).
3. **HOLD TTL** — cached HOLD verdicts expire after `hold_ttl_hours` (default 24h); backward-compatible.
4. **Epic-starter** — when no gated child of an in-progress epic is advanceable, autopilot promotes the highest-priority non-security Ready epic to In progress and marks its children `ready-for-agent` (promote & delegate), one per starved cycle, counted against the daily cap. New `pick_next_epic` selector + `epic_started` outcome mapped in the scheduler.
5. **Live wiring** — `LiveIO.fetch_ready_epics`/`promote_epic` GraphQL adapters, `config.yaml` knobs, and four new `_set_cfg` exports.

### Verification
- 34 Python unit tests pass (`tests/test_epic_autopilot.py`), run on Linux (host can't import the package — `fcntl`).
- Two grep-based scheduler tests pass (`test_scheduler_ceiling.sh` new, `test_scheduler_autopilot_guard.sh` unchanged).
- Built task-by-task (TDD) with a per-task spec+quality review and a final whole-branch review. One review-found Critical (`promote_epic` passed the status *name* to `set_board_status`, which needs the option-id `STATUS_IN_PROGRESS`) was fixed in `1b0524f`.

### Deferred (safe-direction) minors
Logged, non-blocking: `hold_ttl_hours=0` is falsy→treated as "no TTL" (default 24); `sensitive_keywords` regex unguarded (scheduler wraps `|| true`, fail-soft); `_EPIC_EXCLUDE_RE` uses an unescaped `factory.self`; `run_once` docstring lost one sentence; a couple of `pick_next_epic` edge tests.

### Notes
- **Deploy is a separate step:** these are baked factory files — after merge, `docker compose build backlog-scheduler && docker compose up -d --force-recreate backlog-scheduler`.
- This branch also carries the **#591 main-red auto-fix spec** (design only — implementation tracked separately in omniscient/dark-factory#137; not closed by this PR).
- Human-implemented factory self-edit (not auto-dispatched through the factory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
