### PR TITLE
fix(scope-gate): exempt documentation from scope excision/ticketing

### DIFF
--- a/.archon/commands/dark-factory-conformance.md
+++ b/.archon/commands/dark-factory-conformance.md
@@ -178,7 +178,23 @@ fi
 
 This phase runs when the reviewer found `[OOS]` entries and `SCOPE_ENFORCEMENT=true`.
 
-For each `[OOS]` entry:
+### 3.6.0 — Documentation exemption (drop doc-file OOS entries first)
+
+The factory maintains documentation as **in-scope housekeeping**: the implement agent's
+Phase 4 DOCUMENT step is **required** to update the documentation map (`ARCHITECTURE.md`,
+`PROJECT_STRUCTURE.md`, `ENV_VARIABLES.md`, `README.md`, `CLAUDE.md`, files under `docs/`) so it
+tracks the files / endpoints / models the implementation added or changed. Those doc updates
+are **never** out-of-scope and must **never** be excised or filed as backlog tickets — doing so
+just churns the docs the implement agent correctly wrote (the exact failure that produced the
+`scope-spillover` doc tickets this rule removes).
+
+Before any excision (3.6.1) or ticketing (3.6.2), **drop every `[OOS]` entry whose file/area is
+a documentation file** — its file/area (the text before the `—` separator) matching `.md` or
+under `docs/`. Only non-doc (code / config / seed) OOS entries proceed to remediation. Log
+each dropped doc entry:
+`echo "scope-enforcement: doc change kept in-scope (not excised/ticketed): <entry>"`.
+
+For each remaining (non-doc) `[OOS]` entry:
 
 ### 3.6.1 — Attempt excision (if `EXCISE_OOS=true`)
 
@@ -214,7 +230,16 @@ set in Phase 3.1 step 5 and appended on each reconcile cycle):
 OOS_ENTRIES=()
 while IFS= read -r line; do
   stripped="${line#- }"
-  [[ "$stripped" == \[OOS\]* ]] && OOS_ENTRIES+=("$stripped")
+  [[ "$stripped" == \[OOS\]* ]] || continue
+  # Documentation exemption (3.6.0): the factory maintains docs in-scope (implement Phase 4
+  # DOCUMENT), so doc-map updates are never excised/ticketed. Match only the file/area
+  # (before the em-dash) so a code finding that merely *mentions* a doc isn't dropped.
+  area="${stripped%%—*}"
+  if printf '%s' "$area" | grep -qiE '\.md([^a-z0-9]|$)|(^|[^a-z])docs/'; then
+    echo "scope-enforcement: doc change kept in-scope (not excised/ticketed): $stripped"
+    continue
+  fi
+  OOS_ENTRIES+=("$stripped")
 done <<< "$CONFORMANCE_DIALOGUE"
 ```
 

--- a/.claude/skills/refinement/conformance-reviewer-prompt.md
+++ b/.claude/skills/refinement/conformance-reviewer-prompt.md
@@ -24,7 +24,7 @@ For each requirement or key decision in the spec, evaluate four dimensions:
 - **MINOR DEVIATION** — one or more deviations exist, but each is clearly documented/justified or cosmetic; no deviation changes *what gets built* relative to the spec.
 - **MATERIAL DIVERGENCE** — one or more deviations change *what gets built* relative to the spec (different approach chosen, requirement dropped or added, explicit constraint violated).
 
-A different file name, an extra helper function, or a split/merged task is not material unless it violates a spec constraint. Changes not named in the spec — including fixes to pre-existing, unrelated defects — are **out-of-scope deviations** and must be listed in the `## Out-of-Scope Changes` section even if they appear beneficial.
+A different file name, an extra helper function, or a split/merged task is not material unless it violates a spec constraint. Changes not named in the spec — including fixes to pre-existing, unrelated defects — are **out-of-scope deviations** and must be listed in the `## Out-of-Scope Changes` section even if they appear beneficial. (Exception: documentation-map updates that back the in-scope work are in-scope housekeeping — see the **Documentation exception** under Out-of-Scope Changes — never list those.)
 
 ## Output Format
 
@@ -59,6 +59,15 @@ whitespace rewraps, line-length splits, or isort import reorders in touched `.py
 These changes are non-actionable housekeeping — the formatter re-applies them on every
 commit. Only flag as `[OOS]` if the reformatting appears in a file with no spec-required
 changes.
+
+**Documentation exception:** Updates to the project's documentation map — `ARCHITECTURE.md`,
+`PROJECT_STRUCTURE.md`, `ENV_VARIABLES.md`, `README.md`, `CLAUDE.md`, and files under `docs/` —
+that document a file, model, router, service, endpoint, or env var **added or changed by the
+in-scope work** are category (b) supporting housekeeping and are **NOT** out-of-scope, even
+when the spec's file-change list does not name them. The dark factory's implement step is
+**required** (Phase 4 DOCUMENT) to make these updates, and excising them only churns work that
+must be redone. Do NOT emit an `[OOS]` bullet for them. Only flag a doc change as `[OOS]` if it
+documents something entirely unrelated to the in-scope work.
 
 - [OOS] <file or area> — <one-sentence description of the unrelated change>
 


### PR DESCRIPTION
## Stop the scope gate from excising documentation

The dark-factory implement step is **required** (Phase 4 DOCUMENT) to update the doc map (`ARCHITECTURE.md`, `PROJECT_STRUCTURE.md`, `ENV_VARIABLES.md`, …) for the files/endpoints/models it adds. But the **conformance scope gate** then ripped those doc rows back out and filed a `scope-spillover` ticket to re-do them — pure churn. See the smoking-gun spillover tickets #584 / #585:

> "the row was added by the implement agent **but excised by the scope gate because updating ARCHITECTURE.md was not named in the spec's file-change list**."

The reviewer was treating feature-backing doc updates as out-of-scope because the spec never *names* the doc files — ignoring its own rule (b) that "supporting housekeeping directly backing an in-scope change" is **not** out-of-scope.

### Fix (two layers)

1. **`conformance-reviewer-prompt.md`** (baked → needs image rebuild) — adds an explicit **Documentation exception** (mirroring the existing formatter exception): doc-map updates that document something **added/changed by the in-scope work** are category-(b) housekeeping and must not be emitted as `[OOS]`.
2. **`.archon/commands/dark-factory-conformance.md`** (clone-read → effective on merge, no rebuild) — Phase 3.6 now **drops any `[OOS]` entry whose file/area is a doc file** (`.md` / `docs/`) before excision or ticketing. Belt-and-suspenders: even if the reviewer misjudges, docs are never excised or ticketed.

**Code out-of-scope enforcement is unchanged** — unrelated bug-fixes, seed edits, etc. are still excised and ticketed. Only documentation is exempted. The filter matches only the file/area before the `—`, so a code finding that merely *mentions* a `.md` in its description is still enforced.

### Follow-up (not in this PR)
The existing bogus doc spillover tickets (#584, #585, and similar) can be closed once their trivial doc rows are restored on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
