### PR TITLE
feat: weekly restore drill — verify backups via throwaway postgres (#386)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -89,7 +89,7 @@ graph TD
     dbbackup -->|"failure events"| seq
     dbrestoredrill -->|"read backups"| dbbackup
     dbrestoredrill -->|"drill events"| seq
-    dbrestoredrill -.->|"docker run throwaway"| postgres
+    dbrestoredrill -.->|"initdb+restore (isolated)"| dbbackup
 ```
 
 ### Container Users
@@ -100,7 +100,7 @@ graph TD
 | `markethawk-frontend` | `frontend` | `node` | Non-root; default node image user |
 | `markethawk-dark-factory` | `dark-factory`, `backlog-scheduler` | `factory` (uid 1000) | Non-root; created in `dark-factory/Dockerfile` |
 | `markethawk-forecast` | `forecast-worker` | `root` | Exception: HuggingFace model weights (~800 MB) cached at `/root/.cache/huggingface` via `timesfm_cache` named volume; converting to non-root requires relocating the cache path (tracked as a separate follow-up) |
-| `markethawk-db-restore-drill` | `db-restore-drill` | `root` | Exception: Docker socket mount (`/var/run/docker.sock`) requires root to manage the throwaway postgres container; access is limited to ops tooling only. |
+| `markethawk-db-restore-drill` | `db-restore-drill` | `postgres` | Runs as the postgres system user (required to run `initdb` / `postgres` daemon); no Docker socket access. |
 
 ## Scan Execution Flow
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -28,6 +28,7 @@ graph TD
         seqgelf["seq-gelf :12201/udp"]
         forecastworker["forecast-worker (profile: forecasting)"]
         dbbackup["db-backup"]
+        dbrestoredrill["db-restore-drill"]
     end
 
     subgraph factory["factory-network"]
@@ -86,6 +87,9 @@ graph TD
     forecastworker --> redis
     dbbackup -->|"pg_dump"| postgres
     dbbackup -->|"failure events"| seq
+    dbrestoredrill -->|"read backups"| dbbackup
+    dbrestoredrill -->|"drill events"| seq
+    dbrestoredrill -.->|"docker run throwaway"| postgres
 ```
 
 ### Container Users
@@ -96,6 +100,7 @@ graph TD
 | `markethawk-frontend` | `frontend` | `node` | Non-root; default node image user |
 | `markethawk-dark-factory` | `dark-factory`, `backlog-scheduler` | `factory` (uid 1000) | Non-root; created in `dark-factory/Dockerfile` |
 | `markethawk-forecast` | `forecast-worker` | `root` | Exception: HuggingFace model weights (~800 MB) cached at `/root/.cache/huggingface` via `timesfm_cache` named volume; converting to non-root requires relocating the cache path (tracked as a separate follow-up) |
+| `markethawk-db-restore-drill` | `db-restore-drill` | `root` | Exception: Docker socket mount (`/var/run/docker.sock`) requires root to manage the throwaway postgres container; access is limited to ops tooling only. |
 
 ## Scan Execution Flow
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,9 +87,8 @@ graph TD
     forecastworker --> redis
     dbbackup -->|"pg_dump"| postgres
     dbbackup -->|"failure events"| seq
-    dbrestoredrill -->|"read backups"| dbbackup
+    dbrestoredrill -->|"read backups :ro"| dbbackup
     dbrestoredrill -->|"drill events"| seq
-    dbrestoredrill -.->|"initdb+restore (isolated)"| dbbackup
 ```
 
 ### Container Users

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -127,6 +127,15 @@ Set when using the `--profile tls` Caddy service. See [deployment-guide.md — S
 
 ---
 
+## Weekly Restore Drill (`db-restore-drill` service)
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `RESTORE_DRILL_SCHEDULE` | `0 4 * * 0` | Supercronic cron expression (UTC) controlling when the restore drill runs. Default is Sundays at 4 AM UTC — one hour after the daily backup. |
+| `EXPECTED_ALEMBIC_HEAD` | `` (empty) | Expected alembic migration revision to assert after restore. When set, the drill fails if the restored `alembic_version` does not match this value exactly. When empty, the drill asserts only that `alembic_version` is non-empty. Set this in `.env` to the output of `python -m alembic current` after each migration. |
+
+---
+
 ## Monitoring
 
 | Variable | Default | Purpose |

--- a/dark-factory/tests/test_restore_drill.sh
+++ b/dark-factory/tests/test_restore_drill.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Tests for restore-drill.sh conformance to spec (issue #386)
+#
+# R2: when no backup file exists, should exit 0 (skip) — not exit 1 (failure)
+# R3: must NOT use docker socket/docker-run; must use initdb + UNIX socket instead
+
+set -eu
+
+SCRIPT="/workspace/markethawk/scripts/restore-drill.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL+1)); }
+
+# --- Test 1: no-backup path exits 0 ---
+TMPDIR=$(mktemp -d)
+set +e
+BACKUP_DIR="$TMPDIR" SEQ_URL="" PGPASSWORD="dummy" sh "$SCRIPT" >/dev/null 2>&1
+RC=$?
+set -e
+rm -rf "$TMPDIR"
+if [ "$RC" -eq 0 ]; then
+    pass "R2: no-backup exits 0 (skip, not failure)"
+else
+    fail "R2: no-backup exits $RC (expected 0); spec requires exit 0 on fresh-deploy skip"
+fi
+
+# --- Test 2: script does not call 'docker run' (initdb approach required) ---
+if grep -q 'docker run' "$SCRIPT"; then
+    fail "R3: script calls 'docker run' — spec requires initdb+UNIX-socket approach (Alternative 1 was rejected)"
+else
+    pass "R3: script does not call 'docker run' (initdb approach confirmed)"
+fi
+
+# --- Test 3: Dockerfile apk install line does not include docker-cli ---
+DOCKERFILE="/workspace/markethawk/docker/Dockerfile.restore-drill"
+if grep -E 'apk (add|install).*docker-cli' "$DOCKERFILE"; then
+    fail "R3: Dockerfile installs docker-cli — hermetic initdb design must not need it"
+else
+    pass "R3: Dockerfile does not install docker-cli"
+fi
+
+# --- Test 4: docker-compose.yml does not mount Docker socket ---
+COMPOSE="/workspace/markethawk/docker-compose.yml"
+if grep -A 30 'db-restore-drill:' "$COMPOSE" | grep -q 'docker.sock'; then
+    fail "R3: docker-compose.yml mounts /var/run/docker.sock — spec explicitly rejected this"
+else
+    pass "R3: docker-compose.yml does not mount Docker socket"
+fi
+
+# --- Test 5: docker-compose.yml has no depends_on: postgres ---
+if grep -A 40 'db-restore-drill:' "$COMPOSE" | grep -q 'depends_on'; then
+    fail "Hermetic: db-restore-drill has depends_on (spec: 'No depends_on: [postgres]')"
+else
+    pass "Hermetic: db-restore-drill has no depends_on"
+fi
+
+# --- Test 6: ENV_VARIABLES.md documents RESTORE_DRILL_SCHEDULE ---
+ENV_VARS="/workspace/markethawk/ENV_VARIABLES.md"
+if grep -q 'RESTORE_DRILL_SCHEDULE' "$ENV_VARS"; then
+    pass "R9: RESTORE_DRILL_SCHEDULE documented in ENV_VARIABLES.md"
+else
+    fail "R9: RESTORE_DRILL_SCHEDULE missing from ENV_VARIABLES.md"
+fi
+
+# --- Test 7: ENV_VARIABLES.md documents EXPECTED_ALEMBIC_HEAD ---
+if grep -qE 'EXPECTED_ALEMBIC_HEAD|ALEMBIC_EXPECTED_HEAD' "$ENV_VARS"; then
+    pass "R9: alembic head env var documented in ENV_VARIABLES.md"
+else
+    fail "R9: alembic head env var missing from ENV_VARIABLES.md"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/deployment-guide.md
+++ b/deployment-guide.md
@@ -90,6 +90,75 @@ gunzip -c ${BACKUP_DIR:-/var/lib/markethawk/backups}/stockscanner_YYYYMMDD_HHMMS
 docker compose start backend celery-worker celery-beat
 ```
 
+### Weekly Restore Drill
+
+The `db-restore-drill` sidecar runs weekly to verify that the latest backup can actually be restored. It starts automatically with `docker-compose up -d` alongside the other services.
+
+**What it does**
+
+1. Locates the most recent `stockscanner_*.sql.gz` file in `BACKUP_DIR`.
+2. Starts a throwaway `postgres:15-alpine` container on the internal compose network.
+3. Restores the dump into that container via `psql`.
+4. Asserts that five critical tables (`scanner_events`, `trades`, `signal_reviews`, `scanner_configs`, `stock_aggregates`) each have at least one row.
+5. Asserts that `alembic_version` has a non-empty value (schema migration was restored).
+6. Emits a structured Seq event and unconditionally tears down the throwaway container.
+
+The live `stockscanner-db` is never touched — the drill connects only to the throwaway container.
+
+**Schedule**
+
+Runs every Sunday at 4 AM UTC by default (one hour after the daily backup window).
+
+**Configuration (`.env`)**
+
+| Variable | Default | Description |
+|---|---|---|
+| `RESTORE_DRILL_SCHEDULE` | `0 4 * * 0` | Cron schedule (UTC, supercronic syntax) |
+| `DRILL_NETWORK` | `markethawk_stockscanner-network` | Docker network the throwaway container joins |
+| `ALEMBIC_EXPECTED_HEAD` | _(empty)_ | Optional: exact alembic revision to assert; leave empty to accept any non-empty head |
+
+**Trigger a manual one-shot drill**
+
+```bash
+docker compose run --rm db-restore-drill /scripts/restore-drill.sh
+```
+
+**Reading drill results in Seq**
+
+Every drill emits a `backup.restore_drill` CLEF event. Filter in Seq:
+
+```
+EventType = 'backup.restore_drill'
+```
+
+Successful drill: `@l = 'Information'`, `Verdict = 'success'`, per-table counts in `TableCounts`.  
+Failed drill: `@l = 'Error'`, `Verdict = 'failure'`, `ErrorReason` explains why it failed.
+
+Set up a Seq alert on `@l = 'Error' and EventType = 'backup.restore_drill'` to be notified immediately when a drill fails.
+
+**Simulating a corrupted backup**
+
+To verify the drill catches bad backups, truncate a copy of the latest dump and run the drill against it:
+
+```bash
+# Truncate a copy of the latest backup to simulate corruption
+LATEST=$(ls -t ${BACKUP_DIR:-/var/lib/markethawk/backups}/stockscanner_*.sql.gz | head -1)
+cp "${LATEST}" "${LATEST%.sql.gz}_corrupt.sql.gz"
+truncate -s 512 "${LATEST%.sql.gz}_corrupt.sql.gz"
+
+# Rename to make it the "latest" file temporarily (alphabetically last by timestamp)
+mv "${LATEST}" "${LATEST}.bak"
+mv "${LATEST%.sql.gz}_corrupt.sql.gz" "${LATEST}"
+
+# Run the drill — it should fail loudly
+docker compose run --rm db-restore-drill /scripts/restore-drill.sh
+
+# Restore the original
+mv "${LATEST}" "${LATEST%.sql.gz}_corrupt.sql.gz"
+mv "${LATEST}.bak" "${LATEST}"
+rm "${LATEST%.sql.gz}_corrupt.sql.gz"
+```
+
 ### SSL / TLS
 
 A Caddy reverse proxy service is included in `docker-compose.yml`, gated behind `profiles: ["tls"]`. Caddy auto-provisions and renews Let's Encrypt certificates from a single `DOMAIN` environment variable — no pre-provisioned secrets required.

--- a/deployment-guide.md
+++ b/deployment-guide.md
@@ -96,14 +96,14 @@ The `db-restore-drill` sidecar runs weekly to verify that the latest backup can 
 
 **What it does**
 
-1. Locates the most recent `stockscanner_*.sql.gz` file in `BACKUP_DIR`.
-2. Starts a throwaway `postgres:15-alpine` container on the internal compose network.
-3. Restores the dump into that container via `psql`.
+1. Locates the most recent `stockscanner_*.sql.gz` file in `BACKUP_DIR`; if none exists (fresh deploy), logs a warning and exits cleanly (not a failure).
+2. Starts a throwaway postgres cluster inside the container via `initdb` + UNIX socket (no TCP, no external container, no live DB contact).
+3. Restores the dump into the throwaway cluster via `gunzip | psql`.
 4. Asserts that five critical tables (`scanner_events`, `trades`, `signal_reviews`, `scanner_configs`, `stock_aggregates`) each have at least one row.
 5. Asserts that `alembic_version` has a non-empty value (schema migration was restored).
-6. Emits a structured Seq event and unconditionally tears down the throwaway container.
+6. Emits a structured Seq event and unconditionally kills the throwaway postgres process and removes temp directories.
 
-The live `stockscanner-db` is never touched — the drill connects only to the throwaway container.
+The live `stockscanner-db` is never contacted — the drill embeds an isolated postgres cluster with no network listener and no live DB credentials.
 
 **Schedule**
 
@@ -114,8 +114,7 @@ Runs every Sunday at 4 AM UTC by default (one hour after the daily backup window
 | Variable | Default | Description |
 |---|---|---|
 | `RESTORE_DRILL_SCHEDULE` | `0 4 * * 0` | Cron schedule (UTC, supercronic syntax) |
-| `DRILL_NETWORK` | `markethawk_stockscanner-network` | Docker network the throwaway container joins |
-| `ALEMBIC_EXPECTED_HEAD` | _(empty)_ | Optional: exact alembic revision to assert; leave empty to accept any non-empty head |
+| `EXPECTED_ALEMBIC_HEAD` | _(empty)_ | Optional: exact alembic revision to assert after restore. Set to the output of `python -m alembic current` in your `.env`. When empty, the drill asserts only that `alembic_version` is non-empty. |
 
 **Trigger a manual one-shot drill**
 
@@ -131,8 +130,8 @@ Every drill emits a `backup.restore_drill` CLEF event. Filter in Seq:
 EventType = 'backup.restore_drill'
 ```
 
-Successful drill: `@l = 'Information'`, `Verdict = 'success'`, per-table counts in `TableCounts`.  
-Failed drill: `@l = 'Error'`, `Verdict = 'failure'`, `ErrorReason` explains why it failed.
+Successful drill: `@l = 'Information'`, `Verdict = 'passed'`, per-table counts in `TableCounts`.  
+Failed drill: `@l = 'Error'`, `Verdict = 'failed'`, `FailReason` explains why it failed.
 
 Set up a Seq alert on `@l = 'Error' and EventType = 'backup.restore_drill'` to be notified immediately when a drill fails.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,28 +56,20 @@ services:
         limits:
           memory: 128M
 
-  # Restore drill sidecar — weekly scheduled restore into a throwaway container to verify backups
+  # Restore drill sidecar — weekly restore into an embedded throwaway cluster (initdb + UNIX
+  # socket) to verify backups. Never contacts the live DB; no live DB credentials needed.
   db-restore-drill:
     build:
       context: .
       dockerfile: docker/Dockerfile.restore-drill
     container_name: markethawk-db-restore-drill
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_DB: ${POSTGRES_DB:-stockscanner}
-      PGPASSWORD: ${POSTGRES_PASSWORD}
       SEQ_URL: http://seq:5341
       BACKUP_DIR: ${BACKUP_DIR:-/backups}
       RESTORE_DRILL_SCHEDULE: ${RESTORE_DRILL_SCHEDULE:-0 4 * * 0}
-      DRILL_NETWORK: ${DRILL_NETWORK:-markethawk_stockscanner-network}
-      RESTORE_POSTGRES_IMAGE: postgres:15-alpine
-      ALEMBIC_EXPECTED_HEAD: ${ALEMBIC_EXPECTED_HEAD:-}
+      EXPECTED_ALEMBIC_HEAD: ${EXPECTED_ALEMBIC_HEAD:-}
     volumes:
       - ${BACKUP_DIR:-/var/lib/markethawk/backups}:/backups:ro
-      - /var/run/docker.sock:/var/run/docker.sock
-    depends_on:
-      postgres:
-        condition: service_healthy
     networks:
       - stockscanner-network
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,36 @@ services:
         limits:
           memory: 128M
 
+  # Restore drill sidecar — weekly scheduled restore into a throwaway container to verify backups
+  db-restore-drill:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.restore-drill
+    container_name: markethawk-db-restore-drill
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-stockscanner}
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      SEQ_URL: http://seq:5341
+      BACKUP_DIR: ${BACKUP_DIR:-/backups}
+      RESTORE_DRILL_SCHEDULE: ${RESTORE_DRILL_SCHEDULE:-0 4 * * 0}
+      DRILL_NETWORK: ${DRILL_NETWORK:-markethawk_stockscanner-network}
+      RESTORE_POSTGRES_IMAGE: postgres:15-alpine
+      ALEMBIC_EXPECTED_HEAD: ${ALEMBIC_EXPECTED_HEAD:-}
+    volumes:
+      - ${BACKUP_DIR:-/var/lib/markethawk/backups}:/backups:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - stockscanner-network
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+
   # Redis for caching and Celery broker
   redis:
     image: redis:7-alpine

--- a/docker/Dockerfile.restore-drill
+++ b/docker/Dockerfile.restore-drill
@@ -1,0 +1,23 @@
+FROM alpine:3.19@sha256:6baf43584bcb78f2e5847d1de515f23499913ac9f12bdf834811a3145eb11ca1
+
+# postgresql15-client (psql, pg_isready), docker-cli (manage throwaway container), curl (Seq events)
+RUN apk add --no-cache postgresql15-client docker-cli curl
+
+# Install supercronic (arch-aware) — same version as Dockerfile.backup
+ARG SUPERCRONIC_VERSION=0.2.29
+RUN ARCH=$(uname -m); \
+    case "${ARCH}" in \
+        x86_64)  SC_ARCH="linux-amd64" ;; \
+        aarch64) SC_ARCH="linux-arm64" ;; \
+        armv7l)  SC_ARCH="linux-arm" ;; \
+        *)       echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac; \
+    wget -q "https://github.com/aptible/supercronic/releases/download/v${SUPERCRONIC_VERSION}/supercronic-${SC_ARCH}" \
+         -O /usr/local/bin/supercronic && \
+    chmod +x /usr/local/bin/supercronic
+
+COPY scripts/restore-drill.sh /scripts/restore-drill.sh
+COPY scripts/restore-drill-entrypoint.sh /entrypoint.sh
+RUN chmod +x /scripts/restore-drill.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile.restore-drill
+++ b/docker/Dockerfile.restore-drill
@@ -1,7 +1,8 @@
 FROM alpine:3.19@sha256:6baf43584bcb78f2e5847d1de515f23499913ac9f12bdf834811a3145eb11ca1
 
-# postgresql15-client (psql, pg_isready), docker-cli (manage throwaway container), curl (Seq events)
-RUN apk add --no-cache postgresql15-client docker-cli curl
+# postgresql15 (server + client: initdb, postgres, psql), curl (Seq events)
+# No docker-cli needed — throwaway cluster runs via initdb + UNIX socket inside the container
+RUN apk add --no-cache postgresql15 curl
 
 # Install supercronic (arch-aware) — same version as Dockerfile.backup
 ARG SUPERCRONIC_VERSION=0.2.29
@@ -20,4 +21,6 @@ COPY scripts/restore-drill.sh /scripts/restore-drill.sh
 COPY scripts/restore-drill-entrypoint.sh /entrypoint.sh
 RUN chmod +x /scripts/restore-drill.sh /entrypoint.sh
 
+# postgres daemon cannot run as root; run as the postgres system user created by the package
+USER postgres
 ENTRYPOINT ["/entrypoint.sh"]

--- a/scripts/restore-drill-entrypoint.sh
+++ b/scripts/restore-drill-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Entrypoint for the db-restore-drill container: writes crontab from env, then runs supercronic.
+set -eu
+
+RESTORE_DRILL_SCHEDULE="${RESTORE_DRILL_SCHEDULE:-0 4 * * 0}"
+BACKUP_DIR="${BACKUP_DIR:-/backups}"
+
+mkdir -p "${BACKUP_DIR}"
+
+CRONTAB_FILE="/tmp/restore-drill-crontab"
+printf '%s /scripts/restore-drill.sh >> /proc/1/fd/1 2>&1\n' "${RESTORE_DRILL_SCHEDULE}" > "${CRONTAB_FILE}"
+
+echo "db-restore-drill: schedule='${RESTORE_DRILL_SCHEDULE}' network=${DRILL_NETWORK:-markethawk_stockscanner-network} dir=${BACKUP_DIR}"
+
+exec /usr/local/bin/supercronic "${CRONTAB_FILE}"

--- a/scripts/restore-drill-entrypoint.sh
+++ b/scripts/restore-drill-entrypoint.sh
@@ -10,6 +10,6 @@ mkdir -p "${BACKUP_DIR}"
 CRONTAB_FILE="/tmp/restore-drill-crontab"
 printf '%s /scripts/restore-drill.sh >> /proc/1/fd/1 2>&1\n' "${RESTORE_DRILL_SCHEDULE}" > "${CRONTAB_FILE}"
 
-echo "db-restore-drill: schedule='${RESTORE_DRILL_SCHEDULE}' network=${DRILL_NETWORK:-markethawk_stockscanner-network} dir=${BACKUP_DIR}"
+echo "db-restore-drill: schedule='${RESTORE_DRILL_SCHEDULE}' dir=${BACKUP_DIR}"
 
 exec /usr/local/bin/supercronic "${CRONTAB_FILE}"

--- a/scripts/restore-drill.sh
+++ b/scripts/restore-drill.sh
@@ -1,0 +1,169 @@
+#!/bin/sh
+# Weekly restore drill — restores the latest pg_dump into a throwaway postgres container,
+# asserts row counts for critical tables, checks alembic_version, emits a Seq event,
+# and tears down the throwaway container unconditionally via trap.
+#
+# Critical tables must have COUNT(*) > 0 after restore for the drill to pass.
+# alembic_version must have at least one row (confirms schema migration was restored).
+# Failure emits a Seq Error event; success emits an Information event.
+# Both include per-table counts as a structured field.
+set -eu
+
+BACKUP_DIR="${BACKUP_DIR:-/backups}"
+POSTGRES_USER="${POSTGRES_USER:-postgres}"
+POSTGRES_DB="${POSTGRES_DB:-stockscanner}"
+PGPASSWORD="${PGPASSWORD:-}"
+SEQ_URL="${SEQ_URL:-}"
+DRILL_NETWORK="${DRILL_NETWORK:-markethawk_stockscanner-network}"
+RESTORE_POSTGRES_IMAGE="${RESTORE_POSTGRES_IMAGE:-postgres:15-alpine}"
+# Optional: set to a specific alembic revision to assert exact head match
+ALEMBIC_EXPECTED_HEAD="${ALEMBIC_EXPECTED_HEAD:-}"
+
+CRITICAL_TABLES="scanner_events trades signal_reviews scanner_configs stock_aggregates"
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+DRILL_CONTAINER="mh-restore-drill-${TIMESTAMP}"
+
+EXIT_CODE=0
+VERDICT="success"
+ERROR_REASON=""
+COUNTS_JSON="{}"
+LATEST_BACKUP=""
+ALEMBIC_VERSION=""
+
+cleanup() {
+    # Unconditional teardown — always attempt to remove the throwaway container
+    docker rm -f "${DRILL_CONTAINER}" >/dev/null 2>&1 || true
+
+    if [ -n "${SEQ_URL}" ]; then
+        SEQ_LEVEL="Information"
+        [ "${VERDICT}" = "failure" ] && SEQ_LEVEL="Error"
+        curl -sf -X POST \
+            "${SEQ_URL}/api/events/raw?clef" \
+            -H "Content-Type: application/vnd.serilog.clef" \
+            -d "{\"@t\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"@mt\":\"Database restore drill ${VERDICT}\",\"@l\":\"${SEQ_LEVEL}\",\"EventType\":\"backup.restore_drill\",\"Verdict\":\"${VERDICT}\",\"ErrorReason\":\"${ERROR_REASON}\",\"TableCounts\":${COUNTS_JSON},\"AlembicVersion\":\"${ALEMBIC_VERSION}\",\"BackupFile\":\"${LATEST_BACKUP}\"}" \
+            || true
+    fi
+
+    exit "${EXIT_CODE}"
+}
+
+trap cleanup EXIT
+
+# --- Step 1: Find the most recent backup ---
+LATEST_BACKUP=$(ls -t "${BACKUP_DIR}"/stockscanner_*.sql.gz 2>/dev/null | head -1 || true)
+if [ -z "${LATEST_BACKUP}" ]; then
+    echo "restore-drill: ERROR — no backup files found in ${BACKUP_DIR}" >&2
+    VERDICT="failure"
+    ERROR_REASON="no backup files found in ${BACKUP_DIR}"
+    EXIT_CODE=1
+    exit 1
+fi
+echo "restore-drill: using backup $(basename "${LATEST_BACKUP}")"
+
+# --- Step 2: Spin up throwaway postgres container on the compose network ---
+docker run -d \
+    --name "${DRILL_CONTAINER}" \
+    --network "${DRILL_NETWORK}" \
+    -e POSTGRES_USER="${POSTGRES_USER}" \
+    -e POSTGRES_PASSWORD="${PGPASSWORD}" \
+    -e POSTGRES_DB="${POSTGRES_DB}" \
+    "${RESTORE_POSTGRES_IMAGE}" >/dev/null
+echo "restore-drill: started throwaway container ${DRILL_CONTAINER}"
+
+# --- Step 3: Wait up to 30 s for postgres to be ready ---
+READY=0
+for i in $(seq 1 30); do
+    if PGPASSWORD="${PGPASSWORD}" pg_isready \
+            -h "${DRILL_CONTAINER}" \
+            -U "${POSTGRES_USER}" >/dev/null 2>&1; then
+        READY=1
+        break
+    fi
+    sleep 1
+done
+if [ "${READY}" -eq 0 ]; then
+    echo "restore-drill: ERROR — throwaway postgres did not become ready within 30 s" >&2
+    VERDICT="failure"
+    ERROR_REASON="throwaway postgres did not become ready within 30 s"
+    EXIT_CODE=1
+    exit 1
+fi
+echo "restore-drill: throwaway postgres ready"
+
+# --- Step 4: Restore the dump ---
+if ! gunzip -c "${LATEST_BACKUP}" | PGPASSWORD="${PGPASSWORD}" psql \
+        -h "${DRILL_CONTAINER}" \
+        -U "${POSTGRES_USER}" \
+        -d "${POSTGRES_DB}" \
+        -v ON_ERROR_STOP=1 \
+        >/dev/null 2>/tmp/restore_stderr; then
+    RESTORE_ERR=$(head -1 /tmp/restore_stderr 2>/dev/null || true)
+    echo "restore-drill: ERROR — restore failed: ${RESTORE_ERR}" >&2
+    VERDICT="failure"
+    ERROR_REASON="psql restore failed: ${RESTORE_ERR}"
+    EXIT_CODE=1
+    exit 1
+fi
+echo "restore-drill: restore complete"
+
+# --- Step 5: Assert row counts > 0 for critical tables ---
+FAILED_TABLES=""
+FIRST=1
+COUNTS_JSON="{"
+for TABLE in ${CRITICAL_TABLES}; do
+    COUNT=$(PGPASSWORD="${PGPASSWORD}" psql \
+        -h "${DRILL_CONTAINER}" \
+        -U "${POSTGRES_USER}" \
+        -d "${POSTGRES_DB}" \
+        -t -c "SELECT COUNT(*) FROM ${TABLE}" 2>/dev/null | tr -d ' \n' || echo "0")
+    COUNT="${COUNT:-0}"
+
+    if [ "${FIRST}" -eq 1 ]; then
+        FIRST=0
+    else
+        COUNTS_JSON="${COUNTS_JSON},"
+    fi
+    COUNTS_JSON="${COUNTS_JSON}\"${TABLE}\":${COUNT}"
+
+    if [ "${COUNT}" -le 0 ] 2>/dev/null || [ "${COUNT}" = "0" ]; then
+        FAILED_TABLES="${FAILED_TABLES} ${TABLE}"
+    fi
+done
+COUNTS_JSON="${COUNTS_JSON}}"
+echo "restore-drill: table counts: ${COUNTS_JSON}"
+
+if [ -n "${FAILED_TABLES}" ]; then
+    echo "restore-drill: ERROR — zero rows in:${FAILED_TABLES}" >&2
+    VERDICT="failure"
+    ERROR_REASON="zero rows in critical tables:${FAILED_TABLES}"
+    EXIT_CODE=1
+    exit 1
+fi
+
+# --- Step 6: Assert alembic_version is non-empty ---
+ALEMBIC_VERSION=$(PGPASSWORD="${PGPASSWORD}" psql \
+    -h "${DRILL_CONTAINER}" \
+    -U "${POSTGRES_USER}" \
+    -d "${POSTGRES_DB}" \
+    -t -c "SELECT version_num FROM alembic_version LIMIT 1" 2>/dev/null | tr -d ' \n' || true)
+
+if [ -z "${ALEMBIC_VERSION}" ]; then
+    echo "restore-drill: ERROR — alembic_version table empty or missing" >&2
+    VERDICT="failure"
+    ERROR_REASON="alembic_version table empty or missing after restore"
+    EXIT_CODE=1
+    exit 1
+fi
+
+# Optional strict head check
+if [ -n "${ALEMBIC_EXPECTED_HEAD}" ] && [ "${ALEMBIC_VERSION}" != "${ALEMBIC_EXPECTED_HEAD}" ]; then
+    echo "restore-drill: ERROR — alembic head mismatch: got ${ALEMBIC_VERSION}, expected ${ALEMBIC_EXPECTED_HEAD}" >&2
+    VERDICT="failure"
+    ERROR_REASON="alembic head mismatch: got ${ALEMBIC_VERSION}, expected ${ALEMBIC_EXPECTED_HEAD}"
+    EXIT_CODE=1
+    exit 1
+fi
+
+echo "restore-drill: PASS — backup=$(basename "${LATEST_BACKUP}") alembic=${ALEMBIC_VERSION}"
+# Cleanup + Seq emit happen in the trap

--- a/scripts/restore-drill.sh
+++ b/scripts/restore-drill.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
-# Weekly restore drill — restores the latest pg_dump into a throwaway postgres container,
-# asserts row counts for critical tables, checks alembic_version, emits a Seq event,
-# and tears down the throwaway container unconditionally via trap.
+# Weekly restore drill — restores the latest pg_dump into a throwaway postgres cluster
+# (initdb + UNIX socket, no TCP, no live DB contact), asserts row counts for critical
+# tables, checks alembic_version, emits a Seq event, and tears down the cluster
+# unconditionally via trap.
 #
 # Critical tables must have COUNT(*) > 0 after restore for the drill to pass.
 # alembic_version must have at least one row (confirms schema migration was restored).
@@ -10,112 +11,104 @@
 set -eu
 
 BACKUP_DIR="${BACKUP_DIR:-/backups}"
-POSTGRES_USER="${POSTGRES_USER:-postgres}"
-POSTGRES_DB="${POSTGRES_DB:-stockscanner}"
-PGPASSWORD="${PGPASSWORD:-}"
 SEQ_URL="${SEQ_URL:-}"
-DRILL_NETWORK="${DRILL_NETWORK:-markethawk_stockscanner-network}"
-RESTORE_POSTGRES_IMAGE="${RESTORE_POSTGRES_IMAGE:-postgres:15-alpine}"
-# Optional: set to a specific alembic revision to assert exact head match
-ALEMBIC_EXPECTED_HEAD="${ALEMBIC_EXPECTED_HEAD:-}"
+# Set to a specific alembic revision to assert exact head match; empty = non-empty check only
+EXPECTED_ALEMBIC_HEAD="${EXPECTED_ALEMBIC_HEAD:-}"
 
 CRITICAL_TABLES="scanner_events trades signal_reviews scanner_configs stock_aggregates"
 
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-DRILL_CONTAINER="mh-restore-drill-${TIMESTAMP}"
+PGDATA="/tmp/drill_pgdata_$$"
+PGSOCKET="/tmp/drill_socket_$$"
+PGPID=""
 
 EXIT_CODE=0
-VERDICT="success"
-ERROR_REASON=""
+VERDICT="passed"
+FAIL_REASON=""
 COUNTS_JSON="{}"
+ALEMBIC_HEAD=""
 LATEST_BACKUP=""
-ALEMBIC_VERSION=""
 
 cleanup() {
-    # Unconditional teardown — always attempt to remove the throwaway container
-    docker rm -f "${DRILL_CONTAINER}" >/dev/null 2>&1 || true
+    # Unconditional teardown: kill throwaway postgres and remove temp dirs
+    [ -n "${PGPID}" ] && kill "${PGPID}" 2>/dev/null || true
+    rm -rf "${PGDATA}" "${PGSOCKET}"
 
     if [ -n "${SEQ_URL}" ]; then
         SEQ_LEVEL="Information"
-        [ "${VERDICT}" = "failure" ] && SEQ_LEVEL="Error"
+        [ "${VERDICT}" = "failed" ] && SEQ_LEVEL="Error"
         curl -sf -X POST \
             "${SEQ_URL}/api/events/raw?clef" \
             -H "Content-Type: application/vnd.serilog.clef" \
-            -d "{\"@t\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"@mt\":\"Database restore drill ${VERDICT}\",\"@l\":\"${SEQ_LEVEL}\",\"EventType\":\"backup.restore_drill\",\"Verdict\":\"${VERDICT}\",\"ErrorReason\":\"${ERROR_REASON}\",\"TableCounts\":${COUNTS_JSON},\"AlembicVersion\":\"${ALEMBIC_VERSION}\",\"BackupFile\":\"${LATEST_BACKUP}\"}" \
+            -d "{\"@t\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"@mt\":\"Restore drill {Verdict}\",\"@l\":\"${SEQ_LEVEL}\",\"EventType\":\"backup.restore_drill\",\"Verdict\":\"${VERDICT}\",\"FailReason\":\"${FAIL_REASON}\",\"AlembicHead\":\"${ALEMBIC_HEAD}\",\"BackupFile\":\"$(basename "${LATEST_BACKUP:-none}")\",\"TableCounts\":${COUNTS_JSON}}" \
             || true
     fi
 
     exit "${EXIT_CODE}"
 }
 
-trap cleanup EXIT
-
 # --- Step 1: Find the most recent backup ---
 LATEST_BACKUP=$(ls -t "${BACKUP_DIR}"/stockscanner_*.sql.gz 2>/dev/null | head -1 || true)
 if [ -z "${LATEST_BACKUP}" ]; then
-    echo "restore-drill: ERROR — no backup files found in ${BACKUP_DIR}" >&2
-    VERDICT="failure"
-    ERROR_REASON="no backup files found in ${BACKUP_DIR}"
-    EXIT_CODE=1
-    exit 1
+    echo "restore-drill: no backup found in ${BACKUP_DIR} — skipping (fresh deploy?)"
+    exit 0
 fi
 echo "restore-drill: using backup $(basename "${LATEST_BACKUP}")"
 
-# --- Step 2: Spin up throwaway postgres container on the compose network ---
-docker run -d \
-    --name "${DRILL_CONTAINER}" \
-    --network "${DRILL_NETWORK}" \
-    -e POSTGRES_USER="${POSTGRES_USER}" \
-    -e POSTGRES_PASSWORD="${PGPASSWORD}" \
-    -e POSTGRES_DB="${POSTGRES_DB}" \
-    "${RESTORE_POSTGRES_IMAGE}" >/dev/null
-echo "restore-drill: started throwaway container ${DRILL_CONTAINER}"
+# Backup confirmed — register cleanup trap (nothing to tear down in the skip path above)
+trap cleanup EXIT
 
-# --- Step 3: Wait up to 30 s for postgres to be ready ---
+# --- Step 2: initdb throwaway postgres cluster on UNIX socket (no TCP listener) ---
+mkdir -p "${PGDATA}" "${PGSOCKET}"
+initdb -D "${PGDATA}" --no-locale --encoding=UTF8 -A trust -U postgres >/dev/null 2>&1
+postgres -D "${PGDATA}" -k "${PGSOCKET}" -h '' >/dev/null 2>&1 &
+PGPID=$!
+echo "restore-drill: started throwaway postgres (pid ${PGPID})"
+
+# Wait up to 30 s for socket to appear
 READY=0
 for i in $(seq 1 30); do
-    if PGPASSWORD="${PGPASSWORD}" pg_isready \
-            -h "${DRILL_CONTAINER}" \
-            -U "${POSTGRES_USER}" >/dev/null 2>&1; then
+    if [ -S "${PGSOCKET}/.s.PGSQL.5432" ]; then
         READY=1
         break
     fi
     sleep 1
 done
 if [ "${READY}" -eq 0 ]; then
-    echo "restore-drill: ERROR — throwaway postgres did not become ready within 30 s" >&2
-    VERDICT="failure"
-    ERROR_REASON="throwaway postgres did not become ready within 30 s"
+    echo "restore-drill: ERROR — postgres socket did not appear within 30 s" >&2
+    VERDICT="failed"
+    FAIL_REASON="throwaway postgres socket did not appear within 30 s"
     EXIT_CODE=1
     exit 1
 fi
 echo "restore-drill: throwaway postgres ready"
 
-# --- Step 4: Restore the dump ---
-if ! gunzip -c "${LATEST_BACKUP}" | PGPASSWORD="${PGPASSWORD}" psql \
-        -h "${DRILL_CONTAINER}" \
-        -U "${POSTGRES_USER}" \
-        -d "${POSTGRES_DB}" \
-        -v ON_ERROR_STOP=1 \
+# pg_dump plain format does not include CREATE DATABASE; create it before restoring
+psql -h "${PGSOCKET}" -U postgres -c "CREATE DATABASE stockscanner;" >/dev/null 2>&1
+
+# --- Step 3: Restore the dump ---
+if ! gunzip -c "${LATEST_BACKUP}" | psql \
+        -h "${PGSOCKET}" \
+        -U postgres \
+        -d stockscanner \
         >/dev/null 2>/tmp/restore_stderr; then
     RESTORE_ERR=$(head -1 /tmp/restore_stderr 2>/dev/null || true)
     echo "restore-drill: ERROR — restore failed: ${RESTORE_ERR}" >&2
-    VERDICT="failure"
-    ERROR_REASON="psql restore failed: ${RESTORE_ERR}"
+    VERDICT="failed"
+    FAIL_REASON="psql restore failed: ${RESTORE_ERR}"
     EXIT_CODE=1
     exit 1
 fi
 echo "restore-drill: restore complete"
 
-# --- Step 5: Assert row counts > 0 for critical tables ---
+# --- Step 4: Assert row counts > 0 for critical tables ---
 FAILED_TABLES=""
 FIRST=1
 COUNTS_JSON="{"
 for TABLE in ${CRITICAL_TABLES}; do
-    COUNT=$(PGPASSWORD="${PGPASSWORD}" psql \
-        -h "${DRILL_CONTAINER}" \
-        -U "${POSTGRES_USER}" \
-        -d "${POSTGRES_DB}" \
+    COUNT=$(psql \
+        -h "${PGSOCKET}" \
+        -U postgres \
+        -d stockscanner \
         -t -c "SELECT COUNT(*) FROM ${TABLE}" 2>/dev/null | tr -d ' \n' || echo "0")
     COUNT="${COUNT:-0}"
 
@@ -126,7 +119,7 @@ for TABLE in ${CRITICAL_TABLES}; do
     fi
     COUNTS_JSON="${COUNTS_JSON}\"${TABLE}\":${COUNT}"
 
-    if [ "${COUNT}" -le 0 ] 2>/dev/null || [ "${COUNT}" = "0" ]; then
+    if [ "${COUNT}" = "0" ]; then
         FAILED_TABLES="${FAILED_TABLES} ${TABLE}"
     fi
 done
@@ -135,35 +128,35 @@ echo "restore-drill: table counts: ${COUNTS_JSON}"
 
 if [ -n "${FAILED_TABLES}" ]; then
     echo "restore-drill: ERROR — zero rows in:${FAILED_TABLES}" >&2
-    VERDICT="failure"
-    ERROR_REASON="zero rows in critical tables:${FAILED_TABLES}"
+    VERDICT="failed"
+    FAIL_REASON="zero rows in critical tables:${FAILED_TABLES}"
     EXIT_CODE=1
     exit 1
 fi
 
-# --- Step 6: Assert alembic_version is non-empty ---
-ALEMBIC_VERSION=$(PGPASSWORD="${PGPASSWORD}" psql \
-    -h "${DRILL_CONTAINER}" \
-    -U "${POSTGRES_USER}" \
-    -d "${POSTGRES_DB}" \
+# --- Step 5: Assert alembic_version is non-empty ---
+ALEMBIC_HEAD=$(psql \
+    -h "${PGSOCKET}" \
+    -U postgres \
+    -d stockscanner \
     -t -c "SELECT version_num FROM alembic_version LIMIT 1" 2>/dev/null | tr -d ' \n' || true)
 
-if [ -z "${ALEMBIC_VERSION}" ]; then
+if [ -z "${ALEMBIC_HEAD}" ]; then
     echo "restore-drill: ERROR — alembic_version table empty or missing" >&2
-    VERDICT="failure"
-    ERROR_REASON="alembic_version table empty or missing after restore"
+    VERDICT="failed"
+    FAIL_REASON="alembic_version table empty or missing after restore"
     EXIT_CODE=1
     exit 1
 fi
 
 # Optional strict head check
-if [ -n "${ALEMBIC_EXPECTED_HEAD}" ] && [ "${ALEMBIC_VERSION}" != "${ALEMBIC_EXPECTED_HEAD}" ]; then
-    echo "restore-drill: ERROR — alembic head mismatch: got ${ALEMBIC_VERSION}, expected ${ALEMBIC_EXPECTED_HEAD}" >&2
-    VERDICT="failure"
-    ERROR_REASON="alembic head mismatch: got ${ALEMBIC_VERSION}, expected ${ALEMBIC_EXPECTED_HEAD}"
+if [ -n "${EXPECTED_ALEMBIC_HEAD}" ] && [ "${ALEMBIC_HEAD}" != "${EXPECTED_ALEMBIC_HEAD}" ]; then
+    echo "restore-drill: ERROR — alembic head mismatch: got ${ALEMBIC_HEAD}, expected ${EXPECTED_ALEMBIC_HEAD}" >&2
+    VERDICT="failed"
+    FAIL_REASON="alembic head mismatch: got ${ALEMBIC_HEAD} expected ${EXPECTED_ALEMBIC_HEAD}"
     EXIT_CODE=1
     exit 1
 fi
 
-echo "restore-drill: PASS — backup=$(basename "${LATEST_BACKUP}") alembic=${ALEMBIC_VERSION}"
-# Cleanup + Seq emit happen in the trap
+echo "restore-drill: PASS — backup=$(basename "${LATEST_BACKUP}") alembic=${ALEMBIC_HEAD}"
+# Cleanup trap fires: kills postgres, rm -rf PGDATA/PGSOCKET, emits Seq event


### PR DESCRIPTION
## Summary

- Adds a `db-restore-drill` sidecar service that runs weekly to verify the most recent pg_dump artifact can be restored
- Uses an embedded throwaway postgres cluster (`initdb` + UNIX socket) — the live DB is never contacted, structurally isolated (no network path, no live credentials)
- Emits a `backup.restore_drill` Seq CLEF event on every run (`@l=Information` on pass, `@l=Error` on failure) with per-table counts and alembic head
- Manual one-shot: `docker compose run --rm db-restore-drill /scripts/restore-drill.sh`

## Files changed

| File | Change |
|---|---|
| `docker/Dockerfile.restore-drill` | New — Alpine 3.19 + postgresql15 (server+client) + supercronic, runs as `postgres` user |
| `scripts/restore-drill.sh` | New — core drill: find backup, initdb, restore, assert row counts + alembic version, Seq event, unconditional trap teardown |
| `scripts/restore-drill-entrypoint.sh` | New — writes supercronic crontab from `RESTORE_DRILL_SCHEDULE`, execs supercronic |
| `docker-compose.yml` | Added `db-restore-drill` service (`:ro` backup mount, no `depends_on: [postgres]`, 256M memory limit) |
| `ARCHITECTURE.md` | Added service to Mermaid graph + Container Users table |
| `ENV_VARIABLES.md` | Documented `RESTORE_DRILL_SCHEDULE` and `EXPECTED_ALEMBIC_HEAD` |
| `deployment-guide.md` | Added "Weekly Restore Drill" subsection: schedule, config, manual invocation, Seq queries, corrupted-backup simulation |
| `dark-factory/tests/test_restore_drill.sh` | 7 conformance tests (all pass) |

## Acceptance criteria

- [x] Drill runs weekly without human action and survives `docker-compose up -d` recreation (`restart: unless-stopped`, schedule via `RESTORE_DRILL_SCHEDULE`)
- [x] A deliberately corrupted/truncated dump makes the drill fail loudly (Seq Error event) — documented simulation in `deployment-guide.md`
- [x] Live DB is provably untouched — drill connects only to the throwaway `initdb` cluster on a UNIX socket; no `depends_on: [postgres]`; no live DB credentials
- [x] Manual one-shot invocation documented (`docker compose run --rm db-restore-drill /scripts/restore-drill.sh`)

## Test plan

- [x] Run conformance tests: `sh dark-factory/tests/test_restore_drill.sh` → 7/7 pass
- [ ] Manual drill: start the stack, confirm the sidecar runs via `docker compose logs db-restore-drill`
- [ ] Verify Seq event: filter `EventType = 'backup.restore_drill'` in Seq after a drill run
- [ ] Simulate corrupted backup: follow `deployment-guide.md` instructions and confirm drill exits non-zero with a Seq Error event

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)