### PR TITLE
fix(frontend): drop npm cache to clear stale-tarball Trivy false positive

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,15 @@ COPY package*.json ./
 # npm ci (not npm install) — install the exact locked versions so the image is
 # reproducible and matches what was security-scanned. npm install would resolve
 # newest-in-range at build time, drifting the CVE surface between builds.
-RUN npm ci
+#
+# Clean the npm cache in the same layer. `npm ci` leaves resolved-but-overridden
+# tarballs in /root/.npm/_cacache — e.g. undici 6.26.0 (CVE-2026-12151), fetched
+# during resolution then replaced at install time by the `^7.28.0` override in
+# package.json. node_modules ships the fixed 7.28.0, but Trivy scans the stale
+# cache tarball and fails the HIGH/CRITICAL image gate on a vuln that isn't
+# actually installed. Dropping the cache clears the false positive (and shrinks
+# the image); the build below only needs node_modules, never the cache.
+RUN npm ci && npm cache clean --force
 
 COPY . .
 


### PR DESCRIPTION
## What
Clean the npm cache (`npm cache clean --force`) inside the frontend image's `npm ci` layer.

## Why
ci-publish's frontend Trivy gate (HIGH/CRITICAL) is red on:

```
undici (package.json) | CVE-2026-12151 | HIGH | Installed 6.26.0 | Fixed 6.27.0, 7.28.0, 8.5.0
```

But the installed dependency is already fixed — `frontend/package.json` overrides `undici` to `^7.28.0`, and the lockfile resolves the single `node_modules/undici` to **7.28.0**. The 6.26.0 hit is a stale tarball left in `/root/.npm/_cacache` during `npm ci` resolution (the Trivy log shows it scanning a 23 MB `_cacache` blob). Dropping the cache removes the false positive and shrinks the image; the build only needs `node_modules`, never the cache.

## Validation
- The required `docker-frontend` check rebuilds the image on this PR.
- After merge, ci-publish's frontend Trivy scan should go green (currently the only thing keeping main's image publish red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
