### PR TITLE
fix(frontend): replace npm's bundled undici to clear Trivy HIGH gate

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,9 +1,19 @@
 FROM node:26-alpine@sha256:a2dc166a387cc6ca1e62d0c8e265e49ca985d6e60abc9fe6e6c3d6ce8e63f606
 
-# Upgrade npm to 11.x. node:22-alpine bundles npm 10.9.8, whose vendored
-# picomatch 4.0.3 carries a HIGH ReDoS (CVE-2026-33671); npm 11 drops that
-# bundled dependency entirely, clearing the Trivy image gate.
-RUN npm install -g npm@11.17.0
+# Upgrade npm to 11.x and patch npm's *bundled* undici.
+#
+# npm@11.17.0 (the newest release) vendors undici 6.26.0 — CVE-2026-12151, a
+# HIGH DoS via unbounded memory. No npm release has shipped a fixed bundle yet,
+# so we delete the vulnerable copy and install the patched undici 6.27.0 in the
+# global root, where npm still resolves it (verified: npm and its registry/HTTP
+# stack work against the relocated copy). The app's own undici is separately
+# pinned to 7.28.0 via package.json overrides; this only concerns npm's vendored
+# HTTP client. (npm 11 also drops the picomatch 4.0.3 ReDoS, CVE-2026-33671,
+# that the older bundled npm on node:22-alpine carried.)
+RUN npm install -g npm@11.17.0 && \
+    rm -rf "$(npm root -g)/npm/node_modules/undici" && \
+    npm install -g undici@6.27.0 && \
+    npm cache clean --force
 
 WORKDIR /app
 


### PR DESCRIPTION
## What
Replace npm's **bundled** undici (6.26.0) with the patched 6.27.0 in the frontend image.

## Why
ci-publish's frontend Trivy gate (HIGH/CRITICAL) is red on:

```
usr/local/lib/node_modules/npm/node_modules/undici  ->  CVE-2026-12151  (undici 6.26.0, HIGH DoS)
```

This is npm's **own vendored** undici, installed by `npm install -g npm@11.17.0`. The `package.json` `undici: ^7.28.0` override only governs the app's copy (`app/node_modules/undici` → 7.28.0, 0 vulns); it can't touch npm's bundled dependency.

`npm@latest` is still 11.17.0 and still bundles undici 6.26.0 — **no npm release fixes this yet** — so bumping/removing the pin can't clear it. Instead we drop npm's vulnerable bundled copy and install the patched undici 6.27.0 in the global root, where npm continues to resolve it.

## Verified (in the exact pinned `node:26-alpine` image)
- `npm/node_modules/undici` → **ABSENT**; relocated `node_modules/undici` → **6.27.0**
- `npm --version` → 11.17.0; `npm view undici version` → 8.5.0 (npm's undici-backed HTTP still works)

## Validation
- Required `docker-frontend` check builds the full image on this PR.
- After merge, ci-publish's frontend Trivy scan should go green — the last thing keeping main's image publish red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
