### PR TITLE
feat(factory): rescue Blocked tickets whose PR is already green (#607)

### DIFF
--- a/.claude/skills/refinement/config.yaml
+++ b/.claude/skills/refinement/config.yaml
@@ -6,6 +6,7 @@ scheduler:
   factory_wip_limit: 1           # max concurrent factory containers; env: FACTORY_WIP_LIMIT overrides
   main_red_recheck_enabled: true # periodically recheck a red main to self-clear (#365); env: MAIN_RED_RECHECK_ENABLED overrides
   main_red_recheck_minutes: 20   # interval between red-main recheck dispatches; env: MAIN_RED_RECHECK_MINUTES overrides
+  blocked_rescue_enabled: true   # promote a Blocked ticket whose PR is green+mergeable to In review instead of re-running it; env: BLOCKED_RESCUE_ENABLED overrides
 
 refine:
   wip_limit: 2                   # env: REFINE_WIP_LIMIT overrides

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -71,6 +71,7 @@ read_config() {
   _set_cfg FACTORY_WIP_LIMIT          '.scheduler.factory_wip_limit'
   _set_cfg MAIN_RED_RECHECK_ENABLED   '.scheduler.main_red_recheck_enabled'
   _set_cfg MAIN_RED_RECHECK_MINUTES   '.scheduler.main_red_recheck_minutes'
+  _set_cfg BLOCKED_RESCUE_ENABLED     '.scheduler.blocked_rescue_enabled'
   _set_cfg REFINE_WIP_LIMIT           '.refine.wip_limit'
   _set_cfg DIRECT_TO_PR_LABEL         '.direct_to_pr.label'
   _set_cfg SPEC_GRACE_MINUTES         '.direct_to_pr.spec_grace_minutes'
@@ -828,6 +829,33 @@ ${FAIL_LIST}
     CI_BLOCKED="${CI_BLOCKED} ${ISSUE} "
   done < <(echo "$IN_REVIEW" | jq -c '.[]')
 
+  # --- Priority 0.6: rescue Blocked items whose PR is already green + mergeable ---
+  # Inverse of Priority 0. A ticket can sit in Blocked (CI gate, circuit-breaker trip,
+  # orphaned-run sweep) while its PR is actually green and conflict-free. The Priority 3
+  # retry loop below would re-dispatch "Continue" on it — re-running the whole pipeline,
+  # burning the Max session window, re-hitting the same gate — until the retry counter
+  # exhausts and trip_to_blocked parks it FOREVER with a mergeable PR stranded. Instead,
+  # promote it to In review so the normal merge flow (human / "Close issue #N") takes it.
+  # Dispatch-free (only sets board status + marks the PR ready + comments), so it runs
+  # every cycle regardless of factory capacity, like Priority 0. RESCUED is consumed by
+  # Priority 3 so a just-rescued issue is not retried in the same cycle.
+  RESCUED=""
+  if [ "${BLOCKED_RESCUE_ENABLED:-true}" = "true" ]; then
+    while IFS= read -r item; do
+      ISSUE=$(get_issue_number "$item")
+      if has_skip_label "$item"; then continue; fi
+      # Above-ceiling items are parked in Blocked by design (#339), not failed.
+      if has_above_ceiling_label "$item"; then continue; fi
+      if is_issue_running "$ISSUE"; then continue; fi
+      RESCUE_OUT=$(python3 "$FACTORY_CORE_CLI" rescue-blocked --issue "$ISSUE" 2>/dev/null) || true
+      if [ "$RESCUE_OUT" = "rescued" ]; then
+        echo "[$(date -u +%FT%TZ)] blocked_rescue issue=#${ISSUE} action=promoted_to_in_review"
+        RESCUED="${RESCUED} ${ISSUE} "
+        reset_retry "$ISSUE" || true
+      fi
+    done < <(echo "$BLOCKED" | jq -c '.[]')
+  fi
+
   # Guard: cap concurrent factory containers at FACTORY_WIP_LIMIT (Claude Max 5h-window
   # burn scales with concurrency — default 1, override in .archon/.env). Everything
   # below DISPATCHES factory work, so it waits for a free slot; the CI gate above has
@@ -1003,6 +1031,9 @@ To proceed:
       [ -n "$DISPATCHED" ] && break
       ISSUE=$(get_issue_number "$item")
       if has_skip_label "$item"; then continue; fi
+      # Promoted to In review by the Priority 0.6 rescue this cycle — don't re-dispatch
+      # (its green PR is now in the merge flow; BLOCKED was snapshotted before the move).
+      case "$RESCUED" in *" $ISSUE "*) continue ;; esac
       # Above-ceiling items in Blocked are parked by design (#339), not failed — the
       # retry loop must not auto-dispatch them.
       if has_above_ceiling_label "$item"; then continue; fi

--- a/dark-factory/scripts/factory_core/cli.py
+++ b/dark-factory/scripts/factory_core/cli.py
@@ -77,6 +77,11 @@ def _epic_autopilot(args):
     main_once()
 
 
+def _rescue_blocked(args):
+    from factory_core.rescue import rescue_blocked
+    print(rescue_blocked(args.issue))
+
+
 def main():
     parser = argparse.ArgumentParser(prog="factory-core")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -117,6 +122,10 @@ def main():
     ea = sub.add_parser("epic-autopilot")
     ea.add_argument("--once", action="store_true")
     ea.set_defaults(func=_epic_autopilot)
+
+    rb = sub.add_parser("rescue-blocked")
+    rb.add_argument("--issue", type=int, required=True)
+    rb.set_defaults(func=_rescue_blocked)
 
     parsed = parser.parse_args()
     parsed.func(parsed)

--- a/dark-factory/scripts/factory_core/rescue.py
+++ b/dark-factory/scripts/factory_core/rescue.py
@@ -1,0 +1,138 @@
+"""factory_core.rescue — un-strand Blocked tickets whose PR is already green.
+
+A ticket can land in **Blocked** (the In-review CI gate, a circuit-breaker trip, or
+an orphaned-run sweep) while its PR is actually green, conflict-free, and mergeable.
+The Priority-3 retry loop then re-dispatches ``Continue`` on it, which re-runs the
+whole factory pipeline — burning the Max 5h session window and re-hitting the same
+gate/limit — and once the retry counter is exhausted ``trip_to_blocked`` parks it in
+Blocked **permanently**, stranding a perfectly mergeable PR forever.
+
+This module detects that case and promotes the ticket to **In review** so the normal
+merge flow (a human, or a ``Close issue #N`` dispatch) can take it, instead of
+re-running the factory. It deliberately escalates only to In review — it never merges
+(the factory's human-merge / draft-PR policy is preserved).
+
+The scheduler calls ``rescue-blocked --issue N`` once per Blocked item each cycle,
+*before* the Priority-3 retry loop, and skips any issue this returns ``rescued`` for.
+"""
+import json
+import subprocess
+
+from factory_core import board
+
+OWNER = board.OWNER
+REPO = board.REPO
+
+# Idempotency marker so post_or_update_comment edits one comment instead of spamming.
+RESCUE_MARKER = "<!-- df:blocked-rescue -->"
+
+
+def _repo() -> str:
+    return f"{OWNER}/{REPO}"
+
+
+def pr_for_issue(issue_num: int) -> dict | None:
+    """The open PR for an issue's feature branch (feat/issue-<N>-*), or None.
+
+    Returns the first match with the fields rescue needs. ``gh`` is run with
+    ``--repo`` because the scheduler executes outside a git checkout.
+    """
+    r = subprocess.run(
+        ["gh", "pr", "list", "--repo", _repo(),
+         "--search", f"head:feat/issue-{issue_num}-",
+         "--json", "number,isDraft,mergeable"],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        return None
+    try:
+        arr = json.loads(r.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(arr, list) or not arr:
+        return None
+    return arr[0]
+
+
+def pr_check_buckets(pr_num: int) -> list:
+    """Bucket of every check on a PR ("pass" / "fail" / "pending" / "skipping" / …).
+
+    ``gh pr checks`` exits non-zero when any check is failing or pending, but still
+    prints valid JSON on stdout, so the return code is ignored and stdout is parsed
+    defensively (empty / non-array ⇒ []).
+    """
+    r = subprocess.run(
+        ["gh", "pr", "checks", str(pr_num), "--repo", _repo(), "--json", "bucket"],
+        capture_output=True, text=True,
+    )
+    try:
+        arr = json.loads(r.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return []
+    if not isinstance(arr, list):
+        return []
+    return [c.get("bucket") for c in arr]
+
+
+def assess(issue_num: int) -> tuple[str, str]:
+    """Decide whether a Blocked issue's PR can be rescued.
+
+    Returns ``("rescue", "<pr_num>")`` only when the PR is green (≥1 check, none
+    failing, none pending), conflict-free (mergeable == MERGEABLE), so it is genuinely
+    ready for the merge flow. Otherwise ``("skip", "<reason>")`` — a no-PR or red /
+    pending / conflicting PR is left for the Priority-3 retry loop to drive.
+    """
+    pr = pr_for_issue(issue_num)
+    if not pr:
+        return ("skip", "no_pr")
+    pr_num = pr["number"]
+
+    buckets = pr_check_buckets(pr_num)
+    if not buckets:
+        return ("skip", "no_checks")
+    if "fail" in buckets:
+        return ("skip", "failing_ci")
+    if "pending" in buckets:
+        return ("skip", "pending_ci")
+
+    if pr.get("mergeable") != "MERGEABLE":
+        return ("skip", "mergeable_%s" % (pr.get("mergeable") or "UNKNOWN"))
+
+    return ("rescue", str(pr_num))
+
+
+def _comment_body(issue_num: int, pr_num: int) -> str:
+    return (
+        f"{RESCUE_MARKER}\n"
+        "## Dark Factory — Rescued from Blocked\n\n"
+        f"This ticket was in **Blocked**, but PR #{pr_num} is **green and conflict-free** "
+        "(all checks passing, no merge conflicts). Re-running the factory on it would only "
+        "burn another session window and re-trip the breaker, so the scheduler promoted it "
+        "to **In review** instead — ready for the normal merge flow "
+        f"(merge the PR, or dispatch `Close issue #{issue_num}`).\n\n"
+        "---\n"
+        "*Posted by MarketHawk Backlog Scheduler*"
+    )
+
+
+def rescue_blocked(issue_num: int) -> str:
+    """Promote a Blocked issue with a green, mergeable PR to In review.
+
+    Returns ``"rescued"`` when it acts, or ``"skip:<reason>"`` otherwise. A draft PR
+    is marked ready first so it is actually mergeable by the normal flow. Never merges.
+    """
+    action, detail = assess(issue_num)
+    if action != "rescue":
+        return f"skip:{detail}"
+    pr_num = detail
+
+    pr = pr_for_issue(issue_num)
+    if pr and pr.get("isDraft"):
+        subprocess.run(
+            ["gh", "pr", "ready", str(pr_num), "--repo", _repo()],
+            capture_output=True,
+        )
+
+    board.set_board_status(issue_num, board.STATUS_IN_REVIEW)
+    board.post_or_update_comment(issue_num, RESCUE_MARKER, _comment_body(issue_num, int(pr_num)))
+    return "rescued"

--- a/dark-factory/tests/test_factory_core_rescue.py
+++ b/dark-factory/tests/test_factory_core_rescue.py
@@ -1,0 +1,116 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+from factory_core import rescue
+
+
+def _cp(stdout="", code=0):
+    return subprocess.CompletedProcess([], code, stdout=stdout, stderr="")
+
+
+def _fake_gh(pr=None, checks=None, *, record=None):
+    """Build a subprocess.run replacement routing by the gh subcommand in cmd.
+
+    pr     -> the object returned by `gh pr list ... --json number,isDraft,mergeable`
+              (wrapped in a one-element array), or None for "no PR".
+    checks -> list of bucket strings returned by `gh pr checks ... --json bucket`.
+    record -> optional list that every cmd is appended to (for asserting side effects).
+    """
+    checks = checks or []
+
+    def run(cmd, **kw):
+        if record is not None:
+            record.append(cmd)
+        joined = " ".join(cmd)
+        if "pr" in cmd and "list" in cmd:
+            return _cp(json.dumps([pr] if pr else []))
+        if "pr" in cmd and "checks" in cmd:
+            code = 0 if all(b == "pass" for b in checks) else 1
+            return _cp(json.dumps([{"bucket": b} for b in checks]), code)
+        if "pr" in cmd and "ready" in cmd:
+            return _cp()
+        if "item-list" in joined:
+            return _cp(json.dumps({"items": [
+                {"id": "ITEM", "content": {"number": 7, "type": "Issue"}}]}))
+        # item-edit, gh api comments lookup, gh issue comment, anything else
+        if "--jq" in cmd:           # comment-id lookup -> none exists
+            return _cp("")
+        return _cp()
+
+    return run
+
+
+def test_rescue_green_mergeable_promotes(monkeypatch):
+    calls = []
+    monkeypatch.setattr(subprocess, "run", _fake_gh(
+        pr={"number": 7, "isDraft": False, "mergeable": "MERGEABLE"},
+        checks=["pass", "pass", "skipping"], record=calls))
+    assert rescue.rescue_blocked(7) == "rescued"
+    # moved to In review
+    edits = [c for c in calls if "item-edit" in " ".join(c)]
+    assert edits and rescue.board.STATUS_IN_REVIEW in edits[0]
+    # posted the rescue comment
+    assert any("comment" in " ".join(c) for c in calls)
+
+
+def test_rescue_marks_draft_ready_first(monkeypatch):
+    calls = []
+    monkeypatch.setattr(subprocess, "run", _fake_gh(
+        pr={"number": 7, "isDraft": True, "mergeable": "MERGEABLE"},
+        checks=["pass"], record=calls))
+    assert rescue.rescue_blocked(7) == "rescued"
+    assert any("pr" in c and "ready" in c for c in calls)
+
+
+def test_skip_no_pr(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", _fake_gh(pr=None))
+    assert rescue.rescue_blocked(7) == "skip:no_pr"
+
+
+def test_skip_no_checks(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", _fake_gh(
+        pr={"number": 7, "isDraft": False, "mergeable": "MERGEABLE"}, checks=[]))
+    assert rescue.rescue_blocked(7) == "skip:no_checks"
+
+
+def test_skip_failing_ci(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", _fake_gh(
+        pr={"number": 7, "isDraft": False, "mergeable": "MERGEABLE"},
+        checks=["pass", "fail"]))
+    assert rescue.rescue_blocked(7) == "skip:failing_ci"
+
+
+def test_skip_pending_ci(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", _fake_gh(
+        pr={"number": 7, "isDraft": False, "mergeable": "MERGEABLE"},
+        checks=["pass", "pending"]))
+    assert rescue.rescue_blocked(7) == "skip:pending_ci"
+
+
+def test_skip_conflicting(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", _fake_gh(
+        pr={"number": 7, "isDraft": False, "mergeable": "CONFLICTING"},
+        checks=["pass"]))
+    assert rescue.rescue_blocked(7) == "skip:mergeable_CONFLICTING"
+
+
+def test_skip_unknown_mergeable(monkeypatch):
+    monkeypatch.setattr(subprocess, "run", _fake_gh(
+        pr={"number": 7, "isDraft": False, "mergeable": "UNKNOWN"},
+        checks=["pass"]))
+    assert rescue.rescue_blocked(7) == "skip:mergeable_UNKNOWN"
+
+
+def test_failing_ci_does_not_promote(monkeypatch):
+    """A red PR must never be moved to In review (board untouched)."""
+    calls = []
+    monkeypatch.setattr(subprocess, "run", _fake_gh(
+        pr={"number": 7, "isDraft": False, "mergeable": "MERGEABLE"},
+        checks=["fail"], record=calls))
+    rescue.rescue_blocked(7)
+    assert not any("item-edit" in " ".join(c) for c in calls)


### PR DESCRIPTION
## Problem

A ticket can land in **Blocked** (the In-review CI gate, a circuit-breaker trip, or the orphaned-run sweep) while its PR is actually **green, conflict-free, and mergeable**. The Priority-3 retry loop then re-dispatches `Continue` on it — re-running the whole factory pipeline, burning the Max 5h session window, and re-hitting the same gate/limit — until the retry counter exhausts and `trip_to_blocked` parks it **permanently**, stranding a mergeable PR forever.

This is exactly what happened overnight 2026-06-22: omniscient/markethawk#494/#495/#518/#392 all sat in Blocked with **fully green PRs** (#603/#604/#605/#598) while `factory_running=0`, `skip=nothing_to_do`. They were merged manually.

## Root cause

`scheduler.sh` Priority 0 has a one-way gate: **In review + red CI → Blocked**. There is no inverse — nothing notices **Blocked + green PR** and promotes it back out. Priority 3 only knows how to *re-run* a Blocked ticket, never to *release* one whose work is already done.

## Fix (this PR)

New **Priority 0.6** pass in `scheduler.sh`, dispatch-free (runs every cycle like Priority 0):

- For each Blocked item (skip-label / above-ceiling / running-guarded), call `factory-core rescue-blocked --issue N`.
- `factory_core/rescue.py` (new, unit-tested): rescue **only** when the PR exists, has ≥1 check, **none failing**, **none pending**, and `mergeable == MERGEABLE`. A draft PR is marked ready first. Then promote the ticket to **In review** and post a comment. **Never merges** — the human-merge / draft-PR policy is preserved.
- Priority 3 skips any issue rescued this cycle (`RESCUED` guard) so it isn't re-dispatched.
- Gated by `scheduler.blocked_rescue_enabled` (config.yaml, default true; env `BLOCKED_RESCUE_ENABLED`).

A red / pending / conflicting / no-PR Blocked ticket is left untouched for the Priority-3 retry loop, exactly as today.

## Tests

`dark-factory/tests/test_factory_core_rescue.py` — 9 cases: green→rescued, draft→marked ready, and skip for no_pr / no_checks / failing_ci / pending_ci / conflicting / unknown-mergeable / red-never-promotes. Full `factory_core` suite green (47 passed).

## Deploy note

`scheduler.sh` is baked → needs `docker compose build backlog-scheduler` + force-recreate to activate. `factory_core/*` + `config.yaml` are read from the mount (no rebuild).
