### PR TITLE
feat(main-red-fix): autonomous pipeline recovery — closes #591

### DIFF
--- a/.claude/skills/refinement/config.yaml
+++ b/.claude/skills/refinement/config.yaml
@@ -93,8 +93,11 @@ epic_autopilot:
   # See docs/superpowers/specs/2026-06-20-epic-autopilot-design.md
 
 main_red_autofix:
-  enabled: false              # kill-switch — ships OFF. env MAIN_RED_AUTOFIX_ENABLED
-  model: claude-opus-4-8      # fix-agent model. env MAIN_RED_AUTOFIX_MODEL
-  max_attempts: 3             # fix→CI cycles per red event. env MAIN_RED_AUTOFIX_MAX_ATTEMPTS
-  throttle_minutes: 15        # min minutes between fixer dispatches. env MAIN_RED_AUTOFIX_THROTTLE_MIN
-  ci_wait_minutes: 20         # bounded wait for branch CI. env MAIN_RED_AUTOFIX_CI_WAIT_MINUTES
+  # kill-switch — ships OFF. To ENABLE, set MAIN_RED_AUTOFIX_ENABLED=true in .archon/.env
+  # (like EPIC_AUTOPILOT_ENABLED): the dispatched "Fix main" container reads .archon/.env, NOT this
+  # file, so flipping `enabled` here alone does NOT turn the feature on. env MAIN_RED_AUTOFIX_ENABLED
+  enabled: false
+  model: claude-opus-4-8      # fix-agent model (container default; env MAIN_RED_AUTOFIX_MODEL)
+  max_attempts: 3             # fix→CI cycles per red event (container default; env MAIN_RED_AUTOFIX_MAX_ATTEMPTS)
+  throttle_minutes: 15        # min minutes between fixer dispatches (scheduler; env MAIN_RED_AUTOFIX_THROTTLE_MIN)
+  ci_wait_minutes: 20         # bounded wait for branch CI (container default; env MAIN_RED_AUTOFIX_CI_WAIT_MINUTES)

--- a/.claude/skills/refinement/config.yaml
+++ b/.claude/skills/refinement/config.yaml
@@ -91,3 +91,10 @@ epic_autopilot:
   # When starved (a poll dispatched nothing) and main is green, review the refined, below-ceiling
   # children of in-progress epics with Opus and advance the low-risk ones via direct-to-pr.
   # See docs/superpowers/specs/2026-06-20-epic-autopilot-design.md
+
+main_red_autofix:
+  enabled: false              # kill-switch — ships OFF. env MAIN_RED_AUTOFIX_ENABLED
+  model: claude-opus-4-8      # fix-agent model. env MAIN_RED_AUTOFIX_MODEL
+  max_attempts: 3             # fix→CI cycles per red event. env MAIN_RED_AUTOFIX_MAX_ATTEMPTS
+  throttle_minutes: 15        # min minutes between fixer dispatches. env MAIN_RED_AUTOFIX_THROTTLE_MIN
+  ci_wait_minutes: 20         # bounded wait for branch CI. env MAIN_RED_AUTOFIX_CI_WAIT_MINUTES

--- a/dark-factory/entrypoint.sh
+++ b/dark-factory/entrypoint.sh
@@ -84,6 +84,9 @@ fi
 ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oP '#\K\d+' | head -1 || true)
 INTENT=$(echo "$ARGUMENTS" | grep -oiP '^\s*\K(fix|continue|close|refine|plan|deconflict|recheck)' | head -1 | tr '[:upper:]' '[:lower:]' || true)
 INTENT=${INTENT:-fix}
+case "$ARGUMENTS" in
+  "Fix main"|"fix main") INTENT="fix-main" ;;
+esac
 
 # --- Canonical run identity and artifact directory ---
 # ARCHON_RUN_ID is not set by archon; always generate a UUID for correlation.
@@ -485,6 +488,16 @@ fi
 
 # --- Install pre-commit hooks so codeindex-blast warn hook fires in the run log ---
 pre-commit install --allow-missing-config 2>/dev/null || true
+
+if [ "$INTENT" = "fix-main" ]; then
+  echo "[fix-main] dispatched main-red auto-fix; repo cloned at ${CLONE_DIR}"
+  if [ "${MAIN_RED_AUTOFIX_ENABLED:-false}" != "true" ]; then
+    echo "[fix-main] disabled (MAIN_RED_AUTOFIX_ENABLED != true); exiting"
+    exit 0
+  fi
+  python3 "$CLONE_DIR/dark-factory/scripts/factory_core/cli.py" main-red-fix --once || true
+  exit 0
+fi
 
 # --- Smoke gate: verify origin/main is green before any per-ticket work ---
 # Applies to fix (new), continue, deconflict (resolve), and recheck intents.

--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -89,6 +89,10 @@ read_config() {
   _set_cfg EPIC_AUTOPILOT_SIZE_CEILING      '.epic_autopilot.size_ceiling'
   _set_cfg EPIC_AUTOPILOT_START_EPICS       '.epic_autopilot.start_epics'
   _set_cfg EPIC_AUTOPILOT_SENSITIVE_KEYWORDS '.epic_autopilot.sensitive_keywords'
+  _set_cfg MAIN_RED_AUTOFIX_ENABLED        '.main_red_autofix.enabled'
+  _set_cfg MAIN_RED_AUTOFIX_MODEL          '.main_red_autofix.model'
+  _set_cfg MAIN_RED_AUTOFIX_MAX_ATTEMPTS   '.main_red_autofix.max_attempts'
+  _set_cfg MAIN_RED_AUTOFIX_THROTTLE_MIN   '.main_red_autofix.throttle_minutes'
 
   echo "[config] loaded from ${cfg}"
 }
@@ -203,6 +207,32 @@ main_red_recheck_check() {
     DISPATCHED="Recheck main"
     touch "$RECHECK_STAMP_FILE"
     echo "[$(date -u +%FT%TZ)] main_red_recheck=dispatched interval=${MAIN_RED_RECHECK_MINUTES}m"
+  fi
+}
+
+FIXER_STAMP_FILE="${SCHEDULER_STATE_DIR}/main-red-fixer-last-run"
+
+is_fixer_running() {
+  docker ps --no-trunc --format '{{.Command}}' 2>/dev/null | grep -q 'Fix main' && return 0
+  return 1
+}
+
+fixer_due() {
+  [ -f "$FIXER_STAMP_FILE" ] || return 0
+  local last now
+  last=$(stat -c %Y "$FIXER_STAMP_FILE" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  [ $(( now - last )) -ge $(( ${MAIN_RED_AUTOFIX_THROTTLE_MIN:-15} * 60 )) ]
+}
+
+main_red_fixer_check() {
+  [ "${MAIN_RED_AUTOFIX_ENABLED:-false}" = "true" ] || return 0
+  is_fixer_running && return 0
+  fixer_due || return 0
+  if dispatch "Fix main"; then
+    DISPATCHED="Fix main"
+    touch "$FIXER_STAMP_FILE"
+    echo "[$(date -u +%FT%TZ)] main_red_fixer=dispatched"
   fi
 }
 
@@ -897,6 +927,7 @@ This issue was left in **In progress** with no running factory container — the
   if [ "$MAIN_IS_RED" = "true" ]; then
     echo "[$(date -u +%FT%TZ)] main_red_gate=active action=skip_implement_dispatch"
     main_red_recheck_check
+    main_red_fixer_check
   fi
 
   # --- Priority 1.5: In Review items with merge conflicts (proactive auto-resolve) ---

--- a/dark-factory/scripts/factory_core/cli.py
+++ b/dark-factory/scripts/factory_core/cli.py
@@ -77,6 +77,11 @@ def _epic_autopilot(args):
     main_once()
 
 
+def _main_red_fix(args):
+    from factory_core.main_red_fixer import main_once
+    main_once()
+
+
 def _rescue_blocked(args):
     from factory_core.rescue import rescue_blocked
     print(rescue_blocked(args.issue))
@@ -122,6 +127,10 @@ def main():
     ea = sub.add_parser("epic-autopilot")
     ea.add_argument("--once", action="store_true")
     ea.set_defaults(func=_epic_autopilot)
+
+    mr = sub.add_parser("main-red-fix")
+    mr.add_argument("--once", action="store_true")
+    mr.set_defaults(func=_main_red_fix)
 
     rb = sub.add_parser("rescue-blocked")
     rb.add_argument("--issue", type=int, required=True)

--- a/dark-factory/scripts/factory_core/main_red_fixer.py
+++ b/dark-factory/scripts/factory_core/main_red_fixer.py
@@ -102,10 +102,12 @@ def run_once(cfg: dict, io, state: dict) -> dict:
     pr = io.open_pr(branch, issue, failure)
     ci = io.poll_ci(pr)
     if ci == "green":
-        io.merge(pr)
-        io.notify(f"Main-red auto-fix merged PR #{pr}",
-                  f"main is green again (regression #{issue}).", "info", None)
-        return {"outcome": "merged", "issue": issue, "pr": pr}
+        if io.merge(pr):
+            io.notify(f"Main-red auto-fix merged PR #{pr}",
+                      f"main is green again (regression #{issue}).", "info", None)
+            return {"outcome": "merged", "issue": issue, "pr": pr}
+        io.escalate(issue, "merge-failed", pr=pr)
+        return {"outcome": "fixing", "issue": issue, "pr": pr, "reason": "merge-failed"}
 
     io.escalate(issue, f"ci:{ci}", pr=pr)
     return {"outcome": "fixing", "issue": issue, "pr": pr, "reason": f"ci:{ci}"}
@@ -114,8 +116,6 @@ def run_once(cfg: dict, io, state: dict) -> dict:
 # ── Live IO (exercised in manual validation, not unit tests) ────────────────
 OWNER = "omniscient/markethawk"
 CLONE_DIR = os.environ.get("CLONE_DIR", "/workspace/markethawk")
-SMOKE_MARKER = "<!-- df-main-red -->"
-
 
 def _run(cmd, cwd=None, timeout=600, stdin=None):
     return subprocess.run(cmd, cwd=cwd or CLONE_DIR, input=stdin,
@@ -166,14 +166,18 @@ class LiveIO:
     def open_pr(self, branch, issue, failure):
         _run(["git", "add", "-A"])
         _run(["git", "commit", "-m", f"fix: main-red recovery (regression #{issue})"])
-        _run(["git", "push", "-u", "origin", branch, "--force-with-lease"])
+        push = _run(["git", "push", "-u", "origin", branch, "--force-with-lease"])
+        if push.returncode != 0:
+            raise RuntimeError(f"git push failed for {branch}: {push.stderr.strip()}")
         body = (f"Closes #{issue}\n\nAutonomous main-red recovery. Reproduced failure:\n\n"
                 f"```\n{failure[:4000]}\n```\n\n---\n*MarketHawk Main-Red Auto-Fix*")
         r = _run(["gh", "pr", "create", "--repo", OWNER, "--base", "main",
                   "--head", branch, "--title", f"fix: main-red recovery (#{issue})",
                   "--body", body])
         m = re.search(r"/pull/(\d+)", r.stdout or "")
-        return int(m.group(1)) if m else 0
+        if not m:
+            raise RuntimeError(f"could not parse PR number from gh output: {(r.stdout or r.stderr).strip()}")
+        return int(m.group(1))
 
     def poll_ci(self, pr):
         import time
@@ -194,7 +198,8 @@ class LiveIO:
         return "pending"
 
     def merge(self, pr):
-        _run(["gh", "pr", "merge", str(pr), "--repo", OWNER, "--merge", "--delete-branch"])
+        r = _run(["gh", "pr", "merge", str(pr), "--repo", OWNER, "--merge", "--delete-branch"])
+        return r.returncode == 0
 
     def comment(self, issue, body):
         _run(["gh", "issue", "comment", str(issue), "--repo", OWNER, "--body", body])
@@ -242,11 +247,13 @@ def main_once() -> int:
                        "docker-compose", ".github/", ".env"],
         blocked_paths=["dark-factory/scheduler.sh", "dark-factory/scripts/factory_core/",
                        "dark-factory/entrypoint.sh"])
-    out = run_once(cfg, LiveIO(cfg), state)
     try:
-        with open(path, "w") as f:
-            json.dump(state, f)
-    except Exception:
-        pass
+        out = run_once(cfg, LiveIO(cfg), state)
+    finally:
+        try:
+            with open(path, "w") as f:
+                json.dump(state, f)
+        except Exception:
+            pass
     print(f"main_red_fixer={out['outcome']} issue=#{out.get('issue')}")
     return 0

--- a/dark-factory/scripts/factory_core/main_red_fixer.py
+++ b/dark-factory/scripts/factory_core/main_red_fixer.py
@@ -52,3 +52,60 @@ def record_attempt(state: dict, issue: int) -> None:
 def should_escalate(attempts: int, cap: int, scope: str) -> bool:
     """Escalate when the attempt cap is reached or the fix scope is not cleanly 'allowed'."""
     return attempts >= cap or scope in ("protected", "unknown")
+
+
+def build_fix_prompt(failure: str, allowed: list, blocked: list) -> str:
+    return f"""main is RED — the dark-factory smoke gate (tsc + python import) is failing on origin/main.
+Your job: make the smoke checks pass with the SMALLEST, safest change.
+
+Reproduced failure output:
+---
+{failure[:6000]}
+---
+
+You MAY edit files under: {', '.join(allowed)}.
+You MUST NOT edit: {', '.join(blocked)} (the scheduler/factory's own control loop).
+If the only correct fix is in a forbidden path, make NO changes and stop — a human will take it.
+
+Make the minimal fix, then stop. Do not commit, push, or open a PR — the harness does that.
+"""
+
+
+def run_once(cfg: dict, io, state: dict) -> dict:
+    """One bounded fix attempt. Returns {outcome, issue, ...}."""
+    issue = io.regression_issue()
+    if issue is None:
+        return {"outcome": "noop", "issue": None, "reason": "not-red"}
+
+    attempts = attempts_for(state, issue)
+    if should_escalate(attempts, cfg["max_attempts"], "allowed"):  # cap-only check here
+        io.escalate(issue, "cap")
+        return {"outcome": "escalated", "issue": issue, "reason": "cap"}
+    record_attempt(state, issue)
+
+    failure = io.reproduce()
+    if not failure:
+        return {"outcome": "noop", "issue": issue, "reason": "not-reproduced"}
+
+    branch = io.start_branch(issue)
+    io.apply_fix(build_fix_prompt(failure, cfg["allowed_paths"], cfg["blocked_paths"]))
+    changed = io.changed_paths()
+    if not changed:
+        io.escalate(issue, "empty-diff")
+        return {"outcome": "escalated", "issue": issue, "reason": "empty-diff"}
+
+    scope = classify_scope(changed, cfg["allowed_paths"], cfg["blocked_paths"])
+    if scope != "allowed":
+        io.escalate(issue, f"scope:{scope}")
+        return {"outcome": "escalated", "issue": issue, "reason": f"scope:{scope}"}
+
+    pr = io.open_pr(branch, issue, failure)
+    ci = io.poll_ci(pr)
+    if ci == "green":
+        io.merge(pr)
+        io.notify(f"Main-red auto-fix merged PR #{pr}",
+                  f"main is green again (regression #{issue}).", "info", None)
+        return {"outcome": "merged", "issue": issue, "pr": pr}
+
+    io.escalate(issue, f"ci:{ci}", pr=pr)
+    return {"outcome": "fixing", "issue": issue, "pr": pr, "reason": f"ci:{ci}"}

--- a/dark-factory/scripts/factory_core/main_red_fixer.py
+++ b/dark-factory/scripts/factory_core/main_red_fixer.py
@@ -1,0 +1,54 @@
+"""Main-Red Auto-Fix — bounded autonomous pipeline recovery (pure core + injected IO).
+
+When the smoke gate marks main red, reproduce the break, run a claude -p fix agent
+constrained to allowed paths, verify the diff stays in scope, open a ready PR, poll
+branch CI, and merge only on green. See
+docs/superpowers/specs/2026-06-21-main-red-autofix-design.md. Ships OFF.
+
+The pure functions below take/return plain data so they unit-test with no IO.
+"""
+import json
+import os
+import re
+import subprocess
+
+
+def classify_scope(changed_paths: list, allowed: list, blocked: list) -> str:
+    """'protected' if ANY changed path matches a blocked prefix (fail-closed, dominates);
+    'allowed' only if EVERY path matches an allowed prefix; else 'unknown'. Empty → 'unknown'."""
+    if not changed_paths:
+        return "unknown"
+    for p in changed_paths:
+        if any(b in p for b in blocked):
+            return "protected"
+    if all(any(a in p for a in allowed) for p in changed_paths):
+        return "allowed"
+    return "unknown"
+
+
+def ci_status(checks: list) -> str:
+    """Reduce `gh pr checks --json bucket` to green|red|pending. Any fail → red;
+    else any pending → pending; else (and at least one check) all pass/skipping → green;
+    no checks yet → pending (keep waiting)."""
+    buckets = [c.get("bucket") for c in checks]
+    if any(b == "fail" for b in buckets):
+        return "red"
+    if any(b == "pending" for b in buckets):
+        return "pending"
+    if buckets and all(b in ("pass", "skipping") for b in buckets):
+        return "green"
+    return "pending"
+
+
+def attempts_for(state: dict, issue: int) -> int:
+    return (state.get("issues") or {}).get(str(issue), {}).get("attempts", 0)
+
+
+def record_attempt(state: dict, issue: int) -> None:
+    d = state.setdefault("issues", {}).setdefault(str(issue), {"attempts": 0})
+    d["attempts"] = d.get("attempts", 0) + 1
+
+
+def should_escalate(attempts: int, cap: int, scope: str) -> bool:
+    """Escalate when the attempt cap is reached or the fix scope is not cleanly 'allowed'."""
+    return attempts >= cap or scope in ("protected", "unknown")

--- a/dark-factory/scripts/factory_core/main_red_fixer.py
+++ b/dark-factory/scripts/factory_core/main_red_fixer.py
@@ -54,6 +54,15 @@ def should_escalate(attempts: int, cap: int, scope: str) -> bool:
     return attempts >= cap or scope in ("protected", "unknown")
 
 
+def cap_escalated(state: dict, issue: int) -> bool:
+    return (state.get("issues") or {}).get(str(issue), {}).get("cap_escalated", False)
+
+
+def mark_cap_escalated(state: dict, issue: int) -> None:
+    d = state.setdefault("issues", {}).setdefault(str(issue), {"attempts": 0})
+    d["cap_escalated"] = True
+
+
 def build_fix_prompt(failure: str, allowed: list, blocked: list) -> str:
     return f"""main is RED — the dark-factory smoke gate (tsc + python import) is failing on origin/main.
 Your job: make the smoke checks pass with the SMALLEST, safest change.
@@ -79,7 +88,9 @@ def run_once(cfg: dict, io, state: dict) -> dict:
 
     attempts = attempts_for(state, issue)
     if should_escalate(attempts, cfg["max_attempts"], "allowed"):  # cap-only check here
-        io.escalate(issue, "cap")
+        if not cap_escalated(state, issue):
+            io.escalate(issue, "cap")
+            mark_cap_escalated(state, issue)
         return {"outcome": "escalated", "issue": issue, "reason": "cap"}
     record_attempt(state, issue)
 
@@ -137,16 +148,16 @@ class LiveIO:
             return None
 
     def reproduce(self):
-        """Run the smoke checks in the clone; return combined failure text (empty if green)."""
-        out = []
-        tsc = _run(["npx", "tsc", "--noEmit", "-p", "frontend/tsconfig.app.json"],
-                   cwd=CLONE_DIR, timeout=300)
-        if tsc.returncode != 0:
-            out.append("[tsc]\n" + (tsc.stdout or "") + (tsc.stderr or ""))
-        imp = _run(["python", "-c", "import backend.app.main"], cwd=CLONE_DIR, timeout=120)
-        if imp.returncode != 0:
-            out.append("[python import]\n" + (imp.stdout or "") + (imp.stderr or ""))
-        return "\n\n".join(out)
+        """Run the EXACT smoke-gate checks in the clone by sourcing smoke_gate.sh and
+        calling _smoke_check_main, so diagnosis can never drift from the gate. Returns the
+        combined failure output (empty string if both checks pass). See smoke_gate.sh."""
+        gate = os.path.join(CLONE_DIR, "dark-factory", "smoke_gate.sh")
+        r = _run(["bash", "-c",
+                  f'CLONE_DIR="{CLONE_DIR}" SMOKE_GATE_SOURCE_ONLY=1 source "{gate}" && _smoke_check_main'],
+                 cwd=CLONE_DIR, timeout=600)
+        if r.returncode == 0:
+            return ""
+        return ((r.stdout or "") + (r.stderr or "")).strip()
 
     def start_branch(self, issue):
         branch = f"fix/main-red-{issue}"
@@ -160,7 +171,8 @@ class LiveIO:
              stdin=prompt, timeout=self.cfg.get("agent_timeout", 1200))
 
     def changed_paths(self):
-        r = _run(["git", "diff", "--name-only", "origin/main", "--"])
+        _run(["git", "add", "-A"])
+        r = _run(["git", "diff", "--cached", "--name-only", "origin/main", "--"])
         return [ln.strip() for ln in (r.stdout or "").splitlines() if ln.strip()]
 
     def open_pr(self, branch, issue, failure):

--- a/dark-factory/scripts/factory_core/main_red_fixer.py
+++ b/dark-factory/scripts/factory_core/main_red_fixer.py
@@ -109,3 +109,144 @@ def run_once(cfg: dict, io, state: dict) -> dict:
 
     io.escalate(issue, f"ci:{ci}", pr=pr)
     return {"outcome": "fixing", "issue": issue, "pr": pr, "reason": f"ci:{ci}"}
+
+
+# ── Live IO (exercised in manual validation, not unit tests) ────────────────
+OWNER = "omniscient/markethawk"
+CLONE_DIR = os.environ.get("CLONE_DIR", "/workspace/markethawk")
+SMOKE_MARKER = "<!-- df-main-red -->"
+
+
+def _run(cmd, cwd=None, timeout=600, stdin=None):
+    return subprocess.run(cmd, cwd=cwd or CLONE_DIR, input=stdin,
+                          capture_output=True, text=True, timeout=timeout)
+
+
+class LiveIO:
+    def __init__(self, cfg):
+        self.cfg = cfg
+
+    def regression_issue(self):
+        path = os.path.join(os.environ.get("SCHEDULER_STATE_DIR", "/var/lib/dark-factory"),
+                            "main-is-red-issue")
+        try:
+            with open(path) as f:
+                n = f.read().strip()
+            return int(n) if n else None
+        except Exception:
+            return None
+
+    def reproduce(self):
+        """Run the smoke checks in the clone; return combined failure text (empty if green)."""
+        out = []
+        tsc = _run(["npx", "tsc", "--noEmit", "-p", "frontend/tsconfig.app.json"],
+                   cwd=CLONE_DIR, timeout=300)
+        if tsc.returncode != 0:
+            out.append("[tsc]\n" + (tsc.stdout or "") + (tsc.stderr or ""))
+        imp = _run(["python", "-c", "import backend.app.main"], cwd=CLONE_DIR, timeout=120)
+        if imp.returncode != 0:
+            out.append("[python import]\n" + (imp.stdout or "") + (imp.stderr or ""))
+        return "\n\n".join(out)
+
+    def start_branch(self, issue):
+        branch = f"fix/main-red-{issue}"
+        _run(["git", "checkout", "-B", branch, "origin/main"])
+        return branch
+
+    def apply_fix(self, prompt):
+        # headless claude with edit/bash tools, constrained to the clone dir
+        _run(["claude", "-p", "--model", self.cfg["model"],
+              "--allowedTools", "Edit,Write,Read,Bash,Grep,Glob"],
+             stdin=prompt, timeout=self.cfg.get("agent_timeout", 1200))
+
+    def changed_paths(self):
+        r = _run(["git", "diff", "--name-only", "origin/main", "--"])
+        return [ln.strip() for ln in (r.stdout or "").splitlines() if ln.strip()]
+
+    def open_pr(self, branch, issue, failure):
+        _run(["git", "add", "-A"])
+        _run(["git", "commit", "-m", f"fix: main-red recovery (regression #{issue})"])
+        _run(["git", "push", "-u", "origin", branch, "--force-with-lease"])
+        body = (f"Closes #{issue}\n\nAutonomous main-red recovery. Reproduced failure:\n\n"
+                f"```\n{failure[:4000]}\n```\n\n---\n*MarketHawk Main-Red Auto-Fix*")
+        r = _run(["gh", "pr", "create", "--repo", OWNER, "--base", "main",
+                  "--head", branch, "--title", f"fix: main-red recovery (#{issue})",
+                  "--body", body])
+        m = re.search(r"/pull/(\d+)", r.stdout or "")
+        return int(m.group(1)) if m else 0
+
+    def poll_ci(self, pr):
+        import time
+        deadline = self.cfg.get("ci_wait_minutes", 20) * 60
+        waited, step = 0, 30
+        while waited < deadline:
+            r = _run(["gh", "pr", "checks", str(pr), "--repo", OWNER,
+                      "--json", "name,bucket"], timeout=60)
+            try:
+                checks = json.loads(r.stdout) if r.stdout.strip() else []
+            except Exception:
+                checks = []
+            status = ci_status(checks)
+            if status in ("green", "red"):
+                return status
+            time.sleep(step)
+            waited += step
+        return "pending"
+
+    def merge(self, pr):
+        _run(["gh", "pr", "merge", str(pr), "--repo", OWNER, "--merge", "--delete-branch"])
+
+    def comment(self, issue, body):
+        _run(["gh", "issue", "comment", str(issue), "--repo", OWNER, "--body", body])
+
+    def notify(self, title, body, severity, dedupe_key):
+        token = os.environ.get("INTERNAL_API_TOKEN", "")
+        if not token:
+            return
+        import urllib.request
+        payload = {"title": title, "body": body, "severity": severity}
+        if dedupe_key:
+            payload["dedupe_key"] = dedupe_key
+        try:
+            req = urllib.request.Request(
+                "http://backend:8000/api/v1/alerts/system",
+                data=json.dumps(payload).encode(),
+                headers={"Content-Type": "application/json", "X-Internal-Token": token},
+                method="POST")
+            urllib.request.urlopen(req, timeout=10)
+        except Exception:
+            pass
+
+    def escalate(self, issue, reason, pr=None):
+        pr_txt = f" PR #{pr} left open for review." if pr else ""
+        self.comment(issue, f"\U0001f6e0️ **Main-Red Auto-Fix** — escalating to a human "
+                            f"(reason: {reason}).{pr_txt}\n\n---\n*MarketHawk Main-Red Auto-Fix*")
+        self.notify("Main-red auto-fix needs a human",
+                    f"Regression #{issue}: {reason}.{pr_txt}", "warning", f"main-red-{issue}")
+
+
+def main_once() -> int:
+    state_dir = os.environ.get("SCHEDULER_STATE_DIR", "/var/lib/dark-factory")
+    path = os.path.join(state_dir, "main-red-fixer-state.json")
+    try:
+        with open(path) as f:
+            state = json.load(f)
+    except Exception:
+        state = {}
+    cfg = dict(
+        max_attempts=int(os.environ.get("MAIN_RED_AUTOFIX_MAX_ATTEMPTS", "3")),
+        model=os.environ.get("MAIN_RED_AUTOFIX_MODEL", "claude-opus-4-8"),
+        ci_wait_minutes=int(os.environ.get("MAIN_RED_AUTOFIX_CI_WAIT_MINUTES", "20")),
+        agent_timeout=int(os.environ.get("MAIN_RED_AUTOFIX_AGENT_TIMEOUT", "1200")),
+        allowed_paths=["backend/", "frontend/", "alembic/", "dark-factory/smoke_gate.sh",
+                       "docker-compose", ".github/", ".env"],
+        blocked_paths=["dark-factory/scheduler.sh", "dark-factory/scripts/factory_core/",
+                       "dark-factory/entrypoint.sh"])
+    out = run_once(cfg, LiveIO(cfg), state)
+    try:
+        with open(path, "w") as f:
+            json.dump(state, f)
+    except Exception:
+        pass
+    print(f"main_red_fixer={out['outcome']} issue=#{out.get('issue')}")
+    return 0

--- a/dark-factory/tests/test_entrypoint_fix_main.sh
+++ b/dark-factory/tests/test_entrypoint_fix_main.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Verifies entrypoint.sh routes "Fix main" to the fixer, disambiguated from INTENT=fix,
+# and BEFORE the smoke gate can red-exit.
+# Run: bash dark-factory/tests/test_entrypoint_fix_main.sh
+set -euo pipefail
+ep="$(cd "$(dirname "$0")" && pwd)/../entrypoint.sh"
+
+grep -q 'fix-main' "$ep" \
+  || { echo "FAIL: no fix-main intent override"; exit 1; }
+grep -q 'main-red-fix --once' "$ep" \
+  || { echo "FAIL: entrypoint does not invoke the main-red-fix CLI"; exit 1; }
+
+# The fix-main route must appear BEFORE the smoke-gate invocation (so the gate's
+# red-exit-0 cannot abort the fixer). Compare line numbers.
+route_ln=$(grep -n 'INTENT" = "fix-main"' "$ep" | head -1 | cut -d: -f1)
+smoke_ln=$(grep -n 'run_smoke_gate\|smoke_gate.sh' "$ep" | head -1 | cut -d: -f1)
+[ -n "$route_ln" ] && [ -n "$smoke_ln" ] && [ "$route_ln" -lt "$smoke_ln" ] \
+  || { echo "FAIL: fix-main route ($route_ln) not before smoke gate ($smoke_ln)"; exit 1; }
+
+echo "PASS"

--- a/dark-factory/tests/test_main_red_fixer.py
+++ b/dark-factory/tests/test_main_red_fixer.py
@@ -152,6 +152,15 @@ def test_run_escalates_at_cap_without_attempting():
     assert io.applied == [] and io.escalations and io.escalations[0][0] == 700
 
 
+def test_run_cap_escalation_deduped():
+    io = FakeIO()
+    st = {"issues": {"700": {"attempts": 3}}}
+    out1 = mf.run_once(CFG, io, st)
+    out2 = mf.run_once(CFG, io, st)
+    assert out1["outcome"] == "escalated" and out2["outcome"] == "escalated"
+    assert len(io.escalations) == 1          # comment/escalate fired only once
+
+
 def test_run_escalates_on_red_ci_leaving_pr_open():
     io = FakeIO(ci="red")
     out = mf.run_once(CFG, io, {})

--- a/dark-factory/tests/test_main_red_fixer.py
+++ b/dark-factory/tests/test_main_red_fixer.py
@@ -65,3 +65,106 @@ def test_should_escalate():
     assert mf.should_escalate(0, 3, "protected") is True        # protected scope
     assert mf.should_escalate(0, 3, "unknown") is True          # fail-closed
     assert mf.should_escalate(1, 3, "allowed") is False
+
+
+class FakeIO:
+    def __init__(self, issue=700, failure="tsc error in backend",
+                 changed=None, ci="green"):
+        self._issue = issue
+        self._failure = failure
+        self._changed = ["backend/app/x.py"] if changed is None else changed
+        self._ci = ci
+        self.applied = []
+        self.opened = []
+        self.merged = []
+        self.escalations = []
+        self.notes = []
+        self.comments = []
+
+    def regression_issue(self):
+        return self._issue
+
+    def reproduce(self):
+        return self._failure
+
+    def start_branch(self, issue):
+        return f"fix/main-red-{issue}"
+
+    def apply_fix(self, prompt):
+        self.applied.append(prompt)
+
+    def changed_paths(self):
+        return self._changed
+
+    def open_pr(self, branch, issue, failure):
+        self.opened.append((branch, issue))
+        return 999
+
+    def poll_ci(self, pr):
+        return self._ci
+
+    def merge(self, pr):
+        self.merged.append(pr)
+
+    def comment(self, issue, body):
+        self.comments.append((issue, body))
+
+    def notify(self, title, body, severity, dedupe_key):
+        self.notes.append((severity, dedupe_key))
+
+    def escalate(self, issue, reason, pr=None):
+        self.escalations.append((issue, reason, pr))
+
+
+CFG = dict(max_attempts=3, model="claude-opus-4-8",
+           allowed_paths=ALLOWED, blocked_paths=BLOCKED)
+
+
+def test_run_noop_when_not_red():
+    io = FakeIO(issue=None)
+    out = mf.run_once(CFG, io, {})
+    assert out["outcome"] == "noop" and io.applied == []
+
+
+def test_run_merges_on_green():
+    io = FakeIO(ci="green")
+    st = {}
+    out = mf.run_once(CFG, io, st)
+    assert out["outcome"] == "merged" and io.merged == [999]
+    assert any(sev == "info" for sev, _ in io.notes)        # recovered notice
+    assert mf.attempts_for(st, 700) == 1                    # attempt counted
+
+
+def test_run_escalates_on_protected_scope_without_pr():
+    io = FakeIO(changed=["dark-factory/scheduler.sh"])
+    out = mf.run_once(CFG, io, {})
+    assert out["outcome"] == "escalated" and "scope" in out["reason"]
+    assert io.opened == [] and io.merged == []              # never opened a PR
+
+
+def test_run_escalates_at_cap_without_attempting():
+    io = FakeIO()
+    st = {"issues": {"700": {"attempts": 3}}}
+    out = mf.run_once(CFG, io, st)
+    assert out["outcome"] == "escalated" and out["reason"] == "cap"
+    assert io.applied == [] and io.escalations and io.escalations[0][0] == 700
+
+
+def test_run_escalates_on_red_ci_leaving_pr_open():
+    io = FakeIO(ci="red")
+    out = mf.run_once(CFG, io, {})
+    assert out["outcome"] == "fixing" and io.merged == []
+    assert io.escalations and io.escalations[0][2] == 999    # pr passed to escalate
+
+
+def test_run_escalates_on_empty_diff():
+    io = FakeIO(changed=[])
+    out = mf.run_once(CFG, io, {})
+    assert out["outcome"] == "escalated" and out["reason"] == "empty-diff"
+
+
+def test_build_fix_prompt_names_scope():
+    p = mf.build_fix_prompt("tsc: x.ts(3,1) error", ALLOWED, BLOCKED)
+    assert "tsc: x.ts(3,1) error" in p
+    assert "dark-factory/scheduler.sh" in p          # blocked list shown
+    assert "backend/" in p                            # allowed list shown

--- a/dark-factory/tests/test_main_red_fixer.py
+++ b/dark-factory/tests/test_main_red_fixer.py
@@ -69,11 +69,12 @@ def test_should_escalate():
 
 class FakeIO:
     def __init__(self, issue=700, failure="tsc error in backend",
-                 changed=None, ci="green"):
+                 changed=None, ci="green", merge_ok=True):
         self._issue = issue
         self._failure = failure
         self._changed = ["backend/app/x.py"] if changed is None else changed
         self._ci = ci
+        self._merge_ok = merge_ok
         self.applied = []
         self.opened = []
         self.merged = []
@@ -105,6 +106,7 @@ class FakeIO:
 
     def merge(self, pr):
         self.merged.append(pr)
+        return self._merge_ok
 
     def comment(self, issue, body):
         self.comments.append((issue, body))
@@ -161,6 +163,15 @@ def test_run_escalates_on_empty_diff():
     io = FakeIO(changed=[])
     out = mf.run_once(CFG, io, {})
     assert out["outcome"] == "escalated" and out["reason"] == "empty-diff"
+
+
+def test_run_escalates_on_merge_failure():
+    io = FakeIO(ci="green", merge_ok=False)
+    out = mf.run_once(CFG, io, {})
+    assert out["outcome"] == "fixing" and out["reason"] == "merge-failed"
+    assert io.merged == [999]                       # merge was attempted
+    assert io.escalations and io.escalations[0][2] == 999   # PR passed to escalate
+    assert not any(sev == "info" for sev, _ in io.notes)    # no "recovered" notice
 
 
 def test_build_fix_prompt_names_scope():

--- a/dark-factory/tests/test_main_red_fixer.py
+++ b/dark-factory/tests/test_main_red_fixer.py
@@ -1,0 +1,67 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+from factory_core import main_red_fixer as mf  # noqa: E402
+
+ALLOWED = ["backend/", "frontend/", "alembic/", "dark-factory/smoke_gate.sh",
+           "docker-compose", ".github/", ".env"]
+BLOCKED = ["dark-factory/scheduler.sh", "dark-factory/scripts/factory_core/",
+           "dark-factory/entrypoint.sh"]
+
+
+def test_scope_allowed():
+    assert mf.classify_scope(["backend/app/main.py", "frontend/src/x.ts"], ALLOWED, BLOCKED) == "allowed"
+
+
+def test_scope_allowed_includes_smoke_gate():
+    assert mf.classify_scope(["dark-factory/smoke_gate.sh"], ALLOWED, BLOCKED) == "allowed"
+
+
+def test_scope_protected_blocks_factory_core():
+    assert mf.classify_scope(["dark-factory/scripts/factory_core/board.py"], ALLOWED, BLOCKED) == "protected"
+
+
+def test_scope_protected_wins_over_allowed():
+    # one allowed + one blocked → protected (blocked dominates, fail-closed)
+    assert mf.classify_scope(["backend/app/x.py", "dark-factory/scheduler.sh"], ALLOWED, BLOCKED) == "protected"
+
+
+def test_scope_unknown_for_unclassified_path():
+    assert mf.classify_scope(["README.md"], ALLOWED, BLOCKED) == "unknown"
+
+
+def test_scope_unknown_for_empty():
+    assert mf.classify_scope([], ALLOWED, BLOCKED) == "unknown"
+
+
+def test_ci_status_green():
+    assert mf.ci_status([{"bucket": "pass"}, {"bucket": "skipping"}, {"bucket": "pass"}]) == "green"
+
+
+def test_ci_status_red_on_any_fail():
+    assert mf.ci_status([{"bucket": "pass"}, {"bucket": "fail"}, {"bucket": "pending"}]) == "red"
+
+
+def test_ci_status_pending():
+    assert mf.ci_status([{"bucket": "pass"}, {"bucket": "pending"}]) == "pending"
+
+
+def test_ci_status_no_checks_is_pending():
+    assert mf.ci_status([]) == "pending"
+
+
+def test_attempts_roundtrip_and_cap():
+    st = {}
+    assert mf.attempts_for(st, 700) == 0
+    mf.record_attempt(st, 700)
+    mf.record_attempt(st, 700)
+    assert mf.attempts_for(st, 700) == 2
+    assert mf.attempts_for(st, 701) == 0  # per-issue keyed
+
+
+def test_should_escalate():
+    assert mf.should_escalate(3, 3, "allowed") is True          # cap reached
+    assert mf.should_escalate(0, 3, "protected") is True        # protected scope
+    assert mf.should_escalate(0, 3, "unknown") is True          # fail-closed
+    assert mf.should_escalate(1, 3, "allowed") is False

--- a/dark-factory/tests/test_scheduler_main_red_fixer.sh
+++ b/dark-factory/tests/test_scheduler_main_red_fixer.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Verifies scheduler.sh dispatches a main-red fixer, gated by enable + dedupe + throttle,
+# only inside the MAIN_IS_RED block.
+# Run: bash dark-factory/tests/test_scheduler_main_red_fixer.sh
+set -euo pipefail
+sched="$(cd "$(dirname "$0")" && pwd)/../scheduler.sh"
+
+grep -q 'MAIN_RED_AUTOFIX_ENABLED' "$sched" \
+  || { echo "FAIL: no MAIN_RED_AUTOFIX_ENABLED kill-switch"; exit 1; }
+grep -q 'is_fixer_running' "$sched" \
+  || { echo "FAIL: no is_fixer_running dedupe helper"; exit 1; }
+grep -qE 'dispatch "Fix main"' "$sched" \
+  || { echo "FAIL: scheduler never dispatches 'Fix main'"; exit 1; }
+
+# The fixer dispatch must live inside the MAIN_IS_RED block (after the recheck call).
+block="$(awk '/Read main-is-red sentinel/{f=1} f{print} f&&/^fi$/{exit}' "$sched")"
+echo "$block" | grep -q 'main_red_fixer_check' \
+  || { echo "FAIL: main_red_fixer_check not called in the MAIN_IS_RED block"; exit 1; }
+
+echo "PASS"


### PR DESCRIPTION
## Main-Red Auto-Fix — autonomous pipeline recovery

Implements the spec `docs/superpowers/specs/2026-06-21-main-red-autofix-design.md` and plan `docs/superpowers/plans/2026-06-21-main-red-autofix.md`. Part of Epic omniscient/dark-factory#133.

When the smoke gate marks `main` red (writes the `main-is-red` sentinel + a regression ticket and pauses all implementation dispatch), this feature autonomously **diagnoses → fixes → verifies-CI-green → merges**, within a bounded scope envelope, escalating to a human when it can't. **Ships OFF** behind a kill-switch.

### Flow
1. **`scheduler.sh`** — in the `MAIN_IS_RED` block, `main_red_fixer_check` dispatches a `"Fix main"` container when enabled, deduped on a running fixer + throttled by a stamp file (mirrors the existing `"Recheck main"` mechanism).
2. **`entrypoint.sh`** — an exact-match override maps `"Fix main"` → `INTENT=fix-main`; a route placed *after* clone + dep-install but *before* the smoke gate invokes `factory-core main-red-fix --once` (gated again by the kill-switch).
3. **`factory_core/main_red_fixer.py`** — pure core (`classify_scope` / `ci_status` / attempt-state / `should_escalate`) + `run_once` orchestrator + `LiveIO` adapters + `main_once`. One bounded attempt: reproduce (reuses `smoke_gate.sh`'s `_smoke_check_main`), run a scope-constrained `claude -p` fix agent, verify the produced diff stays in the scope envelope (fail-closed, incl. untracked files), open a ready PR, poll CI, **merge only on green**; escalate (comment + notify) on cap / protected-or-unknown scope / non-green CI / failed merge.
4. **`config.yaml`** — `main_red_autofix:` knobs.

### Safety
- **Ships OFF.** Double-gated: the scheduler dispatch and the entrypoint route both require `MAIN_RED_AUTOFIX_ENABLED=true`. Nothing fires with the shipped `enabled: false`.
- **Scope envelope (pipeline-yes / own-brain-no).** May edit `backend/`, `frontend/`, `alembic/`, `dark-factory/smoke_gate.sh`, `docker-compose*`, `.github/`, `.env*`; **blocked** from `dark-factory/scheduler.sh`, `dark-factory/scripts/factory_core/`, `dark-factory/entrypoint.sh`. The produced diff is classified *after* the agent runs (fail-closed): anything protected or unknown → escalate, never open/merge a PR.
- **Never merges red.** Bounded attempt cap (default 3) per red event keyed by the regression issue number; at cap → leave PR open, notify once, stop.

### Notable design decisions (deltas from the plan's literal text, surfaced for review)
- **`reproduce()` reuses the real gate.** Rather than re-implement the smoke checks (which drifted — wrong tsc cwd; `import backend.app.main` with no env → phantom `ModuleNotFoundError: No module named 'app'` on a green backend every run), it sources `smoke_gate.sh` with `SMOKE_GATE_SOURCE_ONLY=1` and calls `_smoke_check_main`, so diagnosis can never diverge from the gate.
- **Merge-failure handling.** `LiveIO.merge` returns a success bool; a failed `gh pr merge` escalates with the PR left open (outcome `fixing`), mirroring the non-green-CI path — not a raise (state is persisted in `main_once`'s `finally`, so the attempt still counts toward the cap).
- **Scope check sees untracked files** (`git add -A` then `git diff --cached`), closing a hole where an agent-created blocked-path file would be invisible to the classifier.
- **cli invoked via `$CLONE_DIR/.../cli.py`** (the freshly-cloned copy), matching the existing entrypoint convention.

### Enabling (Task 7 — human/operational)
This is a **factory self-edit**: `scheduler.sh` / `entrypoint.sh` / `factory_core/` are baked, so deploy needs a human `docker compose build backlog-scheduler && docker compose up -d --force-recreate backlog-scheduler`. To enable, set `MAIN_RED_AUTOFIX_ENABLED=true` in `.archon/.env` (overrides the config default and is read by the dispatched container — like `EPIC_AUTOPILOT_ENABLED`). Staging induce-red drills (app-code break, protected-zone cause, attempt-cap) per the plan's Task 7 remain a human gate before flipping it on.

### Tests
- 21 Python unit tests (`tests/test_main_red_fixer.py`) — scope classification, CI-status reduction, attempt-state + cap, escalate-on-protected/unknown/red-CI/merge-failure, cap-escalation dedupe.
- Grep tests: `test_entrypoint_fix_main.sh`, `test_scheduler_main_red_fixer.sh`. Existing `test_scheduler_ceiling.sh` / `test_scheduler_autopilot_guard.sh` still green; `bash -n` clean on both shell files.

Built task-by-task with per-task spec+quality review and an Opus whole-branch review; all Critical/Important findings fixed and re-verified. Non-blocking Minors tracked in a follow-up issue.

Closes omniscient/dark-factory#137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
