### PR TITLE
cleanup(dark-factory): factory-failures.jsonl to ARTIFACTS_DIR, not a git worktree (#521)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ backend/celerybeat-schedule
 
 # Dark factory runtime
 dark-factory/tmp/
+dark-factory/evals/factory-failures.jsonl
 
 # Local artifacts (log dumps, scratch DBs)
 *.db

--- a/dark-factory/entrypoint.sh
+++ b/dark-factory/entrypoint.sh
@@ -178,10 +178,10 @@ run_post_mortem() {
   fi
 
   local artifacts_context=""
-  local ARTIFACTS_DIR="${HOME}/.archon/workspaces/omniscient/markethawk/artifacts/runs"
+  local ARTIFACTS_BASE_DIR="${HOME}/.archon/workspaces/omniscient/markethawk/artifacts/runs"
   # Find the most recent run artifacts directory for this issue
   local run_dir
-  run_dir=$(ls -dt "${ARTIFACTS_DIR}"/*/issue.json 2>/dev/null \
+  run_dir=$(ls -dt "${ARTIFACTS_BASE_DIR}"/*/issue.json 2>/dev/null \
     | xargs grep -l "\"resolved_number\": ${ISSUE_NUM}" 2>/dev/null \
     | head -1 | xargs dirname 2>/dev/null || true)
 
@@ -233,11 +233,9 @@ ${post_mortem_text}
 ---
 *Posted by MarketHawk Dark Factory*" || true
 
-  # Write failure telemetry to main via a temporary detached worktree.
-  # The feature-branch CLONE_DIR working tree and index are never touched,
-  # so factory-failures.jsonl can never appear in the feature-branch diff.
-  if [ -d "${CLONE_DIR}" ]; then
-    local JSONL_PATH="dark-factory/evals/factory-failures.jsonl"
+  # Write failure telemetry to per-run ARTIFACTS_DIR (no git operations).
+  if [ -n "${ARTIFACTS_DIR:-}" ]; then
+    local JSONL_PATH="${ARTIFACTS_DIR}/factory-failures.jsonl"
     local excerpt
     excerpt=$(echo "$post_mortem_text" | head -c 500 | tr '\n' ' ')
     local record
@@ -248,17 +246,7 @@ ${post_mortem_text}
       "${exit_code}" \
       "$(echo "$excerpt" | sed 's/"/\\"/g')" \
       "$PROMOTED_AT")
-    (
-      git -C "${CLONE_DIR}" fetch origin main 2>/dev/null || true
-      WT=$(mktemp -d)
-      git -C "${CLONE_DIR}" worktree add --detach "$WT" origin/main 2>/dev/null
-      echo "$record" >> "${WT}/${JSONL_PATH}"
-      git -C "$WT" add "${JSONL_PATH}"
-      git -C "$WT" commit -m "eval: record factory failure for issue #${ISSUE_NUM}"
-      git -C "$WT" push origin HEAD:main 2>/dev/null
-      git -C "${CLONE_DIR}" worktree remove --force "$WT" 2>/dev/null || true
-      rm -rf "$WT" 2>/dev/null || true
-    ) 2>/dev/null || true
+    echo "$record" >> "$JSONL_PATH" 2>/dev/null || true
   fi
 }
 

--- a/dark-factory/tests/test_431_telemetry_isolation.sh
+++ b/dark-factory/tests/test_431_telemetry_isolation.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Test: run_post_mortem() writes failure telemetry via a git worktree on main,
-# never touching the feature-branch CLONE_DIR.
-# Issue #431
+# Test: run_post_mortem() writes failure telemetry to ARTIFACTS_DIR,
+# with zero git operations — no worktree, no push, no commit.
+# Issue #521
 # Run: bash dark-factory/tests/test_431_telemetry_isolation.sh
 set -uo pipefail
 
@@ -11,20 +11,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 export GH_TOKEN="stub-token"
 export CLAUDE_CODE_OAUTH_TOKEN="stub-token"
 
-GIT_LOG=$(mktemp /tmp/431-git-XXXXXX.log)
+GIT_LOG=$(mktemp /tmp/521-git-XXXXXX.log)
 
 git() {
   echo "git $*" >> "$GIT_LOG"
-  local prev=""
-  for arg in "$@"; do
-    if [ "$prev" = "--detach" ]; then
-      mkdir -p "${arg}/dark-factory/evals"
-      echo '{"issue":1,"title":"prior","phase":"fix","exit_code":1,"postmortem":"prior","promoted_at":"2026-01-01T00:00:00Z"}' \
-        > "${arg}/dark-factory/evals/factory-failures.jsonl"
-      break
-    fi
-    prev="$arg"
-  done
   return 0
 }
 export -f git
@@ -41,22 +31,26 @@ export -f claude
 # ── Source entrypoint (guard prevents clone + main execution) ─────────────
 ENTRYPOINT_SOURCE_ONLY=1 source "$SCRIPT_DIR/../entrypoint.sh"
 
-# Reset error handling set by entrypoint — test context manages its own flow
+# Reset strict error handling from entrypoint — test context manages its own flow
 trap - ERR
 set +e
+set +u
 set +o pipefail
 
+# Reset git log: sourcing entrypoint runs top-level git config calls; we only
+# want to count git operations from run_post_mortem itself.
+> "$GIT_LOG"
+
 # ── Test fixture ──────────────────────────────────────────────────────────
-CLONE_DIR=$(mktemp -d /tmp/431-clone-XXXXXX)
-JSONL_IN_CLONE="${CLONE_DIR}/dark-factory/evals/factory-failures.jsonl"
-mkdir -p "$(dirname "$JSONL_IN_CLONE")"
-echo '{"issue":1,"title":"prior","phase":"fix","exit_code":1,"postmortem":"prior","promoted_at":"2026-01-01T00:00:00Z"}' \
-  > "$JSONL_IN_CLONE"
+CLONE_DIR=$(mktemp -d /tmp/521-clone-XXXXXX)
 
-INITIAL_LINES=$(wc -l < "$JSONL_IN_CLONE")
-INITIAL_MD5=$(md5sum "$JSONL_IN_CLONE" | awk '{print $1}')
+# Set ARTIFACTS_DIR to a temp directory (simulates the global per-run dir)
+ARTIFACTS_DIR=$(mktemp -d /tmp/521-artifacts-XXXXXX)
+export ARTIFACTS_DIR
 
-ISSUE_NUM=431
+JSONL_IN_ARTIFACTS="${ARTIFACTS_DIR}/factory-failures.jsonl"
+
+ISSUE_NUM=521
 INTENT=fix
 
 # ── Run ───────────────────────────────────────────────────────────────────
@@ -73,34 +67,38 @@ assert_eq() {
     FAILED=$((FAILED + 1))
   fi
 }
+assert_true() {
+  local desc="$1" condition="$2"
+  if eval "$condition"; then
+    echo "  PASS: $desc"; PASSED=$((PASSED + 1))
+  else
+    echo "  FAIL: $desc — condition false: $condition" >&2
+    FAILED=$((FAILED + 1))
+  fi
+}
 
-echo "=== #431: Telemetry isolation — worktree on main, never touches CLONE_DIR ==="
+echo "=== #521: Telemetry isolation — ARTIFACTS_DIR write, zero git operations ==="
 echo ""
 
-FINAL_MD5=$(md5sum "$JSONL_IN_CLONE" | awk '{print $1}')
-assert_eq "CLONE_DIR jsonl not modified (md5)" "$INITIAL_MD5" "$FINAL_MD5"
+GIT_CALL_COUNT=$(wc -l < "$GIT_LOG" 2>/dev/null || echo "0")
+assert_eq "no git operations called" "0" "$GIT_CALL_COUNT"
 
-FINAL_LINES=$(wc -l < "$JSONL_IN_CLONE")
-assert_eq "CLONE_DIR jsonl line count unchanged" "$INITIAL_LINES" "$FINAL_LINES"
+assert_true "factory-failures.jsonl exists in ARTIFACTS_DIR" "[ -f '$JSONL_IN_ARTIFACTS' ]"
 
-PUSH_TO_MAIN=$(grep 'push origin HEAD:main' "$GIT_LOG" 2>/dev/null | wc -l)
-assert_eq "push targets HEAD:main exactly once" "1" "$PUSH_TO_MAIN"
+LINE_COUNT=$(wc -l < "$JSONL_IN_ARTIFACTS" 2>/dev/null || echo "0")
+assert_eq "exactly one JSONL line written" "1" "$LINE_COUNT"
 
-PUSH_TO_BRANCH=$(grep 'push origin' "$GIT_LOG" 2>/dev/null | grep -v 'HEAD:main' | wc -l)
-assert_eq "no direct push to feature branch" "0" "$PUSH_TO_BRANCH"
+# Use stdin redirection so Python does not need to resolve the Unix tmp path
+# (avoids Git Bash /tmp path incompatibility with Windows Python).
+VALID_JSON=$(python3 -c "import json,sys; json.loads(sys.stdin.read())" < "$JSONL_IN_ARTIFACTS" 2>/dev/null && echo "ok" || echo "invalid")
+assert_eq "JSONL line is valid JSON" "ok" "$VALID_JSON"
 
-WORKTREE_ADD=$(grep 'worktree add' "$GIT_LOG" 2>/dev/null | wc -l)
-assert_eq "worktree add called" "1" "$WORKTREE_ADD"
-
-WORKTREE_REMOVE=$(grep 'worktree remove' "$GIT_LOG" 2>/dev/null | wc -l)
-assert_eq "worktree remove called" "1" "$WORKTREE_REMOVE"
-
-FETCH_MAIN=$(grep 'fetch origin main' "$GIT_LOG" 2>/dev/null | wc -l)
-assert_eq "git fetch origin main called" "1" "$FETCH_MAIN"
+ISSUE_FIELD=$(python3 -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('issue','missing'))" < "$JSONL_IN_ARTIFACTS" 2>/dev/null || echo "missing")
+assert_eq "issue field matches ISSUE_NUM" "521" "$ISSUE_FIELD"
 
 # ── Cleanup ───────────────────────────────────────────────────────────────
 rm -f "$GIT_LOG"
-rm -rf "$CLONE_DIR"
+rm -rf "$CLONE_DIR" "$ARTIFACTS_DIR"
 
 echo ""
 echo "Results: ${PASSED} passed, ${FAILED} failed"


### PR DESCRIPTION
Implements the approved plan `docs/superpowers/plans/2026-06-22-factory-failures-telemetry-destination.md`.

The post-mortem previously wrote `factory-failures.jsonl` by spinning up a temporary detached git worktree on `origin/main` and committing+pushing the record — polluting main with OOS telemetry commits (the bug this ticket fixes). Now it appends the record to the per-run `${ARTIFACTS_DIR}/factory-failures.jsonl` with **no git operations**; durable telemetry already ships to Seq.

- `entrypoint.sh`: renamed the shadowing `local ARTIFACTS_DIR` → `ARTIFACTS_BASE_DIR` (un-shadows the exported global), replaced the 25-line worktree/commit/push block with a 2-line local append.
- `.gitignore`: ignore `dark-factory/evals/factory-failures.jsonl` (existing tracked file left in place per the plan).
- `test_431_telemetry_isolation.sh`: asserts zero git ops + the ARTIFACTS_DIR write (5/5 pass). Two host-only Windows test-compat tweaks vs the plan; no effect on Linux assertions.

Implemented manually (factory implement node circuit-broke on Max-5h session-window exhaustion). Closes omniscient/dark-factory#131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)