### PR TITLE
fix(infra): seq needs restart: unless-stopped so it recovers with the stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -481,6 +481,7 @@ services:
         condition: service_completed_successfully
     networks:
       - stockscanner-network
+    restart: unless-stopped
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Problem
The `seq` server (`stockscanner-seq`) had **no `restart:` policy** (Docker default `no`), while its own `seq-gelf` sidecar has `restart: unless-stopped`. So when Seq crashed (~46h ago), it stayed dead while the rest of the stack — including the gelf sidecar forwarding logs to it — kept running. Logs had nowhere to land.

**Impact:** centralized logging was silently dead, which is why the dark-factory failure post-mortems all read *"transcript empty / no logs"* — the `claude.result_is_error` events that would have explained the overnight session-window-exhaustion cascade were dropped.

## Fix
Add `restart: unless-stopped` to the `seq` service (matching `seq-gelf` and the rest of the stack), so Seq is brought back up automatically if it ever exits.

Already applied at runtime (`docker update --restart=unless-stopped stockscanner-seq && docker start`) — Seq is back up, serving :5380 (HTTP 200), 80 MiB/1 GiB. This PR makes it durable across recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)