### PR TITLE
fix(dark-factory): append-only guard for memory writes to prevent valid-entry deletion (#522)

### DIFF
--- a/.archon/commands/dark-factory-implement.md
+++ b/.archon/commands/dark-factory-implement.md
@@ -322,35 +322,38 @@ it — it prevents the same wrong claim from being re-added during the TTL windo
 Run this block after all R3/R4/R5 operations and before `git add .archon/memory/`:
 
 ```bash
-# Memory write guard — detect unexpected deletions and restore
+# Memory write guard — detect unexpected deletions and restore (append-only; never reverts this run's new entries)
 for MEM_FILE in .archon/memory/*.md; do
   [ -f "$MEM_FILE" ] || continue
-  # Lines starting with '-' that are not file-header markers
+  # Deleted content lines (diff marker '-'), excluding file-header markers
   DELETED=$(git diff "$MEM_FILE" | grep '^-' | grep -v '^---' | grep -v '^-#' | grep -v '^-<!--' || true)
   if [ -n "$DELETED" ]; then
-    # Filter out expected deletions: expiry-cleaned lines (expired dates),
-    # R4 drops (oldest-date lines), R5 rewrites (tag-only change, body unchanged)
+    # Added content lines with the diff '+' marker stripped, for R5 body comparison
+    ADDED=$(git diff "$MEM_FILE" | grep '^+' | grep -v '^+++' | sed 's/^+//')
     TODAY=$(date +%Y-%m-%d)
     UNEXPECTED=$(echo "$DELETED" | while IFS= read -r line; do
-      # Skip lines whose expires: date is in the past (legitimate expiry cleanup)
-      if echo "$line" | grep -q 'expires:'; then
-        EXPIRY=$(echo "$line" | sed 's/.*expires:\([0-9-]*\).*/\1/')
+      # Strip the diff '-' marker to recover the file-content line
+      CONTENT=$(printf '%s' "$line" | sed 's/^-//')
+      # Legitimate expiry cleanup: an expires: date in the past
+      if echo "$CONTENT" | grep -q 'expires:'; then
+        EXPIRY=$(echo "$CONTENT" | sed 's/.*expires:\([0-9-]*\).*/\1/')
         [ "$EXPIRY" \< "$TODAY" ] && continue
       fi
-      # Skip R5 invalidations: deleted line body matches an added line body (tag change only)
-      BODY=$(echo "$line" | sed 's/^\- \[PATTERN\]//' | sed 's/^\- \[AVOID\]//' | sed 's/^\- \[FIX\]//')
-      if git diff "$MEM_FILE" | grep '^+' | grep -v '^+++' | grep -qF "$BODY"; then
+      # Legitimate R5 invalidation: same body re-added with a changed tag.
+      # Strip a leading "- [ANYTAG]" to get the bare body, then look for it among added lines.
+      BODY=$(printf '%s' "$CONTENT" | sed 's/^- \[[^]]*\]//')
+      if [ -n "$BODY" ] && printf '%s\n' "$ADDED" | grep -qF -- "$BODY"; then
         continue
       fi
-      echo "$line"
+      printf '%s\n' "$CONTENT"
     done)
     if [ -n "$UNEXPECTED" ]; then
-      echo "MEMORY GUARD: unexpected deletions detected in $MEM_FILE — restoring"
-      echo "$UNEXPECTED"
-      git checkout HEAD -- "$MEM_FILE"
-      # Re-apply only the intended new entries by echoing them back
-      # (The agent must re-append them after the restore.)
-      echo "MEMORY GUARD: re-append your new entries to $MEM_FILE now"
+      echo "MEMORY GUARD: unexpected deletion(s) in $MEM_FILE — re-appending to preserve them:"
+      printf '%s\n' "$UNEXPECTED"
+      # Append-only restore: re-append the deleted authoritative line(s). This preserves
+      # this run's new entries (unlike a whole-file checkout) and is self-healing for R4
+      # cap-drops (a re-appended over-cap entry is simply re-capped on the next run).
+      printf '%s\n' "$UNEXPECTED" >> "$MEM_FILE"
     fi
   fi
 done

--- a/.archon/commands/dark-factory-implement.md
+++ b/.archon/commands/dark-factory-implement.md
@@ -276,6 +276,17 @@ Format:
 - [PATTERN|AVOID|FIX] <concise actionable sentence, specific paths/commands/names where relevant> <!-- issue:#$ISSUE_NUM date:$(date +%Y-%m-%d) expires:$(date -d '+6 months' +%Y-%m-%d 2>/dev/null || date -v+6m +%Y-%m-%d) source:implement -->
 ```
 
+**Append-only rule:** New memory entries must be written with shell appends:
+  echo '- [PATTERN] ...' >> .archon/memory/backend-patterns.md
+NEVER use the Write or Edit tool on a memory file to add new entries — doing so risks
+regenerating the file from a stale in-context copy and silently dropping existing entries.
+
+The ONLY operations permitted to remove or modify existing lines are:
+  (a) the awk expiry-cleanup block (entries with a past `expires:` date)
+  (b) R4 cap-drop (explicit drop of the oldest/lowest-signal entries when COUNT > 30)
+  (c) R5 invalidation (rewrite `[PATTERN]` → `[INVALID: reason]` for a single entry)
+Each of these operations must touch ONLY the targeted lines and leave all other lines verbatim.
+
 ### Per-file authoritative entry cap (R4)
 
 After appending, count authoritative entries in the target file:
@@ -305,6 +316,45 @@ Example:
 
 The tombstone counts toward the 30-entry cap and expires on the original TTL. Do not delete
 it — it prevents the same wrong claim from being re-added during the TTL window.
+
+### Post-write verification backstop
+
+Run this block after all R3/R4/R5 operations and before `git add .archon/memory/`:
+
+```bash
+# Memory write guard — detect unexpected deletions and restore
+for MEM_FILE in .archon/memory/*.md; do
+  [ -f "$MEM_FILE" ] || continue
+  # Lines starting with '-' that are not file-header markers
+  DELETED=$(git diff "$MEM_FILE" | grep '^-' | grep -v '^---' | grep -v '^-#' | grep -v '^-<!--' || true)
+  if [ -n "$DELETED" ]; then
+    # Filter out expected deletions: expiry-cleaned lines (expired dates),
+    # R4 drops (oldest-date lines), R5 rewrites (tag-only change, body unchanged)
+    TODAY=$(date +%Y-%m-%d)
+    UNEXPECTED=$(echo "$DELETED" | while IFS= read -r line; do
+      # Skip lines whose expires: date is in the past (legitimate expiry cleanup)
+      if echo "$line" | grep -q 'expires:'; then
+        EXPIRY=$(echo "$line" | sed 's/.*expires:\([0-9-]*\).*/\1/')
+        [ "$EXPIRY" \< "$TODAY" ] && continue
+      fi
+      # Skip R5 invalidations: deleted line body matches an added line body (tag change only)
+      BODY=$(echo "$line" | sed 's/^\- \[PATTERN\]//' | sed 's/^\- \[AVOID\]//' | sed 's/^\- \[FIX\]//')
+      if git diff "$MEM_FILE" | grep '^+' | grep -v '^+++' | grep -qF "$BODY"; then
+        continue
+      fi
+      echo "$line"
+    done)
+    if [ -n "$UNEXPECTED" ]; then
+      echo "MEMORY GUARD: unexpected deletions detected in $MEM_FILE — restoring"
+      echo "$UNEXPECTED"
+      git checkout HEAD -- "$MEM_FILE"
+      # Re-apply only the intended new entries by echoing them back
+      # (The agent must re-append them after the restore.)
+      echo "MEMORY GUARD: re-append your new entries to $MEM_FILE now"
+    fi
+  fi
+done
+```
 
 ### Commit
 

--- a/.archon/commands/dark-factory-refine.md
+++ b/.archon/commands/dark-factory-refine.md
@@ -174,6 +174,17 @@ Follow the process in `orchestrator-prompt.md`:
       - [AVOID] <the rejected approach and the concrete reason it was rejected> <!-- issue:#$ISSUE_NUM date:$(date +%Y-%m-%d) expires:$(date -d '+6 months' +%Y-%m-%d 2>/dev/null || date -v+6m +%Y-%m-%d) source:refine -->
       ```
 
+   **Append-only rule:** New memory entries must be written with shell appends:
+     echo '- [PATTERN] ...' >> .archon/memory/architecture.md
+   NEVER use the Write or Edit tool on a memory file to add new entries — doing so risks
+   regenerating the file from a stale in-context copy and silently dropping existing entries.
+
+   The ONLY operations permitted to remove or modify existing lines are:
+     (a) the awk expiry-cleanup block (entries with a past `expires:` date)
+     (b) R4 cap-drop (explicit drop of the oldest/lowest-signal entries when COUNT > 30)
+     (c) R5 invalidation (rewrite `[PATTERN]` → `[INVALID: reason]` for a single entry)
+   Each of these operations must touch ONLY the targeted lines and leave all other lines verbatim.
+
    **Provisional tier for empirical claims (R2):**
 
    If an architectural decision depends on an empirically-observed runtime behavior (e.g.,
@@ -198,6 +209,43 @@ Follow the process in `orchestrator-prompt.md`:
    c. Before appending any entry, check for duplicates: `grep -F "<core sentence of the new entry>" .archon/memory/architecture.md`. If a matching line exists, skip that entry.
 
    d. Do NOT write to `codebase-patterns.md` from the refine agent — that file is maintained by the implement agent for runtime-proven lessons only.
+
+   **Post-write verification backstop** — run after all R3/R4 operations and before `git add .archon/memory/`:
+
+   ```bash
+   # Memory write guard — detect unexpected deletions and restore
+   for MEM_FILE in .archon/memory/*.md; do
+     [ -f "$MEM_FILE" ] || continue
+     # Lines starting with '-' that are not file-header markers
+     DELETED=$(git diff "$MEM_FILE" | grep '^-' | grep -v '^---' | grep -v '^-#' | grep -v '^-<!--' || true)
+     if [ -n "$DELETED" ]; then
+       # Filter out expected deletions: expiry-cleaned lines (expired dates),
+       # R4 drops (oldest-date lines), R5 rewrites (tag-only change, body unchanged)
+       TODAY=$(date +%Y-%m-%d)
+       UNEXPECTED=$(echo "$DELETED" | while IFS= read -r line; do
+         # Skip lines whose expires: date is in the past (legitimate expiry cleanup)
+         if echo "$line" | grep -q 'expires:'; then
+           EXPIRY=$(echo "$line" | sed 's/.*expires:\([0-9-]*\).*/\1/')
+           [ "$EXPIRY" \< "$TODAY" ] && continue
+         fi
+         # Skip R5 invalidations: deleted line body matches an added line body (tag change only)
+         BODY=$(echo "$line" | sed 's/^\- \[PATTERN\]//' | sed 's/^\- \[AVOID\]//' | sed 's/^\- \[FIX\]//')
+         if git diff "$MEM_FILE" | grep '^+' | grep -v '^+++' | grep -qF "$BODY"; then
+           continue
+         fi
+         echo "$line"
+       done)
+       if [ -n "$UNEXPECTED" ]; then
+         echo "MEMORY GUARD: unexpected deletions detected in $MEM_FILE — restoring"
+         echo "$UNEXPECTED"
+         git checkout HEAD -- "$MEM_FILE"
+         # Re-apply only the intended new entries by echoing them back
+         # (The agent must re-append them after the restore.)
+         echo "MEMORY GUARD: re-append your new entries to $MEM_FILE now"
+       fi
+     fi
+   done
+   ```
 
    e. If any entries were added, commit:
       ```bash

--- a/.archon/commands/dark-factory-refine.md
+++ b/.archon/commands/dark-factory-refine.md
@@ -213,38 +213,41 @@ Follow the process in `orchestrator-prompt.md`:
    **Post-write verification backstop** — run after all R3/R4 operations and before `git add .archon/memory/`:
 
    ```bash
-   # Memory write guard — detect unexpected deletions and restore
-   for MEM_FILE in .archon/memory/*.md; do
-     [ -f "$MEM_FILE" ] || continue
-     # Lines starting with '-' that are not file-header markers
-     DELETED=$(git diff "$MEM_FILE" | grep '^-' | grep -v '^---' | grep -v '^-#' | grep -v '^-<!--' || true)
-     if [ -n "$DELETED" ]; then
-       # Filter out expected deletions: expiry-cleaned lines (expired dates),
-       # R4 drops (oldest-date lines), R5 rewrites (tag-only change, body unchanged)
-       TODAY=$(date +%Y-%m-%d)
-       UNEXPECTED=$(echo "$DELETED" | while IFS= read -r line; do
-         # Skip lines whose expires: date is in the past (legitimate expiry cleanup)
-         if echo "$line" | grep -q 'expires:'; then
-           EXPIRY=$(echo "$line" | sed 's/.*expires:\([0-9-]*\).*/\1/')
-           [ "$EXPIRY" \< "$TODAY" ] && continue
-         fi
-         # Skip R5 invalidations: deleted line body matches an added line body (tag change only)
-         BODY=$(echo "$line" | sed 's/^\- \[PATTERN\]//' | sed 's/^\- \[AVOID\]//' | sed 's/^\- \[FIX\]//')
-         if git diff "$MEM_FILE" | grep '^+' | grep -v '^+++' | grep -qF "$BODY"; then
-           continue
-         fi
-         echo "$line"
-       done)
-       if [ -n "$UNEXPECTED" ]; then
-         echo "MEMORY GUARD: unexpected deletions detected in $MEM_FILE — restoring"
-         echo "$UNEXPECTED"
-         git checkout HEAD -- "$MEM_FILE"
-         # Re-apply only the intended new entries by echoing them back
-         # (The agent must re-append them after the restore.)
-         echo "MEMORY GUARD: re-append your new entries to $MEM_FILE now"
-       fi
-     fi
-   done
+# Memory write guard — detect unexpected deletions and restore (append-only; never reverts this run's new entries)
+for MEM_FILE in .archon/memory/*.md; do
+  [ -f "$MEM_FILE" ] || continue
+  # Deleted content lines (diff marker '-'), excluding file-header markers
+  DELETED=$(git diff "$MEM_FILE" | grep '^-' | grep -v '^---' | grep -v '^-#' | grep -v '^-<!--' || true)
+  if [ -n "$DELETED" ]; then
+    # Added content lines with the diff '+' marker stripped, for R5 body comparison
+    ADDED=$(git diff "$MEM_FILE" | grep '^+' | grep -v '^+++' | sed 's/^+//')
+    TODAY=$(date +%Y-%m-%d)
+    UNEXPECTED=$(echo "$DELETED" | while IFS= read -r line; do
+      # Strip the diff '-' marker to recover the file-content line
+      CONTENT=$(printf '%s' "$line" | sed 's/^-//')
+      # Legitimate expiry cleanup: an expires: date in the past
+      if echo "$CONTENT" | grep -q 'expires:'; then
+        EXPIRY=$(echo "$CONTENT" | sed 's/.*expires:\([0-9-]*\).*/\1/')
+        [ "$EXPIRY" \< "$TODAY" ] && continue
+      fi
+      # Legitimate R5 invalidation: same body re-added with a changed tag.
+      # Strip a leading "- [ANYTAG]" to get the bare body, then look for it among added lines.
+      BODY=$(printf '%s' "$CONTENT" | sed 's/^- \[[^]]*\]//')
+      if [ -n "$BODY" ] && printf '%s\n' "$ADDED" | grep -qF -- "$BODY"; then
+        continue
+      fi
+      printf '%s\n' "$CONTENT"
+    done)
+    if [ -n "$UNEXPECTED" ]; then
+      echo "MEMORY GUARD: unexpected deletion(s) in $MEM_FILE — re-appending to preserve them:"
+      printf '%s\n' "$UNEXPECTED"
+      # Append-only restore: re-append the deleted authoritative line(s). This preserves
+      # this run's new entries (unlike a whole-file checkout) and is self-healing for R4
+      # cap-drops (a re-appended over-cap entry is simply re-capped on the next run).
+      printf '%s\n' "$UNEXPECTED" >> "$MEM_FILE"
+    fi
+  fi
+done
    ```
 
    e. If any entries were added, commit:


### PR DESCRIPTION
Adds an append-only guard to both dark-factory command prompts to prevent the failure mode documented in #391, where the implement agent silently dropped valid memory entries by regenerating a file from a stale in-context copy. Two complementary controls are added to each command: (1) an explicit instruction block requiring shell `echo >>` appends for new entries and forbidding Write/Edit on memory files as a whole; and (2) a deterministic `git diff`-based verification backstop that runs before `git add .archon/memory/` and restores the file from HEAD if unexpected deletions are detected. The backstop whitelists the three legitimate mutating operations: awk expiry cleanup, R4 cap-drop, and R5 invalidation (tag-only rewrites). No app code, tests, or Docker images are affected — these are clone-read factory command files.

Closes #522
