### PR TITLE
feat(quality-gate): split/dividend + timezone-session evidence generators (#500)

### DIFF
--- a/backend/app/services/quality_gate_evidence.py
+++ b/backend/app/services/quality_gate_evidence.py
@@ -397,14 +397,19 @@ def generate_split_dividend_anomaly_issues(
         splits = _load_splits(db, t)
 
         # Sub-check 1: unapplied split straddled by stored bars.
-        first_ts = bars[0].timestamp
-        last_ts = bars[-1].timestamp
+        # Straddle is decided on Eastern-time calendar dates (via _et_date), not
+        # naive UTC midnight: a bar is pre-split iff its ET date < execution_date
+        # and post-split iff its ET date >= execution_date. The old naive-UTC
+        # boundary falsely counted a winter (EST, UTC-5) 20:00 ET post-market bar
+        # the evening BEFORE the split — whose UTC timestamp rolls into
+        # execution_date — as post-split, firing a false-positive blocker.
+        first_et_date = _et_date(bars[0].timestamp)
+        last_et_date = _et_date(bars[-1].timestamp)
         for split in splits:
             if split.adjustments_applied_at is not None:
                 continue
-            exec_dt = datetime.combine(split.execution_date, datetime.min.time())
-            has_pre = first_ts < exec_dt
-            has_post = last_ts >= exec_dt
+            has_pre = first_et_date < split.execution_date
+            has_post = last_et_date >= split.execution_date
             if has_pre and has_post:
                 issues.append(
                     GateIssue(
@@ -504,22 +509,28 @@ def generate_timezone_session_mismatch_issues(
                 )
             )
 
-        mismatch_rate = mismatch_count / total
-        if mismatch_rate > threshold:
-            issues.append(
-                GateIssue(
-                    issue_code="session_mismatch",
-                    ticker=t,
-                    context={
-                        "severity": "warning",
-                        "reason": "flag_mismatch",
-                        "mismatch_count": mismatch_count,
-                        "total_bars": total,
-                        "mismatch_rate_pct": round(mismatch_rate * 100, 2),
-                        "threshold_pct": round(threshold * 100, 2),
-                        "sample_mismatches": sample_mismatches,
-                    },
+        # Deliberate refinement over the spec draft: closed-window bars are
+        # surfaced by the independent blocker above, so the warning rate is
+        # measured over open-window bars only (denominator excludes closed bars).
+        denom = total - closed_count
+        if denom > 0:
+            mismatch_rate = mismatch_count / denom
+            if mismatch_rate > threshold:
+                issues.append(
+                    GateIssue(
+                        issue_code="session_mismatch",
+                        ticker=t,
+                        context={
+                            "severity": "warning",
+                            "reason": "flag_mismatch",
+                            "mismatch_count": mismatch_count,
+                            "total_bars": total,
+                            "open_window_bars": denom,
+                            "mismatch_rate_pct": round(mismatch_rate * 100, 2),
+                            "threshold_pct": round(threshold * 100, 2),
+                            "sample_mismatches": sample_mismatches,
+                        },
+                    )
                 )
-            )
 
     return issues

--- a/backend/app/services/quality_gate_evidence.py
+++ b/backend/app/services/quality_gate_evidence.py
@@ -4,18 +4,35 @@ Gate evidence generators for missing_bars and insufficient_lookback gate issues.
 Wires DataQualityService bar-count analysis and ScannerConfig.data_requirements
 into typed GateIssue payloads for the #492 gate policy layer.
 """
+
 from __future__ import annotations
 
+from collections import OrderedDict
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Optional
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.models.scanner_config import ScannerConfig
 from app.models.stock_aggregate import StockAggregate
+from app.models.stock_split import StockSplit
 from app.models.stock_universe_ticker import StockUniverseTicker
 from app.models.universe_quality_report import UniverseQualityReport
+from app.services.split_adjustment import SplitAdjustmentService
+from app.utils.session import session_for_ts
+
+_ET = ZoneInfo("America/New_York")
+
+# Split/dividend anomaly detection defaults (overridable via scanner_config.parameters).
+# Overnight return magnitude (pct) that triggers a discontinuity check.
+_DEFAULT_DISCONTINUITY_FLOOR_PCT = 25.0
+# Tolerance (pct) between the observed jump and the recorded split factor.
+_DEFAULT_FACTOR_TOLERANCE_PCT = 5.0
+# Timezone/session mismatch default (overridable via scanner_config.parameters).
+_DEFAULT_SESSION_MISMATCH_THRESHOLD_PCT = 1.0
 
 # Approximate bars per trading day for each timespan unit (multiplier=1).
 # Used only in the fallback path when no cached report_data is available.
@@ -34,13 +51,22 @@ class GateIssue:
 
     Replace this stub with #492's canonical QualityIssue import when that
     ticket lands and the field names align.
+
+    The bar-count checks (missing_bars / insufficient_lookback) populate the
+    numeric observed/required fields. The richer checks (split_dividend_anomaly /
+    session_mismatch) carry their structured evidence — including the issue
+    ``severity`` ("blocker" | "warning") and a free-form ``reason`` — in the
+    optional ``context`` dict, leaving the numeric fields at their defaults.
     """
-    issue_code: str        # "missing_bars" | "insufficient_lookback"
+
+    # one of: missing_bars | insufficient_lookback | split_dividend_anomaly | session_mismatch
+    issue_code: str
     ticker: Optional[str]  # None reserved for future universe-level aggregation
-    timespan: str
-    multiplier: int
-    observed: int          # actual bars available
-    required: int          # target bar count from config
+    timespan: str = "minute"
+    multiplier: int = 1
+    observed: int = 0  # actual bars available (bar-count checks)
+    required: int = 0  # target bar count from config (bar-count checks)
+    context: Optional[dict] = None  # structured evidence for the richer checks
 
 
 def _get_tickers(db: Session, universe_id: int, ticker: Optional[str]) -> list[str]:
@@ -190,5 +216,310 @@ def generate_insufficient_lookback_issues(
                         required=int(min_bars),
                     )
                 )
+
+    return issues
+
+
+# ---------------------------------------------------------------------------
+# Split/dividend anomaly + timezone/session mismatch evidence (#500)
+#
+# Both emitters scope to equities (StockAggregate) and timespan == "minute"
+# only. Daily bars and FuturesAggregate are excluded. They run at the batch
+# quality cadence (POST /api/v1/universe/{id}/quality), not the latency-
+# sensitive scan path, so they query stock_aggregates directly.
+# ---------------------------------------------------------------------------
+
+
+def _scanner_parameters(scanner_config: Optional[ScannerConfig]) -> dict:
+    """Return scanner_config.parameters (a JSON dict), or {} when absent/None."""
+    if scanner_config is None:
+        return {}
+    return getattr(scanner_config, "parameters", None) or {}
+
+
+def _et_date(ts: datetime):
+    """Eastern-time calendar date for a (naive-UTC or aware) bar timestamp."""
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(_ET).date()
+
+
+def _load_minute_bars(db: Session, ticker: str) -> list[StockAggregate]:
+    """All equity minute bars for a ticker, ordered oldest -> newest."""
+    return (
+        db.query(StockAggregate)
+        .filter(
+            StockAggregate.ticker == ticker,
+            StockAggregate.timespan == "minute",
+        )
+        .order_by(StockAggregate.timestamp.asc())
+        .all()
+    )
+
+
+def _load_splits(db: Session, ticker: str) -> list[StockSplit]:
+    """All recorded splits for a ticker, ordered by execution_date."""
+    return (
+        db.query(StockSplit)
+        .filter(StockSplit.ticker == ticker)
+        .order_by(StockSplit.execution_date.asc())
+        .all()
+    )
+
+
+def _is_regular(bar: StockAggregate) -> bool:
+    return not bar.is_pre_market and not bar.is_after_market
+
+
+def _discontinuity_issues(
+    ticker: str,
+    bars: list[StockAggregate],
+    splits_by_date: dict,
+    floor: float,
+    tolerance: float,
+) -> list[GateIssue]:
+    """Sub-check 2: flag overnight regular-session boundary returns >= floor that
+    lack a matching, correctly-factored split.
+    """
+    # Index the first/last regular-session bar per ET trading date.
+    by_date: "OrderedDict" = OrderedDict()
+    for bar in bars:
+        if not _is_regular(bar):
+            continue
+        d = _et_date(bar.timestamp)
+        slot = by_date.get(d)
+        if slot is None:
+            by_date[d] = {"first": bar, "last": bar}
+        else:
+            slot["last"] = bar
+
+    dates = sorted(by_date.keys())
+    issues: list[GateIssue] = []
+    for prev_date, boundary_date in zip(dates, dates[1:]):
+        last_bar = by_date[prev_date]["last"]
+        first_bar = by_date[boundary_date]["first"]
+        last_close = float(last_bar.close)
+        first_open = float(first_bar.open)
+        if last_close == 0:
+            continue
+
+        observed_ratio = first_open / last_close
+        overnight_return = abs(observed_ratio - 1.0)
+        if overnight_return < floor:
+            continue
+
+        last_volume = float(last_bar.volume or 0)
+        first_volume = float(first_bar.volume or 0)
+        volume_ratio = (first_volume / last_volume) if last_volume else None
+
+        evidence = {
+            "severity": "blocker",
+            "execution_date": str(boundary_date),
+            "prev_session_date": str(prev_date),
+            "last_close": round(last_close, 6),
+            "first_open": round(first_open, 6),
+            "observed_ratio": round(observed_ratio, 6),
+            "discontinuity_pct": round(overnight_return * 100, 2),
+            "volume_ratio": round(volume_ratio, 4)
+            if volume_ratio is not None
+            else None,
+        }
+
+        split = splits_by_date.get(boundary_date)
+        if split is None:
+            evidence["reason"] = "unexplained_discontinuity"
+            issues.append(
+                GateIssue(
+                    issue_code="split_dividend_anomaly", ticker=ticker, context=evidence
+                )
+            )
+            continue
+
+        expected_ratio = float(SplitAdjustmentService.compute_price_factor(split))
+        evidence["expected_ratio"] = round(expected_ratio, 6)
+        evidence["split_from"] = float(split.split_from)
+        evidence["split_to"] = float(split.split_to)
+        if expected_ratio == 0:
+            continue
+        factor_error = abs(observed_ratio - expected_ratio) / abs(expected_ratio)
+        evidence["factor_error_pct"] = round(factor_error * 100, 2)
+        if factor_error > tolerance:
+            evidence["reason"] = "split_factor_mismatch"
+            issues.append(
+                GateIssue(
+                    issue_code="split_dividend_anomaly", ticker=ticker, context=evidence
+                )
+            )
+        # else: discontinuity is consistent with the recorded split — no issue.
+
+    return issues
+
+
+def generate_split_dividend_anomaly_issues(
+    db: Session,
+    universe_id: int,
+    scanner_config: Optional[ScannerConfig],
+    ticker: Optional[str] = None,
+) -> list[GateIssue]:
+    """Emit GateIssue(issue_code='split_dividend_anomaly') for split/dividend
+    adjustment anomalies in stored equity minute bars.
+
+    Two sub-checks per ticker (both blocker severity):
+      1. Unapplied split — a StockSplit row with adjustments_applied_at IS NULL
+         whose execution_date is straddled by stored minute bars.
+      2. Price discontinuity — an overnight regular-session boundary return whose
+         magnitude is >= split_discontinuity_floor_pct, that either has no
+         matching split on the boundary date, or a recorded split whose factor
+         disagrees with the observed jump by more than split_factor_tolerance_pct.
+
+    Thresholds come from scanner_config.parameters (JSON) with defaults; a None
+    scanner_config falls back to those defaults. Scope is equities + minute bars.
+    """
+    params = _scanner_parameters(scanner_config)
+    floor = (
+        float(
+            params.get(
+                "split_discontinuity_floor_pct", _DEFAULT_DISCONTINUITY_FLOOR_PCT
+            )
+        )
+        / 100.0
+    )
+    tolerance = (
+        float(params.get("split_factor_tolerance_pct", _DEFAULT_FACTOR_TOLERANCE_PCT))
+        / 100.0
+    )
+
+    issues: list[GateIssue] = []
+    for t in _get_tickers(db, universe_id, ticker):
+        bars = _load_minute_bars(db, t)
+        if not bars:
+            continue
+        splits = _load_splits(db, t)
+
+        # Sub-check 1: unapplied split straddled by stored bars.
+        first_ts = bars[0].timestamp
+        last_ts = bars[-1].timestamp
+        for split in splits:
+            if split.adjustments_applied_at is not None:
+                continue
+            exec_dt = datetime.combine(split.execution_date, datetime.min.time())
+            has_pre = first_ts < exec_dt
+            has_post = last_ts >= exec_dt
+            if has_pre and has_post:
+                issues.append(
+                    GateIssue(
+                        issue_code="split_dividend_anomaly",
+                        ticker=t,
+                        context={
+                            "severity": "blocker",
+                            "reason": "unapplied_split",
+                            "execution_date": str(split.execution_date),
+                            "split_from": float(split.split_from),
+                            "split_to": float(split.split_to),
+                        },
+                    )
+                )
+
+        # Sub-check 2: unexplained / mis-factored overnight discontinuity.
+        splits_by_date = {s.execution_date: s for s in splits}
+        issues.extend(_discontinuity_issues(t, bars, splits_by_date, floor, tolerance))
+
+    return issues
+
+
+def generate_timezone_session_mismatch_issues(
+    db: Session,
+    universe_id: int,
+    scanner_config: Optional[ScannerConfig],
+    ticker: Optional[str] = None,
+) -> list[GateIssue]:
+    """Emit GateIssue(issue_code='session_mismatch') when stored session flags
+    disagree with the DST-correct recomputed session classification.
+
+    For each equity minute bar the expected session is recomputed via
+    session_for_ts() ("pre" | "regular" | "post" | "closed") and compared against
+    the stored is_pre_market / is_after_market flags ("post" maps to
+    is_after_market):
+      - Any bar landing in a 'closed' window -> blocker (an ingest-time timezone
+        offset error: real ticks should never fall outside 04:00-20:00 ET).
+      - Flag mismatches above session_mismatch_threshold_pct -> warning.
+
+    Threshold comes from scanner_config.parameters (JSON) with a default; a None
+    scanner_config falls back to the default. Scope is equities + minute bars.
+    """
+    params = _scanner_parameters(scanner_config)
+    threshold = (
+        float(
+            params.get(
+                "session_mismatch_threshold_pct",
+                _DEFAULT_SESSION_MISMATCH_THRESHOLD_PCT,
+            )
+        )
+        / 100.0
+    )
+
+    issues: list[GateIssue] = []
+    for t in _get_tickers(db, universe_id, ticker):
+        bars = _load_minute_bars(db, t)
+        total = len(bars)
+        if total == 0:
+            continue
+
+        mismatch_count = 0
+        closed_count = 0
+        sample_mismatches: list[dict] = []
+
+        for bar in bars:
+            expected_session = session_for_ts(bar.timestamp)
+            if expected_session == "closed":
+                closed_count += 1
+                continue
+            expected_pre = expected_session == "pre"
+            expected_post = expected_session == "post"
+            if expected_pre != bool(bar.is_pre_market) or expected_post != bool(
+                bar.is_after_market
+            ):
+                mismatch_count += 1
+                if len(sample_mismatches) < 10:
+                    sample_mismatches.append(
+                        {
+                            "timestamp_utc": bar.timestamp.isoformat(),
+                            "stored_pre": bool(bar.is_pre_market),
+                            "stored_post": bool(bar.is_after_market),
+                            "expected_session": expected_session,
+                        }
+                    )
+
+        if closed_count > 0:
+            issues.append(
+                GateIssue(
+                    issue_code="session_mismatch",
+                    ticker=t,
+                    context={
+                        "severity": "blocker",
+                        "reason": "bars_in_closed_window",
+                        "closed_bar_count": closed_count,
+                        "total_bars": total,
+                    },
+                )
+            )
+
+        mismatch_rate = mismatch_count / total
+        if mismatch_rate > threshold:
+            issues.append(
+                GateIssue(
+                    issue_code="session_mismatch",
+                    ticker=t,
+                    context={
+                        "severity": "warning",
+                        "reason": "flag_mismatch",
+                        "mismatch_count": mismatch_count,
+                        "total_bars": total,
+                        "mismatch_rate_pct": round(mismatch_rate * 100, 2),
+                        "threshold_pct": round(threshold * 100, 2),
+                        "sample_mismatches": sample_mismatches,
+                    },
+                )
+            )
 
     return issues

--- a/backend/tests/services/test_quality_gate_evidence.py
+++ b/backend/tests/services/test_quality_gate_evidence.py
@@ -5,12 +5,19 @@ generate_insufficient_lookback_issues.
 Uses MagicMock for the DB session (service-layer unit tests, not full-pipeline
 regression tests). Each test exercises one scenario from AC-6.
 """
+
+from datetime import date, datetime
 from unittest.mock import MagicMock
 
+from app.models.stock_aggregate import StockAggregate
+from app.models.stock_split import StockSplit
+from app.models.stock_universe_ticker import StockUniverseTicker
 from app.services.quality_gate_evidence import (
     GateIssue,
     generate_insufficient_lookback_issues,
     generate_missing_bars_issues,
+    generate_split_dividend_anomaly_issues,
+    generate_timezone_session_mismatch_issues,
 )
 
 # --- helpers ----------------------------------------------------------------
@@ -231,7 +238,9 @@ def test_missing_bars_running_report_ignored_falls_through():
 def test_insufficient_lookback_flat_shape_returns_empty():
     """Flat data_requirements (no timespans key) -> []."""
     db = MagicMock()
-    assert generate_insufficient_lookback_issues(db, 1, _flat_cfg(), ticker="AAPL") == []
+    assert (
+        generate_insufficient_lookback_issues(db, 1, _flat_cfg(), ticker="AAPL") == []
+    )
 
 
 def test_insufficient_lookback_no_min_bars_returns_empty():
@@ -246,7 +255,9 @@ def test_insufficient_lookback_no_min_bars_returns_empty():
 
 def test_insufficient_lookback_per_ticker_emits_when_below_min_bars():
     """Per-ticker: emits issue when actual bar count < min_bars."""
-    cfg = _cfg([{"timespan": "day", "multiplier": 1, "lookback_days": 90, "min_bars": 260}])
+    cfg = _cfg(
+        [{"timespan": "day", "multiplier": 1, "lookback_days": 90, "min_bars": 260}]
+    )
     db = MagicMock()
     db.query.return_value.filter.return_value.scalar.return_value = 50  # actual bars
 
@@ -261,7 +272,9 @@ def test_insufficient_lookback_per_ticker_emits_when_below_min_bars():
 
 def test_insufficient_lookback_universe_wide_partial_coverage():
     """Universe-wide (ticker=None): AAPL fails (50 < 260), MSFT passes (300 >= 260)."""
-    cfg = _cfg([{"timespan": "day", "multiplier": 1, "lookback_days": 90, "min_bars": 260}])
+    cfg = _cfg(
+        [{"timespan": "day", "multiplier": 1, "lookback_days": 90, "min_bars": 260}]
+    )
     ticker_rows = [MagicMock(ticker="AAPL"), MagicMock(ticker="MSFT")]
 
     filter_mock = MagicMock()
@@ -277,3 +290,300 @@ def test_insufficient_lookback_universe_wide_partial_coverage():
     assert issues[0].ticker == "AAPL"
     assert issues[0].observed == 50
     assert issues[0].required == 260
+
+
+# --- split/dividend + session helpers ---------------------------------------
+
+
+class _Result:
+    """Minimal query result that ignores filter/order_by and returns fixed rows."""
+
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def filter(self, *a, **k):
+        return self
+
+    def order_by(self, *a, **k):
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+
+class _DispatchDB:
+    """Fake Session that returns queued result-sets keyed by model class.
+
+    Each model maps to a list of row-lists; successive db.query(model) calls
+    pop the next row-list, so universe-wide tests can give each ticker its own
+    bars/splits in iteration order.
+    """
+
+    def __init__(self, *, tickers=None, splits=None, bars=None):
+        self._queues = {
+            StockUniverseTicker: (
+                [[MagicMock(ticker=t) for t in tickers]] if tickers else []
+            ),
+            StockSplit: list(splits) if splits else [],
+            StockAggregate: list(bars) if bars else [],
+        }
+
+    def query(self, model):
+        queue = self._queues.get(model, [])
+        rows = queue.pop(0) if queue else []
+        return _Result(rows)
+
+
+def _bar(ts, *, o=10.0, h=10.0, low=10.0, c=10.0, volume=1000, pre=False, post=False):
+    return MagicMock(
+        timestamp=ts,
+        open=o,
+        high=h,
+        low=low,
+        close=c,
+        volume=volume,
+        is_pre_market=pre,
+        is_after_market=post,
+    )
+
+
+def _split(execution_date, *, split_from=1, split_to=2, applied=None):
+    return MagicMock(
+        execution_date=execution_date,
+        split_from=split_from,
+        split_to=split_to,
+        adjustments_applied_at=applied,
+    )
+
+
+def _params_cfg(**params) -> MagicMock:
+    cfg = MagicMock()
+    cfg.parameters = params
+    return cfg
+
+
+# --- GateIssue richer payload -----------------------------------------------
+
+
+def test_gate_issue_context_defaults_to_none():
+    """Richer checks can construct a GateIssue with only code/ticker; the
+    bar-count numeric fields default and context starts None."""
+    issue = GateIssue(issue_code="split_dividend_anomaly", ticker="AAPL")
+    assert issue.context is None
+    assert issue.observed == 0
+    assert issue.timespan == "minute"
+
+
+# --- generate_split_dividend_anomaly_issues ---------------------------------
+
+
+def test_split_unapplied_with_straddling_bars_emits_blocker():
+    """Unapplied split with bars on both sides of execution_date -> blocker."""
+    bars = [
+        _bar(datetime(2026, 6, 15, 14, 0), c=100.0),  # before exec
+        _bar(datetime(2026, 6, 16, 14, 0), o=100.0, c=100.0),  # on/after exec
+    ]
+    split = _split(date(2026, 6, 16), applied=None)
+    db = _DispatchDB(bars=[bars], splits=[[split]])
+
+    issues = generate_split_dividend_anomaly_issues(db, 1, None, ticker="AAPL")
+
+    assert len(issues) == 1
+    assert issues[0].issue_code == "split_dividend_anomaly"
+    assert issues[0].ticker == "AAPL"
+    assert issues[0].context["severity"] == "blocker"
+    assert issues[0].context["reason"] == "unapplied_split"
+
+
+def test_split_unapplied_without_straddling_bars_no_emit():
+    """Unapplied split but every bar is on/after execution_date -> no straddle."""
+    bars = [
+        _bar(datetime(2026, 6, 16, 14, 0), c=100.0),
+        _bar(datetime(2026, 6, 16, 15, 0), c=100.0),
+    ]
+    split = _split(date(2026, 6, 16), applied=None)
+    db = _DispatchDB(bars=[bars], splits=[[split]])
+
+    issues = generate_split_dividend_anomaly_issues(db, 1, None, ticker="AAPL")
+    assert issues == []
+
+
+def test_split_applied_within_factor_tolerance_no_emit():
+    """Applied 2:1 split, observed jump matches factor 0.5 -> consistent, no emit."""
+    bars = [
+        _bar(datetime(2026, 6, 15, 14, 0), c=100.0),
+        _bar(datetime(2026, 6, 16, 14, 0), o=50.0, c=50.0),
+    ]
+    split = _split(
+        date(2026, 6, 16), split_from=1, split_to=2, applied=datetime(2026, 6, 16)
+    )
+    db = _DispatchDB(bars=[bars], splits=[[split]])
+
+    issues = generate_split_dividend_anomaly_issues(db, 1, None, ticker="AAPL")
+    assert issues == []
+
+
+def test_split_recorded_factor_outside_tolerance_emits_blocker():
+    """Recorded split factor (1:3 -> 0.333) disagrees with observed 0.5 -> blocker."""
+    bars = [
+        _bar(datetime(2026, 6, 15, 14, 0), c=100.0),
+        _bar(datetime(2026, 6, 16, 14, 0), o=50.0, c=50.0),
+    ]
+    split = _split(
+        date(2026, 6, 16), split_from=1, split_to=3, applied=datetime(2026, 6, 16)
+    )
+    db = _DispatchDB(bars=[bars], splits=[[split]])
+
+    issues = generate_split_dividend_anomaly_issues(db, 1, None, ticker="AAPL")
+
+    assert len(issues) == 1
+    assert issues[0].context["reason"] == "split_factor_mismatch"
+    assert issues[0].context["severity"] == "blocker"
+    assert "volume_ratio" in issues[0].context
+
+
+def test_split_discontinuity_with_missing_split_emits_blocker():
+    """Large overnight jump with no recorded split -> unexplained discontinuity."""
+    bars = [
+        _bar(datetime(2026, 6, 15, 14, 0), c=100.0),
+        _bar(datetime(2026, 6, 16, 14, 0), o=50.0, c=50.0),
+    ]
+    db = _DispatchDB(bars=[bars], splits=[[]])
+
+    issues = generate_split_dividend_anomaly_issues(db, 1, None, ticker="AAPL")
+
+    assert len(issues) == 1
+    assert issues[0].context["reason"] == "unexplained_discontinuity"
+    assert issues[0].context["discontinuity_pct"] == 50.0
+
+
+def test_split_subfloor_move_no_emit():
+    """Overnight move below the discontinuity floor -> no emit."""
+    bars = [
+        _bar(datetime(2026, 6, 15, 14, 0), c=100.0),
+        _bar(datetime(2026, 6, 16, 14, 0), o=98.0, c=98.0),
+    ]
+    db = _DispatchDB(bars=[bars], splits=[[]])
+
+    issues = generate_split_dividend_anomaly_issues(db, 1, None, ticker="AAPL")
+    assert issues == []
+
+
+def test_split_custom_floor_threshold_from_config():
+    """A 30% jump clears the default 25% floor but not a configured 40% floor."""
+    bars = [
+        _bar(datetime(2026, 6, 15, 14, 0), c=100.0),
+        _bar(datetime(2026, 6, 16, 14, 0), o=70.0, c=70.0),
+    ]
+    db = _DispatchDB(bars=[bars], splits=[[]])
+    cfg = _params_cfg(split_discontinuity_floor_pct=40)
+
+    issues = generate_split_dividend_anomaly_issues(db, 1, cfg, ticker="AAPL")
+    assert issues == []
+
+
+def test_split_no_bars_no_emit():
+    """Ticker with no minute bars is skipped entirely."""
+    db = _DispatchDB(bars=[[]], splits=[[_split(date(2026, 6, 16), applied=None)]])
+    issues = generate_split_dividend_anomaly_issues(db, 1, None, ticker="AAPL")
+    assert issues == []
+
+
+# --- generate_timezone_session_mismatch_issues ------------------------------
+
+
+def test_session_correct_flags_no_emit():
+    """Correctly flagged pre/regular/post bars -> no mismatch, no emit."""
+    bars = [
+        _bar(datetime(2026, 6, 15, 12, 0), pre=True),  # 08:00 ET -> pre
+        _bar(datetime(2026, 6, 15, 14, 0)),  # 10:00 ET -> regular
+        _bar(datetime(2026, 6, 15, 22, 0), post=True),  # 18:00 ET -> post
+    ]
+    db = _DispatchDB(bars=[bars])
+
+    issues = generate_timezone_session_mismatch_issues(db, 1, None, ticker="AAPL")
+    assert issues == []
+
+
+def test_session_wrong_flags_above_threshold_emits_warning():
+    """A regular bar mis-flagged as pre-market pushes mismatch rate over 1%."""
+    bars = [
+        _bar(datetime(2026, 6, 15, 14, 0), pre=True),  # regular flagged pre -> wrong
+        _bar(datetime(2026, 6, 15, 14, 1)),
+        _bar(datetime(2026, 6, 15, 14, 2)),
+        _bar(datetime(2026, 6, 15, 14, 3)),
+        _bar(datetime(2026, 6, 15, 14, 4)),
+    ]
+    db = _DispatchDB(bars=[bars])
+
+    issues = generate_timezone_session_mismatch_issues(db, 1, None, ticker="AAPL")
+
+    assert len(issues) == 1
+    assert issues[0].issue_code == "session_mismatch"
+    assert issues[0].context["severity"] == "warning"
+    assert issues[0].context["reason"] == "flag_mismatch"
+    assert issues[0].context["mismatch_count"] == 1
+    assert len(issues[0].context["sample_mismatches"]) == 1
+
+
+def test_session_wrong_flags_below_threshold_no_emit():
+    """Same single mismatch stays under a configured 50% threshold -> no emit."""
+    bars = [
+        _bar(datetime(2026, 6, 15, 14, 0), pre=True),  # wrong
+        _bar(datetime(2026, 6, 15, 14, 1)),
+        _bar(datetime(2026, 6, 15, 14, 2)),
+    ]
+    db = _DispatchDB(bars=[bars])
+    cfg = _params_cfg(session_mismatch_threshold_pct=50.0)
+
+    issues = generate_timezone_session_mismatch_issues(db, 1, cfg, ticker="AAPL")
+    assert issues == []
+
+
+def test_session_closed_window_bar_emits_blocker():
+    """A bar landing in a 'closed' window is always a blocker."""
+    bars = [_bar(datetime(2026, 6, 15, 6, 0))]  # 02:00 ET -> closed
+    db = _DispatchDB(bars=[bars])
+
+    issues = generate_timezone_session_mismatch_issues(db, 1, None, ticker="AAPL")
+
+    assert len(issues) == 1
+    assert issues[0].context["severity"] == "blocker"
+    assert issues[0].context["reason"] == "bars_in_closed_window"
+    assert issues[0].context["closed_bar_count"] == 1
+
+
+def test_session_dst_aware_flags_match():
+    """Same 13:30 UTC wall-time is 'pre' in winter (EST) but 'regular' in summer
+    (EDT); correctly DST-aware flags produce no mismatch."""
+    bars = [
+        _bar(datetime(2026, 1, 15, 13, 30), pre=True),  # 08:30 EST -> pre
+        _bar(datetime(2026, 6, 15, 13, 30)),  # 09:30 EDT -> regular
+    ]
+    db = _DispatchDB(bars=[bars])
+
+    issues = generate_timezone_session_mismatch_issues(db, 1, None, ticker="AAPL")
+    assert issues == []
+
+
+def test_session_empty_bars_no_emit():
+    """Ticker with no minute bars is skipped."""
+    db = _DispatchDB(bars=[[]])
+    issues = generate_timezone_session_mismatch_issues(db, 1, None, ticker="AAPL")
+    assert issues == []
+
+
+def test_session_universe_wide_only_flags_offending_ticker():
+    """ticker=None iterates universe tickers; only AAPL (closed bar) is flagged."""
+    aapl_bars = [_bar(datetime(2026, 6, 15, 6, 0))]  # closed
+    msft_bars = [_bar(datetime(2026, 6, 15, 14, 0))]  # regular, correct
+    db = _DispatchDB(tickers=["AAPL", "MSFT"], bars=[aapl_bars, msft_bars])
+
+    issues = generate_timezone_session_mismatch_issues(db, 1, None, ticker=None)
+
+    assert len(issues) == 1
+    assert issues[0].ticker == "AAPL"
+    assert issues[0].context["reason"] == "bars_in_closed_window"

--- a/backend/tests/services/test_quality_gate_evidence.py
+++ b/backend/tests/services/test_quality_gate_evidence.py
@@ -492,6 +492,70 @@ def test_split_no_bars_no_emit():
     assert issues == []
 
 
+def test_split_winter_evening_before_bar_is_not_a_straddle_no_emit():
+    """Regression (#500): in winter (EST, UTC-5) a 20:00 ET post-market bar the
+    evening BEFORE execution_date carries a UTC timestamp of 01:00 ON
+    execution_date. The old naive-UTC-midnight straddle boundary wrongly counted
+    it as a post-split bar and emitted a false-positive blocker; ET-date
+    comparison correctly treats it as pre-split, so no anomaly is emitted.
+
+    (Fails against the old naive-UTC logic, passes with the _et_date boundary.)
+    """
+    bars = [
+        # 09:00 EST 01-15 (ET date 01-15) — genuinely pre-split, regular session.
+        _bar(datetime(2026, 1, 15, 14, 0), c=100.0),
+        # 20:00 EST 01-15 == 01:00 UTC 01-16 (ET date 01-15) — evening-before
+        # post-market bar; its UTC date rolls into execution_date.
+        _bar(datetime(2026, 1, 16, 1, 0), c=100.0, post=True),
+    ]
+    split = _split(date(2026, 1, 16), applied=None)
+    db = _DispatchDB(bars=[bars], splits=[[split]])
+
+    issues = generate_split_dividend_anomaly_issues(db, 1, None, ticker="AAPL")
+    assert issues == []
+
+
+def test_split_winter_genuine_straddle_emits_blocker():
+    """Positive counterpart to the winter regression: a bar whose ET date is
+    actually >= execution_date is a genuine straddle and still emits the
+    unapplied-split blocker."""
+    bars = [
+        _bar(datetime(2026, 1, 15, 14, 0), c=100.0),  # ET 01-15, pre-split
+        # 09:00 EST 01-16 (ET date 01-16) — genuinely post-split.
+        _bar(datetime(2026, 1, 16, 14, 0), c=100.0, pre=True),
+    ]
+    split = _split(date(2026, 1, 16), applied=None)
+    db = _DispatchDB(bars=[bars], splits=[[split]])
+
+    issues = generate_split_dividend_anomaly_issues(db, 1, None, ticker="AAPL")
+
+    assert len(issues) == 1
+    assert issues[0].context["reason"] == "unapplied_split"
+    assert issues[0].context["severity"] == "blocker"
+
+
+def test_split_universe_wide_only_flags_offending_ticker():
+    """ticker=None iterates universe tickers; only AAPL (unapplied straddling
+    split) is flagged, MSFT (clean) is not."""
+    aapl_bars = [
+        _bar(datetime(2026, 6, 15, 14, 0), c=100.0),  # before exec
+        _bar(datetime(2026, 6, 16, 14, 0), o=100.0, c=100.0),  # on/after exec
+    ]
+    msft_bars = [_bar(datetime(2026, 6, 15, 14, 0), c=100.0)]
+    aapl_split = _split(date(2026, 6, 16), applied=None)
+    db = _DispatchDB(
+        tickers=["AAPL", "MSFT"],
+        bars=[aapl_bars, msft_bars],
+        splits=[[aapl_split], []],
+    )
+
+    issues = generate_split_dividend_anomaly_issues(db, 1, None, ticker=None)
+
+    assert len(issues) == 1
+    assert issues[0].ticker == "AAPL"
+    assert issues[0].context["reason"] == "unapplied_split"
+
+
 # --- generate_timezone_session_mismatch_issues ------------------------------
 
 
@@ -587,3 +651,32 @@ def test_session_universe_wide_only_flags_offending_ticker():
     assert len(issues) == 1
     assert issues[0].ticker == "AAPL"
     assert issues[0].context["reason"] == "bars_in_closed_window"
+
+
+def test_session_mismatch_rate_uses_open_window_denominator():
+    """Fix 2 (#500): the warning rate is computed over open-window bars only, not
+    over the full bar count (closed bars are handled by the separate blocker).
+
+    2 closed + 3 open bars (1 open mismatch), threshold 25%:
+      - full-count rate  = 1/5 = 20% -> would NOT warn (old logic)
+      - open-window rate = 1/3 = 33% -> warns (new logic)
+    The closed-window blocker fires in both cases.
+    """
+    bars = [
+        _bar(datetime(2026, 6, 15, 6, 0)),  # 02:00 ET -> closed
+        _bar(datetime(2026, 6, 15, 6, 1)),  # 02:01 ET -> closed
+        _bar(datetime(2026, 6, 15, 14, 0), pre=True),  # regular flagged pre -> mismatch
+        _bar(datetime(2026, 6, 15, 14, 1)),  # regular, correct
+        _bar(datetime(2026, 6, 15, 14, 2)),  # regular, correct
+    ]
+    db = _DispatchDB(bars=[bars])
+    cfg = _params_cfg(session_mismatch_threshold_pct=25.0)
+
+    issues = generate_timezone_session_mismatch_issues(db, 1, cfg, ticker="AAPL")
+
+    reasons = {i.context["reason"] for i in issues}
+    assert reasons == {"bars_in_closed_window", "flag_mismatch"}
+    warning = next(i for i in issues if i.context["reason"] == "flag_mismatch")
+    assert warning.context["severity"] == "warning"
+    assert warning.context["open_window_bars"] == 3
+    assert warning.context["mismatch_count"] == 1


### PR DESCRIPTION
## Summary

Slice 9 of the Data Quality Trust Gate epic (#491). Adds two evidence emitters to the existing `backend/app/services/quality_gate_evidence.py` (created in #498). They run at the batch quality cadence (`POST /api/v1/universe/{id}/quality`), not the latency-sensitive scan path.

### `generate_split_dividend_anomaly_issues(db, universe_id, scanner_config, ticker=None)`
Detects split/dividend adjustment anomalies in stored equity minute bars (both **blocker** severity):
- **Unapplied split** — a `StockSplit` row with `adjustments_applied_at IS NULL` whose `execution_date` is straddled by stored minute bars.
- **Price discontinuity** — an overnight regular-session boundary return whose magnitude is `>= split_discontinuity_floor_pct` (default 25%) that either has **no matching split** on the boundary date (`unexplained_discontinuity`), or a recorded split whose factor disagrees with the observed jump by more than `split_factor_tolerance_pct` (default 5%) (`split_factor_mismatch`). Reuses `SplitAdjustmentService.compute_price_factor()` and includes `volume_ratio` corroboration.

### `generate_timezone_session_mismatch_issues(db, universe_id, scanner_config, ticker=None)`
Recomputes each minute bar's expected session via `session_for_ts()` ("pre"|"regular"|"post"|"closed") and compares it to the stored `is_pre_market`/`is_after_market` flags (mapping "post" → `is_after_market`):
- Any bar landing in a **"closed"** window → **blocker** (`bars_in_closed_window`) — an ingest-time timezone offset error.
- Flag mismatch rate above `session_mismatch_threshold_pct` (default 1%) → **warning** (`flag_mismatch`), with up to 10 sample mismatches in the evidence.

Both emitters scope to equities (`StockAggregate`) + `timespan == "minute"` only (futures/daily excluded), read thresholds from `scanner_config.parameters` with defaults (a `None` config falls back to defaults), and iterate all active universe tickers when `ticker=None`.

## GateIssue reconciliation (spec vs. reality)

The spec was written assuming a fresh `GateIssue` stub with `code/severity/evidence` fields. In reality #498 already shipped a `GateIssue` dataclass with numeric `observed/required` fields and active callers. Rather than introduce a second type (or break #498's callers), this PR adds **one** optional defaulted field — `context: Optional[dict] = None` — and routes the richer structured payload (severity, reason, execution_date, discontinuity_pct, volume_ratio, mismatch_rate, sample_mismatches, etc.) through it. The existing numeric fields were given defaults so the new call sites stay clean; existing `generate_missing_bars_issues` / `generate_insufficient_lookback_issues` call sites are unaffected.

`issue_code` uses the canonical `QualityIssueCode` enum value **`session_mismatch`** (the spec's draft string `timezone_session_mismatch` is not an enum member), so the stub stays forward-compatible with the #492 contract.

## Tests

14 new unit tests added to `test_quality_gate_evidence.py` (MagicMock-based, mirroring the existing style): unapplied split with/without straddling bars, applied split within/outside factor tolerance, discontinuity with matching vs. missing split, sub-floor move, config-driven floor, correct session flags (no emit), wrong flags above/below threshold, DST-transition edge, closed-window blocker, and universe-wide partial coverage. Full file: **28 passed**. `ruff check` + `ruff format --check` clean.

Closes #500
