### PR TITLE
feat(quality-gate): stale-quote + provider-gap subtypes in gate assessment (#499)

### DIFF
--- a/backend/app/services/quality_gate.py
+++ b/backend/app/services/quality_gate.py
@@ -5,8 +5,8 @@ assessment. Split into a pure builder (no DB) and a thin DB-aware wrapper.
 
 from __future__ import annotations
 
-from datetime import date, timedelta
-from typing import List, Optional
+from datetime import date, datetime, timedelta
+from typing import List, Optional, Set, Tuple
 
 from sqlalchemy.orm import Session
 
@@ -18,7 +18,79 @@ from app.schemas.quality_gate import (
     QualityGateVerdict,
     QualityIssueCode,
 )
-from app.utils.time import utc_now
+from app.utils.time import to_utc_naive, utc_now
+
+# Reuse the freshness window used elsewhere (system_service): a quality report
+# snapshot older than this can no longer certify per-ticker freshness.
+STALE_REPORT_MAX_AGE_HOURS = 4
+# Intraday timespans tolerate far less staleness than daily+ resolutions.
+INTRADAY_TIMESPANS = ("minute", "hour")
+
+
+def _parse_iso_datetime(value) -> Optional[datetime]:
+    """Parse an ISO timestamp (tz-aware or naive) to naive UTC; None on failure."""
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except (ValueError, TypeError):
+        return None
+    return to_utc_naive(parsed)
+
+
+def _parse_iso_date(value) -> Optional[date]:
+    """Parse the date portion of an ISO string; None on failure."""
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(str(value)[:10])
+    except (ValueError, TypeError):
+        return None
+
+
+def _median(values: List[float]) -> float:
+    ordered = sorted(values)
+    n = len(ordered)
+    mid = n // 2
+    if n % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2.0
+
+
+def _trading_days_stale(
+    last_bar: date,
+    reference: date,
+    holidays: Set[date],
+    cap: int,
+) -> int:
+    """
+    Count trading days (weekday and not a full-close holiday) strictly after
+    ``last_bar`` up to and including ``reference``. Returns 0 when the data
+    already covers ``reference``. Stops counting once the result exceeds
+    ``cap`` (the verdict only needs to know it crossed the threshold), so the
+    loop stays bounded even for very old data.
+    """
+    if reference <= last_bar:
+        return 0
+    count = 0
+    day = last_bar + timedelta(days=1)
+    while day <= reference:
+        if day.weekday() < 5 and day not in holidays:
+            count += 1
+            if count > cap:
+                return count
+        day += timedelta(days=1)
+    return count
+
+
+def _stale_threshold(policy: QualityGatePolicy, timespan) -> Tuple[int, str]:
+    """Return (max acceptable trading-day staleness, issue severity)."""
+    if policy == QualityGatePolicy.strict:
+        return 1, "blocker"
+    # advisory: looser tolerances, warning severity
+    if timespan in INTRADAY_TIMESPANS:
+        return 5, "warning"
+    return 7, "warning"
 
 
 def _derive_verdict(
@@ -43,8 +115,10 @@ def _build_assessment(
     data_requirements: Optional[dict],
     scope: QualityGateScope,
     policy: QualityGatePolicy,
+    market_holidays: Optional[Set[date]] = None,
 ) -> QualityGateAssessment:
     now = utc_now()
+    holidays: Set[date] = market_holidays if market_holidays is not None else set()
 
     if policy == QualityGatePolicy.off:
         return QualityGateAssessment(
@@ -111,7 +185,153 @@ def _build_assessment(
             )
         )
 
-    # provider_gap: gate on worst ticker continuity_score and any gap_count
+    # stale_quote: report-freshness guard, then per-ticker staleness.
+    # The report-freshness guard fires a single scope-level issue when the
+    # snapshot itself is too old to certify per-ticker freshness; when it fires
+    # the per-ticker loop is skipped (the scope issue already covers everything).
+    # An optional ``as_of_date`` in data_requirements shifts the reference date
+    # for historical/backtest consumers (and disables the freshness guard, which
+    # only makes sense for live "now" consumers).
+    as_of_date = _parse_iso_date((data_requirements or {}).get("as_of_date"))
+    reference_date = as_of_date or now.date()
+    report_stale_emitted = False
+
+    if as_of_date is None:
+        generated_at = _parse_iso_datetime(report_data.get("generated_at"))
+        if generated_at is not None:
+            age_hours = (now - generated_at).total_seconds() / 3600.0
+            if age_hours > STALE_REPORT_MAX_AGE_HOURS:
+                sev = "blocker" if policy == QualityGatePolicy.strict else "warning"
+                issues.append(
+                    QualityGateIssue(
+                        code=QualityIssueCode.stale_quote,
+                        severity=sev,
+                        message=(
+                            "Quality report is stale (generated"
+                            f" {generated_at.isoformat()}, {age_hours:.1f}h ago,"
+                            f" exceeds {STALE_REPORT_MAX_AGE_HOURS}h)"
+                        ),
+                        detail={
+                            "subtype": "report_stale",
+                            "ticker": None,
+                            "generated_at": report_data.get("generated_at"),
+                            "age_hours": round(age_hours, 1),
+                            "threshold_hours": STALE_REPORT_MAX_AGE_HOURS,
+                            "as_of_date": None,
+                            "source": None,
+                        },
+                    )
+                )
+                report_stale_emitted = True
+
+    if not report_stale_emitted:
+        for t in tickers:
+            last_bar_date = _parse_iso_date(t.get("last_bar"))
+            if last_bar_date is None:
+                # Total absence is handled by the provider_gap "absent" subtype.
+                continue
+            if as_of_date is not None and last_bar_date >= as_of_date:
+                # Data already covers the requested historical date → fresh.
+                continue
+            threshold, sev = _stale_threshold(policy, t.get("timespan"))
+            stale_days = _trading_days_stale(
+                last_bar_date, reference_date, holidays, threshold
+            )
+            if stale_days > threshold:
+                issues.append(
+                    QualityGateIssue(
+                        code=QualityIssueCode.stale_quote,
+                        severity=sev,
+                        message=(
+                            f"{t.get('ticker')} last bar"
+                            f" {last_bar_date.isoformat()} is {stale_days} trading"
+                            f" day(s) stale (threshold {threshold})"
+                        ),
+                        detail={
+                            "subtype": "ticker_stale",
+                            "ticker": t.get("ticker"),
+                            "timespan": t.get("timespan"),
+                            "multiplier": t.get("multiplier"),
+                            "last_bar": t.get("last_bar"),
+                            "trading_days_stale": stale_days,
+                            "threshold_trading_days": threshold,
+                            "as_of_date": (
+                                as_of_date.isoformat() if as_of_date else None
+                            ),
+                            "source": None,
+                        },
+                    )
+                )
+
+    # provider_gap: absent (zero bars) + partial (low coverage) + structural.
+    # absent/partial are per-ticker and only apply to reports that carry the
+    # coverage fields (real reports always do; legacy/synthetic entries without
+    # an ``actual_bars`` key fall through to the retained structural check).
+    coverages = [
+        t["coverage_pct"]
+        for t in tickers
+        if (t.get("actual_bars") or 0) > 0 and t.get("coverage_pct") is not None
+    ]
+    universe_median_coverage = _median(coverages) if coverages else None
+
+    for t in tickers:
+        actual_bars = t.get("actual_bars")
+        if actual_bars is None:
+            continue
+        if actual_bars == 0:
+            # Provider returned nothing for a ticker that was asked for. Never
+            # acceptable, so severity=blocker regardless of policy (advisory
+            # still downgrades the verdict via _derive_verdict).
+            issues.append(
+                QualityGateIssue(
+                    code=QualityIssueCode.provider_gap,
+                    severity="blocker",
+                    message=f"{t.get('ticker')} returned zero bars from the provider",
+                    detail={
+                        "subtype": "absent",
+                        "ticker": t.get("ticker"),
+                        "timespan": t.get("timespan"),
+                        "multiplier": t.get("multiplier"),
+                        "actual_bars": 0,
+                        "expected_bars": t.get("expected_bars"),
+                        "source": None,
+                    },
+                )
+            )
+            continue
+        coverage_pct = t.get("coverage_pct")
+        if coverage_pct is None:
+            continue
+        is_partial = coverage_pct < 50 or (
+            universe_median_coverage is not None
+            and coverage_pct < 80
+            and coverage_pct < universe_median_coverage - 30
+        )
+        if is_partial:
+            sev = "blocker" if policy == QualityGatePolicy.strict else "warning"
+            issues.append(
+                QualityGateIssue(
+                    code=QualityIssueCode.provider_gap,
+                    severity=sev,
+                    message=(
+                        f"{t.get('ticker')} coverage {coverage_pct:.1f}% indicates"
+                        " a partial provider return"
+                    ),
+                    detail={
+                        "subtype": "partial",
+                        "ticker": t.get("ticker"),
+                        "timespan": t.get("timespan"),
+                        "multiplier": t.get("multiplier"),
+                        "coverage_pct": coverage_pct,
+                        "universe_median_coverage": universe_median_coverage,
+                        "actual_bars": actual_bars,
+                        "expected_bars": t.get("expected_bars"),
+                        "source": None,
+                    },
+                )
+            )
+
+    # structural: retained #492 gap-based detection (universe-level worst case).
     has_gap = any(t.get("gap_count", 0) >= 1 for t in tickers)
     worst_continuity = min(
         (t.get("continuity_score", 100.0) for t in tickers), default=100.0
@@ -125,7 +345,10 @@ def _build_assessment(
                     f"Worst ticker continuity {worst_continuity:.1f}% is below"
                     " the 70% threshold (>6 gaps)"
                 ),
-                detail={"worst_continuity_score": worst_continuity},
+                detail={
+                    "subtype": "structural",
+                    "worst_continuity_score": worst_continuity,
+                },
             )
         )
     elif has_gap:
@@ -134,7 +357,10 @@ def _build_assessment(
                 code=QualityIssueCode.provider_gap,
                 severity="warning",
                 message="One or more tickers have provider data gaps",
-                detail={"worst_continuity_score": worst_continuity},
+                detail={
+                    "subtype": "structural",
+                    "worst_continuity_score": worst_continuity,
+                },
             )
         )
 
@@ -212,6 +438,7 @@ class QualityGateService:
         db: Session,
         request,
     ) -> QualityGateAssessment:
+        from app.models.market_holiday import MarketHoliday
         from app.models.scanner_config import ScannerConfig
         from app.models.universe_quality_report import UniverseQualityReport
 
@@ -275,4 +502,27 @@ class QualityGateService:
         ):
             data_requirements = request.requirements.model_dump()
 
-        return _build_assessment(report_data, data_requirements, scope, policy)
+        # Trading-day staleness thresholds respect the NYSE full-close calendar.
+        # We resolve it here (where a DB session exists) into a plain date set so
+        # _build_assessment stays a pure, DB-free function (no MAX(timestamp) or
+        # per-ticker live queries). Only needed when a report is present, since
+        # the stale-quote checks run against report_data tickers.
+        market_holidays: Optional[Set[date]] = None
+        if report_data is not None:
+            holiday_rows = (
+                db.query(MarketHoliday.date)
+                .filter(
+                    MarketHoliday.exchange == "NYSE",
+                    MarketHoliday.event_type == "full_close",
+                )
+                .all()
+            )
+            market_holidays = {row.date for row in holiday_rows}
+
+        return _build_assessment(
+            report_data,
+            data_requirements,
+            scope,
+            policy,
+            market_holidays=market_holidays,
+        )

--- a/backend/tests/services/test_quality_gate_service.py
+++ b/backend/tests/services/test_quality_gate_service.py
@@ -3,7 +3,7 @@ Unit tests for quality_gate._build_assessment and QualityGateService.assess().
 No DB fixture required for builder tests — all use plain dict inputs.
 """
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from app.schemas.quality_gate import (
     QualityGatePolicy,
@@ -12,6 +12,15 @@ from app.schemas.quality_gate import (
     QualityIssueCode,
 )
 from app.services.quality_gate import _build_assessment
+
+# Most fixtures want a "fresh" last_bar so the stale_quote check does not fire
+# for tests that are about other checks. Use today so it is never stale.
+_FRESH_LAST_BAR = date.today().isoformat() + "T00:00:00"
+
+
+def _stale_last_bar(days: int = 14) -> str:
+    """An ISO last_bar that is comfortably stale under every threshold."""
+    return (date.today() - timedelta(days=days)).isoformat() + "T00:00:00"
 
 
 def _scope() -> QualityGateScope:
@@ -26,7 +35,7 @@ def _report(overall_score=90.0, overall_grade="A", tickers=None):
                 "gap_count": 0,
                 "continuity_score": 100.0,
                 "first_bar": "2025-01-01T00:00:00",
-                "last_bar": "2026-06-19T00:00:00",
+                "last_bar": _FRESH_LAST_BAR,
                 "coverage_pct": overall_score,
             }
         ]
@@ -146,7 +155,7 @@ def test_gap_count_one_emits_provider_gap_warning():
                 "gap_count": 1,
                 "continuity_score": 95.0,
                 "first_bar": "2025-01-01T00:00:00",
-                "last_bar": "2026-06-19T00:00:00",
+                "last_bar": _FRESH_LAST_BAR,
                 "coverage_pct": 90.0,
             }
         ],
@@ -172,7 +181,7 @@ def test_continuity_below_70_strict_is_blocked():
                 "gap_count": 15,
                 "continuity_score": 25.0,
                 "first_bar": "2025-01-01T00:00:00",
-                "last_bar": "2026-06-19T00:00:00",
+                "last_bar": _FRESH_LAST_BAR,
                 "coverage_pct": 90.0,
             }
         ],
@@ -198,7 +207,7 @@ def test_insufficient_lookback_emits_blocker():
                 "gap_count": 0,
                 "continuity_score": 100.0,
                 "first_bar": first_bar,
-                "last_bar": "2026-06-19T00:00:00",
+                "last_bar": _FRESH_LAST_BAR,
                 "coverage_pct": 92.0,
             }
         ],
@@ -248,7 +257,7 @@ def test_continuity_below_70_advisory_is_warning():
                 "gap_count": 20,
                 "continuity_score": 10.0,
                 "first_bar": "2025-01-01T00:00:00",
-                "last_bar": "2026-06-19T00:00:00",
+                "last_bar": _FRESH_LAST_BAR,
                 "coverage_pct": 90.0,
             }
         ],
@@ -279,7 +288,7 @@ def test_assess_wrapper_with_complete_report():
                 "gap_count": 0,
                 "continuity_score": 100.0,
                 "first_bar": "2025-01-01T00:00:00",
-                "last_bar": "2026-06-19T00:00:00",
+                "last_bar": _FRESH_LAST_BAR,
                 "coverage_pct": 92.0,
             }
         ],
@@ -287,6 +296,8 @@ def test_assess_wrapper_with_complete_report():
 
     mock_db = MagicMock()
     mock_db.query.return_value.filter.return_value.first.return_value = mock_report
+    # MarketHoliday lookup uses .all(); return no holidays.
+    mock_db.query.return_value.filter.return_value.all.return_value = []
 
     body = GateRequest(universe_id=1, policy="strict", consumer="scanner")
     result = QualityGateService.assess(db=mock_db, request=body)
@@ -332,3 +343,239 @@ def test_assess_wrapper_incomplete_report_strict():
     result = QualityGateService.assess(db=mock_db, request=body)
     assert result.verdict == QualityGateVerdict.blocked
     assert any(i.code == QualityIssueCode.missing_bars for i in result.issues)
+
+
+# ── #499: stale_quote ─────────────────────────────────────────────────────────
+
+
+def _clean_ticker(**overrides) -> dict:
+    """A fully-fresh, high-coverage ticker entry; override per test."""
+    base = {
+        "ticker": "AAPL",
+        "timespan": "minute",
+        "multiplier": 5,
+        "gap_count": 0,
+        "continuity_score": 100.0,
+        "first_bar": "2025-01-01T00:00:00",
+        "last_bar": _FRESH_LAST_BAR,
+        "coverage_pct": 95.0,
+        "actual_bars": 1000,
+        "expected_bars": 1050,
+    }
+    base.update(overrides)
+    return base
+
+
+def _report_with(tickers, overall_score=95.0, generated_at=None) -> dict:
+    report = {
+        "overall_score": overall_score,
+        "overall_grade": "A",
+        "tickers": tickers,
+    }
+    if generated_at is not None:
+        report["generated_at"] = generated_at
+    return report
+
+
+def test_stale_strict_emits_blocker():
+    report = _report_with([_clean_ticker(last_bar=_stale_last_bar(14))])
+    result = _build_assessment(report, None, _scope(), QualityGatePolicy.strict)
+    assert result.verdict == QualityGateVerdict.blocked
+    stale = [i for i in result.issues if i.code == QualityIssueCode.stale_quote]
+    assert stale and stale[0].severity == "blocker"
+    assert stale[0].detail["subtype"] == "ticker_stale"
+    assert stale[0].detail["threshold_trading_days"] == 1
+    assert stale[0].detail["source"] is None
+
+
+def test_stale_advisory_emits_warning():
+    report = _report_with([_clean_ticker(last_bar=_stale_last_bar(21))])
+    result = _build_assessment(report, None, _scope(), QualityGatePolicy.advisory)
+    assert result.verdict == QualityGateVerdict.warning
+    stale = [i for i in result.issues if i.code == QualityIssueCode.stale_quote]
+    assert stale and stale[0].severity == "warning"
+    assert stale[0].detail["threshold_trading_days"] == 5  # intraday advisory
+
+
+def test_fresh_ticker_not_stale():
+    report = _report_with([_clean_ticker()])
+    result = _build_assessment(report, None, _scope(), QualityGatePolicy.strict)
+    assert not any(i.code == QualityIssueCode.stale_quote for i in result.issues)
+    assert result.verdict == QualityGateVerdict.trusted
+
+
+def test_report_freshness_guard_strict_blocks_and_skips_tickers():
+    generated = (datetime.now(timezone.utc) - timedelta(hours=5)).isoformat()
+    # last_bar is fresh, so any stale_quote can only come from the report guard.
+    report = _report_with([_clean_ticker()], generated_at=generated)
+    result = _build_assessment(report, None, _scope(), QualityGatePolicy.strict)
+    stale = [i for i in result.issues if i.code == QualityIssueCode.stale_quote]
+    assert len(stale) == 1
+    assert stale[0].severity == "blocker"
+    assert stale[0].detail["subtype"] == "report_stale"
+    assert result.verdict == QualityGateVerdict.blocked
+
+
+def test_report_freshness_guard_advisory_warns():
+    generated = (datetime.now(timezone.utc) - timedelta(hours=6)).isoformat()
+    report = _report_with([_clean_ticker()], generated_at=generated)
+    result = _build_assessment(report, None, _scope(), QualityGatePolicy.advisory)
+    stale = [i for i in result.issues if i.code == QualityIssueCode.stale_quote]
+    assert len(stale) == 1
+    assert stale[0].severity == "warning"
+    assert stale[0].detail["subtype"] == "report_stale"
+
+
+def test_report_freshness_fresh_report_does_not_fire():
+    generated = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    report = _report_with([_clean_ticker()], generated_at=generated)
+    result = _build_assessment(report, None, _scope(), QualityGatePolicy.strict)
+    assert not any(i.code == QualityIssueCode.stale_quote for i in result.issues)
+
+
+def test_as_of_date_override_suppresses_stale():
+    # last_bar covers the requested historical date → never stale, even though
+    # it is months old in calendar terms and the report snapshot is old.
+    generated = (datetime.now(timezone.utc) - timedelta(hours=8)).isoformat()
+    report = _report_with(
+        [_clean_ticker(last_bar="2026-01-05T00:00:00")], generated_at=generated
+    )
+    reqs = {"as_of_date": "2026-01-05"}
+    result = _build_assessment(report, reqs, _scope(), QualityGatePolicy.strict)
+    assert not any(i.code == QualityIssueCode.stale_quote for i in result.issues)
+    assert result.verdict == QualityGateVerdict.trusted
+
+
+def test_as_of_date_stale_when_last_bar_predates_it():
+    report = _report_with([_clean_ticker(last_bar="2025-12-01T00:00:00")])
+    reqs = {"as_of_date": "2026-01-15"}
+    result = _build_assessment(report, reqs, _scope(), QualityGatePolicy.strict)
+    stale = [i for i in result.issues if i.code == QualityIssueCode.stale_quote]
+    assert stale and stale[0].severity == "blocker"
+    assert stale[0].detail["as_of_date"] == "2026-01-15"
+
+
+def test_market_holidays_reduce_staleness():
+    # last_bar Friday, reference the following Tuesday with Monday a holiday →
+    # only Tuesday counts as a trading day (1 day stale) → not stale under strict.
+    last = date(2026, 6, 12)  # Friday
+    ref = date(2026, 6, 16)  # Tuesday
+    report = _report_with([_clean_ticker(last_bar=last.isoformat() + "T00:00:00")])
+    reqs = {"as_of_date": ref.isoformat()}
+    holidays = {date(2026, 6, 15)}  # Monday holiday
+    result = _build_assessment(
+        report, reqs, _scope(), QualityGatePolicy.strict, market_holidays=holidays
+    )
+    assert not any(i.code == QualityIssueCode.stale_quote for i in result.issues)
+    # Without the holiday, Mon+Tue = 2 trading days → stale blocker.
+    result_no_holiday = _build_assessment(
+        report, reqs, _scope(), QualityGatePolicy.strict, market_holidays=set()
+    )
+    assert any(i.code == QualityIssueCode.stale_quote for i in result_no_holiday.issues)
+
+
+# ── #499: provider_gap subtypes ──────────────────────────────────────────────
+
+
+def test_provider_gap_absent_is_blocker():
+    report = _report_with(
+        [_clean_ticker(actual_bars=0, coverage_pct=0.0, last_bar=None)],
+        overall_score=95.0,
+    )
+    result = _build_assessment(report, None, _scope(), QualityGatePolicy.strict)
+    absent = [
+        i
+        for i in result.issues
+        if i.code == QualityIssueCode.provider_gap
+        and i.detail.get("subtype") == "absent"
+    ]
+    assert absent and absent[0].severity == "blocker"
+    assert result.verdict == QualityGateVerdict.blocked
+
+
+def test_provider_gap_absent_blocker_under_advisory_is_warning_verdict():
+    report = _report_with(
+        [_clean_ticker(actual_bars=0, coverage_pct=0.0, last_bar=None)]
+    )
+    result = _build_assessment(report, None, _scope(), QualityGatePolicy.advisory)
+    absent = [
+        i
+        for i in result.issues
+        if i.code == QualityIssueCode.provider_gap
+        and i.detail.get("subtype") == "absent"
+    ]
+    assert absent and absent[0].severity == "blocker"
+    assert result.verdict == QualityGateVerdict.warning
+
+
+def test_provider_gap_partial_absolute():
+    report = _report_with(
+        [_clean_ticker(coverage_pct=40.0, actual_bars=400)], overall_score=95.0
+    )
+    result = _build_assessment(report, None, _scope(), QualityGatePolicy.strict)
+    partial = [
+        i
+        for i in result.issues
+        if i.code == QualityIssueCode.provider_gap
+        and i.detail.get("subtype") == "partial"
+    ]
+    assert partial and partial[0].severity == "blocker"
+    assert partial[0].detail["coverage_pct"] == 40.0
+
+
+def test_provider_gap_partial_advisory_is_warning():
+    report = _report_with([_clean_ticker(coverage_pct=40.0, actual_bars=400)])
+    result = _build_assessment(report, None, _scope(), QualityGatePolicy.advisory)
+    partial = [
+        i
+        for i in result.issues
+        if i.code == QualityIssueCode.provider_gap
+        and i.detail.get("subtype") == "partial"
+    ]
+    assert partial and partial[0].severity == "warning"
+
+
+def test_provider_gap_partial_relative_outlier():
+    # Two high-coverage tickers anchor the median; the third is >30pts below it
+    # and < 80 → flagged as a relative-outlier partial return.
+    tickers = [
+        _clean_ticker(ticker="AAA", coverage_pct=95.0),
+        _clean_ticker(ticker="BBB", coverage_pct=95.0),
+        _clean_ticker(ticker="CCC", coverage_pct=60.0, actual_bars=600),
+    ]
+    report = _report_with(tickers, overall_score=90.0)
+    result = _build_assessment(report, None, _scope(), QualityGatePolicy.strict)
+    partial = [
+        i
+        for i in result.issues
+        if i.code == QualityIssueCode.provider_gap
+        and i.detail.get("subtype") == "partial"
+    ]
+    assert len(partial) == 1
+    assert partial[0].detail["ticker"] == "CCC"
+    assert partial[0].detail["universe_median_coverage"] == 95.0
+
+
+def test_provider_gap_structural_retained():
+    report = _report_with(
+        [_clean_ticker(gap_count=15, continuity_score=25.0)], overall_score=90.0
+    )
+    result = _build_assessment(report, None, _scope(), QualityGatePolicy.strict)
+    structural = [
+        i
+        for i in result.issues
+        if i.code == QualityIssueCode.provider_gap
+        and i.detail.get("subtype") == "structural"
+    ]
+    assert structural and structural[0].severity == "blocker"
+
+
+def test_policy_off_suppresses_stale_and_provider_gap():
+    tickers = [
+        _clean_ticker(last_bar=_stale_last_bar(30)),
+        _clean_ticker(ticker="ZZZ", actual_bars=0, coverage_pct=0.0, last_bar=None),
+    ]
+    report = _report_with(tickers, generated_at="2020-01-01T00:00:00+00:00")
+    result = _build_assessment(report, None, _scope(), QualityGatePolicy.off)
+    assert result.verdict == QualityGateVerdict.skipped
+    assert result.issues == []


### PR DESCRIPTION
## What

Slice 8 of the Data Quality Trust Gate epic (#491). Extends the **gate service**
(`backend/app/services/quality_gate.py` → `_build_assessment`) to emit two more
issue types from the `report_data` / `data_requirements` dicts it already
receives. This is the service layer (emits `QualityGateIssue`), distinct from the
evidence module touched by #500.

### `stale_quote`
- **Report-freshness guard** — if `report_data["generated_at"]` is older than 4h
  (the same threshold `system_service` uses), a single **scope-level**
  `stale_quote` issue fires (strict → blocker, advisory → warning) and the
  per-ticker loop is skipped (`subtype="report_stale"`).
- **Per-ticker staleness** — measured in **trading days** (weekday + holiday
  filtered), not calendar days: strict → T-1 blocker; advisory → T-5 (intraday)
  / T-7 (daily+) warning (`subtype="ticker_stale"`).
- **`as_of_date` override** — an optional `data_requirements["as_of_date"]`
  shifts the staleness reference for historical/backtest consumers and disables
  the freshness guard; a ticker whose `last_bar` covers `as_of_date` is never
  stale.

### `provider_gap` (extends the #492 proxy)
- **`absent`** — `actual_bars == 0` → blocker regardless of policy (advisory
  still downgrades the verdict).
- **`partial`** — `coverage_pct < 50`, or more than 30 pts below the universe
  median *and* `< 80` → strict blocker / advisory warning. Median is computed
  once over tickers with `actual_bars > 0` (robust to absent outliers).
- **`structural`** — the existing `gap_count` / `continuity_score` universe-level
  check, retained unchanged, now tagged `subtype="structural"`.

`source` stays `None` everywhere (no per-ticker provider attribution exists in
stored data yet — forward-compatible).

## Handling the no-DB constraint

`_build_assessment` must stay a pure, DB-free function (no `MAX(timestamp)` or
per-ticker live queries, per the #492 contract and the approved spec). Trading-day
staleness needs the `MarketHoliday` calendar, which is DB-derived, so:

- `QualityGateService.assess()` (which *has* a `Session`) resolves the **NYSE
  full-close** calendar once into a plain `set[date]` and passes it into
  `_build_assessment` via a new optional `market_holidays` parameter (only when a
  report is present).
- `_build_assessment` consumes that set and falls back to a **weekday-only**
  filter when it is empty/None — exactly the fallback the spec sanctions.

No schema change was needed: the structured context payloads ride on the existing
`QualityGateIssue.detail` field.

## Tests

`backend/tests/services/test_quality_gate_service.py` — 33 passing. New coverage:
strict-blocker vs advisory-warning staleness; report-freshness >4h scope guard
(strict + advisory) and the fresh-report negative; `as_of_date` suppression and
the predates-as_of stale case; holiday-aware trading-day counting; provider_gap
`absent` / `partial` (absolute + relative-outlier) / `structural` subtypes; and
`policy="off"` passthrough. Existing fixtures' hard-coded `last_bar` dates were
made relative to today so unrelated tests don't trip the new staleness check.

Ruff `check` + `format --check` clean on all changed files.

Closes #499
