### PR TITLE
fix(deps): bump scientific stack to cp314-wheel versions to unblock the Python 3.14 factory (#622)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,11 +13,13 @@ alembic==1.18.4
 polygon-api-client==1.16.3
 websockets==16.0
 pandas==2.3.3
-numpy==2.2.6
+numpy==2.3.3
 lightgbm==4.6.0
-shap==0.47.2
-scikit-learn==1.6.1
-scipy==1.15.3
+shap==0.51.0
+numba==0.63.0      # pinned for cp314 wheels (Python 3.14 factory)
+llvmlite==0.46.0   # pinned for cp314 wheels (Python 3.14 factory)
+scikit-learn==1.7.2
+scipy==1.16.1
 hmmlearn>=0.3
 ib_insync==0.9.86
 


### PR DESCRIPTION
## Root cause

The dark-factory image runs **Python 3.14.4**. The pinned `scipy==1.15.3` has **no cp314 wheel**, so `pip install -r backend/requirements.txt` (run by `entrypoint.sh` on every refine + implement) falls back to a **source build of scipy**, which fails because the image ships `gcc`/`g++` but **no Fortran compiler (`gfortran`)**. That `exit 1` was leaving factory tickets **Blocked**.

## The fix (requirements bump only)

Bump the scientific stack to versions that ship **cp314 manylinux wheels** — and that **still ship cp312 wheels**, so the 3.12 backend runtime and CI are unaffected:

| package | old | new |
|---|---|---|
| numpy | 2.2.6 | **2.3.3** |
| scipy | 1.15.3 | **1.16.1** (removes the Fortran source build) |
| scikit-learn | 1.6.1 | **1.7.2** |
| shap | 0.47.2 | **0.51.0** |

Plus two former-transitive deps pinned explicitly to guarantee cp314 wheels + reproducibility:

- `numba==0.63.0`
- `llvmlite==0.46.0`

**Unchanged:** `pandas` (already cp314), `lightgbm` (py3-none), `hmmlearn` (builds from sdist with `g++` only — no Fortran — so it still installs).

## Scope notes

- **No `backend/Dockerfile` change.** It stays `python:3.12-slim`; the runtime-to-3.14 move is a deferred follow-up, out of scope here.
- **No image rebuild needed.** The factory installs requirements from a fresh clone at runtime, so **merging this auto-recovers the factory** on the next refine/implement.

## Validation

**(A) Factory fix proof — clean install on the Python 3.14 factory image** (`ghcr.io/omniscient/markethawk-dark-factory:latest`, Python 3.14.4):

```
Downloading numpy-2.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (16.6 MB)
Downloading shap-0.51.0-cp314-cp314-manylinux2014_x86_64...whl (1.1 MB)
Downloading numba-0.63.0-cp314-cp314-manylinux2014_x86_64...whl (3.8 MB)
Downloading llvmlite-0.46.0-cp314-cp314-manylinux2014_x86_64...whl (56.3 MB)
Downloading scikit_learn-1.7.2-cp314-cp314-manylinux2014_x86_64...whl (9.4 MB)
Downloading scipy-1.16.1-cp314-cp314-manylinux2014_x86_64...whl (35.2 MB)
EXIT=0

IMPORTS_OK scipy 1.16.1 numpy 2.3.3 shap 0.51.0
```

All six packages download **cp314 wheels** — **no scipy source build, no `gfortran`, no `metadata-generation-failed`** — and imports succeed. The original failure is gone.

**(B) API-break sanity check** — targeted backend tests (`test_statistical_discovery.py`, `test_regime_service.py`) pass: **36 passed**. Caveat: the local backend test image is Python 3.12 with the **old** deps baked in (scipy 1.15.3 / sklearn 1.6.1 / shap 0.47.2), so this validates the test/API shape at the old-version level, **not** the new versions. The authoritative new-version API gate is this PR's CI **`test`** + **`docker-backend`** jobs, which rebuild against the new `requirements.txt`.

Closes omniscient/dark-factory#139
