### PR TITLE
feat(security): F-TRADE-01 — non-bypassable live IBKR order guards (#368)

### DIFF
--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -200,3 +200,19 @@ curl http://localhost:8000/health
 3. Read it in `backend/app/core/config.py` via `os.getenv("VAR_NAME", "default")`.
 4. Restart containers: `docker-compose down && docker-compose up -d`.
 5. Document it in this file.
+
+
+---
+
+## Live Trading Safety Controls
+
+These variables control the non-bypassable order guards added at the `place_bracket_order` chokepoint (F-TRADE-01). They must be set at the container/env level — **they are not API-settable**.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `LIVE_TRADING_ARMED` | `false` | **Must be explicitly set to `true` to allow live IBKR order placement.** Defaults to `false` — any container without this env var set will refuse all live orders with `PermissionError`. Requires container restart to change. |
+| `TRADING_KILL_SWITCH` | `` (unset) | Emergency halt: set to `1`, `true`, or `yes` (case-insensitive) to immediately block all live order placement without restarting the container. Checked via `os.getenv()` at call time so it takes effect instantly via `docker exec -e TRADING_KILL_SWITCH=true ...`. |
+| `MAX_ORDER_NOTIONAL` | `10000.0` | Hard USD notional cap per order (`quantity * entry_price`). Orders exceeding this raise `ValueError` before connecting to IBKR. Override if your live account trades larger sizes (e.g. `MAX_ORDER_NOTIONAL=50000`). |
+| `MAX_ORDER_QTY` | `200` | Hard shares-per-order cap. Orders with `quantity > MAX_ORDER_QTY` raise `ValueError`. Override for large-cap positions where 200 shares is too restrictive. |
+
+> **Breaking default:** Any container currently placing live IBKR orders **must** set `LIVE_TRADING_ARMED=true` before deploying this change, or live order placement will be blocked. The default is intentionally safe/conservative.

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -211,8 +211,24 @@ These variables control the non-bypassable order guards added at the `place_brac
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `LIVE_TRADING_ARMED` | `false` | **Must be explicitly set to `true` to allow live IBKR order placement.** Defaults to `false` — any container without this env var set will refuse all live orders with `PermissionError`. Requires container restart to change. |
-| `TRADING_KILL_SWITCH` | `` (unset) | Emergency halt: set to `1`, `true`, or `yes` (case-insensitive) to immediately block all live order placement without restarting the container. Checked via `os.getenv()` at call time so it takes effect instantly via `docker exec -e TRADING_KILL_SWITCH=true ...`. |
-| `MAX_ORDER_NOTIONAL` | `10000.0` | Hard USD notional cap per order (`quantity * entry_price`). Orders exceeding this raise `ValueError` before connecting to IBKR. Override if your live account trades larger sizes (e.g. `MAX_ORDER_NOTIONAL=50000`). |
+| `TRADING_KILL_SWITCH` | `` (unset) | Boot-time env override for the emergency halt. Uses **deny-list semantics**: the switch is considered *disengaged* only if the value is one of `""` (unset), `0`, `false`, `no`, or `off` (case-insensitive, whitespace stripped). Any other value — including `1`, `true`, `yes`, `on`, or custom tokens — is treated as **ENGAGED** and all live orders are blocked with `PermissionError`. Requires a container restart to change; for instant runtime control use the Redis key below. |
+| `MAX_ORDER_NOTIONAL` | `10000.0` | Hard USD notional cap per order. Uses the **highest** available price (entry, target, or stop) so short orders cannot circumvent the cap by using a low-side target price. Orders exceeding this raise `ValueError` before connecting to IBKR. Override if your live account trades larger sizes (e.g. `MAX_ORDER_NOTIONAL=50000`). |
 | `MAX_ORDER_QTY` | `200` | Hard shares-per-order cap. Orders with `quantity > MAX_ORDER_QTY` raise `ValueError`. Override for large-cap positions where 200 shares is too restrictive. |
 
 > **Breaking default:** Any container currently placing live IBKR orders **must** set `LIVE_TRADING_ARMED=true` before deploying this change, or live order placement will be blocked. The default is intentionally safe/conservative.
+
+### Redis runtime kill switch
+
+The kill switch has a **Redis-backed runtime layer** (`trading:kill_switch` key) that can halt live orders instantly **without a container restart**:
+
+```bash
+# Engage — halt all live orders immediately
+docker exec stockscanner-redis redis-cli -a "$REDIS_PASSWORD" set trading:kill_switch 1
+
+# Disengage — resume live orders
+docker exec stockscanner-redis redis-cli -a "$REDIS_PASSWORD" del trading:kill_switch
+```
+
+**Fail-closed behavior:** If Redis is unreachable (connection refused, timeout, server down), the kill switch is treated as **ENGAGED** and all live orders are blocked. This is intentional — it is safer to halt trading than to place orders when the safety infrastructure is unavailable. A 1-second socket timeout prevents a hung Redis from blocking order placement indefinitely.
+
+Either the env var (boot-time) **or** the Redis key (runtime) engaging is sufficient to halt trading. They are independent; both must be clear for orders to proceed.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -104,6 +104,16 @@ class Settings(BaseSettings):
     # Must differ from IBKR_CLIENT_ID and from the live scanner's clientId (5).
     IBKR_TRADING_CLIENT_ID: int = 11
 
+    # ── Live trading safety controls ──────────────────────────────────────────────
+    # LIVE_TRADING_ARMED: must be explicitly True in env to allow real orders.
+    # Not API-settable — requires container/env access to change.
+    LIVE_TRADING_ARMED: bool = False
+    # TRADING_KILL_SWITCH: also checked via os.getenv() at call time for
+    # real-time halt without restart. Settings field provides startup visibility.
+    TRADING_KILL_SWITCH: bool = False
+    MAX_ORDER_NOTIONAL: float = 10_000.0  # USD hard cap per order
+    MAX_ORDER_QTY: int = 200  # shares hard cap per order
+
     # ── Email / SMTP (Alert Notifications) ────────────────────────────────
     # Use Gmail + an App Password (not your real Gmail password).
     # Generate one at: https://myaccount.google.com/apppasswords
@@ -165,6 +175,17 @@ class Settings(BaseSettings):
     @classmethod
     def normalize_environment(cls, v: str) -> str:
         return v.lower()
+
+    @field_validator("LIVE_TRADING_ARMED")
+    @classmethod
+    def warn_live_trading_armed(cls, v: bool) -> bool:
+        if v:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "LIVE_TRADING_ARMED=True — live order placement is ENABLED at the env level."
+            )
+        return v
 
     @field_validator("REDIS_PASSWORD")
     @classmethod

--- a/backend/app/core/metrics.py
+++ b/backend/app/core/metrics.py
@@ -101,3 +101,9 @@ replay_drift_signals_total = Counter(
     "Replay diff drift signals by kind",
     ["scanner_type", "kind"],
 )
+
+live_orders_total = Counter(
+    "live_orders_total",
+    "Total live (non-paper) bracket orders placed to IBKR",
+    ["symbol", "side"],
+)

--- a/backend/app/providers/ibkr_orders.py
+++ b/backend/app/providers/ibkr_orders.py
@@ -26,6 +26,8 @@ import os
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+import redis
+
 from app.core.config import settings
 
 logger = logging.getLogger(__name__)
@@ -228,23 +230,80 @@ class IBKROrderManager:
 
         Returns BracketOrderResult with broker IDs for all three legs.
         """
-        # ── Non-bypassable live-order guards (R1 / R2) ───────────────────────────
+        # ── Non-bypassable live-order guards ─────────────────────────────────────
         # These checks fire before any IBKR connection opens. They cannot be
         # bypassed by flipping API-mutable DB config (AUTO_TRADING_ENABLED, paper_mode).
-        if os.getenv("TRADING_KILL_SWITCH", "").lower() in ("1", "true", "yes"):
+
+        # 1. Kill switch — FIRST guard, before LIVE_TRADING_ARMED or any IBKR I/O.
+        #    (a) Boot-time env override: DENY-LIST semantics — only the explicit
+        #        allow-set ("", "0", "false", "no", "off") disengages it; any other
+        #        value (including custom tokens like "on", "stop", " true ") is ENGAGED.
+        _ks_env = os.getenv("TRADING_KILL_SWITCH", "").strip().lower()
+        if _ks_env not in ("", "0", "false", "no", "off"):
             raise PermissionError(
-                "Trading kill switch engaged — refusing to place order"
+                "Trading kill switch engaged (env TRADING_KILL_SWITCH) "
+                "— refusing to place order"
             )
+        # (b) Redis runtime flag — FAIL-CLOSED: any Redis error (connection refused,
+        #     timeout, server down) treats the switch as ENGAGED. A short socket
+        #     timeout prevents a hung Redis from blocking the caller indefinitely.
+        try:
+            _ks_client = redis.from_url(
+                settings.REDIS_URL,
+                decode_responses=True,
+                socket_timeout=1.0,
+                socket_connect_timeout=1.0,
+            )
+            _ks_val = _ks_client.get("trading:kill_switch")
+        except Exception as _ks_exc:
+            raise PermissionError(
+                "Trading kill switch: Redis unreachable — failing closed, "
+                "refusing to place order"
+            ) from _ks_exc
+        if _ks_val is not None and str(_ks_val).strip().lower() not in (
+            "",
+            "0",
+            "false",
+            "no",
+            "off",
+        ):
+            raise PermissionError(
+                "Trading kill switch engaged (Redis key trading:kill_switch) "
+                "— refusing to place order"
+            )
+
+        # 2. LIVE_TRADING_ARMED must be explicitly set — fails to False by default.
         if not settings.LIVE_TRADING_ARMED:
             raise PermissionError(
                 "LIVE_TRADING_ARMED is not set — live order placement is disabled. "
                 "Set LIVE_TRADING_ARMED=true in the environment to enable."
             )
-        notional = quantity * (entry_price if entry_price is not None else target_price)
+
+        # 3. Positive lower bounds — defense-in-depth at the non-bypassable perimeter.
+        #    Upstream callers already guarantee qty>0 and positive prices, but the
+        #    chokepoint must not rely on caller invariants for live-money protection.
+        if quantity <= 0:
+            raise ValueError(f"quantity must be positive, got {quantity}")
+        # Conservative price basis: use the HIGHEST available price so neither
+        # longs nor shorts can circumvent the notional cap with a low-side price.
+        # For shorts: stop_price > entry > target, so stop is the worst-case notional.
+        _price_candidates = [
+            p for p in (entry_price, target_price, stop_price) if p is not None
+        ]
+        _price_basis = max(_price_candidates) if _price_candidates else 0.0
+        if _price_basis <= 0:
+            raise ValueError(
+                f"effective price basis must be positive, got {_price_basis}"
+            )
+
+        # 4. Notional cap (uses conservative price basis, not just entry).
+        notional = quantity * _price_basis
         if notional > settings.MAX_ORDER_NOTIONAL:
             raise ValueError(
                 f"Order exceeds notional cap: {notional:.2f} > {settings.MAX_ORDER_NOTIONAL}"
             )
+
+        # 5. Quantity cap.
         if quantity > settings.MAX_ORDER_QTY:
             raise ValueError(
                 f"Order exceeds quantity cap: {quantity} > {settings.MAX_ORDER_QTY}"

--- a/backend/app/providers/ibkr_orders.py
+++ b/backend/app/providers/ibkr_orders.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from dataclasses import dataclass, field
 from typing import List, Optional
 
@@ -227,6 +228,44 @@ class IBKROrderManager:
 
         Returns BracketOrderResult with broker IDs for all three legs.
         """
+        # ── Non-bypassable live-order guards (R1 / R2) ───────────────────────────
+        # These checks fire before any IBKR connection opens. They cannot be
+        # bypassed by flipping API-mutable DB config (AUTO_TRADING_ENABLED, paper_mode).
+        if os.getenv("TRADING_KILL_SWITCH", "").lower() in ("1", "true", "yes"):
+            raise PermissionError(
+                "Trading kill switch engaged — refusing to place order"
+            )
+        if not settings.LIVE_TRADING_ARMED:
+            raise PermissionError(
+                "LIVE_TRADING_ARMED is not set — live order placement is disabled. "
+                "Set LIVE_TRADING_ARMED=true in the environment to enable."
+            )
+        notional = quantity * (entry_price if entry_price is not None else target_price)
+        if notional > settings.MAX_ORDER_NOTIONAL:
+            raise ValueError(
+                f"Order exceeds notional cap: {notional:.2f} > {settings.MAX_ORDER_NOTIONAL}"
+            )
+        if quantity > settings.MAX_ORDER_QTY:
+            raise ValueError(
+                f"Order exceeds quantity cap: {quantity} > {settings.MAX_ORDER_QTY}"
+            )
+        # ── WARN-level audit log (all guards passed) ──────────────────────────────
+        logger.warning(
+            "LIVE ORDER PLACEMENT: symbol=%s side=%s qty=%d entry=%s stop=%s target=%s "
+            "notional=%.2f order_ref=%s",
+            symbol,
+            side,
+            quantity,
+            f"{entry_price:.4f}" if entry_price is not None else "MKT",
+            stop_price,
+            target_price,
+            notional,
+            order_ref,
+        )
+        # ── Prometheus counter ────────────────────────────────────────────────────
+        from app.core.metrics import live_orders_total
+
+        live_orders_total.labels(symbol=symbol, side=side).inc()
         ib = await self._connect()
         try:
             contract = Stock(symbol, "SMART", "USD")

--- a/backend/app/routers/auto_trading.py
+++ b/backend/app/routers/auto_trading.py
@@ -83,6 +83,15 @@ def list_strategies(
     return [TradingStrategyResponse.from_orm_dict(s).model_dump() for s in strategies]
 
 
+def _validate_live_strategy(paper_mode: bool, max_position_usd) -> None:
+    """Raise HTTP 422 if a live strategy has no max_position_usd."""
+    if not paper_mode and max_position_usd is None:
+        raise HTTPException(
+            status_code=422,
+            detail="max_position_usd is required when paper_mode=False",
+        )
+
+
 @router.post("/strategies", status_code=201)
 def create_strategy(
     payload: Dict[str, Any],
@@ -106,6 +115,9 @@ def create_strategy(
         max_slippage_pct=payload.get("max_slippage_pct", 0.5),
         allowed_sessions=payload.get("allowed_sessions", ["regular"]),
         direction=payload.get("direction", "long_only"),
+    )
+    _validate_live_strategy(
+        paper_mode=strategy.paper_mode, max_position_usd=strategy.max_position_usd
     )
     db.add(strategy)
     db.commit()
@@ -136,6 +148,9 @@ def update_strategy(
         if key in _STRATEGY_UPDATABLE:
             setattr(s, key, value)
 
+    _validate_live_strategy(
+        paper_mode=s.paper_mode, max_position_usd=s.max_position_usd
+    )
     s.updated_at = utc_now()
     db.commit()
     db.refresh(s)

--- a/backend/app/routers/auto_trading.py
+++ b/backend/app/routers/auto_trading.py
@@ -84,8 +84,8 @@ def list_strategies(
 
 
 def _validate_live_strategy(paper_mode: bool, max_position_usd) -> None:
-    """Raise HTTP 422 if a live strategy has no max_position_usd."""
-    if not paper_mode and max_position_usd is None:
+    """Raise HTTP 422 if a live strategy has no or non-positive max_position_usd."""
+    if not paper_mode and (max_position_usd is None or float(max_position_usd) <= 0):
         raise HTTPException(
             status_code=422,
             detail="max_position_usd is required when paper_mode=False",

--- a/backend/app/services/auto_trade_service.py
+++ b/backend/app/services/auto_trade_service.py
@@ -135,11 +135,13 @@ class AutoTradeExecutor:
                 )
                 return None
 
-        # ── 1b. max_position_usd required for live strategies (R3) ─────────────
-        if not strategy.paper_mode and strategy.max_position_usd is None:
+        # ── 1b. max_position_usd required and must be positive for live strategies (R3) ──
+        if not strategy.paper_mode and (
+            strategy.max_position_usd is None or float(strategy.max_position_usd) <= 0
+        ):
             logger.error(
-                "AutoTradeExecutor: live strategy '%s' (id=%s) has no max_position_usd "
-                "— refusing live order for rule %s",
+                "AutoTradeExecutor: live strategy '%s' (id=%s) has no valid max_position_usd "
+                "(None or <= 0) — refusing live order for rule %s",
                 strategy.name,
                 strategy.id,
                 rule.id,

--- a/backend/app/services/auto_trade_service.py
+++ b/backend/app/services/auto_trade_service.py
@@ -135,6 +135,17 @@ class AutoTradeExecutor:
                 )
                 return None
 
+        # ── 1b. max_position_usd required for live strategies (R3) ─────────────
+        if not strategy.paper_mode and strategy.max_position_usd is None:
+            logger.error(
+                "AutoTradeExecutor: live strategy '%s' (id=%s) has no max_position_usd "
+                "— refusing live order for rule %s",
+                strategy.name,
+                strategy.id,
+                rule.id,
+            )
+            return None
+
         # ── 2. Idempotency — one order per symbol/strategy/day ───────────
         today = datetime.now(timezone.utc).date()
         existing = (
@@ -162,7 +173,9 @@ class AutoTradeExecutor:
         try:
             universe_id = self._resolve_universe_id(event, db)
             gate_policy = (
-                QualityGatePolicy.strict if universe_id is not None else QualityGatePolicy.off
+                QualityGatePolicy.strict
+                if universe_id is not None
+                else QualityGatePolicy.off
             )
             _gate_req = SimpleNamespace(
                 policy=gate_policy.value,

--- a/backend/tests/api/test_auto_trading.py
+++ b/backend/tests/api/test_auto_trading.py
@@ -119,7 +119,9 @@ def test_patch_strategy_updates_field(db: Session):
 
 
 def test_patch_strategy_not_found_returns_404(db: Session):
-    response = client.patch("/api/v1/trading/strategies/999999", json={"is_active": True})
+    response = client.patch(
+        "/api/v1/trading/strategies/999999", json={"is_active": True}
+    )
     assert response.status_code == 404
 
 
@@ -258,3 +260,37 @@ def test_patch_config_updates_enabled_flag(db: Session):
     )
     assert response.status_code == 200
     assert response.json()["AUTO_TRADING_ENABLED"] is True
+
+
+# ── Live strategy max_position_usd validation ─────────────────────────────────
+
+
+class TestStrategyLiveRequiresMaxPosition:
+    """Router must return 422 when paper_mode=False and max_position_usd is absent (R3)."""
+
+    def test_create_strategy_live_requires_max_position(self, db: Session):
+        resp = client.post(
+            "/api/v1/trading/strategies",
+            json={
+                "name": "Unguarded Live Strategy",
+                "paper_mode": False,
+                # max_position_usd intentionally omitted
+            },
+        )
+        assert resp.status_code == 422, resp.json()
+        assert "max_position_usd" in resp.json().get("detail", "").lower()
+
+    def test_update_strategy_live_requires_max_position(self, db: Session):
+        # Create a safe paper strategy first
+        s = _strategy(db, paper_mode=True)
+        db.flush()
+
+        # PATCH to live mode without providing max_position_usd → 422
+        resp = client.patch(
+            f"/api/v1/trading/strategies/{s.id}",
+            json={
+                "paper_mode": False
+            },  # max_position_usd absent; existing value is None
+        )
+        assert resp.status_code == 422, resp.json()
+        assert "max_position_usd" in resp.json().get("detail", "").lower()

--- a/backend/tests/api/test_auto_trading.py
+++ b/backend/tests/api/test_auto_trading.py
@@ -266,7 +266,7 @@ def test_patch_config_updates_enabled_flag(db: Session):
 
 
 class TestStrategyLiveRequiresMaxPosition:
-    """Router must return 422 when paper_mode=False and max_position_usd is absent (R3)."""
+    """Router must return 422 when paper_mode=False and max_position_usd is absent or <= 0 (R3)."""
 
     def test_create_strategy_live_requires_max_position(self, db: Session):
         resp = client.post(
@@ -291,6 +291,58 @@ class TestStrategyLiveRequiresMaxPosition:
             json={
                 "paper_mode": False
             },  # max_position_usd absent; existing value is None
+        )
+        assert resp.status_code == 422, resp.json()
+        assert "max_position_usd" in resp.json().get("detail", "").lower()
+
+    def test_create_strategy_live_rejects_zero_max_position(self, db: Session):
+        """max_position_usd=0 with paper_mode=False must return 422 (FIX 5)."""
+        resp = client.post(
+            "/api/v1/trading/strategies",
+            json={
+                "name": "Zero Cap Live Strategy",
+                "paper_mode": False,
+                "max_position_usd": 0,
+            },
+        )
+        assert resp.status_code == 422, resp.json()
+        assert "max_position_usd" in resp.json().get("detail", "").lower()
+
+    def test_create_strategy_live_rejects_negative_max_position(self, db: Session):
+        """max_position_usd=-500 with paper_mode=False must return 422 (FIX 5)."""
+        resp = client.post(
+            "/api/v1/trading/strategies",
+            json={
+                "name": "Negative Cap Live Strategy",
+                "paper_mode": False,
+                "max_position_usd": -500,
+            },
+        )
+        assert resp.status_code == 422, resp.json()
+        assert "max_position_usd" in resp.json().get("detail", "").lower()
+
+    def test_create_strategy_live_accepts_positive_max_position(self, db: Session):
+        """max_position_usd=5000 with paper_mode=False must be accepted (sanity check)."""
+        resp = client.post(
+            "/api/v1/trading/strategies",
+            json={
+                "name": "Valid Live Strategy",
+                "paper_mode": False,
+                "max_position_usd": 5000,
+            },
+        )
+        assert resp.status_code == 201, resp.json()
+        assert resp.json()["paper_mode"] is False
+        assert resp.json()["max_position_usd"] == 5000
+
+    def test_update_strategy_live_rejects_zero_max_position(self, db: Session):
+        """PATCH to max_position_usd=0 on a live strategy must return 422 (FIX 5)."""
+        s = _strategy(db, paper_mode=True)
+        db.flush()
+
+        resp = client.patch(
+            f"/api/v1/trading/strategies/{s.id}",
+            json={"paper_mode": False, "max_position_usd": 0},
         )
         assert resp.status_code == 422, resp.json()
         assert "max_position_usd" in resp.json().get("detail", "").lower()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,6 +5,7 @@ import os
 # SlowAPIASGIMiddleware raises ConnectionError on every request.
 os.environ.setdefault("RATE_LIMITING_ENABLED", "false")
 os.environ.setdefault("LIVE_SCANNER_MOCK", "false")
+os.environ.setdefault("LIVE_TRADING_ARMED", "false")
 
 os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost/test")
 os.environ.setdefault("POLYGON_API_KEY", "test-key-for-unit-tests-only")

--- a/backend/tests/providers/test_ibkr_orders.py
+++ b/backend/tests/providers/test_ibkr_orders.py
@@ -2,6 +2,8 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 
 def _make_manager():
     with patch("app.providers.ibkr_orders.IB_INSYNC_AVAILABLE", True):
@@ -125,3 +127,120 @@ class TestGetAccountAndOrders:
         _, ib_mock = self._run(items, [])
         # Called once with no positional filtering args (tags filtering happens client-side)
         ib_mock.reqAccountSummaryAsync.assert_called_once()
+
+
+class TestPlaceBracketOrderGuards:
+    """Non-bypassable guards at the top of place_bracket_order (R1 / R2)."""
+
+    def _make_manager(self):
+        with patch("app.providers.ibkr_orders.IB_INSYNC_AVAILABLE", True):
+            from app.providers.ibkr_orders import IBKROrderManager
+
+            return IBKROrderManager.__new__(IBKROrderManager)
+
+    def _armed_settings(self):
+        """Settings mock: LIVE_TRADING_ARMED=True, conservative caps."""
+        s = MagicMock()
+        s.LIVE_TRADING_ARMED = True
+        s.TRADING_KILL_SWITCH = False
+        s.MAX_ORDER_NOTIONAL = 10_000.0
+        s.MAX_ORDER_QTY = 200
+        s.IBKR_HOST = "127.0.0.1"
+        s.IBKR_PORT = 7496
+        s.IBKR_TRADING_CLIENT_ID = 11
+        return s
+
+    def _run(
+        self,
+        manager,
+        quantity=10,
+        entry_price=100.0,
+        stop_price=95.0,
+        target_price=110.0,
+    ):
+        import asyncio as _asyncio
+
+        loop = _asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(
+                manager.place_bracket_order(
+                    symbol="AAPL",
+                    side="long",
+                    quantity=quantity,
+                    entry_price=entry_price,
+                    stop_price=stop_price,
+                    target_price=target_price,
+                )
+            )
+        finally:
+            loop.close()
+
+    def _attach_ib_mock(self, manager):
+        """Wire a disconnected IB mock so _connect never touches the network."""
+        ib_mock = MagicMock()
+        ib_mock.placeOrder = MagicMock()
+
+        async def fake_connect():
+            return ib_mock
+
+        async def fake_disconnect(ib):
+            pass
+
+        manager._connect = fake_connect
+        manager._disconnect = fake_disconnect
+        return ib_mock
+
+    def test_place_bracket_order_kill_switch(self):
+        """TRADING_KILL_SWITCH=true must raise PermissionError; placeOrder not called."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        with patch.dict(_os.environ, {"TRADING_KILL_SWITCH": "true"}):
+            with pytest.raises(PermissionError, match="kill switch"):
+                self._run(manager)
+
+        ib_mock.placeOrder.assert_not_called()
+
+    def test_place_bracket_order_not_armed(self):
+        """LIVE_TRADING_ARMED=False (test default via conftest.py) must raise PermissionError."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        # conftest.py sets LIVE_TRADING_ARMED=false; disable kill switch explicitly
+        with patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}):
+            with pytest.raises(PermissionError, match="LIVE_TRADING_ARMED"):
+                self._run(manager)
+
+        ib_mock.placeOrder.assert_not_called()
+
+    def test_place_bracket_order_notional_cap(self):
+        """qty=100 * entry=200.0 → notional=20_000 > 10_000 cap → ValueError."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        with patch("app.providers.ibkr_orders.settings", self._armed_settings()):
+            with patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}):
+                with pytest.raises(ValueError, match="notional cap"):
+                    self._run(manager, quantity=100, entry_price=200.0)
+
+        ib_mock.placeOrder.assert_not_called()
+
+    def test_place_bracket_order_qty_cap(self):
+        """qty=300 > 200 cap → ValueError; notional=300*10=3_000 < cap, so only qty fires."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        with patch("app.providers.ibkr_orders.settings", self._armed_settings()):
+            with patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}):
+                with pytest.raises(ValueError, match="quantity cap"):
+                    self._run(manager, quantity=300, entry_price=10.0)
+
+        ib_mock.placeOrder.assert_not_called()

--- a/backend/tests/providers/test_ibkr_orders.py
+++ b/backend/tests/providers/test_ibkr_orders.py
@@ -4,6 +4,23 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+# Patch target for the Redis kill-switch check in ibkr_orders.
+KS_REDIS_PATCH = "app.providers.ibkr_orders.redis.from_url"
+
+
+def _ks_redis_no_ks():
+    """Mock Redis client that returns None for trading:kill_switch (not engaged)."""
+    client = MagicMock()
+    client.get = MagicMock(return_value=None)
+    return client
+
+
+def _ks_redis_engaged_val(val="1"):
+    """Mock Redis client that returns *val* for trading:kill_switch (engaged)."""
+    client = MagicMock()
+    client.get = MagicMock(return_value=val)
+    return client
+
 
 def _make_manager():
     with patch("app.providers.ibkr_orders.IB_INSYNC_AVAILABLE", True):
@@ -191,7 +208,10 @@ class TestPlaceBracketOrderGuards:
         return ib_mock
 
     def test_place_bracket_order_kill_switch(self):
-        """TRADING_KILL_SWITCH=true must raise PermissionError; placeOrder not called."""
+        """TRADING_KILL_SWITCH=true must raise PermissionError; placeOrder not called.
+
+        Env deny-list fires before the Redis check so no Redis mock needed here.
+        """
         import os as _os
 
         manager = self._make_manager()
@@ -204,43 +224,337 @@ class TestPlaceBracketOrderGuards:
         ib_mock.placeOrder.assert_not_called()
 
     def test_place_bracket_order_not_armed(self):
-        """LIVE_TRADING_ARMED=False (test default via conftest.py) must raise PermissionError."""
+        """LIVE_TRADING_ARMED=False (test default via conftest.py) must raise PermissionError.
+
+        Redis is mocked to not engage the kill switch so the LIVE_TRADING_ARMED guard fires.
+        """
         import os as _os
 
         manager = self._make_manager()
         ib_mock = self._attach_ib_mock(manager)
 
-        # conftest.py sets LIVE_TRADING_ARMED=false; disable kill switch explicitly
-        with patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}):
+        # conftest.py sets LIVE_TRADING_ARMED=false; disable env kill switch, mock Redis ok
+        with (
+            patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}),
+            patch(KS_REDIS_PATCH, return_value=_ks_redis_no_ks()),
+        ):
             with pytest.raises(PermissionError, match="LIVE_TRADING_ARMED"):
                 self._run(manager)
 
         ib_mock.placeOrder.assert_not_called()
 
     def test_place_bracket_order_notional_cap(self):
-        """qty=100 * entry=200.0 → notional=20_000 > 10_000 cap → ValueError."""
+        """qty=100 * max-price=200.0 → notional=20_000 > 10_000 cap → ValueError."""
         import os as _os
 
         manager = self._make_manager()
         ib_mock = self._attach_ib_mock(manager)
 
-        with patch("app.providers.ibkr_orders.settings", self._armed_settings()):
-            with patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}):
-                with pytest.raises(ValueError, match="notional cap"):
-                    self._run(manager, quantity=100, entry_price=200.0)
+        with (
+            patch("app.providers.ibkr_orders.settings", self._armed_settings()),
+            patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}),
+            patch(KS_REDIS_PATCH, return_value=_ks_redis_no_ks()),
+        ):
+            with pytest.raises(ValueError, match="notional cap"):
+                self._run(manager, quantity=100, entry_price=200.0)
 
         ib_mock.placeOrder.assert_not_called()
 
     def test_place_bracket_order_qty_cap(self):
-        """qty=300 > 200 cap → ValueError; notional=300*10=3_000 < cap, so only qty fires."""
+        """qty=300 > 200 cap → ValueError for quantity cap.
+
+        Prices are chosen so that qty * max(entry, target, stop) stays under the
+        notional cap (300 * 12.0 = 3600 < 10000), ensuring ONLY the qty guard fires.
+        """
         import os as _os
 
         manager = self._make_manager()
         ib_mock = self._attach_ib_mock(manager)
 
-        with patch("app.providers.ibkr_orders.settings", self._armed_settings()):
-            with patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}):
-                with pytest.raises(ValueError, match="quantity cap"):
-                    self._run(manager, quantity=300, entry_price=10.0)
+        with (
+            patch("app.providers.ibkr_orders.settings", self._armed_settings()),
+            patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}),
+            patch(KS_REDIS_PATCH, return_value=_ks_redis_no_ks()),
+        ):
+            with pytest.raises(ValueError, match="quantity cap"):
+                import asyncio as _asyncio
+
+                loop = _asyncio.new_event_loop()
+                try:
+                    loop.run_until_complete(
+                        manager.place_bracket_order(
+                            symbol="AAPL",
+                            side="long",
+                            quantity=300,
+                            entry_price=10.0,
+                            stop_price=9.0,  # max(10, 9, 12) = 12; 300*12 = 3600 < 10000
+                            target_price=12.0,
+                        )
+                    )
+                finally:
+                    loop.close()
+
+        ib_mock.placeOrder.assert_not_called()
+
+    # ── New kill-switch tests ─────────────────────────────────────────────────
+
+    def test_kill_switch_redis_flag_halts(self):
+        """Redis trading:kill_switch='1' → PermissionError; placeOrder not called."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        with (
+            patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}),
+            patch(KS_REDIS_PATCH, return_value=_ks_redis_engaged_val("1")),
+        ):
+            with pytest.raises(PermissionError, match="kill switch"):
+                self._run(manager)
+
+        ib_mock.placeOrder.assert_not_called()
+
+    def test_kill_switch_redis_flag_truthy_string_halts(self):
+        """Redis trading:kill_switch='true' → PermissionError."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        with (
+            patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}),
+            patch(KS_REDIS_PATCH, return_value=_ks_redis_engaged_val("true")),
+        ):
+            with pytest.raises(PermissionError, match="kill switch"):
+                self._run(manager)
+
+        ib_mock.placeOrder.assert_not_called()
+
+    def test_kill_switch_redis_absent_proceeds_past_ks(self):
+        """Redis returns None (key absent) → kill switch not engaged; reaches LIVE_TRADING_ARMED check."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        # Redis ok but LIVE_TRADING_ARMED=false (conftest default) → PermissionError about ARMED, not kill switch
+        with (
+            patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}),
+            patch(KS_REDIS_PATCH, return_value=_ks_redis_no_ks()),
+        ):
+            with pytest.raises(PermissionError) as exc_info:
+                self._run(manager)
+
+        # Must NOT be a kill-switch error — confirms the kill switch guard passed
+        assert "kill switch" not in str(exc_info.value).lower()
+        ib_mock.placeOrder.assert_not_called()
+
+    def test_kill_switch_redis_unreachable_fails_closed(self):
+        """Redis raises ConnectionError → fail-closed: PermissionError raised, placeOrder not called."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        def _raise_connection_error(*args, **kwargs):
+            raise ConnectionError("Redis connection refused")
+
+        with (
+            patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}),
+            patch(KS_REDIS_PATCH, side_effect=_raise_connection_error),
+        ):
+            with pytest.raises(PermissionError, match="kill switch"):
+                self._run(manager)
+
+        ib_mock.placeOrder.assert_not_called()
+
+    def test_kill_switch_env_deny_list_on_halts(self):
+        """TRADING_KILL_SWITCH='on' is not in allow-list → PermissionError (no Redis call needed)."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        with patch.dict(_os.environ, {"TRADING_KILL_SWITCH": "on"}):
+            with pytest.raises(PermissionError, match="kill switch"):
+                self._run(manager)
+
+        ib_mock.placeOrder.assert_not_called()
+
+    def test_kill_switch_env_deny_list_stop_halts(self):
+        """TRADING_KILL_SWITCH='stop' is not in allow-list → PermissionError."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        with patch.dict(_os.environ, {"TRADING_KILL_SWITCH": "stop"}):
+            with pytest.raises(PermissionError, match="kill switch"):
+                self._run(manager)
+
+        ib_mock.placeOrder.assert_not_called()
+
+    def test_kill_switch_env_deny_list_space_true_halts(self):
+        """TRADING_KILL_SWITCH=' true ' (with spaces) → stripped 'true' not in allow-list → PermissionError."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        with patch.dict(_os.environ, {"TRADING_KILL_SWITCH": " true "}):
+            with pytest.raises(PermissionError, match="kill switch"):
+                self._run(manager)
+
+        ib_mock.placeOrder.assert_not_called()
+
+    def test_kill_switch_env_allow_list_false_passes(self):
+        """TRADING_KILL_SWITCH='false' is in allow-list → env not engaged; reaches LIVE_TRADING_ARMED."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        with (
+            patch.dict(_os.environ, {"TRADING_KILL_SWITCH": "false"}),
+            patch(KS_REDIS_PATCH, return_value=_ks_redis_no_ks()),
+        ):
+            with pytest.raises(PermissionError) as exc_info:
+                self._run(manager)
+
+        assert "kill switch" not in str(exc_info.value).lower()
+        ib_mock.placeOrder.assert_not_called()
+
+    def test_kill_switch_env_allow_list_zero_passes(self):
+        """TRADING_KILL_SWITCH='0' is in allow-list → env not engaged; reaches LIVE_TRADING_ARMED."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        with (
+            patch.dict(_os.environ, {"TRADING_KILL_SWITCH": "0"}),
+            patch(KS_REDIS_PATCH, return_value=_ks_redis_no_ks()),
+        ):
+            with pytest.raises(PermissionError) as exc_info:
+                self._run(manager)
+
+        assert "kill switch" not in str(exc_info.value).lower()
+        ib_mock.placeOrder.assert_not_called()
+
+    # ── Notional cap / bounds guard new tests ─────────────────────────────────
+
+    def test_notional_cap_short_market_order_uses_max_price(self):
+        """SHORT market order: entry=None, target=80.0, stop=110.0.
+
+        Old code: notional = qty * target = 90 * 80 = 7_200 (under 10_000 cap → passes).
+        New code: price_basis = max(None-excluded, 80.0, 110.0) = 110.0.
+                  notional = 90 * 110 = 9_900 (under cap → still passes).
+
+        Use qty=100, stop=105 so new code rejects (100*105=10_500 > 10_000).
+        """
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        armed = self._armed_settings()
+
+        with (
+            patch("app.providers.ibkr_orders.settings", armed),
+            patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}),
+            patch(KS_REDIS_PATCH, return_value=_ks_redis_no_ks()),
+        ):
+            # qty=100, entry=None (market), target=80.0, stop=105.0
+            # old notional = 100 * 80 = 8_000 (would PASS old cap)
+            # new notional = 100 * max(80.0, 105.0) = 100 * 105 = 10_500 (EXCEEDS new cap)
+            with pytest.raises(ValueError, match="notional cap"):
+                import asyncio as _asyncio
+
+                loop = _asyncio.new_event_loop()
+                try:
+                    loop.run_until_complete(
+                        manager.place_bracket_order(
+                            symbol="TSLA",
+                            side="short",
+                            quantity=100,
+                            entry_price=None,  # market order
+                            stop_price=105.0,
+                            target_price=80.0,
+                        )
+                    )
+                finally:
+                    loop.close()
+
+        ib_mock.placeOrder.assert_not_called()
+
+    def test_quantity_zero_raises(self):
+        """quantity=0 must raise ValueError."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        armed = self._armed_settings()
+
+        with (
+            patch("app.providers.ibkr_orders.settings", armed),
+            patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}),
+            patch(KS_REDIS_PATCH, return_value=_ks_redis_no_ks()),
+        ):
+            with pytest.raises(ValueError, match="quantity must be positive"):
+                self._run(manager, quantity=0, entry_price=100.0)
+
+        ib_mock.placeOrder.assert_not_called()
+
+    def test_quantity_negative_raises(self):
+        """quantity=-1 must raise ValueError."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        armed = self._armed_settings()
+
+        with (
+            patch("app.providers.ibkr_orders.settings", armed),
+            patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}),
+            patch(KS_REDIS_PATCH, return_value=_ks_redis_no_ks()),
+        ):
+            with pytest.raises(ValueError, match="quantity must be positive"):
+                self._run(manager, quantity=-1, entry_price=100.0)
+
+        ib_mock.placeOrder.assert_not_called()
+
+    def test_effective_price_zero_raises(self):
+        """entry=None, target=0.0, stop=0.0 → price_basis=0 → ValueError."""
+        import os as _os
+
+        manager = self._make_manager()
+        ib_mock = self._attach_ib_mock(manager)
+
+        armed = self._armed_settings()
+
+        with (
+            patch("app.providers.ibkr_orders.settings", armed),
+            patch.dict(_os.environ, {"TRADING_KILL_SWITCH": ""}),
+            patch(KS_REDIS_PATCH, return_value=_ks_redis_no_ks()),
+        ):
+            with pytest.raises(ValueError, match="price basis must be positive"):
+                import asyncio as _asyncio
+
+                loop = _asyncio.new_event_loop()
+                try:
+                    loop.run_until_complete(
+                        manager.place_bracket_order(
+                            symbol="AAPL",
+                            side="long",
+                            quantity=10,
+                            entry_price=None,
+                            stop_price=0.0,
+                            target_price=0.0,
+                        )
+                    )
+                finally:
+                    loop.close()
 
         ib_mock.placeOrder.assert_not_called()

--- a/backend/tests/services/test_auto_trade_service.py
+++ b/backend/tests/services/test_auto_trade_service.py
@@ -39,6 +39,7 @@ def _gate_assessment(verdict_str: str):
     a.warnings = []
     return a
 
+
 # ── helpers ────────────────────────────────────────────────────────────────
 
 
@@ -165,7 +166,9 @@ def _event_with_run(db, ticker="AAPL", scanner_run_id_override=None):
         criteria_met={},
         metadata_={"session": "pre_market"},
         opening_price=Decimal("50.00"),
-        scanner_run_id=scanner_run_id_override if scanner_run_id_override is not None else run.id,
+        scanner_run_id=scanner_run_id_override
+        if scanner_run_id_override is not None
+        else run.id,
     )
     db.add(ev)
     db.flush()
@@ -334,6 +337,7 @@ def test_maybe_execute_live_mode_isolates_ibkr(db: Session):
         requires_approval=False,
         max_concurrent_positions=10,
         max_trades_per_day=10,
+        max_position_usd=Decimal("5000.0"),
     )
     rule = _rule(db, strategy)
     event = _event(db)
@@ -614,3 +618,76 @@ def test_quality_gate_blocked_refuses_even_with_bypass(db: Session):
 
     assert order is None
     assert db.query(AutoTradeOrder).count() == 0
+
+
+# ── Guard 1b: max_position_usd required for live strategies ───────────────────
+
+
+class TestMaybeExecuteMaxPositionGuard:
+    """Execution-time guard: live strategy with no max_position_usd returns None (R3)."""
+
+    def test_maybe_execute_rejects_live_strategy_without_max_position(self, db):
+        from app.models.scanner_event import ScannerEvent
+        from app.models.system_config import SystemConfig
+
+        # AUTO_TRADING_ENABLED=true so it passes the kill-switch check for live strategies
+        db.add(SystemConfig(key="AUTO_TRADING_ENABLED", value="true"))
+        strat = _strategy(db, paper_mode=False, max_position_usd=None)
+
+        rule = AlertRule(
+            name="Live Guard Test",
+            auto_trade=True,
+            trading_strategy_id=strat.id,
+        )
+        db.add(rule)
+        event = ScannerEvent(
+            ticker="AAPL",
+            scanner_type="pre_market_volume_spike",
+            event_date=date.today(),
+            indicators={"last_trade_price": 150.0},
+        )
+        db.add(event)
+        db.flush()
+
+        fake_r = fakeredis.FakeRedis(decode_responses=True)
+        executor = AutoTradeExecutor()
+
+        with patch("redis.from_url", return_value=fake_r):
+            result = executor.maybe_execute(rule=rule, event=event, db=db)
+
+        assert result is None, "Live strategy missing max_position_usd must be rejected"
+
+
+class TestPaperOrderNeverCallsPlaceBracketOrder:
+    """Paper mode must never invoke place_bracket_order — validates the upstream invariant (R-V-8)."""
+
+    def test_paper_order_never_calls_place_bracket_order(self, db):
+        from app.models.scanner_event import ScannerEvent
+
+        strat = _strategy(db, paper_mode=True, max_position_usd=Decimal("5000.0"))
+        rule = AlertRule(
+            name="Paper Invariant Test",
+            auto_trade=True,
+            trading_strategy_id=strat.id,
+        )
+        db.add(rule)
+        event = ScannerEvent(
+            ticker="TSLA",
+            scanner_type="pre_market_volume_spike",
+            event_date=date.today(),
+            indicators={"last_trade_price": 200.0},
+        )
+        db.add(event)
+        db.flush()
+
+        fake_r = fakeredis.FakeRedis(decode_responses=True)
+        executor = AutoTradeExecutor()
+
+        with patch("redis.from_url", return_value=fake_r):
+            with patch(
+                "app.providers.ibkr_orders.IBKROrderManager.place_bracket_order",
+                new_callable=AsyncMock,
+            ) as mock_place:
+                executor.maybe_execute(rule=rule, event=event, db=db)
+
+        mock_place.assert_not_called()

--- a/backend/tests/services/test_auto_trade_service.py
+++ b/backend/tests/services/test_auto_trade_service.py
@@ -624,16 +624,15 @@ def test_quality_gate_blocked_refuses_even_with_bypass(db: Session):
 
 
 class TestMaybeExecuteMaxPositionGuard:
-    """Execution-time guard: live strategy with no max_position_usd returns None (R3)."""
+    """Execution-time guard: live strategy with no or invalid max_position_usd returns None (R3)."""
 
-    def test_maybe_execute_rejects_live_strategy_without_max_position(self, db):
+    def _setup(self, db, max_position_usd=None):
+        """Create AUTO_TRADING_ENABLED=true, a live strategy, rule, and event."""
         from app.models.scanner_event import ScannerEvent
         from app.models.system_config import SystemConfig
 
-        # AUTO_TRADING_ENABLED=true so it passes the kill-switch check for live strategies
         db.add(SystemConfig(key="AUTO_TRADING_ENABLED", value="true"))
-        strat = _strategy(db, paper_mode=False, max_position_usd=None)
-
+        strat = _strategy(db, paper_mode=False, max_position_usd=max_position_usd)
         rule = AlertRule(
             name="Live Guard Test",
             auto_trade=True,
@@ -648,14 +647,63 @@ class TestMaybeExecuteMaxPositionGuard:
         )
         db.add(event)
         db.flush()
+        return strat, rule, event
 
-        fake_r = fakeredis.FakeRedis(decode_responses=True)
+    def test_maybe_execute_rejects_live_strategy_without_max_position(self, db):
+        """guard 1b: max_position_usd=None → returns None.
+
+        Uses _get_account_equity mocked to positive equity so the ONLY reason
+        maybe_execute returns None is the max_position_usd guard (not a missing
+        account-equity fallback).  If the guard is removed the code proceeds to
+        create an order and returns it — the assertion then FAILS, making the test
+        non-vacuous.
+        """
+        strat, rule, event = self._setup(db, max_position_usd=None)
         executor = AutoTradeExecutor()
 
-        with patch("redis.from_url", return_value=fake_r):
+        with (
+            patch(REDIS_PATCH, return_value=_fake_redis()),
+            patch.object(executor, "_get_account_equity", return_value=100_000.0),
+            patch.object(executor, "_submit_to_ibkr") as mock_submit,
+        ):
             result = executor.maybe_execute(rule=rule, event=event, db=db)
 
         assert result is None, "Live strategy missing max_position_usd must be rejected"
+        mock_submit.assert_not_called()
+
+    def test_maybe_execute_rejects_live_strategy_with_zero_max_position(self, db):
+        """guard 1b: max_position_usd=0 → returns None (FIX 5: reject <= 0)."""
+        from decimal import Decimal
+
+        strat, rule, event = self._setup(db, max_position_usd=Decimal("0"))
+        executor = AutoTradeExecutor()
+
+        with (
+            patch(REDIS_PATCH, return_value=_fake_redis()),
+            patch.object(executor, "_get_account_equity", return_value=100_000.0),
+            patch.object(executor, "_submit_to_ibkr") as mock_submit,
+        ):
+            result = executor.maybe_execute(rule=rule, event=event, db=db)
+
+        assert result is None, "Live strategy with max_position_usd=0 must be rejected"
+        mock_submit.assert_not_called()
+
+    def test_maybe_execute_rejects_live_strategy_with_negative_max_position(self, db):
+        """guard 1b: max_position_usd=-100 → returns None (FIX 5: reject <= 0)."""
+        from decimal import Decimal
+
+        strat, rule, event = self._setup(db, max_position_usd=Decimal("-100"))
+        executor = AutoTradeExecutor()
+
+        with (
+            patch(REDIS_PATCH, return_value=_fake_redis()),
+            patch.object(executor, "_get_account_equity", return_value=100_000.0),
+            patch.object(executor, "_submit_to_ibkr") as mock_submit,
+        ):
+            result = executor.maybe_execute(rule=rule, event=event, db=db)
+
+        assert result is None, "Live strategy with max_position_usd<0 must be rejected"
+        mock_submit.assert_not_called()
 
 
 class TestPaperOrderNeverCallsPlaceBracketOrder:

--- a/grafana/provisioning/alerting/rules.yaml
+++ b/grafana/provisioning/alerting/rules.yaml
@@ -231,3 +231,36 @@ groups:
             model:
               type: math
               expression: $B > 0.1
+
+  - name: LiveTrading
+    orgId: 1
+    folder: MarketHawk
+    interval: 1m
+    rules:
+      - uid: live-order-placed
+        title: Live Order Placed
+        condition: C
+        for: 0m
+        annotations:
+          summary: >
+            A live bracket order was submitted to IBKR.
+            Symbol: {{ $labels.symbol }}, Side: {{ $labels.side }}
+        labels:
+          severity: critical
+        data:
+          - refId: B
+            relativeTimeRange:
+              from: 60
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: rate(live_orders_total[1m])
+              refId: B
+          - refId: C
+            relativeTimeRange:
+              from: 60
+              to: 0
+            datasourceUid: "-- Grafana --"
+            model:
+              type: math
+              expression: $B > 0


### PR DESCRIPTION
## ⚠️ LIVE-MONEY ORDER PATH — Awaiting human approval before merge

**Breaking default: `LIVE_TRADING_ARMED=False` + caps disarm any currently-live container — set env before deploy.**

Any container currently placing live IBKR orders **must** set `LIVE_TRADING_ARMED=true` in its environment before deploying this change, or live order placement will be blocked with `PermissionError`.

---

## Summary

Closes #368 (Epic #372 — F-TRADE-01: Hard guards on the live IBKR order path)

Adds four non-bypassable security controls at the single `place_bracket_order` chokepoint — the only code path that calls `ib.placeOrder`. These guards fire **before** any IBKR connection opens and cannot be bypassed by flipping API-mutable DB config (`AUTO_TRADING_ENABLED`, `paper_mode`, `requires_approval`).

**New guards (all env-level, not API-settable):**
- `LIVE_TRADING_ARMED=false` — must be explicitly `true` to allow real orders (default: off)
- `TRADING_KILL_SWITCH` — set to `1`/`true`/`yes` at runtime to halt all live orders instantly without restart
- `MAX_ORDER_NOTIONAL=10000` — hard USD notional cap per order; raises `ValueError` if exceeded
- `MAX_ORDER_QTY=200` — hard shares cap per order; raises `ValueError` if exceeded

**Also ships:**
- `max_position_usd` required at execution time (`maybe_execute` returns `None` for live strategies missing it — R3 defence-in-depth)
- `POST`/`PATCH /api/v1/trading/strategies` returns HTTP 422 if `paper_mode=False` and `max_position_usd` is absent
- WARN-level Seq audit log on every live order placement (all guards passed)
- `live_orders_total` Prometheus counter labelled by `symbol` + `side`
- `LiveOrderPlaced` Grafana alert rule (`severity: critical`, fires immediately)
- `ENV_VARIABLES.md` documentation for all four new env vars
- R5 verified: `LIVE_TRADING_ARMED` is **not** in `PATCH /config` allowed keys — no code change needed

## New environment variables

| Variable | Default | Breaking? |
|----------|---------|-----------|
| `LIVE_TRADING_ARMED` | `false` | **Yes** — any live container must set `true` before deploy |
| `TRADING_KILL_SWITCH` | unset (off) | No |
| `MAX_ORDER_NOTIONAL` | `10000.0` | Potentially — live accounts trading > $10k notional must override |
| `MAX_ORDER_QTY` | `200` | Potentially — live accounts trading > 200 shares must override |

## Test plan

- [x] 8 new TDD tests: `TestPlaceBracketOrderGuards` (4 tests), `TestMaybeExecuteMaxPositionGuard` (1), `TestPaperOrderNeverCallsPlaceBracketOrder` (1), `TestStrategyLiveRequiresMaxPosition` (2)
- [x] All 60 related tests pass (no regressions in ibkr_orders, auto_trade_service, auto_trading modules)
- [x] `ruff check` + `ruff format --check` clean on all 9 changed Python files
- [x] Grafana YAML validated via `yaml.safe_load`
- [x] R5 audit: `LIVE_TRADING_ARMED` absent from `allowed` set and `keys` list in `update_trading_config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
