### PR TITLE
docs(pipeline): refresh pipeline report (v2) + v1→v2 comparison

### DIFF
--- a/docs/pipeline-report-comparison-2026-06-04-vs-2026-06-26.html
+++ b/docs/pipeline-report-comparison-2026-06-04-vs-2026-06-26.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MarketHawk — Pipeline Report: 22 Days Later (v1 → v2)</title>
+<style>
+  :root{
+    --bg:#0a0b0e; --bg2:#0e1015; --panel:#13151d; --panel2:#181b24;
+    --line:rgba(255,255,255,.08); --line2:rgba(255,255,255,.14);
+    --ink:#eceef3; --mut:#9aa0ad; --mut2:#6b7280;
+    --amber:#ff8a3d; --amber-hot:#ff6a1a; --amber-soft:#ffc08a;
+    --cyan:#3fe0c8; --cyan-soft:#8af0e2;
+    --green:#54d18a; --red:#ff6b6b; --violet:#a78bfa;
+    --mono: ui-monospace,"Cascadia Code","SF Mono",Menlo,Consolas,monospace;
+    --sans: system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    --grad: linear-gradient(135deg,var(--amber-hot),var(--amber-soft));
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.5;
+       background-image:radial-gradient(1200px 600px at 70% -10%, rgba(255,138,61,.06), transparent 60%);}
+  .wrap{max-width:1080px;margin:0 auto;padding:2.5rem 1.4rem 4rem}
+  .mono{font-family:var(--mono)}
+  .eyebrow{font-family:var(--mono);font-size:.72rem;letter-spacing:.18em;text-transform:uppercase;color:var(--amber-soft)}
+  h1{font-size:2.5rem;line-height:1.1;margin:.4rem 0 .6rem;font-weight:800;
+     background:var(--grad);-webkit-background-clip:text;background-clip:text;color:transparent}
+  h2{font-family:var(--mono);font-size:.95rem;letter-spacing:.12em;text-transform:uppercase;color:var(--amber);
+     margin:2.6rem 0 .9rem;padding-top:1.2rem;border-top:1px solid var(--line)}
+  .sub{color:var(--mut);max-width:64ch}
+  .chips{display:flex;flex-wrap:wrap;gap:.5rem;margin:1rem 0 .4rem}
+  .chip{font-family:var(--mono);font-size:.72rem;color:var(--mut);background:var(--panel);
+        border:1px solid var(--line);border-radius:999px;padding:.3rem .7rem}
+  .thesis{margin-top:1.2rem;padding:1.1rem 1.2rem;background:var(--panel);border:1px solid var(--line);
+           border-left:3px solid var(--amber);border-radius:10px;color:var(--ink)}
+  .grid{display:grid;gap:.8rem}
+  .kpis{grid-template-columns:repeat(3,1fr)}
+  @media(max-width:720px){.kpis{grid-template-columns:repeat(2,1fr)}}
+  .tile{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:1rem 1.1rem}
+  .tile .lbl{font-family:var(--mono);font-size:.68rem;letter-spacing:.1em;text-transform:uppercase;color:var(--mut2)}
+  .tile .old{color:var(--mut2);text-decoration:line-through;font-size:.85rem;font-family:var(--mono)}
+  .tile .new{font-size:1.8rem;font-weight:800;font-family:var(--mono);line-height:1.1;margin-top:.15rem}
+  .pill{display:inline-block;font-family:var(--mono);font-size:.7rem;font-weight:700;border-radius:999px;
+        padding:.16rem .5rem;margin-top:.45rem}
+  .pill.up{background:rgba(84,209,138,.14);color:var(--green);border:1px solid rgba(84,209,138,.3)}
+  .pill.warn{background:rgba(255,107,107,.13);color:var(--red);border:1px solid rgba(255,107,107,.3)}
+  .pill.flat{background:rgba(154,160,173,.12);color:var(--mut);border:1px solid var(--line2)}
+  .pill.info{background:rgba(63,224,200,.12);color:var(--cyan);border:1px solid rgba(63,224,200,.3)}
+  .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:1.2rem 1.3rem;margin-top:.4rem}
+  .row{display:grid;grid-template-columns:140px 1fr 70px;align-items:center;gap:.6rem;margin:.32rem 0;font-size:.82rem}
+  .row .name{font-family:var(--mono);color:var(--mut);text-align:right;font-size:.76rem}
+  .row .val{font-family:var(--mono);color:var(--ink);text-align:right}
+  .bartrack{position:relative;height:20px;background:var(--bg2);border:1px solid var(--line);border-radius:5px;overflow:hidden}
+  .bar{position:absolute;left:0;top:0;bottom:0;border-radius:4px}
+  .bar.v1{background:rgba(154,160,173,.35);height:8px;top:2px}
+  .bar.v2{background:var(--grad);height:8px;bottom:2px}
+  .wk{display:grid;grid-template-columns:84px 1fr 1fr;gap:.5rem;align-items:center;margin:.28rem 0;font-size:.78rem}
+  .wk .w{font-family:var(--mono);color:var(--mut2);font-size:.72rem}
+  .wkbar{position:relative;height:16px;background:var(--bg2);border:1px solid var(--line);border-radius:4px;overflow:hidden}
+  .wkbar > span{position:absolute;left:0;top:0;bottom:0}
+  .legend{display:flex;gap:1.2rem;font-family:var(--mono);font-size:.72rem;color:var(--mut);margin:.2rem 0 .8rem}
+  .legend i{display:inline-block;width:18px;height:8px;border-radius:3px;vertical-align:middle;margin-right:.35rem}
+  .new-chip{font-family:var(--mono);font-size:.6rem;font-weight:700;color:var(--violet);
+            background:rgba(167,139,250,.14);border:1px solid rgba(167,139,250,.35);border-radius:999px;padding:.05rem .4rem;margin-left:.4rem}
+  .verdict{background:linear-gradient(135deg,rgba(255,106,26,.10),rgba(255,192,138,.05));
+           border:1px solid var(--line2);border-left:3px solid var(--amber);border-radius:12px;padding:1.3rem 1.4rem;margin-top:.5rem}
+  .two{display:grid;grid-template-columns:1fr 1fr;gap:.8rem}
+  @media(max-width:720px){.two{grid-template-columns:1fr}}
+  .big{font-size:2rem;font-weight:800;font-family:var(--mono)}
+  footer{margin-top:3rem;padding-top:1.2rem;border-top:1px solid var(--line);color:var(--mut2);
+         font-family:var(--mono);font-size:.72rem}
+  a{color:var(--cyan)}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="eyebrow">MarketHawk · Dark Factory delivery pipeline · comparison</div>
+  <h1>Pipeline Report — 22 Days Later</h1>
+  <div class="sub mono" style="color:var(--mut)">v1 (2026-06-04) &nbsp;→&nbsp; v2 (2026-06-26)</div>
+  <div class="chips">
+    <span class="chip">window: 2026-06-04 → 2026-06-26 (~22 days)</span>
+    <span class="chip">+260 issues tracked</span>
+    <span class="chip">×4.9 cumulative AI spend</span>
+    <span class="chip">autonomy 30% → 43%</span>
+  </div>
+  <div class="thesis">
+    The autonomous production line scaled roughly <strong>3× in throughput</strong> and
+    <strong>~5× in cumulative AI spend</strong> while holding <strong>cost-per-ticket essentially flat (~$6.5)</strong>
+    and lifting the autonomous share from <strong>30% → 43%</strong>. The typical ticket got
+    <strong>slower</strong> (median lead 30h → 49h) as the factory added quality gates — but the
+    <strong>worst-case tail tightened</strong> (p85 226h → 201h): more consistent delivery, fewer extreme stragglers,
+    at the price of a higher median.
+  </div>
+
+  <h2>① Headline KPIs</h2>
+  <div class="grid kpis">
+    <div class="tile"><div class="lbl">Issues tracked</div><div class="old">116</div><div class="new">376</div><span class="pill info">×3.2 · +260</span></div>
+    <div class="tile"><div class="lbl">Issues shipped (closed)</div><div class="old">93</div><div class="new">285</div><span class="pill info">×3.1 · +192</span></div>
+    <div class="tile"><div class="lbl">Open backlog</div><div class="old">23</div><div class="new">91</div><span class="pill flat">+68 (creation-led)</span></div>
+    <div class="tile"><div class="lbl">Autonomous tickets</div><div class="old">35</div><div class="new">162</div><span class="pill up">×4.6 · +127</span></div>
+    <div class="tile"><div class="lbl">% autonomous</div><div class="old">30.2%</div><div class="new">43.1%</div><span class="pill up">+12.9 pts</span></div>
+    <div class="tile"><div class="lbl">Total AI spend</div><div class="old">$214.56</div><div class="new">$1,053.30</div><span class="pill info">×4.9 · +$839</span></div>
+    <div class="tile"><div class="lbl">Avg cost / ticket</div><div class="old">$6.13</div><div class="new">$6.50</div><span class="pill flat">+6% · ~flat</span></div>
+    <div class="tile"><div class="lbl">Median lead time</div><div class="old">30.1 h</div><div class="new">49.3 h</div><span class="pill warn">+64% · slower</span></div>
+    <div class="tile"><div class="lbl">p85 lead time</div><div class="old">226.0 h</div><div class="new">200.6 h</div><span class="pill up">−11% · tighter tail</span></div>
+  </div>
+
+  <h2>② Throughput &amp; flow — created vs. closed per week</h2>
+  <div class="card">
+    <div class="legend"><span><i style="background:var(--amber)"></i>created</span><span><i style="background:var(--cyan)"></i>closed</span><span class="mono" style="color:var(--mut2)">bar width ∝ count (max 176, week of 06-08)</span></div>
+    <!-- scale: 176 -> 100% ; px width via calc on % -->
+    <div class="wk"><span class="w">04-27</span><div class="wkbar"><span style="width:8.5%;background:var(--amber)"></span></div><div class="wkbar"><span style="width:0.6%;background:var(--cyan)"></span></div></div>
+    <div class="wk"><span class="w">05-04</span><div class="wkbar"><span style="width:5.7%;background:var(--amber)"></span></div><div class="wkbar"><span style="width:1.7%;background:var(--cyan)"></span></div></div>
+    <div class="wk"><span class="w">05-11</span><div class="wkbar"><span style="width:1.7%;background:var(--amber)"></span></div><div class="wkbar"><span style="width:10.8%;background:var(--cyan)"></span></div></div>
+    <div class="wk"><span class="w">05-18</span><div class="wkbar"><span style="width:4.0%;background:var(--amber)"></span></div><div class="wkbar"><span style="width:6.3%;background:var(--cyan)"></span></div></div>
+    <div class="wk"><span class="w">05-25</span><div class="wkbar"><span style="width:20.5%;background:var(--amber)"></span></div><div class="wkbar"><span style="width:17.6%;background:var(--cyan)"></span></div></div>
+    <div class="wk"><span class="w">06-01</span><div class="wkbar"><span style="width:46.6%;background:var(--amber)"></span></div><div class="wkbar"><span style="width:27.8%;background:var(--cyan)"></span></div></div>
+    <div class="wk"><span class="w">06-08</span><div class="wkbar"><span style="width:100%;background:var(--amber)"></span></div><div class="wkbar"><span style="width:63.1%;background:var(--cyan)"></span></div></div>
+    <div class="wk"><span class="w">06-15</span><div class="wkbar"><span style="width:18.8%;background:var(--amber)"></span></div><div class="wkbar"><span style="width:20.5%;background:var(--cyan)"></span></div></div>
+    <div class="wk"><span class="w">06-22</span><div class="wkbar"><span style="width:8.0%;background:var(--amber)"></span></div><div class="wkbar"><span style="width:13.6%;background:var(--cyan)"></span></div></div>
+    <p class="sub" style="margin-top:1rem;font-size:.85rem">v1 ended at the <span class="mono">06-01</span> week (cum-closed 93, backlog 23). v2 adds a <strong>176-created / 111-closed surge the week of 06-08</strong> (backlog peaks at 104), then <strong>closes outrun creates</strong> in the final two weeks (06-15: 33/36, 06-22: 14/24) — backlog declining 104 → 101 → 91. Cumulative closed: <span class="mono">93 → 285</span>.</p>
+  </div>
+
+  <h2>③ AI cost — cumulative + by pipeline step</h2>
+  <div class="two">
+    <div class="card">
+      <div class="lbl mono" style="color:var(--mut2);font-size:.7rem;letter-spacing:.1em">CUMULATIVE SPEND</div>
+      <div class="big" style="margin:.3rem 0;color:var(--amber-soft)">$214.56 → $1,053.30</div>
+      <div class="bartrack" style="height:14px"><div class="bar" style="height:100%;width:20.4%;background:rgba(154,160,173,.4)"></div></div>
+      <div class="mono" style="font-size:.68rem;color:var(--mut2);margin:.2rem 0 .6rem">v1 was 20% of today's spend</div>
+      <div class="bartrack" style="height:14px"><div class="bar" style="height:100%;width:100%;background:var(--grad)"></div></div>
+      <p class="sub" style="font-size:.82rem;margin-top:.7rem">+$838.74 over ~22 days. Cost-per-ticket held flat (~$6.5), so spend grew with <em>volume</em>, not waste.</p>
+    </div>
+    <div class="card">
+      <div class="lbl mono" style="color:var(--mut2);font-size:.7rem;letter-spacing:.1em">TOKENS / EFFICIENCY READ</div>
+      <p class="sub" style="font-size:.85rem">Average <span class="mono">$6.13 → $6.50</span> per autonomous ticket — a 6% drift despite 4.6× more autonomous runs and added gates. The pipeline stayed cost-efficient as it scaled; the new spend is throughput, not regression.</p>
+      <p class="sub" style="font-size:.85rem;margin-top:.6rem">% autonomous climbed <span class="mono">30.2% → 43.1%</span> — a larger fraction of delivery now flows through the factory rather than by hand.</p>
+    </div>
+  </div>
+  <div class="card">
+    <div class="legend"><span><i style="background:rgba(154,160,173,.5)"></i>v1 ($)</span><span><i style="background:var(--amber)"></i>v2 ($)</span><span class="mono" style="color:var(--mut2)">bar ∝ $ (max $319, implement)</span></div>
+    <div class="row"><span class="name">implement</span><div class="bartrack"><div class="bar v1" style="width:25.3%"></div><div class="bar v2" style="width:100%"></div></div><span class="val">$319</span></div>
+    <div class="row"><span class="name">plan</span><div class="bartrack"><div class="bar v1" style="width:23.5%"></div><div class="bar v2" style="width:83.1%"></div></div><span class="val">$265</span></div>
+    <div class="row"><span class="name">refine</span><div class="bartrack"><div class="bar v1" style="width:6.2%"></div><div class="bar v2" style="width:70.0%"></div></div><span class="val">$223</span></div>
+    <div class="row"><span class="name">conformance</span><div class="bartrack"><div class="bar v1" style="width:4.7%"></div><div class="bar v2" style="width:41.7%"></div></div><span class="val">$133</span></div>
+    <div class="row"><span class="name">code-review<span class="new-chip">NEW</span></span><div class="bartrack"><div class="bar v1" style="width:0%"></div><div class="bar v2" style="width:16.6%"></div></div><span class="val">$53</span></div>
+    <div class="row"><span class="name">validate</span><div class="bartrack"><div class="bar v1" style="width:6.7%"></div><div class="bar v2" style="width:13.5%"></div></div><span class="val">$43</span></div>
+    <div class="row"><span class="name">parse-intent</span><div class="bartrack"><div class="bar v1" style="width:0.4%"></div><div class="bar v2" style="width:2.2%"></div></div><span class="val">$7</span></div>
+    <div class="row"><span class="name">classify-preview</span><div class="bartrack"><div class="bar v1" style="width:0.2%"></div><div class="bar v2" style="width:1.5%"></div></div><span class="val">$5</span></div>
+    <div class="row"><span class="name">revise-advisory<span class="new-chip">NEW</span></span><div class="bartrack"><div class="bar v1" style="width:0%"></div><div class="bar v2" style="width:1.0%"></div></div><span class="val">$3</span></div>
+    <p class="sub" style="margin-top:1rem;font-size:.85rem">The cost <em>shape</em> changed: <strong>refine ×11.3</strong> ($20→$223) and <strong>conformance ×8.8</strong> ($15→$133) grew far faster than implement (×4.0) — the factory poured spend into <strong>refinement and conformance gates</strong>. New stages appeared: <span class="mono">code-review</span> ($53), <span class="mono">revise-advisory</span>, <span class="mono">de-conflict</span>, <span class="mono">bench-mode-probe</span> — the pipeline added review/verification machinery it didn't have at v1.</p>
+  </div>
+
+  <h2>④ Speed — median vs. p85 lead time</h2>
+  <div class="card">
+    <div class="row"><span class="name">median (v1)</span><div class="bartrack"><div class="bar" style="height:100%;width:13.3%;background:rgba(154,160,173,.4)"></div></div><span class="val">30.1 h</span></div>
+    <div class="row"><span class="name">median (v2)</span><div class="bartrack"><div class="bar" style="height:100%;width:21.8%;background:var(--red)"></div></div><span class="val">49.3 h</span></div>
+    <div class="row"><span class="name">p85 (v1)</span><div class="bartrack"><div class="bar" style="height:100%;width:100%;background:rgba(154,160,173,.4)"></div></div><span class="val">226 h</span></div>
+    <div class="row"><span class="name">p85 (v2)</span><div class="bartrack"><div class="bar" style="height:100%;width:88.8%;background:var(--green)"></div></div><span class="val">201 h</span></div>
+    <p class="sub" style="margin-top:1rem;font-size:.85rem"><strong>Median up, p85 down.</strong> The middle of the distribution slowed (more tickets now pass through code-review + conformance gates), but the long tail tightened by 11% — the factory produces <strong>more consistent</strong> outcomes with fewer multi-day stragglers. A classic throughput-vs-latency trade as quality gates land.</p>
+  </div>
+
+  <h2>⑤ Verdict</h2>
+  <div class="verdict">
+    <p style="margin-top:0"><strong>The autonomous line scaled hard and stayed cost-disciplined.</strong> Over 22 days it tripled throughput (93 → 285 shipped), nearly quintupled spend (driven by volume, not unit cost), and moved from a 30%-autonomous operation to 43%. Cost-per-ticket barely moved (~$6.5), which is the headline efficiency signal: the factory got bigger without getting wasteful.</p>
+    <p>The honest cost of that maturity is a <strong>slower median ticket</strong> (30h → 49h) — the price of the new <span class="mono">code-review</span>, <span class="mono">conformance</span>, and <span class="mono">refine</span> gates (the three fastest-growing cost centers). It bought a tighter worst-case tail (p85 −11%) and presumably higher merge quality. <strong>The two leading indicators to watch next:</strong> cost-per-ticket (keep it flat as volume grows) and median lead time (don't let gate-stacking push it past the point of diminishing returns).</p>
+  </div>
+
+  <footer>
+    Comparison of two point-in-time snapshots of <span class="mono">docs/pipeline-report.html</span> — v1 generated 2026-06-05 (data @ 2026-06-04), v2 generated 2026-06-26 (main @ 56ab037). Figures from the committed <span class="mono">metrics.json</span> snapshots (v1 from git history). Cost/health metrics cover the autonomous subset (35 → 162 cost-reported tickets); throughput/speed cover all tracked issues. Self-contained · regenerate via <span class="mono">scripts/generate.sh</span>.
+  </footer>
+
+</div>
+</body>
+</html>

--- a/docs/pipeline-report.html
+++ b/docs/pipeline-report.html
@@ -361,32 +361,7051 @@ var Vr={},Br={};var Fr=function(){function t(t,e,n){var i=this;this._sleepAfterS
 <script>
 // ── Inject metrics data ──────────────────────────────────────────────────────
 window.__METRICS__ = {
-  "generated_at": "2026-06-05T00:22:40.421551+00:00",
+  "generated_at": "2026-06-26T13:30:11.192065+00:00",
   "summary": {
-    "total_issues": 116,
-    "closed_issues": 93,
-    "open_issues": 23,
-    "autonomous_issues": 35,
-    "pct_autonomous": 30.2,
-    "total_cost_usd": 214.5591,
-    "avg_cost_per_ticket": 6.1303,
-    "median_lead_time_hours": 30.072222222222223,
-    "p85_lead_time_hours": 225.98916666666668
+    "total_issues": 376,
+    "closed_issues": 285,
+    "open_issues": 91,
+    "autonomous_issues": 162,
+    "pct_autonomous": 43.1,
+    "total_cost_usd": 1053.3008,
+    "avg_cost_per_ticket": 6.5019,
+    "median_lead_time_hours": 49.34166666666667,
+    "p85_lead_time_hours": 200.56527777777777
   },
   "issues": [
     {
-      "number": 215,
-      "title": "test: add P1.5-1 increment_retry and P1.5-5 trip_to_blocked scheduler tests",
+      "number": 633,
+      "title": "architecture-v4: QualityGatePolicy interface to decouple gate evidence (3-modules-per-type)",
       "state": "OPEN",
-      "created_at": "2026-06-04T18:10:33Z",
+      "created_at": "2026-06-26T12:54:53Z",
       "closed_at": null,
       "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "architecture-audit-v4"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 632,
+      "title": "architecture-v4: extract app/utils/time.py \u2014 UTC-normalization duplication at 287 sites",
+      "state": "OPEN",
+      "created_at": "2026-06-26T12:54:52Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "architecture-audit-v4"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 631,
+      "title": "architecture-v4: universe_export.py raises HTTPException from a service (SoC leak)",
+      "state": "OPEN",
+      "created_at": "2026-06-26T12:54:51Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "architecture-audit-v4"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 630,
+      "title": "architecture-v4: decompose AutoTradeExecutor.maybe_execute() (290-line / 15-branch cascade)",
+      "state": "OPEN",
+      "created_at": "2026-06-26T12:54:50Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "architecture-audit-v4"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 629,
+      "title": "main is red: tsc/python import failure",
+      "state": "OPEN",
+      "created_at": "2026-06-26T11:50:05Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 625,
+      "title": "Bridge GateIssue (evidence layer) <-> QualityGateIssue (gate service) with an explicit adapter",
+      "state": "OPEN",
+      "created_at": "2026-06-26T11:06:51Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "analytics"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 624,
+      "title": "Move backend runtime image to Python 3.14 (align with factory; deferred from #622)",
+      "state": "OPEN",
+      "created_at": "2026-06-26T11:06:49Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "infrastructure"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 622,
+      "title": "fix(dark-factory): Python 3.14 image can't pip-install sci stack (scipy 1.15.3 has no cp314 wheel) \u2014 modernize deps",
+      "state": "CLOSED",
+      "created_at": "2026-06-26T10:50:19Z",
+      "closed_at": "2026-06-26T11:12:45Z",
+      "lead_time_hours": 0.3738888888888889,
+      "factory_cycle_hours": null,
+      "labels": [
+        "infrastructure",
+        "factory-regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 618,
+      "title": "Scheduler: session-window-aware backoff \u2014 stop circuit-breaking tickets when the Claude 5h window is exhausted",
+      "state": "OPEN",
+      "created_at": "2026-06-26T10:01:21Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 616,
+      "title": "Populate ScannerEvent.scanner_run_id in the scanner (unblocks the #496 strict quality gate)",
+      "state": "OPEN",
+      "created_at": "2026-06-26T03:17:16Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 611,
+      "title": "Main-Red Auto-Fix follow-ups: dispatch guard, observability, scope hardening, config cleanup",
+      "state": "OPEN",
+      "created_at": "2026-06-26T02:04:05Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 609,
+      "title": "Dark factory improvement \u2014 apply Hermes Agent patterns (persistent daemon, prompt hardening, self-interruption)",
+      "state": "OPEN",
+      "created_at": "2026-06-25T06:28:39Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "spec-pending-review",
+        "ready-for-agent",
+        "factory-regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 607,
+      "title": "factory: rescue Blocked tickets whose PR is already green (un-strand mergeable PRs)",
+      "state": "CLOSED",
+      "created_at": "2026-06-22T13:18:22Z",
+      "closed_at": "2026-06-22T16:18:59Z",
+      "lead_time_hours": 3.0102777777777776,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "Dark Factory",
+        "factory-regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 606,
+      "title": "chaos-nightly: schedule paused \u2014 mock harness can't run on hosted CI (needs GHCR auth / self-hosted runner)",
+      "state": "OPEN",
+      "created_at": "2026-06-22T09:21:21Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "spec-pending-review",
+        "ready-for-agent",
+        "factory-regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 591,
+      "title": "Main-Red Auto-Fix \u2014 autonomous pipeline recovery",
+      "state": "CLOSED",
+      "created_at": "2026-06-21T13:44:08Z",
+      "closed_at": "2026-06-26T02:30:16Z",
+      "lead_time_hours": 108.7688888888889,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "Dark Factory",
+        "ready-for-human"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 590,
+      "title": "Epic Autopilot \u2014 broaden reach (drain backlog, start next epic)",
+      "state": "CLOSED",
+      "created_at": "2026-06-21T13:44:07Z",
+      "closed_at": "2026-06-21T15:43:26Z",
+      "lead_time_hours": 1.988611111111111,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "Dark Factory",
+        "ready-for-human"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 588,
+      "title": "Revisit dispatch ceiling (C9) \u2014 re-measure success-by-size/type",
+      "state": "OPEN",
+      "created_at": "2026-06-21T06:24:31Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "spec-pending-review",
+        "Dark Factory",
+        "ready-for-agent"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 587,
+      "title": "Revisit L=always-above-ceiling rule in is_above_ceiling() \u2014 scheduler.sh",
+      "state": "OPEN",
+      "created_at": "2026-06-21T06:24:19Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 585,
+      "title": "docs(data-quality): PROJECT_STRUCTURE.md missing data_quality.py entry after #493 scope excision",
+      "state": "CLOSED",
+      "created_at": "2026-06-21T04:09:32Z",
+      "closed_at": "2026-06-21T20:06:55Z",
+      "lead_time_hours": 15.956388888888888,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 584,
+      "title": "docs(data-quality): ARCHITECTURE.md missing data_quality.py row after #493 scope excision",
+      "state": "CLOSED",
+      "created_at": "2026-06-21T04:09:27Z",
+      "closed_at": "2026-06-21T20:06:55Z",
+      "lead_time_hours": 15.957777777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 579,
+      "title": "test(outcomes): seed_reviews fixture and 6 tests added beyond spec #303 named-file scope",
+      "state": "OPEN",
+      "created_at": "2026-06-20T20:05:47Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 578,
+      "title": "docs(outcomes): ARCHITECTURE.md updated with review_window_days/review-fields info beyond spec #303 scope",
+      "state": "CLOSED",
+      "created_at": "2026-06-20T20:05:39Z",
+      "closed_at": "2026-06-21T20:02:01Z",
+      "lead_time_hours": 23.939444444444444,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 574,
+      "title": "Revisit dispatch ceiling (C9) \u2014 re-measure success-by-size/type",
+      "state": "OPEN",
+      "created_at": "2026-06-20T14:47:52Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "spec-pending-review",
+        "Dark Factory",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.5200049500000006,
+        "in_tokens": 1265,
+        "out_tokens": 29745,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 15:03 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 573,
+      "title": "Revisit L=always-above-ceiling rule in is_above_ceiling() \u2014 scheduler.sh",
+      "state": "OPEN",
+      "created_at": "2026-06-20T14:47:39Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 571,
+      "title": "feat(scheduler): epic autopilot \u2014 bounded self-unlock with Opus review",
+      "state": "CLOSED",
+      "created_at": "2026-06-20T14:35:56Z",
+      "closed_at": "2026-06-20T16:32:41Z",
+      "lead_time_hours": 1.9458333333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "needs-discussion",
+        "infrastructure",
+        "Dark Factory"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 570,
+      "title": "feat(notifications): generic system-notification path (email/push) for non-scanner events",
+      "state": "CLOSED",
+      "created_at": "2026-06-20T14:35:23Z",
+      "closed_at": "2026-06-21T02:05:42Z",
+      "lead_time_hours": 11.505277777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "needs-discussion",
+        "infrastructure",
+        "ready-for-human"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 564,
+      "title": "chore(dark-factory): entrypoint.sh ENTRYPOINT_SOURCE_ONLY guard and arg-check scaffolding not spec-listed in #431",
+      "state": "OPEN",
+      "created_at": "2026-06-20T05:50:27Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 561,
+      "title": "chore(codeindex): docs/codeindex-hotspots.md OOS line-count refreshes committed on feature branches",
+      "state": "CLOSED",
+      "created_at": "2026-06-20T03:03:06Z",
+      "closed_at": "2026-06-20T11:09:07Z",
+      "lead_time_hours": 8.100277777777778,
+      "factory_cycle_hours": 5.101944444444444,
+      "labels": [
+        "needs-discussion",
+        "Dark Factory",
+        "direct-to-pr",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 7.6898820500000005,
+        "in_tokens": 276,
+        "out_tokens": 102106,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 06:03 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 06:49 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 07:46 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 559,
+      "title": "[security] S10: Authz regression suite + ADR + re-run security review (close F-AUTHZ-01)",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:49:44Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "documentation",
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "security",
+        "testing",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 558,
+      "title": "[security] S9: Scope backtests + news preferences to owner",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:49:25Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 557,
+      "title": "[security] S8: Scope trading strategies + auto-trade orders (incl. worker stamping)",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:49:24Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 556,
+      "title": "[security] S7: Scope scanner configs + attribute runs to owner",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:49:23Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 555,
+      "title": "[security] S6: Scope stock universes to owner",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:49:21Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 554,
+      "title": "[security] S5: Scope alerts (rules/delivery/push) to owner",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:49:20Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 553,
+      "title": "[security] S4: Scope journal/trades/tags to owner",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:49:19Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 552,
+      "title": "[security] S3: Per-user data-scoping scaffolding, proven on Watchlist (tracer bullet)",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:48:20Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 551,
+      "title": "[security] S2: Invite-based user provisioning + user-management UI",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:48:19Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "frontend",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 550,
+      "title": "[security] S1: User.role + require_admin + gate admin-only endpoints (authz tracer bullet)",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:47:51Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 549,
+      "title": "main is red: tsc/python import failure",
+      "state": "CLOSED",
+      "created_at": "2026-06-20T01:36:09Z",
+      "closed_at": "2026-06-20T02:48:16Z",
+      "lead_time_hours": 1.2019444444444445,
+      "factory_cycle_hours": null,
+      "labels": [
+        "regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 548,
+      "title": "Epic: Dark Factory platform \u2014 maintenance, telemetry & tooling",
+      "state": "CLOSED",
+      "created_at": "2026-06-19T23:58:06Z",
+      "closed_at": "2026-06-26T11:21:38Z",
+      "lead_time_hours": 155.39222222222222,
+      "factory_cycle_hours": null,
+      "labels": [
+        "epic",
+        "infrastructure"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 531,
+      "title": "[security] Remediate dark-factory image vendored-tooling CVEs (Trivy advisory)",
+      "state": "OPEN",
+      "created_at": "2026-06-19T02:52:20Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "priority: should-have",
+        "size: M",
+        "security",
+        "needs-triage",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 529,
+      "title": "[security] Triage the 5 bandit MEDIUM findings (F-CI-01 follow-up)",
+      "state": "OPEN",
+      "created_at": "2026-06-19T02:27:05Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "priority: should-have",
+        "size: S",
+        "security",
+        "needs-triage",
+        "security-audit-2026-06-12"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 527,
+      "title": "bug(dark-factory): backlog scheduler ignores project items after first page",
+      "state": "CLOSED",
+      "created_at": "2026-06-19T02:05:49Z",
+      "closed_at": "2026-06-19T02:20:30Z",
+      "lead_time_hours": 0.24472222222222223,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "size: S",
+        "Dark Factory",
+        "ready-for-human"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 526,
+      "title": "Add regime performance panel to Scorecard / Edge Explorer",
+      "state": "OPEN",
+      "created_at": "2026-06-15T16:15:15Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "ml",
+        "scanner",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.6199411999999997,
+        "in_tokens": 61,
+        "out_tokens": 16813,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 17:19 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 523,
+      "title": "cleanup(grafana): scanner-performance.json re-serialized and datasource type field stripped from existing panels",
+      "state": "OPEN",
+      "created_at": "2026-06-15T11:43:21Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 522,
+      "title": "cleanup(memory): backend-patterns.md OOS deletions \u2014 FK migration, empty-migration FIX, aggregate-stats patterns",
+      "state": "CLOSED",
+      "created_at": "2026-06-15T11:43:09Z",
+      "closed_at": "2026-06-26T10:42:11Z",
+      "lead_time_hours": 262.9838888888889,
+      "factory_cycle_hours": null,
+      "labels": [
+        "spec-pending-review",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 521,
+      "title": "cleanup(dark-factory): factory-failures.jsonl accumulates OOS telemetry for issue #391 (second occurrence)",
+      "state": "CLOSED",
+      "created_at": "2026-06-15T11:42:59Z",
+      "closed_at": "2026-06-26T02:48:30Z",
+      "lead_time_hours": 255.09194444444444,
+      "factory_cycle_hours": 145.15833333333333,
+      "labels": [
+        "needs-discussion",
+        "ready-for-agent",
+        "scope-spillover",
+        "needs-triage",
+        "factory-regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.2489797499999997,
+        "in_tokens": 2602,
+        "out_tokens": 17244,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 01:39 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 518,
+      "title": "cleanup(dark-factory): orphaned seed files in dark-factory/seed/seed/ from prior failed run",
+      "state": "CLOSED",
+      "created_at": "2026-06-14T21:30:09Z",
+      "closed_at": "2026-06-22T11:44:18Z",
+      "lead_time_hours": 182.23583333333335,
+      "factory_cycle_hours": 58.23833333333334,
+      "labels": [
+        "needs-discussion",
+        "direct-to-pr",
+        "ready-for-agent",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 0.7633842,
+        "in_tokens": 56,
+        "out_tokens": 10607,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 01:30 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 517,
+      "title": "docs(memory): dark-factory-ops.md BuildKit/preview patterns not spec-listed in #436",
+      "state": "CLOSED",
+      "created_at": "2026-06-14T21:30:01Z",
+      "closed_at": "2026-06-26T02:30:18Z",
+      "lead_time_hours": 269.0047222222222,
+      "factory_cycle_hours": 145.005,
+      "labels": [
+        "needs-discussion",
+        "ready-for-agent",
+        "scope-spillover",
+        "factory-regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.1392627500000003,
+        "in_tokens": 53,
+        "out_tokens": 13667,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 01:30 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 516,
+      "title": "docs(architecture): ARCHITECTURE.md buildkit subgraph should be tracked as in-scope doc for #436",
+      "state": "CLOSED",
+      "created_at": "2026-06-14T21:29:55Z",
+      "closed_at": "2026-06-20T11:07:28Z",
+      "lead_time_hours": 133.62583333333333,
+      "factory_cycle_hours": 10.79111111111111,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 4.28426425,
+        "in_tokens": 1428,
+        "out_tokens": 59919,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 00:20 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 01:22 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 05:53 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 508,
+      "title": "Vite dev server: make server.allowedHosts env-driven (Tailscale/tunnel/proxy access)",
+      "state": "CLOSED",
+      "created_at": "2026-06-14T19:08:03Z",
+      "closed_at": "2026-06-14T19:33:44Z",
+      "lead_time_hours": 0.4280555555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "frontend",
+        "infrastructure"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 507,
+      "title": "factory-failures.jsonl: remove stale issue #403 run records",
+      "state": "CLOSED",
+      "created_at": "2026-06-14T14:45:27Z",
+      "closed_at": "2026-06-14T20:32:41Z",
+      "lead_time_hours": 5.787222222222222,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 504,
+      "title": "feat(factory): auto-address advisory code-review findings (revise-advisory DAG node)",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T19:46:16Z",
+      "closed_at": "2026-06-14T14:08:52Z",
+      "lead_time_hours": 18.376666666666665,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "Dark Factory"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 503,
+      "title": "test-infra(conftest): add integration test verifying _testcontainers_url calls probe unconditionally",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:58:08Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "spec-pending-review",
+        "ready-for-agent",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.3106299000000001,
+        "in_tokens": 57,
+        "out_tokens": 17668,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 17:09 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 502,
+      "title": "Define backtesting integration contract for the quality gate",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:11Z",
+      "closed_at": "2026-06-26T11:26:27Z",
+      "lead_time_hours": 304.65444444444444,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "analytics",
+        "needs-discussion",
+        "testing",
+        "ready-for-human",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 501,
+      "title": "Define survivorship-bias gate behavior for historical analysis",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:10Z",
+      "closed_at": "2026-06-26T11:15:02Z",
+      "lead_time_hours": 304.46444444444444,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "analytics",
+        "needs-discussion",
+        "testing",
+        "ready-for-human",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 500,
+      "title": "Generate split/dividend and timezone session gate issues",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:09Z",
+      "closed_at": "2026-06-26T10:53:55Z",
+      "lead_time_hours": 304.11277777777775,
+      "factory_cycle_hours": 161.7486111111111,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.9878961500000005,
+        "in_tokens": 80,
+        "out_tokens": 24382,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 17:09 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 499,
+      "title": "Generate stale quote and provider gap gate issues",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:08Z",
+      "closed_at": "2026-06-26T10:55:18Z",
+      "lead_time_hours": 304.1361111111111,
+      "factory_cycle_hours": 161.92166666666665,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.2329975499999994,
+        "in_tokens": 64,
+        "out_tokens": 22801,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 17:00 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 498,
+      "title": "Generate missing bars and insufficient lookback gate issues",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:07Z",
+      "closed_at": "2026-06-26T03:19:29Z",
+      "lead_time_hours": 296.5394444444444,
+      "factory_cycle_hours": 154.40805555555556,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "scanner",
+        "analytics",
+        "needs-discussion",
+        "testing",
+        "direct-to-pr",
+        "ready-for-agent",
+        "factory-regression",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.09619025,
+        "in_tokens": 647,
+        "out_tokens": 18602,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 16:55 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 497,
+      "title": "Exclude untrusted events from trusted Scorecard metrics",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:06Z",
+      "closed_at": "2026-06-15T01:33:17Z",
+      "lead_time_hours": 30.76972222222222,
+      "factory_cycle_hours": 0.03805555555555556,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "scanner",
+        "analytics",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 4.10247485,
+        "in_tokens": 141,
+        "out_tokens": 53989,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 01:31 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 496,
+      "title": "Apply strict data quality gate to automated trading",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:05Z",
+      "closed_at": "2026-06-26T03:22:24Z",
+      "lead_time_hours": 296.5886111111111,
+      "factory_cycle_hours": 154.59,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "analytics",
+        "needs-discussion",
+        "testing",
+        "direct-to-pr",
+        "factory-regression"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.7806305999999994,
+        "in_tokens": 66,
+        "out_tokens": 17050,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 16:47 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 495,
+      "title": "Show data quality trust status in scanner and quality UI",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:03Z",
+      "closed_at": "2026-06-22T11:44:24Z",
+      "lead_time_hours": 208.95583333333335,
+      "factory_cycle_hours": 66.99,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "frontend",
+        "needs-discussion",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.7360607499999996,
+        "in_tokens": 78,
+        "out_tokens": 26075,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 16:45 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 494,
+      "title": "Apply advisory data quality gate to scanner runs",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:02Z",
+      "closed_at": "2026-06-22T11:44:06Z",
+      "lead_time_hours": 208.95111111111112,
+      "factory_cycle_hours": 79.41833333333334,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "needs-discussion",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.7148631000000005,
+        "in_tokens": 80,
+        "out_tokens": 26239,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 04:19 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 493,
+      "title": "Expose data quality gate preflight API",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:01Z",
+      "closed_at": "2026-06-21T19:52:11Z",
+      "lead_time_hours": 193.0861111111111,
+      "factory_cycle_hours": 63.61972222222222,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "scanner",
+        "analytics",
+        "needs-discussion",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.1371913000000005,
+        "in_tokens": 68,
+        "out_tokens": 20892,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 04:15 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 492,
+      "title": "Add reusable data quality gate contract and service",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:00Z",
+      "closed_at": "2026-06-21T21:15:33Z",
+      "lead_time_hours": 194.47583333333333,
+      "factory_cycle_hours": 65.15916666666666,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "plan-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.9510556000000003,
+        "in_tokens": 61,
+        "out_tokens": 20836,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 04:06 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 491,
+      "title": "Epic: Data Quality Trust Gate",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:46:59Z",
+      "closed_at": "2026-06-26T12:13:11Z",
+      "lead_time_hours": 305.43666666666667,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "scanner",
+        "analytics",
+        "epic"
+      ],
+      "size": null,
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 490,
+      "title": "Replay engine UI: per-signal drill-down + run comparison",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:48Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "size: M",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 489,
+      "title": "Replay engine UI: run summary, equity curve, edge-decay & regime charts",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:47Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "size: L",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 488,
+      "title": "Replay engine: REST API (/api/v1/replay)",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:46Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "size: M",
+        "analytics",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 487,
+      "title": "Replay engine: execution task + metrics computer",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:45Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 486,
+      "title": "Replay engine: benchmark ingestion + regime classifier",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:44Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "size: M",
+        "analytics",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 485,
+      "title": "Replay engine: intraday-accurate exit simulator",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:43Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 484,
+      "title": "Replay engine: data model + manifest resolver + data hash",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:41Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "size: M",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 483,
+      "title": "Epic: Canonical Signal Replay Engine (reproducible, intraday-accurate backtest)",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:27Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "priority: must-have",
+        "scanner",
+        "analytics",
+        "frontend",
+        "epic",
+        "spec-approved"
+      ],
+      "size": null,
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 482,
+      "title": "Add UI controls for optional AI narrative layers",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:57Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "size: M",
+        "ml",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "priority: could-have"
+      ],
+      "size": "M",
+      "priority": "could-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.3007908999999995,
+        "in_tokens": 67,
+        "out_tokens": 19339,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 04:01 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 481,
+      "title": "Add LLM cost, latency, cache, and observability controls",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:55Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "spec-pending-review",
+        "testing",
+        "performance",
+        "observability",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.9288869500000003,
+        "in_tokens": 66,
+        "out_tokens": 26005,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 03:49 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 480,
+      "title": "Add analyst Q&A over explained events and outcomes",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:53Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "size: L",
+        "ml",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "priority: could-have"
+      ],
+      "size": "L",
+      "priority": "could-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 11.664796499999994,
+        "in_tokens": 64,
+        "out_tokens": 17782,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 03:55 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 479,
+      "title": "Add semantic find-signals-like-this search",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:50Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "size: L",
+        "ml",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "priority: could-have"
+      ],
+      "size": "L",
+      "priority": "could-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.9869191500000003,
+        "in_tokens": 68,
+        "out_tokens": 17447,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 03:37 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 478,
+      "title": "Embed news, catalysts, explanations, and narratives",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:48Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.2133070000000004,
+        "in_tokens": 65,
+        "out_tokens": 19741,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 03:36 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 477,
+      "title": "Add embedding storage and retrieval foundation",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:46Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "analytics",
+        "spec-pending-review",
+        "infrastructure",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.7896710499999997,
+        "in_tokens": 62,
+        "out_tokens": 20125,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 16:14 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 476,
+      "title": "Generate signal post-mortems from explanation versus outcome",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:44Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "size: L",
+        "ml",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "priority: could-have"
+      ],
+      "size": "L",
+      "priority": "could-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.8132564000000002,
+        "in_tokens": 62,
+        "out_tokens": 21443,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 16:13 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 475,
+      "title": "Generate AI-assisted alert copy from signal briefs",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:42Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "size: M",
+        "ml",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "priority: could-have"
+      ],
+      "size": "M",
+      "priority": "could-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.3785033,
+        "in_tokens": 58,
+        "out_tokens": 25901,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 16:05 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 474,
+      "title": "Add narrative provenance and forbidden-claim enforcement",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:40Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "ml",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.5123973999999996,
+        "in_tokens": 63,
+        "out_tokens": 18512,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 16:01 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 473,
+      "title": "Add cached scanner event narrative generation",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:38Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.9989233000000004,
+        "in_tokens": 67,
+        "out_tokens": 21022,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:52 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 472,
+      "title": "Add LLM feature flags, provider config, and usage guardrails",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:35Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "spec-pending-review",
+        "infrastructure",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.75714425,
+        "in_tokens": 66,
+        "out_tokens": 25247,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:51 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 471,
+      "title": "Upgrade event-level intelligence UI",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:43Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.944473650000001,
+        "in_tokens": 67,
+        "out_tokens": 20400,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:39 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 470,
+      "title": "Add EdgeExplorer historical analog drill-down",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:41Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.3471966500000003,
+        "in_tokens": 65,
+        "out_tokens": 19764,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:41 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 469,
+      "title": "Add EdgeExplorer explanation trait filters and archetype charts",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:39Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.0664122999999996,
+        "in_tokens": 64,
+        "out_tokens": 22060,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:16 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 468,
+      "title": "Upgrade Scorecard with explanation trait and archetype performance",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:37Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.7488555499999998,
+        "in_tokens": 58,
+        "out_tokens": 19160,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:10 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 467,
+      "title": "Add deterministic AI signal brief endpoint",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:35Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.0571535500000007,
+        "in_tokens": 1924,
+        "out_tokens": 20434,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:01 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 466,
+      "title": "Generate signal archetypes from explanation traits and outcomes",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:33Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.3259658,
+        "in_tokens": 67,
+        "out_tokens": 29583,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:02 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 465,
+      "title": "Add explanation trait performance aggregation",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:31Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.6852426499999997,
+        "in_tokens": 66,
+        "out_tokens": 17208,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 14:49 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 464,
+      "title": "Add deterministic historical analog service",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:29Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.0457764999999997,
+        "in_tokens": 67,
+        "out_tokens": 23617,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 14:49 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 463,
+      "title": "Extract analysis-ready features from scanner explanations",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:27Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.0189290000000004,
+        "in_tokens": 63,
+        "out_tokens": 20379,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 14:38 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 462,
+      "title": "Migrate live and social scanner event writers to explanation contract",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:34Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.1817919499999996,
+        "in_tokens": 73,
+        "out_tokens": 27464,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 14:36 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 461,
+      "title": "Migrate trend pullback scanner to explanation contract",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:32Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.7716779,
+        "in_tokens": 1207,
+        "out_tokens": 30991,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 14:24 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 460,
+      "title": "Migrate oversold bounce and pocket pivot scanners to explanation contract",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:30Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.3149436499999982,
+        "in_tokens": 5332,
+        "out_tokens": 23081,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 13:04 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 459,
+      "title": "Migrate liquidity hunt scanners to explanation contract",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:28Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.2966713999999993,
+        "in_tokens": 69,
+        "out_tokens": 30794,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 14:25 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 458,
+      "title": "Backfill best-effort explanations for historical scanner events",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:26Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.9198970999999994,
+        "in_tokens": 63,
+        "out_tokens": 22158,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 14:04 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 457,
+      "title": "Add practical scanner explanation UI",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:24Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.9362573000000003,
+        "in_tokens": 83,
+        "out_tokens": 18566,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 01:35 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-19 01:38 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 456,
+      "title": "Expose scanner explanations through API contracts",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:21Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.9251088500000006,
+        "in_tokens": 55,
+        "out_tokens": 16191,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 01:26 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 455,
+      "title": "Integrate pre-market volume spike as the reference explained scanner",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:19Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.77526735,
+        "in_tokens": 642,
+        "out_tokens": 21576,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 01:24 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 454,
+      "title": "Enhance data quality and readiness services for event warnings",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:17Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.8636374999999998,
+        "in_tokens": 56,
+        "out_tokens": 17841,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 01:17 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 453,
+      "title": "Build scanner-neutral ExplanationBuilder",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:15Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.2393199,
+        "in_tokens": 50,
+        "out_tokens": 17640,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 12:28 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 452,
+      "title": "Define scanner explanation schema and validation helpers",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:13Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.5727704999999998,
+        "in_tokens": 50,
+        "out_tokens": 14811,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 12:22 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 451,
+      "title": "Add persisted scanner event explanation column",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:11Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "scanner",
+        "spec-pending-review",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.5614802499999998,
+        "in_tokens": 53,
+        "out_tokens": 17915,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 12:19 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 450,
+      "title": "Epic: Optional LLM Narrative and Semantic Intelligence",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:55:15Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "ml",
+        "analytics",
+        "frontend",
+        "epic",
+        "size: XL"
+      ],
+      "size": "XL",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 449,
+      "title": "Epic: Explanation-Aware Edge Intelligence",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:55:14Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "ml",
+        "scanner",
+        "analytics",
+        "frontend",
+        "epic",
+        "size: XL"
+      ],
+      "size": "XL",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 448,
+      "title": "Epic: Explainability Foundation for scanner events",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:55:13Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "scanner",
+        "analytics",
+        "epic",
+        "size: XL"
+      ],
+      "size": "XL",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 446,
+      "title": "Document private extension workflow",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:33Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "documentation",
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "spec-pending-review",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.2909117500000002,
+        "in_tokens": 50,
+        "out_tokens": 15340,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 12:13 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 445,
+      "title": "Add outcome analyzer extension point",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:32Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.6657298000000003,
+        "in_tokens": 57,
+        "out_tokens": 16133,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 12:10 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 444,
+      "title": "Add position sizing and risk rule extension points",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:31Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "spec-pending-review",
+        "infrastructure",
+        "testing",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.9857468000000003,
+        "in_tokens": 99,
+        "out_tokens": 17432,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 10:56 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 443,
+      "title": "Add broker adapter extension point",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:30Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "spec-pending-review",
+        "infrastructure",
+        "testing",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.671712299999999,
+        "in_tokens": 55,
+        "out_tokens": 20663,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 00:30 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 442,
+      "title": "Convert alert channels to registered extension handlers",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:29Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "spec-pending-review",
+        "infrastructure",
+        "testing",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.5051999499999995,
+        "in_tokens": 49,
+        "out_tokens": 18384,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 00:16 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 441,
+      "title": "Unify data provider registration under extension registry",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:27Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "spec-pending-review",
+        "infrastructure",
+        "testing",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.2390874500000004,
+        "in_tokens": 54,
+        "out_tokens": 16355,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 00:06 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 440,
+      "title": "Formalize scanner extension registration",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:26Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.6642564499999999,
+        "in_tokens": 59,
+        "out_tokens": 19258,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 00:04 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 439,
+      "title": "Add extension loader and shared registry primitives",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:25Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "spec-pending-review",
+        "infrastructure",
+        "testing",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.7224443,
+        "in_tokens": 54,
+        "out_tokens": 20336,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 21:52 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 438,
+      "title": "Epic: Formal module extension points for MarketHawk",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:24Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "epic",
+        "size: XL",
+        "feature:extensions"
+      ],
+      "size": "XL",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 436,
+      "title": "Preview env fails on every implement run: BuildKit 403 through docker-socket-proxy (+ EXEC:0 second wall)",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T16:15:53Z",
+      "closed_at": "2026-06-22T13:06:28Z",
+      "lead_time_hours": 212.84305555555557,
+      "factory_cycle_hours": 183.5911111111111,
+      "labels": [
+        "bug",
+        "priority: must-have",
+        "size: M",
+        "infrastructure",
+        "Dark Factory",
+        "regression",
+        "factory-regression",
+        "ready-for-human"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.78484405,
+        "in_tokens": 127,
+        "out_tokens": 45406,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 21:31 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 434,
+      "title": "Regression: dark-factory cost report never posts \u2014 run-record parser can't read archon's multi-line JSON",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T16:14:35Z",
+      "closed_at": "2026-06-13T16:15:08Z",
+      "lead_time_hours": 0.009166666666666667,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "size: S",
+        "Dark Factory",
+        "regression",
+        "factory-regression"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 432,
+      "title": "regime cleanup migrations fail on clean databases (non-idempotent DROPs)",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T15:42:04Z",
+      "closed_at": "2026-06-13T15:51:44Z",
+      "lead_time_hours": 0.16111111111111112,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: must-have",
+        "size: S",
+        "regression",
+        "factory-regression"
+      ],
+      "size": "S",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 431,
+      "title": "cleanup(dark-factory): factory-failures.jsonl accumulates OOS telemetry entries on feature branches",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T15:24:31Z",
+      "closed_at": "2026-06-20T11:06:25Z",
+      "lead_time_hours": 163.69833333333332,
+      "factory_cycle_hours": 133.25694444444446,
+      "labels": [
+        "bug",
+        "needs-discussion",
+        "ready-for-agent",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 8.72932245,
+        "in_tokens": 304,
+        "out_tokens": 136245,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 21:51 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 01:24 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 05:56 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 430,
+      "title": "enhance(pg_discovery): add structured logging for discovery failures",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T15:18:31Z",
+      "closed_at": "2026-06-14T20:32:38Z",
+      "lead_time_hours": 29.235277777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 429,
+      "title": "enhance(pg_discovery): guard isinstance(containers, list) on Docker API response",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T15:18:30Z",
+      "closed_at": "2026-06-20T11:05:18Z",
+      "lead_time_hours": 163.78,
+      "factory_cycle_hours": 133.405,
+      "labels": [
+        "enhancement",
+        "ready-for-agent",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 6.06562485,
+        "in_tokens": 258,
+        "out_tokens": 86558,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 21:41 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 01:10 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 05:40 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 428,
+      "title": "enhance(pg_discovery): add raise_for_status() to Docker API call",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T15:18:19Z",
+      "closed_at": "2026-06-14T20:32:35Z",
+      "lead_time_hours": 29.23777777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 426,
+      "title": "Ship AI-first docs site and reproducible demo mode",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T15:08:42Z",
+      "closed_at": "2026-06-13T16:08:27Z",
+      "lead_time_hours": 0.9958333333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "documentation",
+        "enhancement"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 425,
+      "title": "bug(auth): refresh-token rotation race \u2014 concurrent 401s each fire their own /auth/refresh",
+      "state": "OPEN",
+      "created_at": "2026-06-13T15:06:05Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "size: M",
+        "frontend",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.2296435500000005,
+        "in_tokens": 56,
+        "out_tokens": 16076,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 21:41 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 424,
+      "title": "Regression: Grafana infrastructure webhook 403 \u2014 CSRF middleware missing /api/v1/alerts/infrastructure exempt",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T14:06:13Z",
+      "closed_at": "2026-06-13T14:11:49Z",
+      "lead_time_hours": 0.09333333333333334,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "size: S",
+        "security",
+        "infrastructure",
+        "regression",
+        "factory-regression"
+      ],
+      "size": "S",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 421,
+      "title": "Update dark-factory-ops.md scope enforcement entry to reflect dedupe_oos.py behavior",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T09:50:01Z",
+      "closed_at": "2026-06-26T02:40:08Z",
+      "lead_time_hours": 304.8352777777778,
+      "factory_cycle_hours": 269.1355555555556,
+      "labels": [
+        "documentation",
+        "needs-discussion",
+        "ready-for-agent",
+        "scope-spillover",
+        "factory-regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.4293266,
+        "in_tokens": 105,
+        "out_tokens": 36632,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 21:32 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 01:06 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 419,
+      "title": "forecast-worker: add explicit REDIS_URL env override for Redis auth",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T04:52:05Z",
+      "closed_at": "2026-06-14T20:32:44Z",
+      "lead_time_hours": 39.6775,
+      "factory_cycle_hours": null,
+      "labels": [
+        "wontfix",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 403,
+      "title": "ci: lint .archon/workflows when: expressions against Archon grammar",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T20:46:19Z",
+      "closed_at": "2026-06-14T14:56:23Z",
+      "lead_time_hours": 42.16777777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "direct-to-pr"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 402,
+      "title": "archon: unparseable when: expression should fail the run, not skip fail-closed",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T20:46:01Z",
+      "closed_at": "2026-06-20T14:50:52Z",
+      "lead_time_hours": 186.08083333333335,
+      "factory_cycle_hours": 13.88111111111111,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "ready-for-agent"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 9.70161505,
+        "in_tokens": 338,
+        "out_tokens": 125694,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 00:58 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 02:00 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 11:51 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 397,
+      "title": "classify-preview when: unparseable since PR #359 - all implement runs silently discard their work",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T20:02:46Z",
+      "closed_at": "2026-06-12T20:08:12Z",
+      "lead_time_hours": 0.09055555555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: must-have",
+        "size: S",
+        "Dark Factory",
+        "regression",
+        "factory-regression"
+      ],
+      "size": "S",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 396,
+      "title": "test(frontend): quality-pass the 7 OOS test files from #250 (executes epic #383 decision)",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T18:46:16Z",
+      "closed_at": "2026-06-14T20:06:46Z",
+      "lead_time_hours": 49.34166666666667,
+      "factory_cycle_hours": 0.06277777777777778,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "frontend",
+        "testing",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 4.02002635,
+        "in_tokens": 1335,
+        "out_tokens": 41425,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 20:03 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 394,
+      "title": "Revisit dispatch ceiling (C9) - re-measure success-by-size/type",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T18:40:42Z",
+      "closed_at": "2026-06-21T19:53:19Z",
+      "lead_time_hours": 217.21027777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "priority: should-have",
+        "size: S",
+        "needs-discussion",
+        "Dark Factory",
+        "direct-to-pr",
+        "factory-regression"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 393,
+      "title": "chaos: IBKR gateway kill-test \u2014 verify live-scanner degradation and recovery",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T18:34:15Z",
+      "closed_at": "2026-06-22T01:57:15Z",
+      "lead_time_hours": 223.38333333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "needs-discussion",
+        "infrastructure",
+        "testing",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 392,
+      "title": "scanner: nightly replay-diff \u2014 re-run yesterday's scans and diff vs live signals",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T18:34:14Z",
+      "closed_at": "2026-06-22T13:03:33Z",
+      "lead_time_hours": 234.4886111111111,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "scanner",
+        "needs-discussion",
+        "testing",
+        "observability",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 391,
+      "title": "observability: pre-market scan latency SLO \u2014 metrics + missed-slot alerts",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T18:34:14Z",
+      "closed_at": "2026-06-15T12:11:58Z",
+      "lead_time_hours": 65.6288888888889,
+      "factory_cycle_hours": 15.832777777777778,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "scanner",
+        "needs-discussion",
+        "performance",
+        "observability",
+        "direct-to-pr",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 6.6467836,
+        "in_tokens": 196,
+        "out_tokens": 68597,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 20:22 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 390,
+      "title": "Plan stage implemented the full feature on the refine branch (#339) instead of stopping at the plan",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T18:30:06Z",
+      "closed_at": "2026-06-14T20:16:23Z",
+      "lead_time_hours": 49.771388888888886,
+      "factory_cycle_hours": 0.32305555555555554,
+      "labels": [
+        "priority: should-have",
+        "size: M",
+        "Dark Factory",
+        "direct-to-pr",
+        "factory-regression",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.39528215,
+        "in_tokens": 125,
+        "out_tokens": 28514,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 19:57 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 389,
+      "title": "Scheduler dependencies_met() strands issues whose dependency is closed but off-board",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T18:29:58Z",
+      "closed_at": "2026-06-15T12:54:31Z",
+      "lead_time_hours": 66.40916666666666,
+      "factory_cycle_hours": 0.10861111111111112,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "size: S",
+        "Dark Factory",
+        "direct-to-pr",
+        "ready-for-agent",
+        "cost-report-lost"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 4.5122173000000005,
+        "in_tokens": 165,
+        "out_tokens": 58861,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 12:48 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 388,
+      "title": "providers: define Polygon\u2194IBKR degraded-feed failover for pre-market scans",
+      "state": "OPEN",
+      "created_at": "2026-06-12T17:22:25Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "scanner",
+        "needs-discussion",
+        "infrastructure",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 387,
+      "title": "data-quality: gap/staleness detection on aggregates + corporate-action handling",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T17:22:24Z",
+      "closed_at": "2026-06-21T19:55:04Z",
+      "lead_time_hours": 218.54444444444445,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "needs-discussion",
+        "observability",
+        "direct-to-pr"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 386,
+      "title": "ops: weekly restore drill \u2014 verify #90 backups by restoring into a throwaway container",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T17:22:24Z",
+      "closed_at": "2026-06-22T02:00:02Z",
+      "lead_time_hours": 224.62722222222223,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "needs-discussion",
+        "infrastructure",
+        "testing",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 385,
+      "title": "chore: backlog triage & label-taxonomy overhaul \u2014 2026-06-12 session record",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T17:13:27Z",
+      "closed_at": "2026-06-12T17:13:28Z",
+      "lead_time_hours": 0.0002777777777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "documentation"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 384,
+      "title": "factory: dedupe scope-enforcement findings before filing tickets",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T17:01:09Z",
+      "closed_at": "2026-06-13T13:35:35Z",
+      "lead_time_hours": 20.573888888888888,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "plan-pending-review",
+        "needs-discussion",
+        "Dark Factory",
+        "direct-to-pr",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 383,
+      "title": "Epic: Resolve #250 out-of-scope frontend test debt (keep vs excise)",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T17:00:51Z",
+      "closed_at": "2026-06-14T20:12:15Z",
+      "lead_time_hours": 51.19,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "epic",
+        "testing",
+        "priority: could-have"
+      ],
+      "size": null,
+      "priority": "could-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 382,
+      "title": "[security] F-LOG-01: Add log redaction filter for secrets (Seq)",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:16Z",
+      "closed_at": "2026-06-19T03:12:44Z",
+      "lead_time_hours": 155.95777777777778,
+      "factory_cycle_hours": 96.22888888888889,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "plan-pending-review",
+        "security",
+        "security-audit-2026-06-12",
+        "ready-for-human",
+        "cost-report-lost"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.15555235,
+        "in_tokens": 94,
+        "out_tokens": 53818,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 02:59 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-15 12:05 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 381,
+      "title": "[security] F-FRONT-01: External-content URLs without allowlist; no CSP",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:14Z",
+      "closed_at": "2026-06-13T18:47:30Z",
+      "lead_time_hours": 27.537777777777777,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "plan-pending-review",
+        "security",
+        "direct-to-pr",
+        "security-audit-2026-06-12",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 380,
+      "title": "[security] F-INPUT-02: Weak/decentralized ticker & free-form field validation",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:13Z",
+      "closed_at": "2026-06-19T03:12:45Z",
+      "lead_time_hours": 155.95888888888888,
+      "factory_cycle_hours": 88.2625,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "spec-pending-review",
+        "security",
+        "security-audit-2026-06-12",
+        "ready-for-human"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.3813433000000006,
+        "in_tokens": 59,
+        "out_tokens": 23495,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 10:57 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 379,
+      "title": "[security] F-DOCKER-01: socket-proxy BUILD/POST + preview compose weak creds",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:11Z",
+      "closed_at": "2026-06-15T01:13:29Z",
+      "lead_time_hours": 57.971666666666664,
+      "factory_cycle_hours": 4.491388888888889,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "security",
+        "direct-to-pr",
+        "security-audit-2026-06-12",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.6177463000000003,
+        "in_tokens": 144,
+        "out_tokens": 45013,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 20:44 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 378,
+      "title": "[security] F-CI-01: Trivy advisory-only, no SAST, ci.yml missing permissions block",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:10Z",
+      "closed_at": "2026-06-19T03:12:46Z",
+      "lead_time_hours": 155.96,
+      "factory_cycle_hours": 96.26277777777777,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "spec-pending-review",
+        "security",
+        "security-audit-2026-06-12",
+        "ready-for-human"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 0.99385765,
+        "in_tokens": 47,
+        "out_tokens": 14140,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 02:57 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 377,
+      "title": "[security] F-WS-01: WebSocket resource exhaustion (no conn/msg caps, per-conn pubsub)",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:09Z",
+      "closed_at": "2026-06-15T01:14:27Z",
+      "lead_time_hours": 57.98833333333334,
+      "factory_cycle_hours": 4.490833333333334,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "needs-discussion",
+        "security",
+        "direct-to-pr",
+        "security-audit-2026-06-12",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 8.736621700000002,
+        "in_tokens": 216,
+        "out_tokens": 110866,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 20:45 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 376,
+      "title": "[security] F-INPUT-01: Unbounded pagination + reflective sort on scanner/outcomes",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:07Z",
+      "closed_at": "2026-06-19T03:12:44Z",
+      "lead_time_hours": 155.96027777777778,
+      "factory_cycle_hours": 96.41222222222223,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "plan-pending-review",
+        "security",
+        "security-audit-2026-06-12",
+        "ready-for-human",
+        "cost-report-lost"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.48806,
+        "in_tokens": 101,
+        "out_tokens": 49379,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 02:48 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-15 12:00 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 375,
+      "title": "[security] F-SUPPLY-02: curl|bash installers + unsigned Archon clone in factory image",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:06Z",
+      "closed_at": "2026-06-19T03:12:45Z",
+      "lead_time_hours": 155.96083333333334,
+      "factory_cycle_hours": 96.39583333333333,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "plan-pending-review",
+        "security",
+        "security-audit-2026-06-12",
+        "ready-for-human",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.415409,
+        "in_tokens": 97,
+        "out_tokens": 67027,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 02:49 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-15 11:55 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 374,
+      "title": "[security] F-SUPPLY-01: Pin floating :latest tags + unpinned base images/actions",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:05Z",
+      "closed_at": "2026-06-19T03:12:46Z",
+      "lead_time_hours": 155.96138888888888,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "plan-pending-review",
+        "security",
+        "security-audit-2026-06-12",
+        "ready-for-human",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 373,
+      "title": "[epic] Authorization model \u2014 multi-user, roles, per-user data ownership",
+      "state": "OPEN",
+      "created_at": "2026-06-12T15:15:03Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "epic",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 372,
+      "title": "[epic] Security review 2026-06-12 \u2014 High-severity remediation",
+      "state": "OPEN",
+      "created_at": "2026-06-12T15:08:51Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "epic",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": null,
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 371,
+      "title": "[security] F-ADMIN-01: Admin tools (pgAdmin/Flower/Seq/Grafana) rely on un-enforced credentials",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:08:27Z",
+      "closed_at": "2026-06-19T03:12:45Z",
+      "lead_time_hours": 156.07166666666666,
+      "factory_cycle_hours": 96.6125,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "plan-pending-review",
+        "security",
+        "ready-for-agent",
+        "security-audit-2026-06-12",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 5.22785865,
+        "in_tokens": 105,
+        "out_tokens": 78164,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 02:36 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-15 11:27 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 370,
+      "title": "[security] F-NET-01: Redis has no authentication (requirepass unset)",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:08:25Z",
+      "closed_at": "2026-06-15T17:41:35Z",
+      "lead_time_hours": 74.55277777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "plan-pending-review",
+        "needs-discussion",
+        "security",
+        "direct-to-pr",
+        "factory-regression",
+        "security-audit-2026-06-12",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 369,
+      "title": "[security] F-AUTH-01: Swagger/openapi.json/metrics unauthenticated in production",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:08:24Z",
+      "closed_at": "2026-06-13T03:33:41Z",
+      "lead_time_hours": 12.421388888888888,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: S",
+        "needs-discussion",
+        "security",
+        "direct-to-pr",
+        "security-audit-2026-06-12",
+        "cost-report-lost"
+      ],
+      "size": "S",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 368,
+      "title": "[security] F-TRADE-01: Live IBKR order path needs hard notional cap + kill switch",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:08:23Z",
+      "closed_at": "2026-06-26T12:05:33Z",
+      "lead_time_hours": 332.9527777777778,
+      "factory_cycle_hours": 155.62583333333333,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "plan-pending-review",
+        "security",
+        "ready-for-agent",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.7235800500000007,
+        "in_tokens": 71,
+        "out_tokens": 25130,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 00:28 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 365,
+      "title": "Dark factory: main-red sentinel never self-clears - scheduler stays paused after main goes green",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T12:24:34Z",
+      "closed_at": "2026-06-12T12:55:32Z",
+      "lead_time_hours": 0.5161111111111111,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: must-have",
+        "size: M",
+        "infrastructure",
+        "Dark Factory"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 364,
+      "title": "main is red: tsc/python import failure",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T12:23:08Z",
+      "closed_at": "2026-06-12T13:06:48Z",
+      "lead_time_hours": 0.7277777777777777,
+      "factory_cycle_hours": null,
+      "labels": [
+        "regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 362,
+      "title": "Duplicate volumes key on dark-factory service breaks docker compose parsing on main",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T11:47:23Z",
+      "closed_at": "2026-06-12T11:55:47Z",
+      "lead_time_hours": 0.14,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: must-have",
+        "size: S",
+        "infrastructure",
+        "regression",
+        "factory-regression"
+      ],
+      "size": "S",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 361,
+      "title": "main is red: tsc/python import failure",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T11:38:41Z",
+      "closed_at": "2026-06-12T12:21:11Z",
+      "lead_time_hours": 0.7083333333333334,
+      "factory_cycle_hours": null,
+      "labels": [
+        "regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 360,
+      "title": "test-infra: add postgres discovery fallback when testcontainers exec is blocked",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T10:37:53Z",
+      "closed_at": "2026-06-13T19:38:21Z",
+      "lead_time_hours": 33.007777777777775,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "plan-pending-review",
+        "needs-discussion",
+        "infrastructure",
+        "testing",
+        "direct-to-pr",
+        "ready-for-agent",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 355,
+      "title": "Revisit dispatch ceiling (C9) \u2014 re-measure success-by-size/type",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T08:42:50Z",
+      "closed_at": "2026-06-20T16:45:38Z",
+      "lead_time_hours": 200.04666666666665,
+      "factory_cycle_hours": 1.6605555555555556,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "plan-pending-review",
+        "needs-discussion",
+        "Dark Factory",
+        "ready-for-agent",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 5.54071065,
+        "in_tokens": 172,
+        "out_tokens": 80060,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 15:06 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 350,
+      "title": "Update ARCHITECTURE.md to document /api/ready readiness endpoint",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T02:32:44Z",
+      "closed_at": "2026-06-13T09:40:53Z",
+      "lead_time_hours": 31.135833333333334,
+      "factory_cycle_hours": null,
+      "labels": [
+        "documentation",
+        "enhancement",
+        "ready-for-agent",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 347,
+      "title": "Dark factory: configurable concurrent run limit (FACTORY_WIP_LIMIT)",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T00:53:11Z",
+      "closed_at": "2026-06-12T02:32:48Z",
+      "lead_time_hours": 1.6602777777777777,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "Dark Factory"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 346,
+      "title": "[ci] Wire dark-factory pytest suite into CI test job",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T22:55:33Z",
+      "closed_at": "2026-06-14T19:57:01Z",
+      "lead_time_hours": 69.02444444444444,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "infrastructure",
+        "testing",
+        "Dark Factory",
+        "ready-for-agent",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 343,
+      "title": "chore(factory): stop committing codeindex.json/symbolindex.json \u2014 kill merge-conflict noise",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T21:28:06Z",
+      "closed_at": "2026-06-12T00:18:08Z",
+      "lead_time_hours": 2.8338888888888887,
       "factory_cycle_hours": null,
       "labels": [],
       "size": null,
       "priority": null,
       "autonomous": false,
       "cost": null
+    },
+    {
+      "number": 340,
+      "title": "Epic: Dark Factory measurement & hardening (architecture review 2026-06-11)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:56Z",
+      "closed_at": "2026-06-14T19:57:14Z",
+      "lead_time_hours": 71.98833333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "epic",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 339,
+      "title": "Size/type-aware dispatch ceiling in the scheduler",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:47Z",
+      "closed_at": "2026-06-12T19:24:37Z",
+      "lead_time_hours": 23.447222222222223,
+      "factory_cycle_hours": 14.460277777777778,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "needs-discussion",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 5.403581299999999,
+        "in_tokens": 95,
+        "out_tokens": 55915,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 04:57 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 08:46 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 338,
+      "title": "Single config interface: config.yaml as sole source of factory policy",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:08Z",
+      "closed_at": "2026-06-13T09:39:40Z",
+      "lead_time_hours": 37.708888888888886,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "needs-discussion",
+        "infrastructure",
+        "Dark Factory",
+        "direct-to-pr",
+        "cost-report-lost"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 337,
+      "title": "Extract tested factory core from entrypoint/scheduler/de-conflict bash glue",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:07Z",
+      "closed_at": "2026-06-13T18:56:16Z",
+      "lead_time_hours": 46.98583333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "plan-pending-review",
+        "needs-discussion",
+        "testing",
+        "Dark Factory",
+        "direct-to-pr",
+        "cost-report-lost"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 336,
+      "title": "Failure-to-eval flywheel: post-mortem stage on circuit-break, failures become eval tasks",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:05Z",
+      "closed_at": "2026-06-12T15:14:28Z",
+      "lead_time_hours": 19.289722222222224,
+      "factory_cycle_hours": 10.524444444444445,
+      "labels": [
+        "priority: should-have",
+        "size: M",
+        "needs-discussion",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 9.366599149999999,
+        "in_tokens": 40323,
+        "out_tokens": 115857,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 04:43 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 08:30 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 09:22 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 335,
+      "title": "Replay benchmark: pass^k suite of replayed closed issues to regression-test the harness",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:04Z",
+      "closed_at": "2026-06-12T14:54:51Z",
+      "lead_time_hours": 18.963055555555556,
+      "factory_cycle_hours": 10.414166666666667,
+      "labels": [
+        "priority: should-have",
+        "size: L",
+        "needs-discussion",
+        "testing",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 11.867938999999996,
+        "in_tokens": 272,
+        "out_tokens": 139201,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 04:30 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 05:41 UTC",
+            "run_type": "plan",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-12 10:35 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 334,
+      "title": "Deepen the Gate seam: layered gate policy, judge calibration audit, blast-radius human gate",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:03Z",
+      "closed_at": "2026-06-12T10:00:08Z",
+      "lead_time_hours": 14.051388888888889,
+      "factory_cycle_hours": 5.7188888888888885,
+      "labels": [
+        "priority: must-have",
+        "size: L",
+        "needs-discussion",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 14.629980649999998,
+        "in_tokens": 314,
+        "out_tokens": 165189,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 04:17 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 05:35 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 09:10 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 333,
+      "title": "Run Record: one structured per-run record of every stage verdict (gen_ai.* to Seq + runs.jsonl)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:01Z",
+      "closed_at": "2026-06-12T09:57:37Z",
+      "lead_time_hours": 14.01,
+      "factory_cycle_hours": 5.876944444444445,
+      "labels": [
+        "priority: must-have",
+        "size: M",
+        "needs-discussion",
+        "observability",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 13.077746000000005,
+        "in_tokens": 284,
+        "out_tokens": 164433,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 04:05 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 05:24 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 09:02 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 332,
+      "title": "Baseline-green gate: smoke origin/main before any factory run",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:00Z",
+      "closed_at": "2026-06-12T09:47:50Z",
+      "lead_time_hours": 13.847222222222221,
+      "factory_cycle_hours": 5.7972222222222225,
+      "labels": [
+        "priority: must-have",
+        "size: S",
+        "needs-discussion",
+        "infrastructure",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": "S",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 11.26289075,
+        "in_tokens": 314,
+        "out_tokens": 150596,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 04:00 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 05:05 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 05:42 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-12 05:42 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-12 08:40 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 331,
+      "title": "Factory Scorecard: merge-rate triad, rework rate, 2-week churn, success-by-size",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:56:58Z",
+      "closed_at": "2026-06-11T22:27:34Z",
+      "lead_time_hours": 2.51,
+      "factory_cycle_hours": null,
+      "labels": [
+        "priority: must-have",
+        "size: S",
+        "observability",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": "S",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 329,
+      "title": "docs(docker): document root-user exception in Dockerfile.forecast",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:19:51Z",
+      "closed_at": "2026-06-20T03:53:46Z",
+      "lead_time_hours": 200.56527777777777,
+      "factory_cycle_hours": 0.8127777777777778,
+      "labels": [
+        "documentation",
+        "enhancement",
+        "Dark Factory",
+        "ready-for-agent",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.3262019,
+        "in_tokens": 142,
+        "out_tokens": 29312,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 03:05 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 326,
+      "title": "fix(dark-factory): archon CLI vanishes from PATH on clean rebuilds (bun link regression)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T15:51:58Z",
+      "closed_at": "2026-06-14T19:51:24Z",
+      "lead_time_hours": 75.99055555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "Dark Factory",
+        "scope-spillover",
+        "ready-for-human"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 325,
+      "title": "Update Pocket Pivot seed config (params, criteria, is_active, run_frequency)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T13:50:44Z",
+      "closed_at": "2026-06-11T14:58:11Z",
+      "lead_time_hours": 1.1241666666666668,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 324,
+      "title": "Chart.tsx: revisit Recharts data type cast (object[] vs union)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T13:21:46Z",
+      "closed_at": "2026-06-11T14:58:25Z",
+      "lead_time_hours": 1.6108333333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 323,
+      "title": "Preview stack: review restart policy for postgres and redis services",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T13:21:45Z",
+      "closed_at": "2026-06-11T14:58:23Z",
+      "lead_time_hours": 1.6105555555555555,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 322,
+      "title": "Pocket Pivot seed config: finalize name, criteria, and run_frequency",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T13:21:38Z",
+      "closed_at": "2026-06-12T15:27:58Z",
+      "lead_time_hours": 26.105555555555554,
+      "factory_cycle_hours": null,
+      "labels": [
+        "needs-discussion",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 320,
+      "title": "Fix Chart.tsx TS2322: data prop type mismatch in Recharts commonProps",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T06:40:53Z",
+      "closed_at": "2026-06-12T17:13:06Z",
+      "lead_time_hours": 34.536944444444444,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "frontend",
+        "spec-pending-review",
+        "ready-for-agent",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 319,
+      "title": "frontend: verify Chart.tsx TS2322 on data prop (scope spillover from #276)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T06:17:18Z",
+      "closed_at": "2026-06-12T15:27:54Z",
+      "lead_time_hours": 33.17666666666667,
+      "factory_cycle_hours": null,
+      "labels": [
+        "duplicate",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 317,
+      "title": "Regenerate codeindex artifacts after issue #276 implementation",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T05:40:39Z",
+      "closed_at": "2026-06-12T15:27:56Z",
+      "lead_time_hours": 33.78805555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 316,
+      "title": "test(frontend): scope-correct Settings tests (not in spec #250)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:29:07Z",
+      "closed_at": "2026-06-13T03:05:03Z",
+      "lead_time_hours": 47.59888888888889,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "testing",
+        "direct-to-pr",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 315,
+      "title": "test(frontend): scope-correct ScorecardOverview tests (not in spec #250)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:29:06Z",
+      "closed_at": "2026-06-13T03:21:16Z",
+      "lead_time_hours": 47.86944444444445,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "testing",
+        "direct-to-pr",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 314,
+      "title": "test(frontend): scope-correct PreMarketMovers tests (not in spec #250)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:29:05Z",
+      "closed_at": "2026-06-13T03:20:33Z",
+      "lead_time_hours": 47.85777777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "testing",
+        "direct-to-pr",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 313,
+      "title": "test(frontend): scope-correct AlertBadges tests (not in spec #250)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:28:58Z",
+      "closed_at": "2026-06-13T03:04:08Z",
+      "lead_time_hours": 47.58611111111111,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "testing",
+        "direct-to-pr",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 312,
+      "title": "test(frontend): scope-correct ActiveWatchlist tests (not in spec #250)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:28:57Z",
+      "closed_at": "2026-06-13T03:03:31Z",
+      "lead_time_hours": 47.57611111111111,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "testing",
+        "direct-to-pr",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 311,
+      "title": "test(frontend): scope-correct PageLoader tests (not in spec #250)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:28:57Z",
+      "closed_at": "2026-06-12T20:33:12Z",
+      "lead_time_hours": 41.07083333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "plan-pending-review",
+        "testing",
+        "direct-to-pr",
+        "scope-spillover",
+        "Waste",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 310,
+      "title": "test(frontend): scope-correct ScorecardDetail tests (spec #250 non-goal)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:28:49Z",
+      "closed_at": "2026-06-12T15:27:51Z",
+      "lead_time_hours": 35.98388888888889,
+      "factory_cycle_hours": null,
+      "labels": [
+        "duplicate",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 309,
+      "title": "test(frontend): scope-correct ScorecardDetail tests (spec #250 non-goal)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:28:44Z",
+      "closed_at": "2026-06-12T20:45:16Z",
+      "lead_time_hours": 41.275555555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "plan-pending-review",
+        "testing",
+        "direct-to-pr",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 308,
+      "title": "Add frontend test coverage for ActiveWatchlist page and AlertBadges",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T02:21:27Z",
+      "closed_at": "2026-06-12T15:27:48Z",
+      "lead_time_hours": 37.10583333333334,
+      "factory_cycle_hours": null,
+      "labels": [
+        "duplicate",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 307,
+      "title": "Add frontend test coverage for PageLoader component",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T02:21:26Z",
+      "closed_at": "2026-06-12T15:27:44Z",
+      "lead_time_hours": 37.105,
+      "factory_cycle_hours": null,
+      "labels": [
+        "duplicate",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 306,
+      "title": "Add frontend test coverage for PreMarketMovers page",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T02:21:25Z",
+      "closed_at": "2026-06-12T15:27:41Z",
+      "lead_time_hours": 37.10444444444445,
+      "factory_cycle_hours": null,
+      "labels": [
+        "duplicate",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 305,
+      "title": "Add frontend test coverage for Settings page",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T02:21:15Z",
+      "closed_at": "2026-06-12T15:27:39Z",
+      "lead_time_hours": 37.10666666666667,
+      "factory_cycle_hours": null,
+      "labels": [
+        "duplicate",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 303,
+      "title": "Outcome dashboard: per-scanner ScannerOutcomeSummary aggregates in UI",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T11:25:26Z",
+      "closed_at": "2026-06-21T03:54:33Z",
+      "lead_time_hours": 256.48527777777775,
+      "factory_cycle_hours": 145.55916666666667,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "analytics",
+        "frontend",
+        "needs-discussion",
+        "ready-for-agent",
+        "factory-regression",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 5.8242646,
+        "in_tokens": 114,
+        "out_tokens": 100240,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 02:21 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-15 11:15 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 302,
+      "title": "Backtest comparison run: 5 scanners x representative strategies over 1+ year",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T11:25:25Z",
+      "closed_at": "2026-06-20T14:53:10Z",
+      "lead_time_hours": 243.4625,
+      "factory_cycle_hours": 132.70277777777778,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "scanner",
+        "analytics",
+        "needs-discussion",
+        "ready-for-agent",
+        "factory-regression",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 9.128702050000001,
+        "in_tokens": 125,
+        "out_tokens": 149113,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 02:11 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-15 11:15 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 301,
+      "title": "Backtest harness core: daily-bar replay of TradingStrategy vs scan signals",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T11:25:24Z",
+      "closed_at": "2026-06-14T15:27:40Z",
+      "lead_time_hours": 100.03777777777778,
+      "factory_cycle_hours": 22.02777777777778,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "needs-discussion",
+        "ready-for-agent",
+        "cost-report-lost"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 7.536041499999998,
+        "in_tokens": 192,
+        "out_tokens": 88812,
+        "runs": [
+          {
+            "timestamp": "2026-06-13 17:26 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 300,
+      "title": "Epic: Backtest scanner signals against TradingStrategy definitions",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T11:25:12Z",
+      "closed_at": "2026-06-21T19:56:35Z",
+      "lead_time_hours": 272.5230555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "scanner",
+        "analytics",
+        "epic"
+      ],
+      "size": null,
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 299,
+      "title": "Implement trend_pullback daily scanner (trend-following pullback signals)",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T11:25:08Z",
+      "closed_at": "2026-06-11T23:47:23Z",
+      "lead_time_hours": 36.37083333333333,
+      "factory_cycle_hours": 35.15638888888889,
+      "labels": [
+        "priority: should-have",
+        "size: M",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 16.773903999999998,
+        "in_tokens": 367,
+        "out_tokens": 226064,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 12:38 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 04:58 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 21:19 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 294,
+      "title": "[arch-v3][LOW] Decompose frontend god files: api/scanner.ts (787) + QualityReportModal.tsx (753)",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:20Z",
+      "closed_at": "2026-06-13T17:22:21Z",
+      "lead_time_hours": 86.15027777777777,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "size: M",
+        "frontend",
+        "plan-pending-review",
+        "direct-to-pr",
+        "architecture-audit-v3",
+        "priority: could-have",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "could-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 293,
+      "title": "[arch-v3][LOW] Make Trivy block on HIGH/CRITICAL + add password min-length policy",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:19Z",
+      "closed_at": "2026-06-13T03:21:46Z",
+      "lead_time_hours": 72.14083333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "size: S",
+        "needs-discussion",
+        "security",
+        "infrastructure",
+        "direct-to-pr",
+        "architecture-audit-v3",
+        "priority: could-have",
+        "cost-report-lost"
+      ],
+      "size": "S",
+      "priority": "could-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 292,
+      "title": "[arch-v3][LOW] Validate JSONB writes + enforce severity enum + channel_config schema",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:18Z",
+      "closed_at": "2026-06-14T14:57:07Z",
+      "lead_time_hours": 107.73027777777777,
+      "factory_cycle_hours": 19.76861111111111,
+      "labels": [
+        "enhancement",
+        "size: M",
+        "plan-pending-review",
+        "needs-discussion",
+        "direct-to-pr",
+        "architecture-audit-v3",
+        "priority: could-have",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "could-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 6.601954,
+        "in_tokens": 204,
+        "out_tokens": 87053,
+        "runs": [
+          {
+            "timestamp": "2026-06-13 19:11 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 291,
+      "title": "[arch-v3][LOW] SQL aggregates in get_trade_stats + selectinload pagination fix",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:17Z",
+      "closed_at": "2026-06-12T15:15:07Z",
+      "lead_time_hours": 60.03055555555556,
+      "factory_cycle_hours": 13.101944444444445,
+      "labels": [
+        "spec-pending-review",
+        "needs-discussion",
+        "direct-to-pr",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.1952784499999998,
+        "in_tokens": 56,
+        "out_tokens": 16922,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 02:09 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 290,
+      "title": "[arch-v3][MED] Tweet-monitor cookie auth: expiry alerting or official API (3 reviews unticketed)",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:16Z",
+      "closed_at": "2026-06-12T09:54:53Z",
+      "lead_time_hours": 54.69361111111111,
+      "factory_cycle_hours": 9.064722222222223,
+      "labels": [
+        "direct-to-pr",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 7.670245499999999,
+        "in_tokens": 248,
+        "out_tokens": 104094,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 00:51 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 03:45 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 04:43 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 289,
+      "title": "[arch-v3][MED] Add readiness probe (DB/Redis) + migration gate in deploy path",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:15Z",
+      "closed_at": "2026-06-12T09:43:21Z",
+      "lead_time_hours": 54.501666666666665,
+      "factory_cycle_hours": 9.589166666666667,
+      "labels": [
+        "enhancement",
+        "needs-discussion",
+        "infrastructure",
+        "direct-to-pr",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 12.36656615,
+        "in_tokens": 2830,
+        "out_tokens": 151161,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 00:08 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 01:07 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 02:34 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-12 03:50 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 288,
+      "title": "[arch-v3][MED] Stage run_pre_market_scan into detect/enrich/persist pipeline (346-line function)",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:14Z",
+      "closed_at": "2026-06-12T11:22:59Z",
+      "lead_time_hours": 56.1625,
+      "factory_cycle_hours": 27.633055555555554,
+      "labels": [
+        "plan-pending-review",
+        "needs-discussion",
+        "direct-to-pr",
+        "ready-for-agent",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 23.520659249999998,
+        "in_tokens": 700,
+        "out_tokens": 371782,
+        "runs": [
+          {
+            "timestamp": "2026-06-11 07:45 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 00:33 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 02:02 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 10:43 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 287,
+      "title": "[arch-v3][MED] Decompose DiscoveryService.run_screen into asset-class screeners (CC~43)",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:13Z",
+      "closed_at": "2026-06-11T18:36:29Z",
+      "lead_time_hours": 39.38777777777778,
+      "factory_cycle_hours": 11.508055555555556,
+      "labels": [
+        "direct-to-pr",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 17.456395750000002,
+        "in_tokens": 687,
+        "out_tokens": 235242,
+        "runs": [
+          {
+            "timestamp": "2026-06-11 07:06 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 08:37 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 09:25 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 09:42 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 09:57 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 10:11 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 16:57 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 286,
+      "title": "[arch-v3][MED] Consolidate time-normalization duplication into app/utils/time.py + get_or_404 helper",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:12Z",
+      "closed_at": "2026-06-11T20:50:34Z",
+      "lead_time_hours": 41.62277777777778,
+      "factory_cycle_hours": 14.892777777777777,
+      "labels": [
+        "needs-discussion",
+        "direct-to-pr",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 15.952596000000003,
+        "in_tokens": 386,
+        "out_tokens": 195464,
+        "runs": [
+          {
+            "timestamp": "2026-06-11 05:57 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 07:34 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 20:45 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 285,
+      "title": "[arch-v3][MED] Add ruff check to CI backend job + fix 65 lint errors on main",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:11Z",
+      "closed_at": "2026-06-11T16:48:40Z",
+      "lead_time_hours": 37.591388888888886,
+      "factory_cycle_hours": 11.744444444444444,
+      "labels": [
+        "direct-to-pr",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 8.715559950000001,
+        "in_tokens": 670,
+        "out_tokens": 131789,
+        "runs": [
+          {
+            "timestamp": "2026-06-11 05:04 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 06:56 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 07:55 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 08:04 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 08:12 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 08:20 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 16:28 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 284,
+      "title": "[arch-v3][HIGH] Verify artifacts before closing remediation tickets (factory close-path gate)",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:11Z",
+      "closed_at": "2026-06-11T02:16:12Z",
+      "lead_time_hours": 23.05027777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "duplicate",
+        "invalid",
+        "Dark Factory",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 283,
+      "title": "Epic: Architecture audit v3 \u2014 process honesty & code health follow-ups",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:10Z",
+      "closed_at": "2026-06-14T15:33:32Z",
+      "lead_time_hours": 108.33944444444444,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "epic",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 281,
+      "title": "Decision needed: Pocket Pivot (Evening) seed (#278) contradicts migrations on is_active + criteria",
+      "state": "OPEN",
+      "created_at": "2026-06-10T02:55:53Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "scanner",
+        "needs-discussion"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 276,
+      "title": "Dark-factory scope-enforcement over-reports ruff/isort reformatting of touched files as scope spillover",
+      "state": "CLOSED",
+      "created_at": "2026-06-09T23:08:55Z",
+      "closed_at": "2026-06-11T19:31:58Z",
+      "lead_time_hours": 44.384166666666665,
+      "factory_cycle_hours": 22.949444444444445,
+      "labels": [
+        "priority: should-have",
+        "infrastructure",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 29.425085700000004,
+        "in_tokens": 1183,
+        "out_tokens": 484305,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 20:35 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 21:50 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 04:07 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 05:18 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 05:48 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 06:21 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 06:41 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 19:29 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 19:54 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 275,
+      "title": "Dark-factory re-dirties seed/01_scanner_configs.sql working tree \u2192 recurring phantom seed-drift spillovers",
+      "state": "CLOSED",
+      "created_at": "2026-06-09T23:08:55Z",
+      "closed_at": "2026-06-11T19:57:08Z",
+      "lead_time_hours": 44.80361111111111,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "wontfix",
+        "priority: should-have",
+        "infrastructure",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 274,
+      "title": "Epic: Frontend type-safety, lint & test-coverage debt",
+      "state": "CLOSED",
+      "created_at": "2026-06-09T23:08:54Z",
+      "closed_at": "2026-06-11T16:34:11Z",
+      "lead_time_hours": 41.42138888888889,
+      "factory_cycle_hours": null,
+      "labels": [
+        "priority: should-have",
+        "frontend",
+        "epic"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 272,
+      "title": "Epic: Container & deployment security hardening (least-privilege containers, docker-socket exposure)",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T20:19:55Z",
+      "closed_at": "2026-06-14T20:18:14Z",
+      "lead_time_hours": 167.97194444444443,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "epic",
+        "security",
+        "infrastructure",
+        "architecture-audit-v2"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 271,
+      "title": "Fix seed SQL: restore universe_id column in scanner_config INSERTs",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T18:10:43Z",
+      "closed_at": "2026-06-09T23:10:28Z",
+      "lead_time_hours": 52.99583333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 269,
+      "title": "tracing.py: import order cosmetically changed by ruff during #205 circuit-breakers impl",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T16:47:51Z",
+      "closed_at": "2026-06-09T23:10:41Z",
+      "lead_time_hours": 54.38055555555555,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 268,
+      "title": "tracing.py: cosmetic import reorder and blank-line enforced by ruff during #205",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T16:23:22Z",
+      "closed_at": "2026-06-09T23:10:40Z",
+      "lead_time_hours": 54.788333333333334,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 267,
+      "title": "security: evaluate replacing docker-socket-proxy with direct socket mount for factory services",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T15:02:36Z",
+      "closed_at": "2026-06-14T20:02:41Z",
+      "lead_time_hours": 173.0013888888889,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "needs-discussion",
+        "security",
+        "infrastructure",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 266,
+      "title": "chore: review non-root user setup in backend/frontend/dark-factory Dockerfiles",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T15:02:27Z",
+      "closed_at": "2026-06-11T19:02:09Z",
+      "lead_time_hours": 99.995,
+      "factory_cycle_hours": 30.11916666666667,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 7.16114545,
+        "in_tokens": 548,
+        "out_tokens": 95210,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 12:55 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 02:33 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 02:53 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 12:35 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 12:44 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 12:54 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 18:58 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 264,
+      "title": "Add codeindex ops lessons to factory memory (spillover from #200)",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T14:37:16Z",
+      "closed_at": "2026-06-10T22:15:03Z",
+      "lead_time_hours": 79.62972222222223,
+      "factory_cycle_hours": 1.8841666666666668,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.4776411499999997,
+        "in_tokens": 185,
+        "out_tokens": 51447,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 20:22 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 21:03 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 22:03 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 263,
+      "title": "tracing.py: import order not ruff-compliant (pre-existing)",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T14:22:31Z",
+      "closed_at": "2026-06-09T23:10:38Z",
+      "lead_time_hours": 56.801944444444445,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 262,
+      "title": "Epic: Harden the Dark Factory self-improvement loop",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T14:06:31Z",
+      "closed_at": "2026-06-11T23:48:55Z",
+      "lead_time_hours": 105.70666666666666,
+      "factory_cycle_hours": null,
+      "labels": [
+        "priority: must-have",
+        "epic",
+        "infrastructure",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 261,
+      "title": "feat(infra): run dark-factory container as non-root factory user",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T13:52:48Z",
+      "closed_at": "2026-06-13T03:01:47Z",
+      "lead_time_hours": 133.1497222222222,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "security",
+        "infrastructure",
+        "direct-to-pr",
+        "scope-spillover",
+        "ready-for-human",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 260,
+      "title": "feat(infra): harden docker-socket exposure for dark-factory and backlog-scheduler",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T13:52:44Z",
+      "closed_at": "2026-06-14T20:02:39Z",
+      "lead_time_hours": 174.1652777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "security",
+        "infrastructure",
+        "scope-spillover",
+        "ready-for-human"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 259,
+      "title": "feat(infra): run frontend container as non-root node user",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T13:52:37Z",
+      "closed_at": "2026-06-13T13:36:50Z",
+      "lead_time_hours": 143.73694444444445,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "spec-pending-review",
+        "security",
+        "infrastructure",
+        "direct-to-pr",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 258,
+      "title": "feat(infra): run backend container as non-root appuser",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T13:52:36Z",
+      "closed_at": "2026-06-12T04:09:09Z",
+      "lead_time_hours": 110.27583333333334,
+      "factory_cycle_hours": 3.5025,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 4.6952453499999995,
+        "in_tokens": 683,
+        "out_tokens": 59622,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 00:39 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 03:31 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 04:14 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-12 04:26 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 257,
+      "title": "infra: postgres/redis missing restart policy in compose files",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T13:49:37Z",
+      "closed_at": "2026-06-07T13:49:42Z",
+      "lead_time_hours": 0.001388888888888889,
+      "factory_cycle_hours": null,
+      "labels": [],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 255,
+      "title": "flower service crash-loops: JWT_SECRET_KEY not forwarded (missed by #236)",
+      "state": "CLOSED",
+      "created_at": "2026-06-06T19:27:55Z",
+      "closed_at": "2026-06-06T20:02:13Z",
+      "lead_time_hours": 0.5716666666666667,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "infrastructure"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 254,
+      "title": "Revamp the dark-factory .archon/memory system \u2014 too eager, persists unverified/low-value lessons",
+      "state": "CLOSED",
+      "created_at": "2026-06-06T14:10:26Z",
+      "closed_at": "2026-06-09T23:12:11Z",
+      "lead_time_hours": 81.02916666666667,
+      "factory_cycle_hours": 74.88638888888889,
+      "labels": [
+        "priority: should-have",
+        "size: L",
+        "infrastructure",
+        "Dark Factory",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 9.63853005,
+        "in_tokens": 1011,
+        "out_tokens": 160733,
+        "runs": [
+          {
+            "timestamp": "2026-06-06 20:19 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 18:28 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 20:07 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-09 22:23 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 253,
+      "title": "system.py get_storage_stats: consolidate reformatted get_cached call (formatter-enforced)",
+      "state": "CLOSED",
+      "created_at": "2026-06-06T13:16:58Z",
+      "closed_at": "2026-06-09T23:10:37Z",
+      "lead_time_hours": 81.89416666666666,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 252,
+      "title": "scanner.py get_scanner_configs: consolidate reformatted list comprehension (formatter-enforced)",
+      "state": "CLOSED",
+      "created_at": "2026-06-06T13:16:50Z",
+      "closed_at": "2026-06-09T23:10:36Z",
+      "lead_time_hours": 81.89611111111111,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 250,
+      "title": "Ratchet frontend coverage thresholds to 35%/25% (follow-up from #198)",
+      "state": "CLOSED",
+      "created_at": "2026-06-06T06:03:48Z",
+      "closed_at": "2026-06-11T16:27:55Z",
+      "lead_time_hours": 130.40194444444444,
+      "factory_cycle_hours": 40.18194444444445,
+      "labels": [
+        "needs-discussion",
+        "direct-to-pr"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 34.0853558,
+        "in_tokens": 1843,
+        "out_tokens": 469505,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 00:17 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 02:27 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 10:55 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 02:25 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 03:30 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 13:25 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 13:55 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 16:06 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 249,
+      "title": "Add unit tests for calculateDoubleSuperTrend (frontend/src/utils/indicators.ts)",
+      "state": "CLOSED",
+      "created_at": "2026-06-06T06:01:42Z",
+      "closed_at": "2026-06-10T02:43:15Z",
+      "lead_time_hours": 92.6925,
+      "factory_cycle_hours": 2.6708333333333334,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.899150950000001,
+        "in_tokens": 189,
+        "out_tokens": 54388,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 00:03 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 01:10 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 01:51 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 247,
+      "title": "style: normalize OTel import ordering in tracing.py (ruff-enforced, scope spillover from #205)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T22:27:20Z",
+      "closed_at": "2026-06-09T23:10:34Z",
+      "lead_time_hours": 96.72055555555555,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 246,
+      "title": "fix(seed): restore universe_id and pocket_pivot row in 01_scanner_configs.sql",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T22:04:38Z",
+      "closed_at": "2026-06-09T23:10:26Z",
+      "lead_time_hours": 97.09666666666666,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 241,
+      "title": "Fix prefer-const violation in StockChart.tsx (allMarkers never reassigned)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T13:03:18Z",
+      "closed_at": "2026-06-10T09:49:25Z",
+      "lead_time_hours": 116.76861111111111,
+      "factory_cycle_hours": 9.67361111111111,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.7410623999999997,
+        "in_tokens": 202,
+        "out_tokens": 64425,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 00:09 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 01:20 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 03:19 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 240,
+      "title": "Fix no-unused-expressions in ExportUniverseModal.tsx (ternary-as-statement)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T13:03:11Z",
+      "closed_at": "2026-06-10T02:41:13Z",
+      "lead_time_hours": 109.63388888888889,
+      "factory_cycle_hours": 2.7202777777777776,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.30559235,
+        "in_tokens": 196,
+        "out_tokens": 54803,
+        "runs": [
+          {
+            "timestamp": "2026-06-09 23:58 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 00:51 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 02:49 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 239,
+      "title": "Eliminate ~131 any usages and re-enable no-explicit-any: error in CI",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T12:48:41Z",
+      "closed_at": "2026-06-11T00:11:22Z",
+      "lead_time_hours": 131.37805555555556,
+      "factory_cycle_hours": 14.15611111111111,
+      "labels": [
+        "priority: should-have",
+        "size: M",
+        "frontend",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 55.49635369999999,
+        "in_tokens": 1252,
+        "out_tokens": 474185,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 10:02 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 11:53 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 12:12 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 13:28 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-10 14:02 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-10 14:07 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-10 22:38 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-10 23:09 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-10 23:46 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 238,
+      "title": "Site won't load: backend crash-loops \u2014 docker-compose.yml never forwards JWT_SECRET_KEY (regression from #220)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T12:20:27Z",
+      "closed_at": "2026-06-05T12:20:39Z",
+      "lead_time_hours": 0.0033333333333333335,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: must-have",
+        "size: S",
+        "infrastructure",
+        "regression"
+      ],
+      "size": "S",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 237,
+      "title": "seed: restore universe_id in scanner_configs INSERT statements",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T12:18:55Z",
+      "closed_at": "2026-06-09T23:10:25Z",
+      "lead_time_hours": 106.85833333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 235,
+      "title": "[follow-on] Eliminate ~131 any usages and re-enable no-explicit-any: error in CI",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T12:08:06Z",
+      "closed_at": "2026-06-09T23:10:30Z",
+      "lead_time_hours": 107.04,
+      "factory_cycle_hours": null,
+      "labels": [
+        "frontend"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 233,
+      "title": "Update Pocket Pivot seed row with run_frequency column and corrected parameters",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T09:37:09Z",
+      "closed_at": "2026-06-09T23:10:29Z",
+      "lead_time_hours": 109.55555555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 231,
+      "title": "style: import order in test_metrics.py (ruff-enforced, scope spillover from #194)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T09:08:16Z",
+      "closed_at": "2026-06-09T23:10:33Z",
+      "lead_time_hours": 110.03805555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 229,
+      "title": "chore: align tracing import to alphabetical position in main.py",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T07:49:42Z",
+      "closed_at": "2026-06-09T23:10:32Z",
+      "lead_time_hours": 111.34722222222223,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 227,
+      "title": "Fix seed/01_scanner_configs.sql: universe_id column mismatch (scope spillover from #193)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T07:21:00Z",
+      "closed_at": "2026-06-09T23:10:24Z",
+      "lead_time_hours": 111.82333333333334,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 226,
+      "title": "Add vite-env.d.ts scaffold file to frontend (scope spillover from #193)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T07:20:55Z",
+      "closed_at": "2026-06-10T03:07:36Z",
+      "lead_time_hours": 115.77805555555555,
+      "factory_cycle_hours": 3.26,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.72745115,
+        "in_tokens": 263,
+        "out_tokens": 55243,
+        "runs": [
+          {
+            "timestamp": "2026-06-09 23:52 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 00:42 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 02:36 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-10 03:00 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 224,
+      "title": "[dark-factory] Guard against OR-join trigger_rule regressions in the workflow DAG",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T05:01:22Z",
+      "closed_at": "2026-06-11T23:48:19Z",
+      "lead_time_hours": 162.7825,
+      "factory_cycle_hours": 101.43861111111111,
+      "labels": [
+        "priority: should-have",
+        "size: S",
+        "infrastructure",
+        "ready-for-agent"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 15.53727985,
+        "in_tokens": 587,
+        "out_tokens": 234699,
+        "runs": [
+          {
+            "timestamp": "2026-06-07 18:22 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 12:44 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 04:28 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 21:34 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 21:53 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 23:07 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 223,
+      "title": "fix(seed): restore universe_id + correct Pocket Pivot (Evening) row in 01_scanner_configs.sql (canonical)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T04:41:03Z",
+      "closed_at": "2026-06-10T01:38:55Z",
+      "lead_time_hours": 116.96444444444444,
+      "factory_cycle_hours": 1.8819444444444444,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "direct-to-pr"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 4.475015750000001,
+        "in_tokens": 206,
+        "out_tokens": 72106,
+        "runs": [
+          {
+            "timestamp": "2026-06-09 23:46 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 00:29 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 01:33 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 222,
+      "title": "chore: conftest.py import ordering audit record (scope spillover from #190)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T04:40:58Z",
+      "closed_at": "2026-06-07T13:46:44Z",
+      "lead_time_hours": 57.096111111111114,
+      "factory_cycle_hours": null,
+      "labels": [],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 218,
+      "title": "Add AI code-review sub-stage to dark-factory pipeline",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T00:53:41Z",
+      "closed_at": "2026-06-05T02:03:33Z",
+      "lead_time_hours": 1.1644444444444444,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "needs-discussion",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 215,
+      "title": "test: add P1.5-1 increment_retry and P1.5-5 trip_to_blocked scheduler tests",
+      "state": "CLOSED",
+      "created_at": "2026-06-04T18:10:33Z",
+      "closed_at": "2026-06-10T10:44:08Z",
+      "lead_time_hours": 136.55972222222223,
+      "factory_cycle_hours": 65.06888888888889,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "Dark Factory",
+        "direct-to-pr",
+        "ready-for-agent"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 9.1088484,
+        "in_tokens": 263,
+        "out_tokens": 92289,
+        "runs": [
+          {
+            "timestamp": "2026-06-07 17:40 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 04:01 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 10:14 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 214,
@@ -409,25 +7428,56 @@ window.__METRICS__ = {
     {
       "number": 213,
       "title": "Review all the self-improvement made and make sure they work well",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T16:59:43Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
-      "labels": [],
+      "closed_at": "2026-06-10T01:31:13Z",
+      "lead_time_hours": 128.525,
+      "factory_cycle_hours": 100.27027777777778,
+      "labels": [
+        "priority: must-have",
+        "needs-discussion",
+        "Dark Factory",
+        "ready-for-agent"
+      ],
       "size": null,
-      "priority": null,
-      "autonomous": false,
-      "cost": null
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 11.317244,
+        "in_tokens": 1779,
+        "out_tokens": 184823,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 21:15 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 17:34 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 19:40 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-09 23:38 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 212,
       "title": "Interactive pipeline production report (Dark Factory metrics dashboard)",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T16:44:06Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-05T00:48:06Z",
+      "lead_time_hours": 8.066666666666666,
+      "factory_cycle_hours": 6.0183333333333335,
       "labels": [
         "enhancement",
         "size: L",
@@ -577,219 +7627,510 @@ window.__METRICS__ = {
     {
       "number": 205,
       "title": "[arch-v2][LOW] Add circuit breakers + outbound request timeouts",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:30Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-07T19:19:09Z",
+      "lead_time_hours": 78.49416666666667,
+      "factory_cycle_hours": 51.369166666666665,
       "labels": [
         "priority: should-have",
         "size: M",
-        "timeframe: medium-term",
+        "needs-discussion",
         "performance",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "M",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 30.14031805,
+        "in_tokens": 2043,
+        "out_tokens": 462050,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 15:57 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 21:04 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 22:05 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 22:32 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 14:23 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-07 16:01 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-07 16:24 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-07 16:48 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          }
+        ]
+      }
     },
     {
       "number": 204,
       "title": "[arch-v2][MED] Include Celery tasks in coverage measurement",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:29Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-07T19:13:58Z",
+      "lead_time_hours": 78.40805555555555,
+      "factory_cycle_hours": 52.31611111111111,
       "labels": [
         "priority: should-have",
         "size: M",
-        "timeframe: short-term",
         "testing",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "M",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 16.61461735,
+        "in_tokens": 397,
+        "out_tokens": 246108,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 14:55 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 17:14 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 17:03 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 18:14 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 203,
       "title": "[arch-v2][MED] Harden Docker socket mount (dark-factory / scheduler) + non-root containers",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:28Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-07T13:34:22Z",
+      "lead_time_hours": 72.74833333333333,
+      "factory_cycle_hours": 47.12277777777778,
       "labels": [
         "priority: should-have",
         "size: M",
-        "timeframe: medium-term",
+        "needs-discussion",
         "security",
         "infrastructure",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "M",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 6.7898118,
+        "in_tokens": 254,
+        "out_tokens": 111056,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 14:27 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 16:37 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 20:42 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 202,
       "title": "[arch-v2][MED] Enforce secure cookies + TLS termination",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:27Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-07T19:18:32Z",
+      "lead_time_hours": 78.48472222222222,
+      "factory_cycle_hours": 53.97555555555556,
       "labels": [
         "priority: should-have",
         "size: M",
-        "timeframe: medium-term",
+        "needs-discussion",
         "security",
         "infrastructure",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "M",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 20.01518335,
+        "in_tokens": 2694,
+        "out_tokens": 308988,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 13:20 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 14:45 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 16:23 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 14:00 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-07 15:10 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-07 15:35 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          }
+        ]
+      }
     },
     {
       "number": 201,
       "title": "[arch-v2][MED] Documentation hygiene: sync/async drift, stale tables, ADR numbering, docs casing",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:26Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-10T14:40:52Z",
+      "lead_time_hours": 145.85722222222222,
+      "factory_cycle_hours": 124.19777777777777,
       "labels": [
         "documentation",
         "priority: should-have",
         "size: S",
-        "timeframe: short-term",
-        "architecture-audit-v2"
+        "architecture-audit-v2",
+        "ready-for-agent"
       ],
       "size": "S",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 9.0943708,
+        "in_tokens": 289,
+        "out_tokens": 147528,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 10:29 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 17:26 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 03:31 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 11:14 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 200,
       "title": "[arch-v2][MED] Codeindex artifacts referenced as committed but absent",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:24Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-07T14:53:03Z",
+      "lead_time_hours": 74.06083333333333,
+      "factory_cycle_hours": 52.5675,
       "labels": [
         "documentation",
         "priority: should-have",
         "size: S",
-        "timeframe: short-term",
-        "architecture-audit-v2"
+        "plan-pending-review",
+        "architecture-audit-v2",
+        "ready-for-agent"
       ],
       "size": "S",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 5.7527506,
+        "in_tokens": 280,
+        "out_tokens": 79755,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 10:19 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-06 03:18 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 14:42 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 199,
       "title": "[arch-v2][MED] Decompose scanner.py / futures_data.py god modules",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:23Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-06T03:16:15Z",
+      "lead_time_hours": 38.44777777777778,
+      "factory_cycle_hours": 17.120833333333334,
       "labels": [
         "priority: should-have",
         "size: L",
         "scanner",
-        "timeframe: short-term",
-        "architecture-audit-v2"
+        "direct-to-pr",
+        "architecture-audit-v2",
+        "ready-for-agent"
       ],
       "size": "L",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 18.1514929,
+        "in_tokens": 359,
+        "out_tokens": 282704,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 10:09 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 14:01 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 14:16 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 15:46 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 198,
       "title": "[arch-v2][MED] Expand frontend test breadth (pages/components) + honest coverage",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:22Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-06T16:42:18Z",
+      "lead_time_hours": 51.882222222222225,
+      "factory_cycle_hours": 31.355,
       "labels": [
         "priority: should-have",
         "size: L",
         "frontend",
-        "timeframe: short-term",
+        "needs-discussion",
         "testing",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "L",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 24.85512065,
+        "in_tokens": 676,
+        "out_tokens": 386290,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 09:21 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-06 03:29 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-06 04:31 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-06 04:58 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-06 06:14 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-06 13:59 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 197,
       "title": "[arch-v2][MED] CI lint/audit gates are non-enforcing (ESLint TS rules + non-blocking audits)",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:21Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-06T03:13:27Z",
+      "lead_time_hours": 38.401666666666664,
+      "factory_cycle_hours": 21.574166666666667,
       "labels": [
         "priority: should-have",
         "size: S",
         "frontend",
-        "timeframe: short-term",
+        "needs-discussion",
         "infrastructure",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "S",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 12.62822405,
+        "in_tokens": 457,
+        "out_tokens": 182620,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 05:39 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 09:58 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 12:19 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 13:09 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 196,
       "title": "[arch-v2][MED] Add brute-force rate limit to login/register",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:19Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-06T03:21:00Z",
+      "lead_time_hours": 38.528055555555554,
+      "factory_cycle_hours": 25.216666666666665,
       "labels": [
         "priority: should-have",
         "size: S",
-        "timeframe: immediate",
         "security",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "S",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 6.314425849999999,
+        "in_tokens": 243,
+        "out_tokens": 101790,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 02:08 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 06:58 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 09:44 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 195,
       "title": "[arch-v2][HIGH] Automated database backups (carried over from v1, never ticketed)",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:18Z",
-      "closed_at": null,
-      "lead_time_hours": null,
+      "closed_at": "2026-06-07T13:43:33Z",
+      "lead_time_hours": 72.90416666666667,
       "factory_cycle_hours": null,
       "labels": [
         "priority: must-have",
         "size: M",
-        "timeframe: short-term",
         "infrastructure",
         "architecture-audit-v2"
       ],
@@ -801,107 +8142,257 @@ window.__METRICS__ = {
     {
       "number": 194,
       "title": "[arch-v2][HIGH] Celery/worker Prometheus metrics never scraped",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:17Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-06T13:13:02Z",
+      "lead_time_hours": 48.395833333333336,
+      "factory_cycle_hours": 35.51722222222222,
       "labels": [
         "bug",
         "priority: must-have",
         "size: M",
-        "timeframe: immediate",
+        "needs-discussion",
         "infrastructure",
         "observability",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "M",
       "priority": "must-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 14.221601399999997,
+        "in_tokens": 654,
+        "out_tokens": 202656,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 01:42 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 06:10 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 08:12 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 08:31 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 08:47 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 09:19 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 193,
       "title": "[arch-v2][HIGH] Frontend tsc --noEmit is red \u2014 build/CI gate broken",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:16Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-06T03:18:50Z",
+      "lead_time_hours": 38.492777777777775,
+      "factory_cycle_hours": 25.930555555555557,
       "labels": [
         "bug",
         "priority: must-have",
         "size: S",
         "frontend",
-        "timeframe: immediate",
+        "needs-discussion",
         "testing",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "S",
       "priority": "must-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 6.62427255,
+        "in_tokens": 270,
+        "out_tokens": 116982,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 01:23 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 05:29 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 07:29 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 192,
       "title": "[arch-v2][HIGH] Add CSRF protection for cookie-based auth",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:14Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-06T13:10:15Z",
+      "lead_time_hours": 48.35027777777778,
+      "factory_cycle_hours": 35.62083333333333,
       "labels": [
         "priority: must-have",
         "size: M",
-        "timeframe: immediate",
+        "needs-discussion",
         "security",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "M",
       "priority": "must-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 6.9755208,
+        "in_tokens": 251,
+        "out_tokens": 120687,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 01:33 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 05:57 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 07:54 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 191,
       "title": "[arch-v2][HIGH] Authenticate WebSocket connections (currently bypass auth)",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:13Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-07T13:25:15Z",
+      "lead_time_hours": 72.60055555555556,
+      "factory_cycle_hours": 60.2875,
       "labels": [
         "priority: must-have",
         "size: M",
-        "timeframe: immediate",
+        "needs-discussion",
         "security",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "M",
       "priority": "must-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 13.056638900000001,
+        "in_tokens": 441,
+        "out_tokens": 213343,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 01:08 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 05:19 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 06:44 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-06 13:24 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          }
+        ]
+      }
     },
     {
       "number": 190,
       "title": "[arch-v2][CRITICAL] Reject empty/weak JWT_SECRET_KEY at startup",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:12Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-05T04:55:36Z",
+      "lead_time_hours": 16.106666666666666,
+      "factory_cycle_hours": 3.9433333333333334,
       "labels": [
         "bug",
         "priority: must-have",
         "size: S",
-        "timeframe: immediate",
+        "plan-pending-review",
         "security",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "S",
       "priority": "must-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 11.375203249999998,
+        "in_tokens": 660,
+        "out_tokens": 156429,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 00:59 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 02:01 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 02:20 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 02:34 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 03:57 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 04:13 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 04:42 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          }
+        ]
+      }
     },
     {
       "number": 184,
@@ -1453,8 +8944,7 @@ window.__METRICS__ = {
       "labels": [
         "enhancement",
         "priority: should-have",
-        "scanner",
-        "timeframe: immediate"
+        "scanner"
       ],
       "size": null,
       "priority": "should-have",
@@ -1537,13 +9027,15 @@ window.__METRICS__ = {
     {
       "number": 148,
       "title": "Integrate https://github.com/microsoft/agent-governance-toolkit",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-01T13:26:25Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-26T11:19:59Z",
+      "lead_time_hours": 597.8927777777777,
+      "factory_cycle_hours": 597.6163888888889,
       "labels": [
-        "spec-pending-review"
+        "enhancement",
+        "spec-pending-review",
+        "Dark Factory"
       ],
       "size": null,
       "priority": null,
@@ -1705,7 +9197,9 @@ window.__METRICS__ = {
       "lead_time_hours": null,
       "factory_cycle_hours": null,
       "labels": [
-        "spec-pending-review"
+        "enhancement",
+        "spec-pending-review",
+        "infrastructure"
       ],
       "size": null,
       "priority": null,
@@ -1885,7 +9379,6 @@ window.__METRICS__ = {
         "priority: must-have",
         "size: S",
         "plan-pending-review",
-        "timeframe: immediate",
         "Dark Factory"
       ],
       "size": "S",
@@ -1932,27 +9425,35 @@ window.__METRICS__ = {
     {
       "number": 106,
       "title": "Integrate HMM regime detection to enhance and validate scanner signals",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-05-27T02:56:07Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-15T15:30:39Z",
+      "lead_time_hours": 468.5755555555556,
+      "factory_cycle_hours": 323.7608333333333,
       "labels": [
         "enhancement",
+        "priority: should-have",
         "size: L",
-        "plan-pending-review"
+        "ml",
+        "scanner",
+        "factory-regression"
       ],
       "size": "L",
-      "priority": null,
+      "priority": "should-have",
       "autonomous": true,
       "cost": {
-        "total_usd": 5.638087600000001,
-        "in_tokens": 81,
-        "out_tokens": 87899,
+        "total_usd": 15.869576399999998,
+        "in_tokens": 345,
+        "out_tokens": 172185,
         "runs": [
           {
             "timestamp": "2026-06-02 03:45 UTC",
             "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-14 21:20 UTC",
+            "run_type": "fix",
             "status": "completed"
           }
         ]
@@ -1970,7 +9471,6 @@ window.__METRICS__ = {
         "enhancement",
         "priority: should-have",
         "size: L",
-        "timeframe: strategic",
         "architecture-audit"
       ],
       "size": "L",
@@ -1989,7 +9489,6 @@ window.__METRICS__ = {
       "labels": [
         "priority: should-have",
         "size: L",
-        "timeframe: strategic",
         "infrastructure",
         "architecture-audit"
       ],
@@ -2025,7 +9524,6 @@ window.__METRICS__ = {
       "labels": [
         "priority: should-have",
         "size: L",
-        "timeframe: strategic",
         "infrastructure",
         "observability",
         "architecture-audit"
@@ -2047,7 +9545,6 @@ window.__METRICS__ = {
         "priority: should-have",
         "size: M",
         "frontend",
-        "timeframe: strategic",
         "performance",
         "architecture-audit"
       ],
@@ -2067,7 +9564,6 @@ window.__METRICS__ = {
       "labels": [
         "wontfix",
         "priority: should-have",
-        "timeframe: strategic",
         "size: XL",
         "performance",
         "architecture-audit"
@@ -2099,7 +9595,6 @@ window.__METRICS__ = {
       "labels": [
         "priority: should-have",
         "size: M",
-        "timeframe: medium-term",
         "performance",
         "architecture-audit"
       ],
@@ -2120,8 +9615,9 @@ window.__METRICS__ = {
         "documentation",
         "priority: should-have",
         "size: M",
-        "timeframe: medium-term",
-        "architecture-audit"
+        "needs-discussion",
+        "architecture-audit",
+        "factory-regression"
       ],
       "size": "M",
       "priority": "should-have",
@@ -2139,7 +9635,6 @@ window.__METRICS__ = {
       "labels": [
         "priority: should-have",
         "size: M",
-        "timeframe: medium-term",
         "performance",
         "architecture-audit"
       ],
@@ -2171,7 +9666,6 @@ window.__METRICS__ = {
         "enhancement",
         "priority: should-have",
         "size: S",
-        "timeframe: medium-term",
         "architecture-audit",
         "Dark Factory"
       ],
@@ -2192,7 +9686,6 @@ window.__METRICS__ = {
         "enhancement",
         "priority: should-have",
         "size: M",
-        "timeframe: medium-term",
         "architecture-audit"
       ],
       "size": "M",
@@ -2211,7 +9704,6 @@ window.__METRICS__ = {
       "labels": [
         "priority: should-have",
         "size: L",
-        "timeframe: medium-term",
         "infrastructure",
         "observability",
         "architecture-audit"
@@ -2233,7 +9725,6 @@ window.__METRICS__ = {
         "documentation",
         "priority: should-have",
         "size: M",
-        "timeframe: short-term",
         "architecture-audit"
       ],
       "size": "M",
@@ -2252,7 +9743,6 @@ window.__METRICS__ = {
       "labels": [
         "priority: should-have",
         "size: S",
-        "timeframe: short-term",
         "infrastructure",
         "architecture-audit"
       ],
@@ -2273,7 +9763,6 @@ window.__METRICS__ = {
         "priority: should-have",
         "size: M",
         "frontend",
-        "timeframe: short-term",
         "architecture-audit"
       ],
       "size": "M",
@@ -2293,7 +9782,6 @@ window.__METRICS__ = {
         "enhancement",
         "priority: should-have",
         "size: M",
-        "timeframe: short-term",
         "architecture-audit"
       ],
       "size": "M",
@@ -2304,23 +9792,35 @@ window.__METRICS__ = {
     {
       "number": 90,
       "title": "Implement automated database backups with retention",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-05-27T01:21:52Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-12T20:54:24Z",
+      "lead_time_hours": 403.5422222222222,
+      "factory_cycle_hours": 40.95666666666666,
       "labels": [
+        "enhancement",
         "priority: must-have",
         "size: M",
-        "plan-pending-review",
-        "timeframe: short-term",
+        "needs-discussion",
         "infrastructure",
-        "architecture-audit"
+        "architecture-audit",
+        "cost-report-lost"
       ],
       "size": "M",
       "priority": "must-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.3329495000000002,
+        "in_tokens": 76,
+        "out_tokens": 79951,
+        "runs": [
+          {
+            "timestamp": "2026-06-11 03:57 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 89,
@@ -2335,7 +9835,6 @@ window.__METRICS__ = {
         "size: L",
         "frontend",
         "plan-pending-review",
-        "timeframe: short-term",
         "testing",
         "architecture-audit"
       ],
@@ -2356,10 +9855,11 @@ window.__METRICS__ = {
         "priority: should-have",
         "size: M",
         "plan-pending-review",
-        "timeframe: short-term",
+        "needs-discussion",
         "infrastructure",
         "architecture-audit",
-        "Dark Factory"
+        "Dark Factory",
+        "factory-regression"
       ],
       "size": "M",
       "priority": "should-have",
@@ -2388,7 +9888,6 @@ window.__METRICS__ = {
       "labels": [
         "priority: must-have",
         "size: S",
-        "timeframe: immediate",
         "security",
         "architecture-audit"
       ],
@@ -2409,7 +9908,6 @@ window.__METRICS__ = {
         "priority: must-have",
         "size: S",
         "plan-pending-review",
-        "timeframe: immediate",
         "security",
         "infrastructure",
         "architecture-audit"
@@ -2431,7 +9929,6 @@ window.__METRICS__ = {
         "priority: must-have",
         "size: S",
         "plan-pending-review",
-        "timeframe: immediate",
         "infrastructure",
         "architecture-audit"
       ],
@@ -2451,7 +9948,6 @@ window.__METRICS__ = {
       "labels": [
         "priority: must-have",
         "size: M",
-        "timeframe: immediate",
         "security",
         "architecture-audit"
       ],
@@ -2660,7 +10156,9 @@ window.__METRICS__ = {
       "labels": [
         "enhancement",
         "priority: should-have",
-        "size: L"
+        "size: L",
+        "needs-discussion",
+        "factory-regression"
       ],
       "size": "L",
       "priority": "should-have",
@@ -3149,16 +10647,20 @@ window.__METRICS__ = {
     }
   ],
   "cost_by_step": {
-    "implement": 80.7319,
-    "plan": 74.8324,
-    "validate": 21.5221,
-    "refine": 19.7094,
-    "conformance": 15.057,
-    "parse-intent": 1.386,
-    "classify-preview": 0.5548,
-    "summarize-feedback": 0.3447,
+    "implement": 319.0849,
+    "plan": 265.1221,
+    "refine": 223.2749,
+    "conformance": 132.9592,
+    "code-review": 52.8631,
+    "validate": 42.9506,
+    "parse-intent": 6.9301,
+    "classify-preview": 4.6819,
+    "revise-advisory": 3.1467,
+    "summarize-feedback": 1.866,
     "fetch-issue": 0.0,
+    "bench-mode-probe": 0.0,
     "setup-refine-branch": 0.0,
+    "refine-push": 0.0,
     "plan-push-and-advance": 0.0,
     "setup-branch": 0.0,
     "update-codeindex": 0.0,
@@ -3169,7 +10671,7 @@ window.__METRICS__ = {
     "status-in-review": 0.0,
     "report": 0.0,
     "acknowledge-continue": 0.0,
-    "refine-push": 0.0
+    "de-conflict": 0.0
   },
   "timeseries": {
     "weekly": [
@@ -3210,61 +10712,82 @@ window.__METRICS__ = {
       },
       {
         "week": "2026-06-01",
-        "created": 45,
-        "closed": 28,
-        "cum_closed": 93,
-        "backlog": 23
+        "created": 82,
+        "closed": 49,
+        "cum_closed": 114,
+        "backlog": 39
+      },
+      {
+        "week": "2026-06-08",
+        "created": 176,
+        "closed": 111,
+        "cum_closed": 225,
+        "backlog": 104
+      },
+      {
+        "week": "2026-06-15",
+        "created": 33,
+        "closed": 36,
+        "cum_closed": 261,
+        "backlog": 101
+      },
+      {
+        "week": "2026-06-22",
+        "created": 14,
+        "closed": 24,
+        "cum_closed": 285,
+        "backlog": 91
       }
     ]
   },
   "scorecard": {
-    "generated_at": "2026-06-11T22:26:19.158457+00:00",
+    "generated_at": "2026-06-26T13:33:46.755710+00:00",
     "window": {
       "since": "2026-05-01",
-      "until": "2026-06-11"
+      "until": "2026-06-26"
     },
     "triad": {
-      "merged_clean": 99,
-      "merged_with_edits": 8,
-      "closed": 9,
-      "open": 2,
-      "merge_rate_pct": 92.2
+      "merged_clean": 151,
+      "merged_with_edits": 17,
+      "closed": 12,
+      "open": 0,
+      "merge_rate_pct": 93.3
     },
     "rework": {
-      "regression_count": 0,
-      "merged_factory_prs": 107,
-      "rework_rate_pct": 0.0
+      "regression_count": 28,
+      "merged_factory_prs": 168,
+      "rework_rate_pct": 16.7
     },
     "churn": {
-      "added_lines": 39724,
-      "surviving_lines": 34956,
-      "churn_pct": 12.0,
-      "commits_analyzed": 178,
-      "commits_too_young": 263
+      "added_lines": 163535,
+      "surviving_lines": 58280,
+      "churn_pct": 64.4,
+      "commits_analyzed": 538,
+      "commits_too_young": 128
     },
     "by_size": {
-      "S": {
-        "merged_clean": 22,
-        "merged_with_edits": 3,
-        "closed": 0,
-        "open": 1
-      },
-      "M": {
-        "merged_clean": 33,
-        "merged_with_edits": 3,
-        "closed": 0,
-        "open": 1
-      },
       "unknown": {
-        "merged_clean": 28,
+        "merged_clean": 48,
         "merged_with_edits": 2,
-        "closed": 8,
+        "closed": 10,
         "open": 0
       },
       "L": {
-        "merged_clean": 16,
-        "merged_with_edits": 0,
+        "merged_clean": 22,
+        "merged_with_edits": 3,
         "closed": 0,
+        "open": 0
+      },
+      "M": {
+        "merged_clean": 51,
+        "merged_with_edits": 8,
+        "closed": 0,
+        "open": 0
+      },
+      "S": {
+        "merged_clean": 30,
+        "merged_with_edits": 4,
+        "closed": 1,
         "open": 0
       },
       "XL": {
@@ -4206,18 +11729,514 @@ window.__METRICS__ = {
       {
         "number": 342,
         "title": "Implement trend_pullback daily scanner (trend-following pullback signals)",
-        "classification": "open",
+        "classification": "merged_clean",
         "issue": 299,
         "size": "M",
-        "merged_at": null
+        "merged_at": "2026-06-11T23:47:22Z"
       },
       {
         "number": 344,
         "title": "[dark-factory] Guard against OR-join trigger_rule regressions in the workflow DAG",
-        "classification": "open",
+        "classification": "merged_clean",
         "issue": 224,
         "size": "S",
+        "merged_at": "2026-06-11T23:48:18Z"
+      },
+      {
+        "number": 348,
+        "title": "[arch-v3][MED] Stage run_pre_market_scan into detect/enrich/persist pipeline (346-line function)",
+        "classification": "merged_clean",
+        "issue": 288,
+        "size": "unknown",
+        "merged_at": "2026-06-12T11:22:58Z"
+      },
+      {
+        "number": 351,
+        "title": "[arch-v3][MED] Add readiness probe (DB/Redis) + migration gate in deploy path",
+        "classification": "merged_clean",
+        "issue": 289,
+        "size": "unknown",
+        "merged_at": "2026-06-12T09:43:20Z"
+      },
+      {
+        "number": 352,
+        "title": "feat(infra): run backend container as non-root appuser (#258)",
+        "classification": "closed",
+        "issue": 258,
+        "size": "unknown",
         "merged_at": null
+      },
+      {
+        "number": 353,
+        "title": "[arch-v3][MED] Tweet-monitor cookie auth: expiry alerting or official API (3 reviews unticketed)",
+        "classification": "merged_clean",
+        "issue": 290,
+        "size": "unknown",
+        "merged_at": "2026-06-12T09:54:52Z"
+      },
+      {
+        "number": 354,
+        "title": "Baseline-green gate: smoke origin/main before any factory run",
+        "classification": "merged_clean",
+        "issue": 332,
+        "size": "S",
+        "merged_at": "2026-06-12T09:47:49Z"
+      },
+      {
+        "number": 356,
+        "title": "Run Record: one structured per-run record of every stage verdict (gen_ai.* to Seq + runs.jsonl)",
+        "classification": "merged_clean",
+        "issue": 333,
+        "size": "M",
+        "merged_at": "2026-06-12T09:57:36Z"
+      },
+      {
+        "number": 357,
+        "title": "Deepen the Gate seam: layered gate policy, judge calibration audit, blast-radius human gate",
+        "classification": "merged_clean",
+        "issue": 334,
+        "size": "L",
+        "merged_at": "2026-06-12T10:00:07Z"
+      },
+      {
+        "number": 358,
+        "title": "Failure-to-eval flywheel: post-mortem stage on circuit-break, failures become eval tasks",
+        "classification": "merged_clean",
+        "issue": 336,
+        "size": "M",
+        "merged_at": "2026-06-12T15:14:27Z"
+      },
+      {
+        "number": 359,
+        "title": "Replay benchmark: pass^k suite of replayed closed issues to regression-test the harness",
+        "classification": "merged_clean",
+        "issue": 335,
+        "size": "L",
+        "merged_at": "2026-06-12T14:54:50Z"
+      },
+      {
+        "number": 367,
+        "title": "[arch-v3][LOW] SQL aggregates in get_trade_stats + selectinload pagination fix",
+        "classification": "merged_clean",
+        "issue": 291,
+        "size": "unknown",
+        "merged_at": "2026-06-12T15:15:06Z"
+      },
+      {
+        "number": 399,
+        "title": "test(frontend): scope-correct PageLoader tests (not in spec #250)",
+        "classification": "closed",
+        "issue": 311,
+        "size": "unknown",
+        "merged_at": null
+      },
+      {
+        "number": 400,
+        "title": "test(frontend): scope-correct ScorecardDetail tests (spec #250 non-goal)",
+        "classification": "merged_clean",
+        "issue": 309,
+        "size": "unknown",
+        "merged_at": "2026-06-12T20:45:15Z"
+      },
+      {
+        "number": 401,
+        "title": "Implement automated database backups with retention",
+        "classification": "merged_clean",
+        "issue": 90,
+        "size": "M",
+        "merged_at": "2026-06-12T20:54:23Z"
+      },
+      {
+        "number": 405,
+        "title": "test(frontend): scope-correct AlertBadges tests (not in spec #250)",
+        "classification": "merged_clean",
+        "issue": 313,
+        "size": "unknown",
+        "merged_at": "2026-06-13T03:04:07Z"
+      },
+      {
+        "number": 406,
+        "title": "test(frontend): scope-correct ActiveWatchlist tests (not in spec #250)",
+        "classification": "merged_clean",
+        "issue": 312,
+        "size": "unknown",
+        "merged_at": "2026-06-13T03:03:30Z"
+      },
+      {
+        "number": 407,
+        "title": "test(frontend): scope-correct PreMarketMovers tests (not in spec #250)",
+        "classification": "merged_clean",
+        "issue": 314,
+        "size": "unknown",
+        "merged_at": "2026-06-13T03:20:32Z"
+      },
+      {
+        "number": 408,
+        "title": "test(frontend): scope-correct ScorecardOverview tests (not in spec #250)",
+        "classification": "merged_clean",
+        "issue": 315,
+        "size": "unknown",
+        "merged_at": "2026-06-13T03:21:15Z"
+      },
+      {
+        "number": 409,
+        "title": "test(frontend): scope-correct Settings tests (not in spec #250)",
+        "classification": "merged_clean",
+        "issue": 316,
+        "size": "unknown",
+        "merged_at": "2026-06-13T03:05:02Z"
+      },
+      {
+        "number": 410,
+        "title": "[security] F-AUTH-01: Swagger/openapi.json/metrics unauthenticated in production",
+        "classification": "merged_clean",
+        "issue": 369,
+        "size": "S",
+        "merged_at": "2026-06-13T03:33:40Z"
+      },
+      {
+        "number": 411,
+        "title": "feat(infra): run dark-factory container as non-root factory user",
+        "classification": "merged_clean",
+        "issue": 261,
+        "size": "unknown",
+        "merged_at": "2026-06-13T03:01:46Z"
+      },
+      {
+        "number": 412,
+        "title": "[arch-v3][LOW] Make Trivy block on HIGH/CRITICAL + add password min-length policy",
+        "classification": "merged_with_edits",
+        "issue": 293,
+        "size": "S",
+        "merged_at": "2026-06-13T03:21:45Z"
+      },
+      {
+        "number": 413,
+        "title": "feat(infra): run frontend container as non-root node user",
+        "classification": "merged_clean",
+        "issue": 259,
+        "size": "unknown",
+        "merged_at": "2026-06-13T13:36:49Z"
+      },
+      {
+        "number": 414,
+        "title": "test-infra: add postgres discovery fallback when testcontainers exec is blocked",
+        "classification": "merged_clean",
+        "issue": 360,
+        "size": "unknown",
+        "merged_at": "2026-06-13T19:38:20Z"
+      },
+      {
+        "number": 415,
+        "title": "[security] F-NET-01: Redis has no authentication (requirepass unset)",
+        "classification": "merged_with_edits",
+        "issue": 370,
+        "size": "M",
+        "merged_at": "2026-06-15T17:41:34Z"
+      },
+      {
+        "number": 416,
+        "title": "[arch-v3][LOW] Validate JSONB writes + enforce severity enum + channel_config schema",
+        "classification": "merged_with_edits",
+        "issue": 292,
+        "size": "M",
+        "merged_at": "2026-06-14T14:57:06Z"
+      },
+      {
+        "number": 417,
+        "title": "[arch-v3][LOW] Decompose frontend god files: api/scanner.ts (787) + QualityReportModal.tsx (753)",
+        "classification": "merged_clean",
+        "issue": 294,
+        "size": "M",
+        "merged_at": "2026-06-13T17:22:20Z"
+      },
+      {
+        "number": 418,
+        "title": "Update ARCHITECTURE.md to document /api/ready readiness endpoint",
+        "classification": "merged_clean",
+        "issue": 350,
+        "size": "unknown",
+        "merged_at": "2026-06-13T09:40:52Z"
+      },
+      {
+        "number": 420,
+        "title": "Single config interface: config.yaml as sole source of factory policy",
+        "classification": "merged_clean",
+        "issue": 338,
+        "size": "S",
+        "merged_at": "2026-06-13T09:39:39Z"
+      },
+      {
+        "number": 422,
+        "title": "factory: dedupe scope-enforcement findings before filing tickets",
+        "classification": "merged_clean",
+        "issue": 384,
+        "size": "M",
+        "merged_at": "2026-06-13T13:35:34Z"
+      },
+      {
+        "number": 423,
+        "title": "[security] F-FRONT-01: External-content URLs without allowlist; no CSP",
+        "classification": "merged_with_edits",
+        "issue": 381,
+        "size": "M",
+        "merged_at": "2026-06-13T18:47:29Z"
+      },
+      {
+        "number": 437,
+        "title": "Extract tested factory core from entrypoint/scheduler/de-conflict bash glue",
+        "classification": "merged_with_edits",
+        "issue": 337,
+        "size": "L",
+        "merged_at": "2026-06-13T18:56:15Z"
+      },
+      {
+        "number": 447,
+        "title": "Backtest harness core: daily-bar replay of TradingStrategy vs scan signals",
+        "classification": "merged_with_edits",
+        "issue": 301,
+        "size": "L",
+        "merged_at": "2026-06-14T15:27:39Z"
+      },
+      {
+        "number": 505,
+        "title": "ci: lint .archon/workflows when: expressions against Archon grammar",
+        "classification": "merged_clean",
+        "issue": 403,
+        "size": "S",
+        "merged_at": "2026-06-14T14:56:22Z"
+      },
+      {
+        "number": 510,
+        "title": "Plan stage implemented the full feature on the refine branch (#339) instead of stopping at the plan",
+        "classification": "merged_clean",
+        "issue": 390,
+        "size": "M",
+        "merged_at": "2026-06-14T20:16:22Z"
+      },
+      {
+        "number": 511,
+        "title": "test(frontend): quality-pass the 7 OOS test files from #250 (executes epic #383 decision)",
+        "classification": "merged_clean",
+        "issue": 396,
+        "size": "M",
+        "merged_at": "2026-06-14T20:06:46Z"
+      },
+      {
+        "number": 512,
+        "title": "observability: pre-market scan latency SLO \u2014 metrics + missed-slot alerts",
+        "classification": "merged_with_edits",
+        "issue": 391,
+        "size": "M",
+        "merged_at": "2026-06-15T12:11:57Z"
+      },
+      {
+        "number": 513,
+        "title": "[security] F-DOCKER-01: socket-proxy BUILD/POST + preview compose weak creds",
+        "classification": "merged_clean",
+        "issue": 379,
+        "size": "M",
+        "merged_at": "2026-06-15T01:13:28Z"
+      },
+      {
+        "number": 514,
+        "title": "[security] F-WS-01: WebSocket resource exhaustion (no conn/msg caps, per-conn pubsub)",
+        "classification": "merged_clean",
+        "issue": 377,
+        "size": "M",
+        "merged_at": "2026-06-15T01:14:26Z"
+      },
+      {
+        "number": 515,
+        "title": "feat: HMM regime detection stamps and filters scanner events (#106)",
+        "classification": "merged_with_edits",
+        "issue": 106,
+        "size": "L",
+        "merged_at": "2026-06-15T15:30:38Z"
+      },
+      {
+        "number": 519,
+        "title": "Preview env fails on every implement run: BuildKit 403 through docker-socket-proxy (+ EXEC:0 second wall)",
+        "classification": "merged_clean",
+        "issue": 436,
+        "size": "M",
+        "merged_at": "2026-06-15T01:32:01Z"
+      },
+      {
+        "number": 520,
+        "title": "Exclude untrusted events from trusted Scorecard metrics",
+        "classification": "merged_clean",
+        "issue": 497,
+        "size": "M",
+        "merged_at": "2026-06-15T01:33:16Z"
+      },
+      {
+        "number": 524,
+        "title": "Scheduler dependencies_met() strands issues whose dependency is closed but off-board",
+        "classification": "merged_clean",
+        "issue": 389,
+        "size": "S",
+        "merged_at": "2026-06-15T12:54:30Z"
+      },
+      {
+        "number": 562,
+        "title": "docs(docker): document root-user exception in Dockerfile.forecast",
+        "classification": "merged_clean",
+        "issue": 329,
+        "size": "unknown",
+        "merged_at": "2026-06-20T03:53:45Z"
+      },
+      {
+        "number": 563,
+        "title": "enhance(pg_discovery): guard isinstance(containers, list) on Docker API response",
+        "classification": "merged_clean",
+        "issue": 429,
+        "size": "unknown",
+        "merged_at": "2026-06-20T11:05:17Z"
+      },
+      {
+        "number": 565,
+        "title": "cleanup(dark-factory): factory-failures.jsonl accumulates OOS telemetry entries on feature branches",
+        "classification": "merged_clean",
+        "issue": 431,
+        "size": "unknown",
+        "merged_at": "2026-06-20T11:06:24Z"
+      },
+      {
+        "number": 566,
+        "title": "docs(architecture): ARCHITECTURE.md buildkit subgraph should be tracked as in-scope doc for #436",
+        "classification": "merged_clean",
+        "issue": 516,
+        "size": "unknown",
+        "merged_at": "2026-06-20T11:07:27Z"
+      },
+      {
+        "number": 567,
+        "title": "chore(codeindex): docs/codeindex-hotspots.md OOS line-count refreshes committed on feature branches",
+        "classification": "merged_clean",
+        "issue": 561,
+        "size": "unknown",
+        "merged_at": "2026-06-20T11:09:06Z"
+      },
+      {
+        "number": 568,
+        "title": "fix(dark-factory): unparseable when: fails the run loudly \u2014 pin Archon f83fb556 (#402)",
+        "classification": "merged_clean",
+        "issue": 402,
+        "size": "S",
+        "merged_at": "2026-06-20T14:50:51Z"
+      },
+      {
+        "number": 572,
+        "title": "feat(backtest): 5-scanner x strategy comparison run (#302)",
+        "classification": "merged_clean",
+        "issue": 302,
+        "size": "M",
+        "merged_at": "2026-06-20T14:53:09Z"
+      },
+      {
+        "number": 575,
+        "title": "Revisit dispatch ceiling (C9) \u2014 re-measure success-by-size/type",
+        "classification": "merged_clean",
+        "issue": 355,
+        "size": "M",
+        "merged_at": "2026-06-20T16:45:37Z"
+      },
+      {
+        "number": 580,
+        "title": "Outcome dashboard: per-scanner ScannerOutcomeSummary aggregates in UI",
+        "classification": "merged_clean",
+        "issue": 303,
+        "size": "M",
+        "merged_at": "2026-06-21T03:54:32Z"
+      },
+      {
+        "number": 583,
+        "title": "feat(notifications): generic system-notification path (email/push) for non-scanner events",
+        "classification": "closed",
+        "issue": 570,
+        "size": "S",
+        "merged_at": null
+      },
+      {
+        "number": 586,
+        "title": "Expose data quality gate preflight API",
+        "classification": "merged_clean",
+        "issue": 493,
+        "size": "M",
+        "merged_at": "2026-06-21T19:52:10Z"
+      },
+      {
+        "number": 589,
+        "title": "Revisit dispatch ceiling (C9) - re-measure success-by-size/type",
+        "classification": "merged_clean",
+        "issue": 394,
+        "size": "S",
+        "merged_at": "2026-06-21T19:53:18Z"
+      },
+      {
+        "number": 593,
+        "title": "data-quality: gap/staleness detection on aggregates + corporate-action handling",
+        "classification": "merged_clean",
+        "issue": 387,
+        "size": "L",
+        "merged_at": "2026-06-21T19:55:03Z"
+      },
+      {
+        "number": 597,
+        "title": "Add reusable data quality gate contract and service",
+        "classification": "merged_clean",
+        "issue": 492,
+        "size": "L",
+        "merged_at": "2026-06-21T21:15:32Z"
+      },
+      {
+        "number": 598,
+        "title": "scanner: nightly replay-diff \u2014 re-run yesterday's scans and diff vs live signals",
+        "classification": "merged_with_edits",
+        "issue": 392,
+        "size": "M",
+        "merged_at": "2026-06-22T13:03:31Z"
+      },
+      {
+        "number": 599,
+        "title": "feat: weekly restore drill \u2014 verify backups via throwaway postgres (#386)",
+        "classification": "merged_clean",
+        "issue": 386,
+        "size": "M",
+        "merged_at": "2026-06-22T02:00:02Z"
+      },
+      {
+        "number": 600,
+        "title": "chaos: IBKR gateway kill-test \u2014 verify live-scanner degradation and recovery",
+        "classification": "merged_clean",
+        "issue": 393,
+        "size": "M",
+        "merged_at": "2026-06-22T01:57:14Z"
+      },
+      {
+        "number": 603,
+        "title": "feat: apply advisory data quality gate to scanner runs (#494)",
+        "classification": "merged_clean",
+        "issue": 494,
+        "size": "L",
+        "merged_at": "2026-06-22T11:44:04Z"
+      },
+      {
+        "number": 604,
+        "title": "Show data quality trust status in scanner and quality UI",
+        "classification": "merged_clean",
+        "issue": 495,
+        "size": "L",
+        "merged_at": "2026-06-22T11:44:23Z"
+      },
+      {
+        "number": 605,
+        "title": "cleanup(dark-factory): orphaned seed files in dark-factory/seed/seed/ from prior failed run",
+        "classification": "merged_clean",
+        "issue": 518,
+        "size": "unknown",
+        "merged_at": "2026-06-22T11:44:17Z"
       }
     ]
   }

--- a/metrics.json
+++ b/metrics.json
@@ -1,30 +1,7049 @@
 {
-  "generated_at": "2026-06-05T00:22:40.421551+00:00",
+  "generated_at": "2026-06-26T13:30:11.192065+00:00",
   "summary": {
-    "total_issues": 116,
-    "closed_issues": 93,
-    "open_issues": 23,
-    "autonomous_issues": 35,
-    "pct_autonomous": 30.2,
-    "total_cost_usd": 214.5591,
-    "avg_cost_per_ticket": 6.1303,
-    "median_lead_time_hours": 30.072222222222223,
-    "p85_lead_time_hours": 225.98916666666668
+    "total_issues": 376,
+    "closed_issues": 285,
+    "open_issues": 91,
+    "autonomous_issues": 162,
+    "pct_autonomous": 43.1,
+    "total_cost_usd": 1053.3008,
+    "avg_cost_per_ticket": 6.5019,
+    "median_lead_time_hours": 49.34166666666667,
+    "p85_lead_time_hours": 200.56527777777777
   },
   "issues": [
     {
-      "number": 215,
-      "title": "test: add P1.5-1 increment_retry and P1.5-5 trip_to_blocked scheduler tests",
+      "number": 633,
+      "title": "architecture-v4: QualityGatePolicy interface to decouple gate evidence (3-modules-per-type)",
       "state": "OPEN",
-      "created_at": "2026-06-04T18:10:33Z",
+      "created_at": "2026-06-26T12:54:53Z",
       "closed_at": null,
       "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "architecture-audit-v4"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 632,
+      "title": "architecture-v4: extract app/utils/time.py \u2014 UTC-normalization duplication at 287 sites",
+      "state": "OPEN",
+      "created_at": "2026-06-26T12:54:52Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "architecture-audit-v4"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 631,
+      "title": "architecture-v4: universe_export.py raises HTTPException from a service (SoC leak)",
+      "state": "OPEN",
+      "created_at": "2026-06-26T12:54:51Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "architecture-audit-v4"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 630,
+      "title": "architecture-v4: decompose AutoTradeExecutor.maybe_execute() (290-line / 15-branch cascade)",
+      "state": "OPEN",
+      "created_at": "2026-06-26T12:54:50Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "architecture-audit-v4"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 629,
+      "title": "main is red: tsc/python import failure",
+      "state": "OPEN",
+      "created_at": "2026-06-26T11:50:05Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 625,
+      "title": "Bridge GateIssue (evidence layer) <-> QualityGateIssue (gate service) with an explicit adapter",
+      "state": "OPEN",
+      "created_at": "2026-06-26T11:06:51Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "analytics"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 624,
+      "title": "Move backend runtime image to Python 3.14 (align with factory; deferred from #622)",
+      "state": "OPEN",
+      "created_at": "2026-06-26T11:06:49Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "infrastructure"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 622,
+      "title": "fix(dark-factory): Python 3.14 image can't pip-install sci stack (scipy 1.15.3 has no cp314 wheel) \u2014 modernize deps",
+      "state": "CLOSED",
+      "created_at": "2026-06-26T10:50:19Z",
+      "closed_at": "2026-06-26T11:12:45Z",
+      "lead_time_hours": 0.3738888888888889,
+      "factory_cycle_hours": null,
+      "labels": [
+        "infrastructure",
+        "factory-regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 618,
+      "title": "Scheduler: session-window-aware backoff \u2014 stop circuit-breaking tickets when the Claude 5h window is exhausted",
+      "state": "OPEN",
+      "created_at": "2026-06-26T10:01:21Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 616,
+      "title": "Populate ScannerEvent.scanner_run_id in the scanner (unblocks the #496 strict quality gate)",
+      "state": "OPEN",
+      "created_at": "2026-06-26T03:17:16Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 611,
+      "title": "Main-Red Auto-Fix follow-ups: dispatch guard, observability, scope hardening, config cleanup",
+      "state": "OPEN",
+      "created_at": "2026-06-26T02:04:05Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 609,
+      "title": "Dark factory improvement \u2014 apply Hermes Agent patterns (persistent daemon, prompt hardening, self-interruption)",
+      "state": "OPEN",
+      "created_at": "2026-06-25T06:28:39Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "spec-pending-review",
+        "ready-for-agent",
+        "factory-regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 607,
+      "title": "factory: rescue Blocked tickets whose PR is already green (un-strand mergeable PRs)",
+      "state": "CLOSED",
+      "created_at": "2026-06-22T13:18:22Z",
+      "closed_at": "2026-06-22T16:18:59Z",
+      "lead_time_hours": 3.0102777777777776,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "Dark Factory",
+        "factory-regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 606,
+      "title": "chaos-nightly: schedule paused \u2014 mock harness can't run on hosted CI (needs GHCR auth / self-hosted runner)",
+      "state": "OPEN",
+      "created_at": "2026-06-22T09:21:21Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "spec-pending-review",
+        "ready-for-agent",
+        "factory-regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 591,
+      "title": "Main-Red Auto-Fix \u2014 autonomous pipeline recovery",
+      "state": "CLOSED",
+      "created_at": "2026-06-21T13:44:08Z",
+      "closed_at": "2026-06-26T02:30:16Z",
+      "lead_time_hours": 108.7688888888889,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "Dark Factory",
+        "ready-for-human"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 590,
+      "title": "Epic Autopilot \u2014 broaden reach (drain backlog, start next epic)",
+      "state": "CLOSED",
+      "created_at": "2026-06-21T13:44:07Z",
+      "closed_at": "2026-06-21T15:43:26Z",
+      "lead_time_hours": 1.988611111111111,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "Dark Factory",
+        "ready-for-human"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 588,
+      "title": "Revisit dispatch ceiling (C9) \u2014 re-measure success-by-size/type",
+      "state": "OPEN",
+      "created_at": "2026-06-21T06:24:31Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "spec-pending-review",
+        "Dark Factory",
+        "ready-for-agent"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 587,
+      "title": "Revisit L=always-above-ceiling rule in is_above_ceiling() \u2014 scheduler.sh",
+      "state": "OPEN",
+      "created_at": "2026-06-21T06:24:19Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 585,
+      "title": "docs(data-quality): PROJECT_STRUCTURE.md missing data_quality.py entry after #493 scope excision",
+      "state": "CLOSED",
+      "created_at": "2026-06-21T04:09:32Z",
+      "closed_at": "2026-06-21T20:06:55Z",
+      "lead_time_hours": 15.956388888888888,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 584,
+      "title": "docs(data-quality): ARCHITECTURE.md missing data_quality.py row after #493 scope excision",
+      "state": "CLOSED",
+      "created_at": "2026-06-21T04:09:27Z",
+      "closed_at": "2026-06-21T20:06:55Z",
+      "lead_time_hours": 15.957777777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 579,
+      "title": "test(outcomes): seed_reviews fixture and 6 tests added beyond spec #303 named-file scope",
+      "state": "OPEN",
+      "created_at": "2026-06-20T20:05:47Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 578,
+      "title": "docs(outcomes): ARCHITECTURE.md updated with review_window_days/review-fields info beyond spec #303 scope",
+      "state": "CLOSED",
+      "created_at": "2026-06-20T20:05:39Z",
+      "closed_at": "2026-06-21T20:02:01Z",
+      "lead_time_hours": 23.939444444444444,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 574,
+      "title": "Revisit dispatch ceiling (C9) \u2014 re-measure success-by-size/type",
+      "state": "OPEN",
+      "created_at": "2026-06-20T14:47:52Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "spec-pending-review",
+        "Dark Factory",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.5200049500000006,
+        "in_tokens": 1265,
+        "out_tokens": 29745,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 15:03 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 573,
+      "title": "Revisit L=always-above-ceiling rule in is_above_ceiling() \u2014 scheduler.sh",
+      "state": "OPEN",
+      "created_at": "2026-06-20T14:47:39Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 571,
+      "title": "feat(scheduler): epic autopilot \u2014 bounded self-unlock with Opus review",
+      "state": "CLOSED",
+      "created_at": "2026-06-20T14:35:56Z",
+      "closed_at": "2026-06-20T16:32:41Z",
+      "lead_time_hours": 1.9458333333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "needs-discussion",
+        "infrastructure",
+        "Dark Factory"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 570,
+      "title": "feat(notifications): generic system-notification path (email/push) for non-scanner events",
+      "state": "CLOSED",
+      "created_at": "2026-06-20T14:35:23Z",
+      "closed_at": "2026-06-21T02:05:42Z",
+      "lead_time_hours": 11.505277777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "needs-discussion",
+        "infrastructure",
+        "ready-for-human"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 564,
+      "title": "chore(dark-factory): entrypoint.sh ENTRYPOINT_SOURCE_ONLY guard and arg-check scaffolding not spec-listed in #431",
+      "state": "OPEN",
+      "created_at": "2026-06-20T05:50:27Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 561,
+      "title": "chore(codeindex): docs/codeindex-hotspots.md OOS line-count refreshes committed on feature branches",
+      "state": "CLOSED",
+      "created_at": "2026-06-20T03:03:06Z",
+      "closed_at": "2026-06-20T11:09:07Z",
+      "lead_time_hours": 8.100277777777778,
+      "factory_cycle_hours": 5.101944444444444,
+      "labels": [
+        "needs-discussion",
+        "Dark Factory",
+        "direct-to-pr",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 7.6898820500000005,
+        "in_tokens": 276,
+        "out_tokens": 102106,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 06:03 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 06:49 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 07:46 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 559,
+      "title": "[security] S10: Authz regression suite + ADR + re-run security review (close F-AUTHZ-01)",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:49:44Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "documentation",
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "security",
+        "testing",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 558,
+      "title": "[security] S9: Scope backtests + news preferences to owner",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:49:25Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 557,
+      "title": "[security] S8: Scope trading strategies + auto-trade orders (incl. worker stamping)",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:49:24Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 556,
+      "title": "[security] S7: Scope scanner configs + attribute runs to owner",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:49:23Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 555,
+      "title": "[security] S6: Scope stock universes to owner",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:49:21Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 554,
+      "title": "[security] S5: Scope alerts (rules/delivery/push) to owner",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:49:20Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 553,
+      "title": "[security] S4: Scope journal/trades/tags to owner",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:49:19Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 552,
+      "title": "[security] S3: Per-user data-scoping scaffolding, proven on Watchlist (tracer bullet)",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:48:20Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 551,
+      "title": "[security] S2: Invite-based user provisioning + user-management UI",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:48:19Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "frontend",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 550,
+      "title": "[security] S1: User.role + require_admin + gate admin-only endpoints (authz tracer bullet)",
+      "state": "OPEN",
+      "created_at": "2026-06-20T01:47:51Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 549,
+      "title": "main is red: tsc/python import failure",
+      "state": "CLOSED",
+      "created_at": "2026-06-20T01:36:09Z",
+      "closed_at": "2026-06-20T02:48:16Z",
+      "lead_time_hours": 1.2019444444444445,
+      "factory_cycle_hours": null,
+      "labels": [
+        "regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 548,
+      "title": "Epic: Dark Factory platform \u2014 maintenance, telemetry & tooling",
+      "state": "CLOSED",
+      "created_at": "2026-06-19T23:58:06Z",
+      "closed_at": "2026-06-26T11:21:38Z",
+      "lead_time_hours": 155.39222222222222,
+      "factory_cycle_hours": null,
+      "labels": [
+        "epic",
+        "infrastructure"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 531,
+      "title": "[security] Remediate dark-factory image vendored-tooling CVEs (Trivy advisory)",
+      "state": "OPEN",
+      "created_at": "2026-06-19T02:52:20Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "priority: should-have",
+        "size: M",
+        "security",
+        "needs-triage",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 529,
+      "title": "[security] Triage the 5 bandit MEDIUM findings (F-CI-01 follow-up)",
+      "state": "OPEN",
+      "created_at": "2026-06-19T02:27:05Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "priority: should-have",
+        "size: S",
+        "security",
+        "needs-triage",
+        "security-audit-2026-06-12"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 527,
+      "title": "bug(dark-factory): backlog scheduler ignores project items after first page",
+      "state": "CLOSED",
+      "created_at": "2026-06-19T02:05:49Z",
+      "closed_at": "2026-06-19T02:20:30Z",
+      "lead_time_hours": 0.24472222222222223,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "size: S",
+        "Dark Factory",
+        "ready-for-human"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 526,
+      "title": "Add regime performance panel to Scorecard / Edge Explorer",
+      "state": "OPEN",
+      "created_at": "2026-06-15T16:15:15Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "ml",
+        "scanner",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.6199411999999997,
+        "in_tokens": 61,
+        "out_tokens": 16813,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 17:19 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 523,
+      "title": "cleanup(grafana): scanner-performance.json re-serialized and datasource type field stripped from existing panels",
+      "state": "OPEN",
+      "created_at": "2026-06-15T11:43:21Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 522,
+      "title": "cleanup(memory): backend-patterns.md OOS deletions \u2014 FK migration, empty-migration FIX, aggregate-stats patterns",
+      "state": "CLOSED",
+      "created_at": "2026-06-15T11:43:09Z",
+      "closed_at": "2026-06-26T10:42:11Z",
+      "lead_time_hours": 262.9838888888889,
+      "factory_cycle_hours": null,
+      "labels": [
+        "spec-pending-review",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 521,
+      "title": "cleanup(dark-factory): factory-failures.jsonl accumulates OOS telemetry for issue #391 (second occurrence)",
+      "state": "CLOSED",
+      "created_at": "2026-06-15T11:42:59Z",
+      "closed_at": "2026-06-26T02:48:30Z",
+      "lead_time_hours": 255.09194444444444,
+      "factory_cycle_hours": 145.15833333333333,
+      "labels": [
+        "needs-discussion",
+        "ready-for-agent",
+        "scope-spillover",
+        "needs-triage",
+        "factory-regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.2489797499999997,
+        "in_tokens": 2602,
+        "out_tokens": 17244,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 01:39 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 518,
+      "title": "cleanup(dark-factory): orphaned seed files in dark-factory/seed/seed/ from prior failed run",
+      "state": "CLOSED",
+      "created_at": "2026-06-14T21:30:09Z",
+      "closed_at": "2026-06-22T11:44:18Z",
+      "lead_time_hours": 182.23583333333335,
+      "factory_cycle_hours": 58.23833333333334,
+      "labels": [
+        "needs-discussion",
+        "direct-to-pr",
+        "ready-for-agent",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 0.7633842,
+        "in_tokens": 56,
+        "out_tokens": 10607,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 01:30 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 517,
+      "title": "docs(memory): dark-factory-ops.md BuildKit/preview patterns not spec-listed in #436",
+      "state": "CLOSED",
+      "created_at": "2026-06-14T21:30:01Z",
+      "closed_at": "2026-06-26T02:30:18Z",
+      "lead_time_hours": 269.0047222222222,
+      "factory_cycle_hours": 145.005,
+      "labels": [
+        "needs-discussion",
+        "ready-for-agent",
+        "scope-spillover",
+        "factory-regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.1392627500000003,
+        "in_tokens": 53,
+        "out_tokens": 13667,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 01:30 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 516,
+      "title": "docs(architecture): ARCHITECTURE.md buildkit subgraph should be tracked as in-scope doc for #436",
+      "state": "CLOSED",
+      "created_at": "2026-06-14T21:29:55Z",
+      "closed_at": "2026-06-20T11:07:28Z",
+      "lead_time_hours": 133.62583333333333,
+      "factory_cycle_hours": 10.79111111111111,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 4.28426425,
+        "in_tokens": 1428,
+        "out_tokens": 59919,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 00:20 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 01:22 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 05:53 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 508,
+      "title": "Vite dev server: make server.allowedHosts env-driven (Tailscale/tunnel/proxy access)",
+      "state": "CLOSED",
+      "created_at": "2026-06-14T19:08:03Z",
+      "closed_at": "2026-06-14T19:33:44Z",
+      "lead_time_hours": 0.4280555555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "frontend",
+        "infrastructure"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 507,
+      "title": "factory-failures.jsonl: remove stale issue #403 run records",
+      "state": "CLOSED",
+      "created_at": "2026-06-14T14:45:27Z",
+      "closed_at": "2026-06-14T20:32:41Z",
+      "lead_time_hours": 5.787222222222222,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 504,
+      "title": "feat(factory): auto-address advisory code-review findings (revise-advisory DAG node)",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T19:46:16Z",
+      "closed_at": "2026-06-14T14:08:52Z",
+      "lead_time_hours": 18.376666666666665,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "Dark Factory"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 503,
+      "title": "test-infra(conftest): add integration test verifying _testcontainers_url calls probe unconditionally",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:58:08Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "spec-pending-review",
+        "ready-for-agent",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.3106299000000001,
+        "in_tokens": 57,
+        "out_tokens": 17668,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 17:09 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 502,
+      "title": "Define backtesting integration contract for the quality gate",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:11Z",
+      "closed_at": "2026-06-26T11:26:27Z",
+      "lead_time_hours": 304.65444444444444,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "analytics",
+        "needs-discussion",
+        "testing",
+        "ready-for-human",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 501,
+      "title": "Define survivorship-bias gate behavior for historical analysis",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:10Z",
+      "closed_at": "2026-06-26T11:15:02Z",
+      "lead_time_hours": 304.46444444444444,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "analytics",
+        "needs-discussion",
+        "testing",
+        "ready-for-human",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 500,
+      "title": "Generate split/dividend and timezone session gate issues",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:09Z",
+      "closed_at": "2026-06-26T10:53:55Z",
+      "lead_time_hours": 304.11277777777775,
+      "factory_cycle_hours": 161.7486111111111,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.9878961500000005,
+        "in_tokens": 80,
+        "out_tokens": 24382,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 17:09 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 499,
+      "title": "Generate stale quote and provider gap gate issues",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:08Z",
+      "closed_at": "2026-06-26T10:55:18Z",
+      "lead_time_hours": 304.1361111111111,
+      "factory_cycle_hours": 161.92166666666665,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.2329975499999994,
+        "in_tokens": 64,
+        "out_tokens": 22801,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 17:00 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 498,
+      "title": "Generate missing bars and insufficient lookback gate issues",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:07Z",
+      "closed_at": "2026-06-26T03:19:29Z",
+      "lead_time_hours": 296.5394444444444,
+      "factory_cycle_hours": 154.40805555555556,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "scanner",
+        "analytics",
+        "needs-discussion",
+        "testing",
+        "direct-to-pr",
+        "ready-for-agent",
+        "factory-regression",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.09619025,
+        "in_tokens": 647,
+        "out_tokens": 18602,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 16:55 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 497,
+      "title": "Exclude untrusted events from trusted Scorecard metrics",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:06Z",
+      "closed_at": "2026-06-15T01:33:17Z",
+      "lead_time_hours": 30.76972222222222,
+      "factory_cycle_hours": 0.03805555555555556,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "scanner",
+        "analytics",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 4.10247485,
+        "in_tokens": 141,
+        "out_tokens": 53989,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 01:31 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 496,
+      "title": "Apply strict data quality gate to automated trading",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:05Z",
+      "closed_at": "2026-06-26T03:22:24Z",
+      "lead_time_hours": 296.5886111111111,
+      "factory_cycle_hours": 154.59,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "analytics",
+        "needs-discussion",
+        "testing",
+        "direct-to-pr",
+        "factory-regression"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.7806305999999994,
+        "in_tokens": 66,
+        "out_tokens": 17050,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 16:47 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 495,
+      "title": "Show data quality trust status in scanner and quality UI",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:03Z",
+      "closed_at": "2026-06-22T11:44:24Z",
+      "lead_time_hours": 208.95583333333335,
+      "factory_cycle_hours": 66.99,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "frontend",
+        "needs-discussion",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.7360607499999996,
+        "in_tokens": 78,
+        "out_tokens": 26075,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 16:45 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 494,
+      "title": "Apply advisory data quality gate to scanner runs",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:02Z",
+      "closed_at": "2026-06-22T11:44:06Z",
+      "lead_time_hours": 208.95111111111112,
+      "factory_cycle_hours": 79.41833333333334,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "needs-discussion",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.7148631000000005,
+        "in_tokens": 80,
+        "out_tokens": 26239,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 04:19 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 493,
+      "title": "Expose data quality gate preflight API",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:01Z",
+      "closed_at": "2026-06-21T19:52:11Z",
+      "lead_time_hours": 193.0861111111111,
+      "factory_cycle_hours": 63.61972222222222,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "scanner",
+        "analytics",
+        "needs-discussion",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.1371913000000005,
+        "in_tokens": 68,
+        "out_tokens": 20892,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 04:15 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 492,
+      "title": "Add reusable data quality gate contract and service",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:47:00Z",
+      "closed_at": "2026-06-21T21:15:33Z",
+      "lead_time_hours": 194.47583333333333,
+      "factory_cycle_hours": 65.15916666666666,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "plan-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.9510556000000003,
+        "in_tokens": 61,
+        "out_tokens": 20836,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 04:06 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 491,
+      "title": "Epic: Data Quality Trust Gate",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T18:46:59Z",
+      "closed_at": "2026-06-26T12:13:11Z",
+      "lead_time_hours": 305.43666666666667,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "scanner",
+        "analytics",
+        "epic"
+      ],
+      "size": null,
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 490,
+      "title": "Replay engine UI: per-signal drill-down + run comparison",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:48Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "size: M",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 489,
+      "title": "Replay engine UI: run summary, equity curve, edge-decay & regime charts",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:47Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "size: L",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 488,
+      "title": "Replay engine: REST API (/api/v1/replay)",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:46Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "size: M",
+        "analytics",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 487,
+      "title": "Replay engine: execution task + metrics computer",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:45Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 486,
+      "title": "Replay engine: benchmark ingestion + regime classifier",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:44Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "size: M",
+        "analytics",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 485,
+      "title": "Replay engine: intraday-accurate exit simulator",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:43Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 484,
+      "title": "Replay engine: data model + manifest resolver + data hash",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:41Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "size: M",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 483,
+      "title": "Epic: Canonical Signal Replay Engine (reproducible, intraday-accurate backtest)",
+      "state": "OPEN",
+      "created_at": "2026-06-13T18:45:27Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "priority: must-have",
+        "scanner",
+        "analytics",
+        "frontend",
+        "epic",
+        "spec-approved"
+      ],
+      "size": null,
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 482,
+      "title": "Add UI controls for optional AI narrative layers",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:57Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "size: M",
+        "ml",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "priority: could-have"
+      ],
+      "size": "M",
+      "priority": "could-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.3007908999999995,
+        "in_tokens": 67,
+        "out_tokens": 19339,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 04:01 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 481,
+      "title": "Add LLM cost, latency, cache, and observability controls",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:55Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "spec-pending-review",
+        "testing",
+        "performance",
+        "observability",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.9288869500000003,
+        "in_tokens": 66,
+        "out_tokens": 26005,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 03:49 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 480,
+      "title": "Add analyst Q&A over explained events and outcomes",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:53Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "size: L",
+        "ml",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "priority: could-have"
+      ],
+      "size": "L",
+      "priority": "could-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 11.664796499999994,
+        "in_tokens": 64,
+        "out_tokens": 17782,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 03:55 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 479,
+      "title": "Add semantic find-signals-like-this search",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:50Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "size: L",
+        "ml",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "priority: could-have"
+      ],
+      "size": "L",
+      "priority": "could-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.9869191500000003,
+        "in_tokens": 68,
+        "out_tokens": 17447,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 03:37 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 478,
+      "title": "Embed news, catalysts, explanations, and narratives",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:48Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.2133070000000004,
+        "in_tokens": 65,
+        "out_tokens": 19741,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 03:36 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 477,
+      "title": "Add embedding storage and retrieval foundation",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:46Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "analytics",
+        "spec-pending-review",
+        "infrastructure",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.7896710499999997,
+        "in_tokens": 62,
+        "out_tokens": 20125,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 16:14 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 476,
+      "title": "Generate signal post-mortems from explanation versus outcome",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:44Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "size: L",
+        "ml",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "priority: could-have"
+      ],
+      "size": "L",
+      "priority": "could-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.8132564000000002,
+        "in_tokens": 62,
+        "out_tokens": 21443,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 16:13 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 475,
+      "title": "Generate AI-assisted alert copy from signal briefs",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:42Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "size: M",
+        "ml",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "priority: could-have"
+      ],
+      "size": "M",
+      "priority": "could-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.3785033,
+        "in_tokens": 58,
+        "out_tokens": 25901,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 16:05 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 474,
+      "title": "Add narrative provenance and forbidden-claim enforcement",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:40Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "ml",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.5123973999999996,
+        "in_tokens": 63,
+        "out_tokens": 18512,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 16:01 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 473,
+      "title": "Add cached scanner event narrative generation",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:38Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.9989233000000004,
+        "in_tokens": 67,
+        "out_tokens": 21022,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:52 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 472,
+      "title": "Add LLM feature flags, provider config, and usage guardrails",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:58:35Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "spec-pending-review",
+        "infrastructure",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.75714425,
+        "in_tokens": 66,
+        "out_tokens": 25247,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:51 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 471,
+      "title": "Upgrade event-level intelligence UI",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:43Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.944473650000001,
+        "in_tokens": 67,
+        "out_tokens": 20400,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:39 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 470,
+      "title": "Add EdgeExplorer historical analog drill-down",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:41Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.3471966500000003,
+        "in_tokens": 65,
+        "out_tokens": 19764,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:41 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 469,
+      "title": "Add EdgeExplorer explanation trait filters and archetype charts",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:39Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.0664122999999996,
+        "in_tokens": 64,
+        "out_tokens": 22060,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:16 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 468,
+      "title": "Upgrade Scorecard with explanation trait and archetype performance",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:37Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "analytics",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.7488555499999998,
+        "in_tokens": 58,
+        "out_tokens": 19160,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:10 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 467,
+      "title": "Add deterministic AI signal brief endpoint",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:35Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.0571535500000007,
+        "in_tokens": 1924,
+        "out_tokens": 20434,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:01 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 466,
+      "title": "Generate signal archetypes from explanation traits and outcomes",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:33Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "ml",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.3259658,
+        "in_tokens": 67,
+        "out_tokens": 29583,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 15:02 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 465,
+      "title": "Add explanation trait performance aggregation",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:31Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.6852426499999997,
+        "in_tokens": 66,
+        "out_tokens": 17208,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 14:49 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 464,
+      "title": "Add deterministic historical analog service",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:29Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.0457764999999997,
+        "in_tokens": 67,
+        "out_tokens": 23617,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 14:49 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 463,
+      "title": "Extract analysis-ready features from scanner explanations",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:57:27Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.0189290000000004,
+        "in_tokens": 63,
+        "out_tokens": 20379,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 14:38 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 462,
+      "title": "Migrate live and social scanner event writers to explanation contract",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:34Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.1817919499999996,
+        "in_tokens": 73,
+        "out_tokens": 27464,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 14:36 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 461,
+      "title": "Migrate trend pullback scanner to explanation contract",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:32Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.7716779,
+        "in_tokens": 1207,
+        "out_tokens": 30991,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 14:24 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 460,
+      "title": "Migrate oversold bounce and pocket pivot scanners to explanation contract",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:30Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.3149436499999982,
+        "in_tokens": 5332,
+        "out_tokens": 23081,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 13:04 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 459,
+      "title": "Migrate liquidity hunt scanners to explanation contract",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:28Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.2966713999999993,
+        "in_tokens": 69,
+        "out_tokens": 30794,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 14:25 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 458,
+      "title": "Backfill best-effort explanations for historical scanner events",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:26Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.9198970999999994,
+        "in_tokens": 63,
+        "out_tokens": 22158,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 14:04 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 457,
+      "title": "Add practical scanner explanation UI",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:24Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "frontend",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.9362573000000003,
+        "in_tokens": 83,
+        "out_tokens": 18566,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 01:35 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-19 01:38 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 456,
+      "title": "Expose scanner explanations through API contracts",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:21Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.9251088500000006,
+        "in_tokens": 55,
+        "out_tokens": 16191,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 01:26 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 455,
+      "title": "Integrate pre-market volume spike as the reference explained scanner",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:19Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.77526735,
+        "in_tokens": 642,
+        "out_tokens": 21576,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 01:24 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 454,
+      "title": "Enhance data quality and readiness services for event warnings",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:17Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.8636374999999998,
+        "in_tokens": 56,
+        "out_tokens": 17841,
+        "runs": [
+          {
+            "timestamp": "2026-06-19 01:17 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 453,
+      "title": "Build scanner-neutral ExplanationBuilder",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:15Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: L",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.2393199,
+        "in_tokens": 50,
+        "out_tokens": 17640,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 12:28 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 452,
+      "title": "Define scanner explanation schema and validation helpers",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:13Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.5727704999999998,
+        "in_tokens": 50,
+        "out_tokens": 14811,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 12:22 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 451,
+      "title": "Add persisted scanner event explanation column",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:56:11Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "scanner",
+        "spec-pending-review",
+        "ready-for-agent",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.5614802499999998,
+        "in_tokens": 53,
+        "out_tokens": 17915,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 12:19 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 450,
+      "title": "Epic: Optional LLM Narrative and Semantic Intelligence",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:55:15Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "ml",
+        "analytics",
+        "frontend",
+        "epic",
+        "size: XL"
+      ],
+      "size": "XL",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 449,
+      "title": "Epic: Explanation-Aware Edge Intelligence",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:55:14Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "ml",
+        "scanner",
+        "analytics",
+        "frontend",
+        "epic",
+        "size: XL"
+      ],
+      "size": "XL",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 448,
+      "title": "Epic: Explainability Foundation for scanner events",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:55:13Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "scanner",
+        "analytics",
+        "epic",
+        "size: XL"
+      ],
+      "size": "XL",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 446,
+      "title": "Document private extension workflow",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:33Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "documentation",
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "spec-pending-review",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.2909117500000002,
+        "in_tokens": 50,
+        "out_tokens": 15340,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 12:13 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 445,
+      "title": "Add outcome analyzer extension point",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:32Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "analytics",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.6657298000000003,
+        "in_tokens": 57,
+        "out_tokens": 16133,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 12:10 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 444,
+      "title": "Add position sizing and risk rule extension points",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:31Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "spec-pending-review",
+        "infrastructure",
+        "testing",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.9857468000000003,
+        "in_tokens": 99,
+        "out_tokens": 17432,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 10:56 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 443,
+      "title": "Add broker adapter extension point",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:30Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "spec-pending-review",
+        "infrastructure",
+        "testing",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.671712299999999,
+        "in_tokens": 55,
+        "out_tokens": 20663,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 00:30 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 442,
+      "title": "Convert alert channels to registered extension handlers",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:29Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "spec-pending-review",
+        "infrastructure",
+        "testing",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.5051999499999995,
+        "in_tokens": 49,
+        "out_tokens": 18384,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 00:16 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 441,
+      "title": "Unify data provider registration under extension registry",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:27Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "spec-pending-review",
+        "infrastructure",
+        "testing",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.2390874500000004,
+        "in_tokens": 54,
+        "out_tokens": 16355,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 00:06 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 440,
+      "title": "Formalize scanner extension registration",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:26Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "scanner",
+        "spec-pending-review",
+        "testing",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.6642564499999999,
+        "in_tokens": 59,
+        "out_tokens": 19258,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 00:04 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 439,
+      "title": "Add extension loader and shared registry primitives",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:25Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "spec-pending-review",
+        "infrastructure",
+        "testing",
+        "ready-for-agent",
+        "feature:extensions",
+        "foundation"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.7224443,
+        "in_tokens": 54,
+        "out_tokens": 20336,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 21:52 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 438,
+      "title": "Epic: Formal module extension points for MarketHawk",
+      "state": "OPEN",
+      "created_at": "2026-06-13T17:11:24Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "epic",
+        "size: XL",
+        "feature:extensions"
+      ],
+      "size": "XL",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 436,
+      "title": "Preview env fails on every implement run: BuildKit 403 through docker-socket-proxy (+ EXEC:0 second wall)",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T16:15:53Z",
+      "closed_at": "2026-06-22T13:06:28Z",
+      "lead_time_hours": 212.84305555555557,
+      "factory_cycle_hours": 183.5911111111111,
+      "labels": [
+        "bug",
+        "priority: must-have",
+        "size: M",
+        "infrastructure",
+        "Dark Factory",
+        "regression",
+        "factory-regression",
+        "ready-for-human"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.78484405,
+        "in_tokens": 127,
+        "out_tokens": 45406,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 21:31 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 434,
+      "title": "Regression: dark-factory cost report never posts \u2014 run-record parser can't read archon's multi-line JSON",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T16:14:35Z",
+      "closed_at": "2026-06-13T16:15:08Z",
+      "lead_time_hours": 0.009166666666666667,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "size: S",
+        "Dark Factory",
+        "regression",
+        "factory-regression"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 432,
+      "title": "regime cleanup migrations fail on clean databases (non-idempotent DROPs)",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T15:42:04Z",
+      "closed_at": "2026-06-13T15:51:44Z",
+      "lead_time_hours": 0.16111111111111112,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: must-have",
+        "size: S",
+        "regression",
+        "factory-regression"
+      ],
+      "size": "S",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 431,
+      "title": "cleanup(dark-factory): factory-failures.jsonl accumulates OOS telemetry entries on feature branches",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T15:24:31Z",
+      "closed_at": "2026-06-20T11:06:25Z",
+      "lead_time_hours": 163.69833333333332,
+      "factory_cycle_hours": 133.25694444444446,
+      "labels": [
+        "bug",
+        "needs-discussion",
+        "ready-for-agent",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 8.72932245,
+        "in_tokens": 304,
+        "out_tokens": 136245,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 21:51 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 01:24 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 05:56 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 430,
+      "title": "enhance(pg_discovery): add structured logging for discovery failures",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T15:18:31Z",
+      "closed_at": "2026-06-14T20:32:38Z",
+      "lead_time_hours": 29.235277777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 429,
+      "title": "enhance(pg_discovery): guard isinstance(containers, list) on Docker API response",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T15:18:30Z",
+      "closed_at": "2026-06-20T11:05:18Z",
+      "lead_time_hours": 163.78,
+      "factory_cycle_hours": 133.405,
+      "labels": [
+        "enhancement",
+        "ready-for-agent",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 6.06562485,
+        "in_tokens": 258,
+        "out_tokens": 86558,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 21:41 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 01:10 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 05:40 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 428,
+      "title": "enhance(pg_discovery): add raise_for_status() to Docker API call",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T15:18:19Z",
+      "closed_at": "2026-06-14T20:32:35Z",
+      "lead_time_hours": 29.23777777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 426,
+      "title": "Ship AI-first docs site and reproducible demo mode",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T15:08:42Z",
+      "closed_at": "2026-06-13T16:08:27Z",
+      "lead_time_hours": 0.9958333333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "documentation",
+        "enhancement"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 425,
+      "title": "bug(auth): refresh-token rotation race \u2014 concurrent 401s each fire their own /auth/refresh",
+      "state": "OPEN",
+      "created_at": "2026-06-13T15:06:05Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "size: M",
+        "frontend",
+        "spec-pending-review",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.2296435500000005,
+        "in_tokens": 56,
+        "out_tokens": 16076,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 21:41 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 424,
+      "title": "Regression: Grafana infrastructure webhook 403 \u2014 CSRF middleware missing /api/v1/alerts/infrastructure exempt",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T14:06:13Z",
+      "closed_at": "2026-06-13T14:11:49Z",
+      "lead_time_hours": 0.09333333333333334,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "size: S",
+        "security",
+        "infrastructure",
+        "regression",
+        "factory-regression"
+      ],
+      "size": "S",
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 421,
+      "title": "Update dark-factory-ops.md scope enforcement entry to reflect dedupe_oos.py behavior",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T09:50:01Z",
+      "closed_at": "2026-06-26T02:40:08Z",
+      "lead_time_hours": 304.8352777777778,
+      "factory_cycle_hours": 269.1355555555556,
+      "labels": [
+        "documentation",
+        "needs-discussion",
+        "ready-for-agent",
+        "scope-spillover",
+        "factory-regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.4293266,
+        "in_tokens": 105,
+        "out_tokens": 36632,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 21:32 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 01:06 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 419,
+      "title": "forecast-worker: add explicit REDIS_URL env override for Redis auth",
+      "state": "CLOSED",
+      "created_at": "2026-06-13T04:52:05Z",
+      "closed_at": "2026-06-14T20:32:44Z",
+      "lead_time_hours": 39.6775,
+      "factory_cycle_hours": null,
+      "labels": [
+        "wontfix",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 403,
+      "title": "ci: lint .archon/workflows when: expressions against Archon grammar",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T20:46:19Z",
+      "closed_at": "2026-06-14T14:56:23Z",
+      "lead_time_hours": 42.16777777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "direct-to-pr"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 402,
+      "title": "archon: unparseable when: expression should fail the run, not skip fail-closed",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T20:46:01Z",
+      "closed_at": "2026-06-20T14:50:52Z",
+      "lead_time_hours": 186.08083333333335,
+      "factory_cycle_hours": 13.88111111111111,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "ready-for-agent"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 9.70161505,
+        "in_tokens": 338,
+        "out_tokens": 125694,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 00:58 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 02:00 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-20 11:51 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 397,
+      "title": "classify-preview when: unparseable since PR #359 - all implement runs silently discard their work",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T20:02:46Z",
+      "closed_at": "2026-06-12T20:08:12Z",
+      "lead_time_hours": 0.09055555555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: must-have",
+        "size: S",
+        "Dark Factory",
+        "regression",
+        "factory-regression"
+      ],
+      "size": "S",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 396,
+      "title": "test(frontend): quality-pass the 7 OOS test files from #250 (executes epic #383 decision)",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T18:46:16Z",
+      "closed_at": "2026-06-14T20:06:46Z",
+      "lead_time_hours": 49.34166666666667,
+      "factory_cycle_hours": 0.06277777777777778,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "frontend",
+        "testing",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 4.02002635,
+        "in_tokens": 1335,
+        "out_tokens": 41425,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 20:03 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 394,
+      "title": "Revisit dispatch ceiling (C9) - re-measure success-by-size/type",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T18:40:42Z",
+      "closed_at": "2026-06-21T19:53:19Z",
+      "lead_time_hours": 217.21027777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "priority: should-have",
+        "size: S",
+        "needs-discussion",
+        "Dark Factory",
+        "direct-to-pr",
+        "factory-regression"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 393,
+      "title": "chaos: IBKR gateway kill-test \u2014 verify live-scanner degradation and recovery",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T18:34:15Z",
+      "closed_at": "2026-06-22T01:57:15Z",
+      "lead_time_hours": 223.38333333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "needs-discussion",
+        "infrastructure",
+        "testing",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 392,
+      "title": "scanner: nightly replay-diff \u2014 re-run yesterday's scans and diff vs live signals",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T18:34:14Z",
+      "closed_at": "2026-06-22T13:03:33Z",
+      "lead_time_hours": 234.4886111111111,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "scanner",
+        "needs-discussion",
+        "testing",
+        "observability",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 391,
+      "title": "observability: pre-market scan latency SLO \u2014 metrics + missed-slot alerts",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T18:34:14Z",
+      "closed_at": "2026-06-15T12:11:58Z",
+      "lead_time_hours": 65.6288888888889,
+      "factory_cycle_hours": 15.832777777777778,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "scanner",
+        "needs-discussion",
+        "performance",
+        "observability",
+        "direct-to-pr",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 6.6467836,
+        "in_tokens": 196,
+        "out_tokens": 68597,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 20:22 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 390,
+      "title": "Plan stage implemented the full feature on the refine branch (#339) instead of stopping at the plan",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T18:30:06Z",
+      "closed_at": "2026-06-14T20:16:23Z",
+      "lead_time_hours": 49.771388888888886,
+      "factory_cycle_hours": 0.32305555555555554,
+      "labels": [
+        "priority: should-have",
+        "size: M",
+        "Dark Factory",
+        "direct-to-pr",
+        "factory-regression",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.39528215,
+        "in_tokens": 125,
+        "out_tokens": 28514,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 19:57 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 389,
+      "title": "Scheduler dependencies_met() strands issues whose dependency is closed but off-board",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T18:29:58Z",
+      "closed_at": "2026-06-15T12:54:31Z",
+      "lead_time_hours": 66.40916666666666,
+      "factory_cycle_hours": 0.10861111111111112,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "size: S",
+        "Dark Factory",
+        "direct-to-pr",
+        "ready-for-agent",
+        "cost-report-lost"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 4.5122173000000005,
+        "in_tokens": 165,
+        "out_tokens": 58861,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 12:48 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 388,
+      "title": "providers: define Polygon\u2194IBKR degraded-feed failover for pre-market scans",
+      "state": "OPEN",
+      "created_at": "2026-06-12T17:22:25Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "scanner",
+        "needs-discussion",
+        "infrastructure",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 387,
+      "title": "data-quality: gap/staleness detection on aggregates + corporate-action handling",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T17:22:24Z",
+      "closed_at": "2026-06-21T19:55:04Z",
+      "lead_time_hours": 218.54444444444445,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "needs-discussion",
+        "observability",
+        "direct-to-pr"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 386,
+      "title": "ops: weekly restore drill \u2014 verify #90 backups by restoring into a throwaway container",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T17:22:24Z",
+      "closed_at": "2026-06-22T02:00:02Z",
+      "lead_time_hours": 224.62722222222223,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "needs-discussion",
+        "infrastructure",
+        "testing",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 385,
+      "title": "chore: backlog triage & label-taxonomy overhaul \u2014 2026-06-12 session record",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T17:13:27Z",
+      "closed_at": "2026-06-12T17:13:28Z",
+      "lead_time_hours": 0.0002777777777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "documentation"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 384,
+      "title": "factory: dedupe scope-enforcement findings before filing tickets",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T17:01:09Z",
+      "closed_at": "2026-06-13T13:35:35Z",
+      "lead_time_hours": 20.573888888888888,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "plan-pending-review",
+        "needs-discussion",
+        "Dark Factory",
+        "direct-to-pr",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 383,
+      "title": "Epic: Resolve #250 out-of-scope frontend test debt (keep vs excise)",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T17:00:51Z",
+      "closed_at": "2026-06-14T20:12:15Z",
+      "lead_time_hours": 51.19,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "epic",
+        "testing",
+        "priority: could-have"
+      ],
+      "size": null,
+      "priority": "could-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 382,
+      "title": "[security] F-LOG-01: Add log redaction filter for secrets (Seq)",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:16Z",
+      "closed_at": "2026-06-19T03:12:44Z",
+      "lead_time_hours": 155.95777777777778,
+      "factory_cycle_hours": 96.22888888888889,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "plan-pending-review",
+        "security",
+        "security-audit-2026-06-12",
+        "ready-for-human",
+        "cost-report-lost"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.15555235,
+        "in_tokens": 94,
+        "out_tokens": 53818,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 02:59 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-15 12:05 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 381,
+      "title": "[security] F-FRONT-01: External-content URLs without allowlist; no CSP",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:14Z",
+      "closed_at": "2026-06-13T18:47:30Z",
+      "lead_time_hours": 27.537777777777777,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "plan-pending-review",
+        "security",
+        "direct-to-pr",
+        "security-audit-2026-06-12",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 380,
+      "title": "[security] F-INPUT-02: Weak/decentralized ticker & free-form field validation",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:13Z",
+      "closed_at": "2026-06-19T03:12:45Z",
+      "lead_time_hours": 155.95888888888888,
+      "factory_cycle_hours": 88.2625,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "spec-pending-review",
+        "security",
+        "security-audit-2026-06-12",
+        "ready-for-human"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.3813433000000006,
+        "in_tokens": 59,
+        "out_tokens": 23495,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 10:57 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 379,
+      "title": "[security] F-DOCKER-01: socket-proxy BUILD/POST + preview compose weak creds",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:11Z",
+      "closed_at": "2026-06-15T01:13:29Z",
+      "lead_time_hours": 57.971666666666664,
+      "factory_cycle_hours": 4.491388888888889,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "security",
+        "direct-to-pr",
+        "security-audit-2026-06-12",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.6177463000000003,
+        "in_tokens": 144,
+        "out_tokens": 45013,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 20:44 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 378,
+      "title": "[security] F-CI-01: Trivy advisory-only, no SAST, ci.yml missing permissions block",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:10Z",
+      "closed_at": "2026-06-19T03:12:46Z",
+      "lead_time_hours": 155.96,
+      "factory_cycle_hours": 96.26277777777777,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "spec-pending-review",
+        "security",
+        "security-audit-2026-06-12",
+        "ready-for-human"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 0.99385765,
+        "in_tokens": 47,
+        "out_tokens": 14140,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 02:57 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 377,
+      "title": "[security] F-WS-01: WebSocket resource exhaustion (no conn/msg caps, per-conn pubsub)",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:09Z",
+      "closed_at": "2026-06-15T01:14:27Z",
+      "lead_time_hours": 57.98833333333334,
+      "factory_cycle_hours": 4.490833333333334,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "needs-discussion",
+        "security",
+        "direct-to-pr",
+        "security-audit-2026-06-12",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 8.736621700000002,
+        "in_tokens": 216,
+        "out_tokens": 110866,
+        "runs": [
+          {
+            "timestamp": "2026-06-14 20:45 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 376,
+      "title": "[security] F-INPUT-01: Unbounded pagination + reflective sort on scanner/outcomes",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:07Z",
+      "closed_at": "2026-06-19T03:12:44Z",
+      "lead_time_hours": 155.96027777777778,
+      "factory_cycle_hours": 96.41222222222223,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "plan-pending-review",
+        "security",
+        "security-audit-2026-06-12",
+        "ready-for-human",
+        "cost-report-lost"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.48806,
+        "in_tokens": 101,
+        "out_tokens": 49379,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 02:48 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-15 12:00 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 375,
+      "title": "[security] F-SUPPLY-02: curl|bash installers + unsigned Archon clone in factory image",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:06Z",
+      "closed_at": "2026-06-19T03:12:45Z",
+      "lead_time_hours": 155.96083333333334,
+      "factory_cycle_hours": 96.39583333333333,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "plan-pending-review",
+        "security",
+        "security-audit-2026-06-12",
+        "ready-for-human",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.415409,
+        "in_tokens": 97,
+        "out_tokens": 67027,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 02:49 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-15 11:55 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 374,
+      "title": "[security] F-SUPPLY-01: Pin floating :latest tags + unpinned base images/actions",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:15:05Z",
+      "closed_at": "2026-06-19T03:12:46Z",
+      "lead_time_hours": 155.96138888888888,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "plan-pending-review",
+        "security",
+        "security-audit-2026-06-12",
+        "ready-for-human",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 373,
+      "title": "[epic] Authorization model \u2014 multi-user, roles, per-user data ownership",
+      "state": "OPEN",
+      "created_at": "2026-06-12T15:15:03Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "epic",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 372,
+      "title": "[epic] Security review 2026-06-12 \u2014 High-severity remediation",
+      "state": "OPEN",
+      "created_at": "2026-06-12T15:08:51Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "epic",
+        "security",
+        "security-audit-2026-06-12"
+      ],
+      "size": null,
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 371,
+      "title": "[security] F-ADMIN-01: Admin tools (pgAdmin/Flower/Seq/Grafana) rely on un-enforced credentials",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:08:27Z",
+      "closed_at": "2026-06-19T03:12:45Z",
+      "lead_time_hours": 156.07166666666666,
+      "factory_cycle_hours": 96.6125,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "plan-pending-review",
+        "security",
+        "ready-for-agent",
+        "security-audit-2026-06-12",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 5.22785865,
+        "in_tokens": 105,
+        "out_tokens": 78164,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 02:36 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-15 11:27 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 370,
+      "title": "[security] F-NET-01: Redis has no authentication (requirepass unset)",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:08:25Z",
+      "closed_at": "2026-06-15T17:41:35Z",
+      "lead_time_hours": 74.55277777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "plan-pending-review",
+        "needs-discussion",
+        "security",
+        "direct-to-pr",
+        "factory-regression",
+        "security-audit-2026-06-12",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 369,
+      "title": "[security] F-AUTH-01: Swagger/openapi.json/metrics unauthenticated in production",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:08:24Z",
+      "closed_at": "2026-06-13T03:33:41Z",
+      "lead_time_hours": 12.421388888888888,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: S",
+        "needs-discussion",
+        "security",
+        "direct-to-pr",
+        "security-audit-2026-06-12",
+        "cost-report-lost"
+      ],
+      "size": "S",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 368,
+      "title": "[security] F-TRADE-01: Live IBKR order path needs hard notional cap + kill switch",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T15:08:23Z",
+      "closed_at": "2026-06-26T12:05:33Z",
+      "lead_time_hours": 332.9527777777778,
+      "factory_cycle_hours": 155.62583333333333,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "size: M",
+        "plan-pending-review",
+        "security",
+        "ready-for-agent",
+        "security-audit-2026-06-12"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.7235800500000007,
+        "in_tokens": 71,
+        "out_tokens": 25130,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 00:28 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 365,
+      "title": "Dark factory: main-red sentinel never self-clears - scheduler stays paused after main goes green",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T12:24:34Z",
+      "closed_at": "2026-06-12T12:55:32Z",
+      "lead_time_hours": 0.5161111111111111,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: must-have",
+        "size: M",
+        "infrastructure",
+        "Dark Factory"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 364,
+      "title": "main is red: tsc/python import failure",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T12:23:08Z",
+      "closed_at": "2026-06-12T13:06:48Z",
+      "lead_time_hours": 0.7277777777777777,
+      "factory_cycle_hours": null,
+      "labels": [
+        "regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 362,
+      "title": "Duplicate volumes key on dark-factory service breaks docker compose parsing on main",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T11:47:23Z",
+      "closed_at": "2026-06-12T11:55:47Z",
+      "lead_time_hours": 0.14,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: must-have",
+        "size: S",
+        "infrastructure",
+        "regression",
+        "factory-regression"
+      ],
+      "size": "S",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 361,
+      "title": "main is red: tsc/python import failure",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T11:38:41Z",
+      "closed_at": "2026-06-12T12:21:11Z",
+      "lead_time_hours": 0.7083333333333334,
+      "factory_cycle_hours": null,
+      "labels": [
+        "regression"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 360,
+      "title": "test-infra: add postgres discovery fallback when testcontainers exec is blocked",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T10:37:53Z",
+      "closed_at": "2026-06-13T19:38:21Z",
+      "lead_time_hours": 33.007777777777775,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "plan-pending-review",
+        "needs-discussion",
+        "infrastructure",
+        "testing",
+        "direct-to-pr",
+        "ready-for-agent",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 355,
+      "title": "Revisit dispatch ceiling (C9) \u2014 re-measure success-by-size/type",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T08:42:50Z",
+      "closed_at": "2026-06-20T16:45:38Z",
+      "lead_time_hours": 200.04666666666665,
+      "factory_cycle_hours": 1.6605555555555556,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "plan-pending-review",
+        "needs-discussion",
+        "Dark Factory",
+        "ready-for-agent",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 5.54071065,
+        "in_tokens": 172,
+        "out_tokens": 80060,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 15:06 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 350,
+      "title": "Update ARCHITECTURE.md to document /api/ready readiness endpoint",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T02:32:44Z",
+      "closed_at": "2026-06-13T09:40:53Z",
+      "lead_time_hours": 31.135833333333334,
+      "factory_cycle_hours": null,
+      "labels": [
+        "documentation",
+        "enhancement",
+        "ready-for-agent",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 347,
+      "title": "Dark factory: configurable concurrent run limit (FACTORY_WIP_LIMIT)",
+      "state": "CLOSED",
+      "created_at": "2026-06-12T00:53:11Z",
+      "closed_at": "2026-06-12T02:32:48Z",
+      "lead_time_hours": 1.6602777777777777,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "Dark Factory"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 346,
+      "title": "[ci] Wire dark-factory pytest suite into CI test job",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T22:55:33Z",
+      "closed_at": "2026-06-14T19:57:01Z",
+      "lead_time_hours": 69.02444444444444,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "infrastructure",
+        "testing",
+        "Dark Factory",
+        "ready-for-agent",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 343,
+      "title": "chore(factory): stop committing codeindex.json/symbolindex.json \u2014 kill merge-conflict noise",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T21:28:06Z",
+      "closed_at": "2026-06-12T00:18:08Z",
+      "lead_time_hours": 2.8338888888888887,
       "factory_cycle_hours": null,
       "labels": [],
       "size": null,
       "priority": null,
       "autonomous": false,
       "cost": null
+    },
+    {
+      "number": 340,
+      "title": "Epic: Dark Factory measurement & hardening (architecture review 2026-06-11)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:56Z",
+      "closed_at": "2026-06-14T19:57:14Z",
+      "lead_time_hours": 71.98833333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "epic",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 339,
+      "title": "Size/type-aware dispatch ceiling in the scheduler",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:47Z",
+      "closed_at": "2026-06-12T19:24:37Z",
+      "lead_time_hours": 23.447222222222223,
+      "factory_cycle_hours": 14.460277777777778,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "needs-discussion",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 5.403581299999999,
+        "in_tokens": 95,
+        "out_tokens": 55915,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 04:57 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 08:46 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 338,
+      "title": "Single config interface: config.yaml as sole source of factory policy",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:08Z",
+      "closed_at": "2026-06-13T09:39:40Z",
+      "lead_time_hours": 37.708888888888886,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: S",
+        "needs-discussion",
+        "infrastructure",
+        "Dark Factory",
+        "direct-to-pr",
+        "cost-report-lost"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 337,
+      "title": "Extract tested factory core from entrypoint/scheduler/de-conflict bash glue",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:07Z",
+      "closed_at": "2026-06-13T18:56:16Z",
+      "lead_time_hours": 46.98583333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "plan-pending-review",
+        "needs-discussion",
+        "testing",
+        "Dark Factory",
+        "direct-to-pr",
+        "cost-report-lost"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 336,
+      "title": "Failure-to-eval flywheel: post-mortem stage on circuit-break, failures become eval tasks",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:05Z",
+      "closed_at": "2026-06-12T15:14:28Z",
+      "lead_time_hours": 19.289722222222224,
+      "factory_cycle_hours": 10.524444444444445,
+      "labels": [
+        "priority: should-have",
+        "size: M",
+        "needs-discussion",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 9.366599149999999,
+        "in_tokens": 40323,
+        "out_tokens": 115857,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 04:43 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 08:30 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 09:22 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 335,
+      "title": "Replay benchmark: pass^k suite of replayed closed issues to regression-test the harness",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:04Z",
+      "closed_at": "2026-06-12T14:54:51Z",
+      "lead_time_hours": 18.963055555555556,
+      "factory_cycle_hours": 10.414166666666667,
+      "labels": [
+        "priority: should-have",
+        "size: L",
+        "needs-discussion",
+        "testing",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 11.867938999999996,
+        "in_tokens": 272,
+        "out_tokens": 139201,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 04:30 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 05:41 UTC",
+            "run_type": "plan",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-12 10:35 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 334,
+      "title": "Deepen the Gate seam: layered gate policy, judge calibration audit, blast-radius human gate",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:03Z",
+      "closed_at": "2026-06-12T10:00:08Z",
+      "lead_time_hours": 14.051388888888889,
+      "factory_cycle_hours": 5.7188888888888885,
+      "labels": [
+        "priority: must-have",
+        "size: L",
+        "needs-discussion",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": "L",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 14.629980649999998,
+        "in_tokens": 314,
+        "out_tokens": 165189,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 04:17 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 05:35 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 09:10 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 333,
+      "title": "Run Record: one structured per-run record of every stage verdict (gen_ai.* to Seq + runs.jsonl)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:01Z",
+      "closed_at": "2026-06-12T09:57:37Z",
+      "lead_time_hours": 14.01,
+      "factory_cycle_hours": 5.876944444444445,
+      "labels": [
+        "priority: must-have",
+        "size: M",
+        "needs-discussion",
+        "observability",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 13.077746000000005,
+        "in_tokens": 284,
+        "out_tokens": 164433,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 04:05 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 05:24 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 09:02 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 332,
+      "title": "Baseline-green gate: smoke origin/main before any factory run",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:57:00Z",
+      "closed_at": "2026-06-12T09:47:50Z",
+      "lead_time_hours": 13.847222222222221,
+      "factory_cycle_hours": 5.7972222222222225,
+      "labels": [
+        "priority: must-have",
+        "size: S",
+        "needs-discussion",
+        "infrastructure",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": "S",
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 11.26289075,
+        "in_tokens": 314,
+        "out_tokens": 150596,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 04:00 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 05:05 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 05:42 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-12 05:42 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-12 08:40 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 331,
+      "title": "Factory Scorecard: merge-rate triad, rework rate, 2-week churn, success-by-size",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:56:58Z",
+      "closed_at": "2026-06-11T22:27:34Z",
+      "lead_time_hours": 2.51,
+      "factory_cycle_hours": null,
+      "labels": [
+        "priority: must-have",
+        "size: S",
+        "observability",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": "S",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 329,
+      "title": "docs(docker): document root-user exception in Dockerfile.forecast",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T19:19:51Z",
+      "closed_at": "2026-06-20T03:53:46Z",
+      "lead_time_hours": 200.56527777777777,
+      "factory_cycle_hours": 0.8127777777777778,
+      "labels": [
+        "documentation",
+        "enhancement",
+        "Dark Factory",
+        "ready-for-agent",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.3262019,
+        "in_tokens": 142,
+        "out_tokens": 29312,
+        "runs": [
+          {
+            "timestamp": "2026-06-20 03:05 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 326,
+      "title": "fix(dark-factory): archon CLI vanishes from PATH on clean rebuilds (bun link regression)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T15:51:58Z",
+      "closed_at": "2026-06-14T19:51:24Z",
+      "lead_time_hours": 75.99055555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "Dark Factory",
+        "scope-spillover",
+        "ready-for-human"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 325,
+      "title": "Update Pocket Pivot seed config (params, criteria, is_active, run_frequency)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T13:50:44Z",
+      "closed_at": "2026-06-11T14:58:11Z",
+      "lead_time_hours": 1.1241666666666668,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 324,
+      "title": "Chart.tsx: revisit Recharts data type cast (object[] vs union)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T13:21:46Z",
+      "closed_at": "2026-06-11T14:58:25Z",
+      "lead_time_hours": 1.6108333333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 323,
+      "title": "Preview stack: review restart policy for postgres and redis services",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T13:21:45Z",
+      "closed_at": "2026-06-11T14:58:23Z",
+      "lead_time_hours": 1.6105555555555555,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 322,
+      "title": "Pocket Pivot seed config: finalize name, criteria, and run_frequency",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T13:21:38Z",
+      "closed_at": "2026-06-12T15:27:58Z",
+      "lead_time_hours": 26.105555555555554,
+      "factory_cycle_hours": null,
+      "labels": [
+        "needs-discussion",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 320,
+      "title": "Fix Chart.tsx TS2322: data prop type mismatch in Recharts commonProps",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T06:40:53Z",
+      "closed_at": "2026-06-12T17:13:06Z",
+      "lead_time_hours": 34.536944444444444,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "frontend",
+        "spec-pending-review",
+        "ready-for-agent",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 319,
+      "title": "frontend: verify Chart.tsx TS2322 on data prop (scope spillover from #276)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T06:17:18Z",
+      "closed_at": "2026-06-12T15:27:54Z",
+      "lead_time_hours": 33.17666666666667,
+      "factory_cycle_hours": null,
+      "labels": [
+        "duplicate",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 317,
+      "title": "Regenerate codeindex artifacts after issue #276 implementation",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T05:40:39Z",
+      "closed_at": "2026-06-12T15:27:56Z",
+      "lead_time_hours": 33.78805555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 316,
+      "title": "test(frontend): scope-correct Settings tests (not in spec #250)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:29:07Z",
+      "closed_at": "2026-06-13T03:05:03Z",
+      "lead_time_hours": 47.59888888888889,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "testing",
+        "direct-to-pr",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 315,
+      "title": "test(frontend): scope-correct ScorecardOverview tests (not in spec #250)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:29:06Z",
+      "closed_at": "2026-06-13T03:21:16Z",
+      "lead_time_hours": 47.86944444444445,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "testing",
+        "direct-to-pr",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 314,
+      "title": "test(frontend): scope-correct PreMarketMovers tests (not in spec #250)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:29:05Z",
+      "closed_at": "2026-06-13T03:20:33Z",
+      "lead_time_hours": 47.85777777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "testing",
+        "direct-to-pr",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 313,
+      "title": "test(frontend): scope-correct AlertBadges tests (not in spec #250)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:28:58Z",
+      "closed_at": "2026-06-13T03:04:08Z",
+      "lead_time_hours": 47.58611111111111,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "testing",
+        "direct-to-pr",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 312,
+      "title": "test(frontend): scope-correct ActiveWatchlist tests (not in spec #250)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:28:57Z",
+      "closed_at": "2026-06-13T03:03:31Z",
+      "lead_time_hours": 47.57611111111111,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "testing",
+        "direct-to-pr",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 311,
+      "title": "test(frontend): scope-correct PageLoader tests (not in spec #250)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:28:57Z",
+      "closed_at": "2026-06-12T20:33:12Z",
+      "lead_time_hours": 41.07083333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "plan-pending-review",
+        "testing",
+        "direct-to-pr",
+        "scope-spillover",
+        "Waste",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 310,
+      "title": "test(frontend): scope-correct ScorecardDetail tests (spec #250 non-goal)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:28:49Z",
+      "closed_at": "2026-06-12T15:27:51Z",
+      "lead_time_hours": 35.98388888888889,
+      "factory_cycle_hours": null,
+      "labels": [
+        "duplicate",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 309,
+      "title": "test(frontend): scope-correct ScorecardDetail tests (spec #250 non-goal)",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T03:28:44Z",
+      "closed_at": "2026-06-12T20:45:16Z",
+      "lead_time_hours": 41.275555555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "frontend",
+        "plan-pending-review",
+        "testing",
+        "direct-to-pr",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 308,
+      "title": "Add frontend test coverage for ActiveWatchlist page and AlertBadges",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T02:21:27Z",
+      "closed_at": "2026-06-12T15:27:48Z",
+      "lead_time_hours": 37.10583333333334,
+      "factory_cycle_hours": null,
+      "labels": [
+        "duplicate",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 307,
+      "title": "Add frontend test coverage for PageLoader component",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T02:21:26Z",
+      "closed_at": "2026-06-12T15:27:44Z",
+      "lead_time_hours": 37.105,
+      "factory_cycle_hours": null,
+      "labels": [
+        "duplicate",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 306,
+      "title": "Add frontend test coverage for PreMarketMovers page",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T02:21:25Z",
+      "closed_at": "2026-06-12T15:27:41Z",
+      "lead_time_hours": 37.10444444444445,
+      "factory_cycle_hours": null,
+      "labels": [
+        "duplicate",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 305,
+      "title": "Add frontend test coverage for Settings page",
+      "state": "CLOSED",
+      "created_at": "2026-06-11T02:21:15Z",
+      "closed_at": "2026-06-12T15:27:39Z",
+      "lead_time_hours": 37.10666666666667,
+      "factory_cycle_hours": null,
+      "labels": [
+        "duplicate",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 303,
+      "title": "Outcome dashboard: per-scanner ScannerOutcomeSummary aggregates in UI",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T11:25:26Z",
+      "closed_at": "2026-06-21T03:54:33Z",
+      "lead_time_hours": 256.48527777777775,
+      "factory_cycle_hours": 145.55916666666667,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "analytics",
+        "frontend",
+        "needs-discussion",
+        "ready-for-agent",
+        "factory-regression",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 5.8242646,
+        "in_tokens": 114,
+        "out_tokens": 100240,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 02:21 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-15 11:15 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 302,
+      "title": "Backtest comparison run: 5 scanners x representative strategies over 1+ year",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T11:25:25Z",
+      "closed_at": "2026-06-20T14:53:10Z",
+      "lead_time_hours": 243.4625,
+      "factory_cycle_hours": 132.70277777777778,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: M",
+        "scanner",
+        "analytics",
+        "needs-discussion",
+        "ready-for-agent",
+        "factory-regression",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 9.128702050000001,
+        "in_tokens": 125,
+        "out_tokens": 149113,
+        "runs": [
+          {
+            "timestamp": "2026-06-15 02:11 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-15 11:15 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 301,
+      "title": "Backtest harness core: daily-bar replay of TradingStrategy vs scan signals",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T11:25:24Z",
+      "closed_at": "2026-06-14T15:27:40Z",
+      "lead_time_hours": 100.03777777777778,
+      "factory_cycle_hours": 22.02777777777778,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "size: L",
+        "scanner",
+        "analytics",
+        "needs-discussion",
+        "ready-for-agent",
+        "cost-report-lost"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 7.536041499999998,
+        "in_tokens": 192,
+        "out_tokens": 88812,
+        "runs": [
+          {
+            "timestamp": "2026-06-13 17:26 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 300,
+      "title": "Epic: Backtest scanner signals against TradingStrategy definitions",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T11:25:12Z",
+      "closed_at": "2026-06-21T19:56:35Z",
+      "lead_time_hours": 272.5230555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "scanner",
+        "analytics",
+        "epic"
+      ],
+      "size": null,
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 299,
+      "title": "Implement trend_pullback daily scanner (trend-following pullback signals)",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T11:25:08Z",
+      "closed_at": "2026-06-11T23:47:23Z",
+      "lead_time_hours": 36.37083333333333,
+      "factory_cycle_hours": 35.15638888888889,
+      "labels": [
+        "priority: should-have",
+        "size: M",
+        "ready-for-agent"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 16.773903999999998,
+        "in_tokens": 367,
+        "out_tokens": 226064,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 12:38 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 04:58 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 21:19 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 294,
+      "title": "[arch-v3][LOW] Decompose frontend god files: api/scanner.ts (787) + QualityReportModal.tsx (753)",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:20Z",
+      "closed_at": "2026-06-13T17:22:21Z",
+      "lead_time_hours": 86.15027777777777,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "size: M",
+        "frontend",
+        "plan-pending-review",
+        "direct-to-pr",
+        "architecture-audit-v3",
+        "priority: could-have",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "could-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 293,
+      "title": "[arch-v3][LOW] Make Trivy block on HIGH/CRITICAL + add password min-length policy",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:19Z",
+      "closed_at": "2026-06-13T03:21:46Z",
+      "lead_time_hours": 72.14083333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "size: S",
+        "needs-discussion",
+        "security",
+        "infrastructure",
+        "direct-to-pr",
+        "architecture-audit-v3",
+        "priority: could-have",
+        "cost-report-lost"
+      ],
+      "size": "S",
+      "priority": "could-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 292,
+      "title": "[arch-v3][LOW] Validate JSONB writes + enforce severity enum + channel_config schema",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:18Z",
+      "closed_at": "2026-06-14T14:57:07Z",
+      "lead_time_hours": 107.73027777777777,
+      "factory_cycle_hours": 19.76861111111111,
+      "labels": [
+        "enhancement",
+        "size: M",
+        "plan-pending-review",
+        "needs-discussion",
+        "direct-to-pr",
+        "architecture-audit-v3",
+        "priority: could-have",
+        "cost-report-lost"
+      ],
+      "size": "M",
+      "priority": "could-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 6.601954,
+        "in_tokens": 204,
+        "out_tokens": 87053,
+        "runs": [
+          {
+            "timestamp": "2026-06-13 19:11 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 291,
+      "title": "[arch-v3][LOW] SQL aggregates in get_trade_stats + selectinload pagination fix",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:17Z",
+      "closed_at": "2026-06-12T15:15:07Z",
+      "lead_time_hours": 60.03055555555556,
+      "factory_cycle_hours": 13.101944444444445,
+      "labels": [
+        "spec-pending-review",
+        "needs-discussion",
+        "direct-to-pr",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 1.1952784499999998,
+        "in_tokens": 56,
+        "out_tokens": 16922,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 02:09 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 290,
+      "title": "[arch-v3][MED] Tweet-monitor cookie auth: expiry alerting or official API (3 reviews unticketed)",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:16Z",
+      "closed_at": "2026-06-12T09:54:53Z",
+      "lead_time_hours": 54.69361111111111,
+      "factory_cycle_hours": 9.064722222222223,
+      "labels": [
+        "direct-to-pr",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 7.670245499999999,
+        "in_tokens": 248,
+        "out_tokens": 104094,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 00:51 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 03:45 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 04:43 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 289,
+      "title": "[arch-v3][MED] Add readiness probe (DB/Redis) + migration gate in deploy path",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:15Z",
+      "closed_at": "2026-06-12T09:43:21Z",
+      "lead_time_hours": 54.501666666666665,
+      "factory_cycle_hours": 9.589166666666667,
+      "labels": [
+        "enhancement",
+        "needs-discussion",
+        "infrastructure",
+        "direct-to-pr",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 12.36656615,
+        "in_tokens": 2830,
+        "out_tokens": 151161,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 00:08 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 01:07 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 02:34 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-12 03:50 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 288,
+      "title": "[arch-v3][MED] Stage run_pre_market_scan into detect/enrich/persist pipeline (346-line function)",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:14Z",
+      "closed_at": "2026-06-12T11:22:59Z",
+      "lead_time_hours": 56.1625,
+      "factory_cycle_hours": 27.633055555555554,
+      "labels": [
+        "plan-pending-review",
+        "needs-discussion",
+        "direct-to-pr",
+        "ready-for-agent",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 23.520659249999998,
+        "in_tokens": 700,
+        "out_tokens": 371782,
+        "runs": [
+          {
+            "timestamp": "2026-06-11 07:45 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 00:33 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 02:02 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 10:43 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 287,
+      "title": "[arch-v3][MED] Decompose DiscoveryService.run_screen into asset-class screeners (CC~43)",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:13Z",
+      "closed_at": "2026-06-11T18:36:29Z",
+      "lead_time_hours": 39.38777777777778,
+      "factory_cycle_hours": 11.508055555555556,
+      "labels": [
+        "direct-to-pr",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 17.456395750000002,
+        "in_tokens": 687,
+        "out_tokens": 235242,
+        "runs": [
+          {
+            "timestamp": "2026-06-11 07:06 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 08:37 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 09:25 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 09:42 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 09:57 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 10:11 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 16:57 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 286,
+      "title": "[arch-v3][MED] Consolidate time-normalization duplication into app/utils/time.py + get_or_404 helper",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:12Z",
+      "closed_at": "2026-06-11T20:50:34Z",
+      "lead_time_hours": 41.62277777777778,
+      "factory_cycle_hours": 14.892777777777777,
+      "labels": [
+        "needs-discussion",
+        "direct-to-pr",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 15.952596000000003,
+        "in_tokens": 386,
+        "out_tokens": 195464,
+        "runs": [
+          {
+            "timestamp": "2026-06-11 05:57 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 07:34 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 20:45 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 285,
+      "title": "[arch-v3][MED] Add ruff check to CI backend job + fix 65 lint errors on main",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:11Z",
+      "closed_at": "2026-06-11T16:48:40Z",
+      "lead_time_hours": 37.591388888888886,
+      "factory_cycle_hours": 11.744444444444444,
+      "labels": [
+        "direct-to-pr",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 8.715559950000001,
+        "in_tokens": 670,
+        "out_tokens": 131789,
+        "runs": [
+          {
+            "timestamp": "2026-06-11 05:04 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 06:56 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 07:55 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 08:04 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 08:12 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 08:20 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 16:28 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 284,
+      "title": "[arch-v3][HIGH] Verify artifacts before closing remediation tickets (factory close-path gate)",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:11Z",
+      "closed_at": "2026-06-11T02:16:12Z",
+      "lead_time_hours": 23.05027777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "duplicate",
+        "invalid",
+        "Dark Factory",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 283,
+      "title": "Epic: Architecture audit v3 \u2014 process honesty & code health follow-ups",
+      "state": "CLOSED",
+      "created_at": "2026-06-10T03:13:10Z",
+      "closed_at": "2026-06-14T15:33:32Z",
+      "lead_time_hours": 108.33944444444444,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "epic",
+        "architecture-audit-v3"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 281,
+      "title": "Decision needed: Pocket Pivot (Evening) seed (#278) contradicts migrations on is_active + criteria",
+      "state": "OPEN",
+      "created_at": "2026-06-10T02:55:53Z",
+      "closed_at": null,
+      "lead_time_hours": null,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "scanner",
+        "needs-discussion"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 276,
+      "title": "Dark-factory scope-enforcement over-reports ruff/isort reformatting of touched files as scope spillover",
+      "state": "CLOSED",
+      "created_at": "2026-06-09T23:08:55Z",
+      "closed_at": "2026-06-11T19:31:58Z",
+      "lead_time_hours": 44.384166666666665,
+      "factory_cycle_hours": 22.949444444444445,
+      "labels": [
+        "priority: should-have",
+        "infrastructure",
+        "Dark Factory",
+        "direct-to-pr"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 29.425085700000004,
+        "in_tokens": 1183,
+        "out_tokens": 484305,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 20:35 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 21:50 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 04:07 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 05:18 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 05:48 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 06:21 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 06:41 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 19:29 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 19:54 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 275,
+      "title": "Dark-factory re-dirties seed/01_scanner_configs.sql working tree \u2192 recurring phantom seed-drift spillovers",
+      "state": "CLOSED",
+      "created_at": "2026-06-09T23:08:55Z",
+      "closed_at": "2026-06-11T19:57:08Z",
+      "lead_time_hours": 44.80361111111111,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "wontfix",
+        "priority: should-have",
+        "infrastructure",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 274,
+      "title": "Epic: Frontend type-safety, lint & test-coverage debt",
+      "state": "CLOSED",
+      "created_at": "2026-06-09T23:08:54Z",
+      "closed_at": "2026-06-11T16:34:11Z",
+      "lead_time_hours": 41.42138888888889,
+      "factory_cycle_hours": null,
+      "labels": [
+        "priority: should-have",
+        "frontend",
+        "epic"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 272,
+      "title": "Epic: Container & deployment security hardening (least-privilege containers, docker-socket exposure)",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T20:19:55Z",
+      "closed_at": "2026-06-14T20:18:14Z",
+      "lead_time_hours": 167.97194444444443,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: should-have",
+        "epic",
+        "security",
+        "infrastructure",
+        "architecture-audit-v2"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 271,
+      "title": "Fix seed SQL: restore universe_id column in scanner_config INSERTs",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T18:10:43Z",
+      "closed_at": "2026-06-09T23:10:28Z",
+      "lead_time_hours": 52.99583333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 269,
+      "title": "tracing.py: import order cosmetically changed by ruff during #205 circuit-breakers impl",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T16:47:51Z",
+      "closed_at": "2026-06-09T23:10:41Z",
+      "lead_time_hours": 54.38055555555555,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 268,
+      "title": "tracing.py: cosmetic import reorder and blank-line enforced by ruff during #205",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T16:23:22Z",
+      "closed_at": "2026-06-09T23:10:40Z",
+      "lead_time_hours": 54.788333333333334,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 267,
+      "title": "security: evaluate replacing docker-socket-proxy with direct socket mount for factory services",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T15:02:36Z",
+      "closed_at": "2026-06-14T20:02:41Z",
+      "lead_time_hours": 173.0013888888889,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "needs-discussion",
+        "security",
+        "infrastructure",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 266,
+      "title": "chore: review non-root user setup in backend/frontend/dark-factory Dockerfiles",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T15:02:27Z",
+      "closed_at": "2026-06-11T19:02:09Z",
+      "lead_time_hours": 99.995,
+      "factory_cycle_hours": 30.11916666666667,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 7.16114545,
+        "in_tokens": 548,
+        "out_tokens": 95210,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 12:55 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 02:33 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 02:53 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 12:35 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 12:44 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 12:54 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 18:58 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 264,
+      "title": "Add codeindex ops lessons to factory memory (spillover from #200)",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T14:37:16Z",
+      "closed_at": "2026-06-10T22:15:03Z",
+      "lead_time_hours": 79.62972222222223,
+      "factory_cycle_hours": 1.8841666666666668,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.4776411499999997,
+        "in_tokens": 185,
+        "out_tokens": 51447,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 20:22 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 21:03 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 22:03 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 263,
+      "title": "tracing.py: import order not ruff-compliant (pre-existing)",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T14:22:31Z",
+      "closed_at": "2026-06-09T23:10:38Z",
+      "lead_time_hours": 56.801944444444445,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 262,
+      "title": "Epic: Harden the Dark Factory self-improvement loop",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T14:06:31Z",
+      "closed_at": "2026-06-11T23:48:55Z",
+      "lead_time_hours": 105.70666666666666,
+      "factory_cycle_hours": null,
+      "labels": [
+        "priority: must-have",
+        "epic",
+        "infrastructure",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 261,
+      "title": "feat(infra): run dark-factory container as non-root factory user",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T13:52:48Z",
+      "closed_at": "2026-06-13T03:01:47Z",
+      "lead_time_hours": 133.1497222222222,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "security",
+        "infrastructure",
+        "direct-to-pr",
+        "scope-spillover",
+        "ready-for-human",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 260,
+      "title": "feat(infra): harden docker-socket exposure for dark-factory and backlog-scheduler",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T13:52:44Z",
+      "closed_at": "2026-06-14T20:02:39Z",
+      "lead_time_hours": 174.1652777777778,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "security",
+        "infrastructure",
+        "scope-spillover",
+        "ready-for-human"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 259,
+      "title": "feat(infra): run frontend container as non-root node user",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T13:52:37Z",
+      "closed_at": "2026-06-13T13:36:50Z",
+      "lead_time_hours": 143.73694444444445,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "spec-pending-review",
+        "security",
+        "infrastructure",
+        "direct-to-pr",
+        "scope-spillover",
+        "cost-report-lost"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 258,
+      "title": "feat(infra): run backend container as non-root appuser",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T13:52:36Z",
+      "closed_at": "2026-06-12T04:09:09Z",
+      "lead_time_hours": 110.27583333333334,
+      "factory_cycle_hours": 3.5025,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 4.6952453499999995,
+        "in_tokens": 683,
+        "out_tokens": 59622,
+        "runs": [
+          {
+            "timestamp": "2026-06-12 00:39 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 03:31 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-12 04:14 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-12 04:26 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 257,
+      "title": "infra: postgres/redis missing restart policy in compose files",
+      "state": "CLOSED",
+      "created_at": "2026-06-07T13:49:37Z",
+      "closed_at": "2026-06-07T13:49:42Z",
+      "lead_time_hours": 0.001388888888888889,
+      "factory_cycle_hours": null,
+      "labels": [],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 255,
+      "title": "flower service crash-loops: JWT_SECRET_KEY not forwarded (missed by #236)",
+      "state": "CLOSED",
+      "created_at": "2026-06-06T19:27:55Z",
+      "closed_at": "2026-06-06T20:02:13Z",
+      "lead_time_hours": 0.5716666666666667,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "infrastructure"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 254,
+      "title": "Revamp the dark-factory .archon/memory system \u2014 too eager, persists unverified/low-value lessons",
+      "state": "CLOSED",
+      "created_at": "2026-06-06T14:10:26Z",
+      "closed_at": "2026-06-09T23:12:11Z",
+      "lead_time_hours": 81.02916666666667,
+      "factory_cycle_hours": 74.88638888888889,
+      "labels": [
+        "priority: should-have",
+        "size: L",
+        "infrastructure",
+        "Dark Factory",
+        "ready-for-agent"
+      ],
+      "size": "L",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 9.63853005,
+        "in_tokens": 1011,
+        "out_tokens": 160733,
+        "runs": [
+          {
+            "timestamp": "2026-06-06 20:19 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 18:28 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 20:07 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-09 22:23 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 253,
+      "title": "system.py get_storage_stats: consolidate reformatted get_cached call (formatter-enforced)",
+      "state": "CLOSED",
+      "created_at": "2026-06-06T13:16:58Z",
+      "closed_at": "2026-06-09T23:10:37Z",
+      "lead_time_hours": 81.89416666666666,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 252,
+      "title": "scanner.py get_scanner_configs: consolidate reformatted list comprehension (formatter-enforced)",
+      "state": "CLOSED",
+      "created_at": "2026-06-06T13:16:50Z",
+      "closed_at": "2026-06-09T23:10:36Z",
+      "lead_time_hours": 81.89611111111111,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 250,
+      "title": "Ratchet frontend coverage thresholds to 35%/25% (follow-up from #198)",
+      "state": "CLOSED",
+      "created_at": "2026-06-06T06:03:48Z",
+      "closed_at": "2026-06-11T16:27:55Z",
+      "lead_time_hours": 130.40194444444444,
+      "factory_cycle_hours": 40.18194444444445,
+      "labels": [
+        "needs-discussion",
+        "direct-to-pr"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 34.0853558,
+        "in_tokens": 1843,
+        "out_tokens": 469505,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 00:17 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 02:27 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 10:55 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 02:25 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 03:30 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 13:25 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 13:55 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 16:06 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 249,
+      "title": "Add unit tests for calculateDoubleSuperTrend (frontend/src/utils/indicators.ts)",
+      "state": "CLOSED",
+      "created_at": "2026-06-06T06:01:42Z",
+      "closed_at": "2026-06-10T02:43:15Z",
+      "lead_time_hours": 92.6925,
+      "factory_cycle_hours": 2.6708333333333334,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 2.899150950000001,
+        "in_tokens": 189,
+        "out_tokens": 54388,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 00:03 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 01:10 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 01:51 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 247,
+      "title": "style: normalize OTel import ordering in tracing.py (ruff-enforced, scope spillover from #205)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T22:27:20Z",
+      "closed_at": "2026-06-09T23:10:34Z",
+      "lead_time_hours": 96.72055555555555,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 246,
+      "title": "fix(seed): restore universe_id and pocket_pivot row in 01_scanner_configs.sql",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T22:04:38Z",
+      "closed_at": "2026-06-09T23:10:26Z",
+      "lead_time_hours": 97.09666666666666,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 241,
+      "title": "Fix prefer-const violation in StockChart.tsx (allMarkers never reassigned)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T13:03:18Z",
+      "closed_at": "2026-06-10T09:49:25Z",
+      "lead_time_hours": 116.76861111111111,
+      "factory_cycle_hours": 9.67361111111111,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.7410623999999997,
+        "in_tokens": 202,
+        "out_tokens": 64425,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 00:09 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 01:20 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 03:19 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 240,
+      "title": "Fix no-unused-expressions in ExportUniverseModal.tsx (ternary-as-statement)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T13:03:11Z",
+      "closed_at": "2026-06-10T02:41:13Z",
+      "lead_time_hours": 109.63388888888889,
+      "factory_cycle_hours": 2.7202777777777776,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.30559235,
+        "in_tokens": 196,
+        "out_tokens": 54803,
+        "runs": [
+          {
+            "timestamp": "2026-06-09 23:58 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 00:51 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 02:49 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 239,
+      "title": "Eliminate ~131 any usages and re-enable no-explicit-any: error in CI",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T12:48:41Z",
+      "closed_at": "2026-06-11T00:11:22Z",
+      "lead_time_hours": 131.37805555555556,
+      "factory_cycle_hours": 14.15611111111111,
+      "labels": [
+        "priority: should-have",
+        "size: M",
+        "frontend",
+        "direct-to-pr"
+      ],
+      "size": "M",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 55.49635369999999,
+        "in_tokens": 1252,
+        "out_tokens": 474185,
+        "runs": [
+          {
+            "timestamp": "2026-06-10 10:02 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 11:53 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 12:12 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 13:28 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-10 14:02 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-10 14:07 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-10 22:38 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-10 23:09 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-10 23:46 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 238,
+      "title": "Site won't load: backend crash-loops \u2014 docker-compose.yml never forwards JWT_SECRET_KEY (regression from #220)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T12:20:27Z",
+      "closed_at": "2026-06-05T12:20:39Z",
+      "lead_time_hours": 0.0033333333333333335,
+      "factory_cycle_hours": null,
+      "labels": [
+        "bug",
+        "priority: must-have",
+        "size: S",
+        "infrastructure",
+        "regression"
+      ],
+      "size": "S",
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 237,
+      "title": "seed: restore universe_id in scanner_configs INSERT statements",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T12:18:55Z",
+      "closed_at": "2026-06-09T23:10:25Z",
+      "lead_time_hours": 106.85833333333333,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 235,
+      "title": "[follow-on] Eliminate ~131 any usages and re-enable no-explicit-any: error in CI",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T12:08:06Z",
+      "closed_at": "2026-06-09T23:10:30Z",
+      "lead_time_hours": 107.04,
+      "factory_cycle_hours": null,
+      "labels": [
+        "frontend"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 233,
+      "title": "Update Pocket Pivot seed row with run_frequency column and corrected parameters",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T09:37:09Z",
+      "closed_at": "2026-06-09T23:10:29Z",
+      "lead_time_hours": 109.55555555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 231,
+      "title": "style: import order in test_metrics.py (ruff-enforced, scope spillover from #194)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T09:08:16Z",
+      "closed_at": "2026-06-09T23:10:33Z",
+      "lead_time_hours": 110.03805555555556,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 229,
+      "title": "chore: align tracing import to alphabetical position in main.py",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T07:49:42Z",
+      "closed_at": "2026-06-09T23:10:32Z",
+      "lead_time_hours": 111.34722222222223,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover",
+        "needs-triage"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 227,
+      "title": "Fix seed/01_scanner_configs.sql: universe_id column mismatch (scope spillover from #193)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T07:21:00Z",
+      "closed_at": "2026-06-09T23:10:24Z",
+      "lead_time_hours": 111.82333333333334,
+      "factory_cycle_hours": null,
+      "labels": [
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 226,
+      "title": "Add vite-env.d.ts scaffold file to frontend (scope spillover from #193)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T07:20:55Z",
+      "closed_at": "2026-06-10T03:07:36Z",
+      "lead_time_hours": 115.77805555555555,
+      "factory_cycle_hours": 3.26,
+      "labels": [
+        "direct-to-pr",
+        "scope-spillover"
+      ],
+      "size": null,
+      "priority": null,
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.72745115,
+        "in_tokens": 263,
+        "out_tokens": 55243,
+        "runs": [
+          {
+            "timestamp": "2026-06-09 23:52 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 00:42 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 02:36 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-10 03:00 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 224,
+      "title": "[dark-factory] Guard against OR-join trigger_rule regressions in the workflow DAG",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T05:01:22Z",
+      "closed_at": "2026-06-11T23:48:19Z",
+      "lead_time_hours": 162.7825,
+      "factory_cycle_hours": 101.43861111111111,
+      "labels": [
+        "priority: should-have",
+        "size: S",
+        "infrastructure",
+        "ready-for-agent"
+      ],
+      "size": "S",
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 15.53727985,
+        "in_tokens": 587,
+        "out_tokens": 234699,
+        "runs": [
+          {
+            "timestamp": "2026-06-07 18:22 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 12:44 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 04:28 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 21:34 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-11 21:53 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-11 23:07 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 223,
+      "title": "fix(seed): restore universe_id + correct Pocket Pivot (Evening) row in 01_scanner_configs.sql (canonical)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T04:41:03Z",
+      "closed_at": "2026-06-10T01:38:55Z",
+      "lead_time_hours": 116.96444444444444,
+      "factory_cycle_hours": 1.8819444444444444,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "direct-to-pr"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 4.475015750000001,
+        "in_tokens": 206,
+        "out_tokens": 72106,
+        "runs": [
+          {
+            "timestamp": "2026-06-09 23:46 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 00:29 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 01:33 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
+    },
+    {
+      "number": 222,
+      "title": "chore: conftest.py import ordering audit record (scope spillover from #190)",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T04:40:58Z",
+      "closed_at": "2026-06-07T13:46:44Z",
+      "lead_time_hours": 57.096111111111114,
+      "factory_cycle_hours": null,
+      "labels": [],
+      "size": null,
+      "priority": null,
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 218,
+      "title": "Add AI code-review sub-stage to dark-factory pipeline",
+      "state": "CLOSED",
+      "created_at": "2026-06-05T00:53:41Z",
+      "closed_at": "2026-06-05T02:03:33Z",
+      "lead_time_hours": 1.1644444444444444,
+      "factory_cycle_hours": null,
+      "labels": [
+        "enhancement",
+        "priority: must-have",
+        "needs-discussion",
+        "Dark Factory"
+      ],
+      "size": null,
+      "priority": "must-have",
+      "autonomous": false,
+      "cost": null
+    },
+    {
+      "number": 215,
+      "title": "test: add P1.5-1 increment_retry and P1.5-5 trip_to_blocked scheduler tests",
+      "state": "CLOSED",
+      "created_at": "2026-06-04T18:10:33Z",
+      "closed_at": "2026-06-10T10:44:08Z",
+      "lead_time_hours": 136.55972222222223,
+      "factory_cycle_hours": 65.06888888888889,
+      "labels": [
+        "bug",
+        "priority: should-have",
+        "Dark Factory",
+        "direct-to-pr",
+        "ready-for-agent"
+      ],
+      "size": null,
+      "priority": "should-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 9.1088484,
+        "in_tokens": 263,
+        "out_tokens": 92289,
+        "runs": [
+          {
+            "timestamp": "2026-06-07 17:40 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 04:01 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 10:14 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 214,
@@ -47,25 +7066,56 @@
     {
       "number": 213,
       "title": "Review all the self-improvement made and make sure they work well",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T16:59:43Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
-      "labels": [],
+      "closed_at": "2026-06-10T01:31:13Z",
+      "lead_time_hours": 128.525,
+      "factory_cycle_hours": 100.27027777777778,
+      "labels": [
+        "priority: must-have",
+        "needs-discussion",
+        "Dark Factory",
+        "ready-for-agent"
+      ],
       "size": null,
-      "priority": null,
-      "autonomous": false,
-      "cost": null
+      "priority": "must-have",
+      "autonomous": true,
+      "cost": {
+        "total_usd": 11.317244,
+        "in_tokens": 1779,
+        "out_tokens": 184823,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 21:15 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 17:34 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 19:40 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-09 23:38 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 212,
       "title": "Interactive pipeline production report (Dark Factory metrics dashboard)",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T16:44:06Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-05T00:48:06Z",
+      "lead_time_hours": 8.066666666666666,
+      "factory_cycle_hours": 6.0183333333333335,
       "labels": [
         "enhancement",
         "size: L",
@@ -215,219 +7265,510 @@
     {
       "number": 205,
       "title": "[arch-v2][LOW] Add circuit breakers + outbound request timeouts",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:30Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-07T19:19:09Z",
+      "lead_time_hours": 78.49416666666667,
+      "factory_cycle_hours": 51.369166666666665,
       "labels": [
         "priority: should-have",
         "size: M",
-        "timeframe: medium-term",
+        "needs-discussion",
         "performance",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "M",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 30.14031805,
+        "in_tokens": 2043,
+        "out_tokens": 462050,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 15:57 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 21:04 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 22:05 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 22:32 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 14:23 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-07 16:01 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-07 16:24 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-07 16:48 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          }
+        ]
+      }
     },
     {
       "number": 204,
       "title": "[arch-v2][MED] Include Celery tasks in coverage measurement",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:29Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-07T19:13:58Z",
+      "lead_time_hours": 78.40805555555555,
+      "factory_cycle_hours": 52.31611111111111,
       "labels": [
         "priority: should-have",
         "size: M",
-        "timeframe: short-term",
         "testing",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "M",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 16.61461735,
+        "in_tokens": 397,
+        "out_tokens": 246108,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 14:55 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 17:14 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 17:03 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 18:14 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 203,
       "title": "[arch-v2][MED] Harden Docker socket mount (dark-factory / scheduler) + non-root containers",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:28Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-07T13:34:22Z",
+      "lead_time_hours": 72.74833333333333,
+      "factory_cycle_hours": 47.12277777777778,
       "labels": [
         "priority: should-have",
         "size: M",
-        "timeframe: medium-term",
+        "needs-discussion",
         "security",
         "infrastructure",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "M",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 6.7898118,
+        "in_tokens": 254,
+        "out_tokens": 111056,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 14:27 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 16:37 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 20:42 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 202,
       "title": "[arch-v2][MED] Enforce secure cookies + TLS termination",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:27Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-07T19:18:32Z",
+      "lead_time_hours": 78.48472222222222,
+      "factory_cycle_hours": 53.97555555555556,
       "labels": [
         "priority: should-have",
         "size: M",
-        "timeframe: medium-term",
+        "needs-discussion",
         "security",
         "infrastructure",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "M",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 20.01518335,
+        "in_tokens": 2694,
+        "out_tokens": 308988,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 13:20 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 14:45 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 16:23 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 14:00 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-07 15:10 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-07 15:35 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          }
+        ]
+      }
     },
     {
       "number": 201,
       "title": "[arch-v2][MED] Documentation hygiene: sync/async drift, stale tables, ADR numbering, docs casing",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:26Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-10T14:40:52Z",
+      "lead_time_hours": 145.85722222222222,
+      "factory_cycle_hours": 124.19777777777777,
       "labels": [
         "documentation",
         "priority: should-have",
         "size: S",
-        "timeframe: short-term",
-        "architecture-audit-v2"
+        "architecture-audit-v2",
+        "ready-for-agent"
       ],
       "size": "S",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 9.0943708,
+        "in_tokens": 289,
+        "out_tokens": 147528,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 10:29 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 17:26 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 03:31 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-10 11:14 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 200,
       "title": "[arch-v2][MED] Codeindex artifacts referenced as committed but absent",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:24Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-07T14:53:03Z",
+      "lead_time_hours": 74.06083333333333,
+      "factory_cycle_hours": 52.5675,
       "labels": [
         "documentation",
         "priority: should-have",
         "size: S",
-        "timeframe: short-term",
-        "architecture-audit-v2"
+        "plan-pending-review",
+        "architecture-audit-v2",
+        "ready-for-agent"
       ],
       "size": "S",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 5.7527506,
+        "in_tokens": 280,
+        "out_tokens": 79755,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 10:19 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-06 03:18 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-07 14:42 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 199,
       "title": "[arch-v2][MED] Decompose scanner.py / futures_data.py god modules",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:23Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-06T03:16:15Z",
+      "lead_time_hours": 38.44777777777778,
+      "factory_cycle_hours": 17.120833333333334,
       "labels": [
         "priority: should-have",
         "size: L",
         "scanner",
-        "timeframe: short-term",
-        "architecture-audit-v2"
+        "direct-to-pr",
+        "architecture-audit-v2",
+        "ready-for-agent"
       ],
       "size": "L",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 18.1514929,
+        "in_tokens": 359,
+        "out_tokens": 282704,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 10:09 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 14:01 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 14:16 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 15:46 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 198,
       "title": "[arch-v2][MED] Expand frontend test breadth (pages/components) + honest coverage",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:22Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-06T16:42:18Z",
+      "lead_time_hours": 51.882222222222225,
+      "factory_cycle_hours": 31.355,
       "labels": [
         "priority: should-have",
         "size: L",
         "frontend",
-        "timeframe: short-term",
+        "needs-discussion",
         "testing",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "L",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 24.85512065,
+        "in_tokens": 676,
+        "out_tokens": 386290,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 09:21 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-06 03:29 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-06 04:31 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-06 04:58 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-06 06:14 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-06 13:59 UTC",
+            "run_type": "continue",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 197,
       "title": "[arch-v2][MED] CI lint/audit gates are non-enforcing (ESLint TS rules + non-blocking audits)",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:21Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-06T03:13:27Z",
+      "lead_time_hours": 38.401666666666664,
+      "factory_cycle_hours": 21.574166666666667,
       "labels": [
         "priority: should-have",
         "size: S",
         "frontend",
-        "timeframe: short-term",
+        "needs-discussion",
         "infrastructure",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "S",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 12.62822405,
+        "in_tokens": 457,
+        "out_tokens": 182620,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 05:39 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 09:58 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 12:19 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 13:09 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 196,
       "title": "[arch-v2][MED] Add brute-force rate limit to login/register",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:19Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-06T03:21:00Z",
+      "lead_time_hours": 38.528055555555554,
+      "factory_cycle_hours": 25.216666666666665,
       "labels": [
         "priority: should-have",
         "size: S",
-        "timeframe: immediate",
         "security",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "S",
       "priority": "should-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 6.314425849999999,
+        "in_tokens": 243,
+        "out_tokens": 101790,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 02:08 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 06:58 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 09:44 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 195,
       "title": "[arch-v2][HIGH] Automated database backups (carried over from v1, never ticketed)",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:18Z",
-      "closed_at": null,
-      "lead_time_hours": null,
+      "closed_at": "2026-06-07T13:43:33Z",
+      "lead_time_hours": 72.90416666666667,
       "factory_cycle_hours": null,
       "labels": [
         "priority: must-have",
         "size: M",
-        "timeframe: short-term",
         "infrastructure",
         "architecture-audit-v2"
       ],
@@ -439,107 +7780,257 @@
     {
       "number": 194,
       "title": "[arch-v2][HIGH] Celery/worker Prometheus metrics never scraped",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:17Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-06T13:13:02Z",
+      "lead_time_hours": 48.395833333333336,
+      "factory_cycle_hours": 35.51722222222222,
       "labels": [
         "bug",
         "priority: must-have",
         "size: M",
-        "timeframe: immediate",
+        "needs-discussion",
         "infrastructure",
         "observability",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "M",
       "priority": "must-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 14.221601399999997,
+        "in_tokens": 654,
+        "out_tokens": 202656,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 01:42 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 06:10 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 08:12 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 08:31 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 08:47 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 09:19 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 193,
       "title": "[arch-v2][HIGH] Frontend tsc --noEmit is red \u2014 build/CI gate broken",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:16Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-06T03:18:50Z",
+      "lead_time_hours": 38.492777777777775,
+      "factory_cycle_hours": 25.930555555555557,
       "labels": [
         "bug",
         "priority: must-have",
         "size: S",
         "frontend",
-        "timeframe: immediate",
+        "needs-discussion",
         "testing",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "S",
       "priority": "must-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 6.62427255,
+        "in_tokens": 270,
+        "out_tokens": 116982,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 01:23 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 05:29 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 07:29 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 192,
       "title": "[arch-v2][HIGH] Add CSRF protection for cookie-based auth",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:14Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-06T13:10:15Z",
+      "lead_time_hours": 48.35027777777778,
+      "factory_cycle_hours": 35.62083333333333,
       "labels": [
         "priority: must-have",
         "size: M",
-        "timeframe: immediate",
+        "needs-discussion",
         "security",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "M",
       "priority": "must-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 6.9755208,
+        "in_tokens": 251,
+        "out_tokens": 120687,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 01:33 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 05:57 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 07:54 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 191,
       "title": "[arch-v2][HIGH] Authenticate WebSocket connections (currently bypass auth)",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:13Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-07T13:25:15Z",
+      "lead_time_hours": 72.60055555555556,
+      "factory_cycle_hours": 60.2875,
       "labels": [
         "priority: must-have",
         "size: M",
-        "timeframe: immediate",
+        "needs-discussion",
         "security",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "M",
       "priority": "must-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 13.056638900000001,
+        "in_tokens": 441,
+        "out_tokens": 213343,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 01:08 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 05:19 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 06:44 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-06 13:24 UTC",
+            "run_type": "continue",
+            "status": "failed"
+          }
+        ]
+      }
     },
     {
       "number": 190,
       "title": "[arch-v2][CRITICAL] Reject empty/weak JWT_SECRET_KEY at startup",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-04T12:49:12Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-05T04:55:36Z",
+      "lead_time_hours": 16.106666666666666,
+      "factory_cycle_hours": 3.9433333333333334,
       "labels": [
         "bug",
         "priority: must-have",
         "size: S",
-        "timeframe: immediate",
+        "plan-pending-review",
         "security",
+        "direct-to-pr",
         "architecture-audit-v2"
       ],
       "size": "S",
       "priority": "must-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 11.375203249999998,
+        "in_tokens": 660,
+        "out_tokens": 156429,
+        "runs": [
+          {
+            "timestamp": "2026-06-05 00:59 UTC",
+            "run_type": "refine",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 02:01 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 02:20 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 02:34 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 03:57 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          },
+          {
+            "timestamp": "2026-06-05 04:13 UTC",
+            "run_type": "fix",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-05 04:42 UTC",
+            "run_type": "fix",
+            "status": "failed"
+          }
+        ]
+      }
     },
     {
       "number": 184,
@@ -1091,8 +8582,7 @@
       "labels": [
         "enhancement",
         "priority: should-have",
-        "scanner",
-        "timeframe: immediate"
+        "scanner"
       ],
       "size": null,
       "priority": "should-have",
@@ -1175,13 +8665,15 @@
     {
       "number": 148,
       "title": "Integrate https://github.com/microsoft/agent-governance-toolkit",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-06-01T13:26:25Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-26T11:19:59Z",
+      "lead_time_hours": 597.8927777777777,
+      "factory_cycle_hours": 597.6163888888889,
       "labels": [
-        "spec-pending-review"
+        "enhancement",
+        "spec-pending-review",
+        "Dark Factory"
       ],
       "size": null,
       "priority": null,
@@ -1343,7 +8835,9 @@
       "lead_time_hours": null,
       "factory_cycle_hours": null,
       "labels": [
-        "spec-pending-review"
+        "enhancement",
+        "spec-pending-review",
+        "infrastructure"
       ],
       "size": null,
       "priority": null,
@@ -1523,7 +9017,6 @@
         "priority: must-have",
         "size: S",
         "plan-pending-review",
-        "timeframe: immediate",
         "Dark Factory"
       ],
       "size": "S",
@@ -1570,27 +9063,35 @@
     {
       "number": 106,
       "title": "Integrate HMM regime detection to enhance and validate scanner signals",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-05-27T02:56:07Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-15T15:30:39Z",
+      "lead_time_hours": 468.5755555555556,
+      "factory_cycle_hours": 323.7608333333333,
       "labels": [
         "enhancement",
+        "priority: should-have",
         "size: L",
-        "plan-pending-review"
+        "ml",
+        "scanner",
+        "factory-regression"
       ],
       "size": "L",
-      "priority": null,
+      "priority": "should-have",
       "autonomous": true,
       "cost": {
-        "total_usd": 5.638087600000001,
-        "in_tokens": 81,
-        "out_tokens": 87899,
+        "total_usd": 15.869576399999998,
+        "in_tokens": 345,
+        "out_tokens": 172185,
         "runs": [
           {
             "timestamp": "2026-06-02 03:45 UTC",
             "run_type": "plan",
+            "status": "completed"
+          },
+          {
+            "timestamp": "2026-06-14 21:20 UTC",
+            "run_type": "fix",
             "status": "completed"
           }
         ]
@@ -1608,7 +9109,6 @@
         "enhancement",
         "priority: should-have",
         "size: L",
-        "timeframe: strategic",
         "architecture-audit"
       ],
       "size": "L",
@@ -1627,7 +9127,6 @@
       "labels": [
         "priority: should-have",
         "size: L",
-        "timeframe: strategic",
         "infrastructure",
         "architecture-audit"
       ],
@@ -1663,7 +9162,6 @@
       "labels": [
         "priority: should-have",
         "size: L",
-        "timeframe: strategic",
         "infrastructure",
         "observability",
         "architecture-audit"
@@ -1685,7 +9183,6 @@
         "priority: should-have",
         "size: M",
         "frontend",
-        "timeframe: strategic",
         "performance",
         "architecture-audit"
       ],
@@ -1705,7 +9202,6 @@
       "labels": [
         "wontfix",
         "priority: should-have",
-        "timeframe: strategic",
         "size: XL",
         "performance",
         "architecture-audit"
@@ -1737,7 +9233,6 @@
       "labels": [
         "priority: should-have",
         "size: M",
-        "timeframe: medium-term",
         "performance",
         "architecture-audit"
       ],
@@ -1758,8 +9253,9 @@
         "documentation",
         "priority: should-have",
         "size: M",
-        "timeframe: medium-term",
-        "architecture-audit"
+        "needs-discussion",
+        "architecture-audit",
+        "factory-regression"
       ],
       "size": "M",
       "priority": "should-have",
@@ -1777,7 +9273,6 @@
       "labels": [
         "priority: should-have",
         "size: M",
-        "timeframe: medium-term",
         "performance",
         "architecture-audit"
       ],
@@ -1809,7 +9304,6 @@
         "enhancement",
         "priority: should-have",
         "size: S",
-        "timeframe: medium-term",
         "architecture-audit",
         "Dark Factory"
       ],
@@ -1830,7 +9324,6 @@
         "enhancement",
         "priority: should-have",
         "size: M",
-        "timeframe: medium-term",
         "architecture-audit"
       ],
       "size": "M",
@@ -1849,7 +9342,6 @@
       "labels": [
         "priority: should-have",
         "size: L",
-        "timeframe: medium-term",
         "infrastructure",
         "observability",
         "architecture-audit"
@@ -1871,7 +9363,6 @@
         "documentation",
         "priority: should-have",
         "size: M",
-        "timeframe: short-term",
         "architecture-audit"
       ],
       "size": "M",
@@ -1890,7 +9381,6 @@
       "labels": [
         "priority: should-have",
         "size: S",
-        "timeframe: short-term",
         "infrastructure",
         "architecture-audit"
       ],
@@ -1911,7 +9401,6 @@
         "priority: should-have",
         "size: M",
         "frontend",
-        "timeframe: short-term",
         "architecture-audit"
       ],
       "size": "M",
@@ -1931,7 +9420,6 @@
         "enhancement",
         "priority: should-have",
         "size: M",
-        "timeframe: short-term",
         "architecture-audit"
       ],
       "size": "M",
@@ -1942,23 +9430,35 @@
     {
       "number": 90,
       "title": "Implement automated database backups with retention",
-      "state": "OPEN",
+      "state": "CLOSED",
       "created_at": "2026-05-27T01:21:52Z",
-      "closed_at": null,
-      "lead_time_hours": null,
-      "factory_cycle_hours": null,
+      "closed_at": "2026-06-12T20:54:24Z",
+      "lead_time_hours": 403.5422222222222,
+      "factory_cycle_hours": 40.95666666666666,
       "labels": [
+        "enhancement",
         "priority: must-have",
         "size: M",
-        "plan-pending-review",
-        "timeframe: short-term",
+        "needs-discussion",
         "infrastructure",
-        "architecture-audit"
+        "architecture-audit",
+        "cost-report-lost"
       ],
       "size": "M",
       "priority": "must-have",
-      "autonomous": false,
-      "cost": null
+      "autonomous": true,
+      "cost": {
+        "total_usd": 3.3329495000000002,
+        "in_tokens": 76,
+        "out_tokens": 79951,
+        "runs": [
+          {
+            "timestamp": "2026-06-11 03:57 UTC",
+            "run_type": "plan",
+            "status": "completed"
+          }
+        ]
+      }
     },
     {
       "number": 89,
@@ -1973,7 +9473,6 @@
         "size: L",
         "frontend",
         "plan-pending-review",
-        "timeframe: short-term",
         "testing",
         "architecture-audit"
       ],
@@ -1994,10 +9493,11 @@
         "priority: should-have",
         "size: M",
         "plan-pending-review",
-        "timeframe: short-term",
+        "needs-discussion",
         "infrastructure",
         "architecture-audit",
-        "Dark Factory"
+        "Dark Factory",
+        "factory-regression"
       ],
       "size": "M",
       "priority": "should-have",
@@ -2026,7 +9526,6 @@
       "labels": [
         "priority: must-have",
         "size: S",
-        "timeframe: immediate",
         "security",
         "architecture-audit"
       ],
@@ -2047,7 +9546,6 @@
         "priority: must-have",
         "size: S",
         "plan-pending-review",
-        "timeframe: immediate",
         "security",
         "infrastructure",
         "architecture-audit"
@@ -2069,7 +9567,6 @@
         "priority: must-have",
         "size: S",
         "plan-pending-review",
-        "timeframe: immediate",
         "infrastructure",
         "architecture-audit"
       ],
@@ -2089,7 +9586,6 @@
       "labels": [
         "priority: must-have",
         "size: M",
-        "timeframe: immediate",
         "security",
         "architecture-audit"
       ],
@@ -2298,7 +9794,9 @@
       "labels": [
         "enhancement",
         "priority: should-have",
-        "size: L"
+        "size: L",
+        "needs-discussion",
+        "factory-regression"
       ],
       "size": "L",
       "priority": "should-have",
@@ -2787,16 +10285,20 @@
     }
   ],
   "cost_by_step": {
-    "implement": 80.7319,
-    "plan": 74.8324,
-    "validate": 21.5221,
-    "refine": 19.7094,
-    "conformance": 15.057,
-    "parse-intent": 1.386,
-    "classify-preview": 0.5548,
-    "summarize-feedback": 0.3447,
+    "implement": 319.0849,
+    "plan": 265.1221,
+    "refine": 223.2749,
+    "conformance": 132.9592,
+    "code-review": 52.8631,
+    "validate": 42.9506,
+    "parse-intent": 6.9301,
+    "classify-preview": 4.6819,
+    "revise-advisory": 3.1467,
+    "summarize-feedback": 1.866,
     "fetch-issue": 0.0,
+    "bench-mode-probe": 0.0,
     "setup-refine-branch": 0.0,
+    "refine-push": 0.0,
     "plan-push-and-advance": 0.0,
     "setup-branch": 0.0,
     "update-codeindex": 0.0,
@@ -2807,7 +10309,7 @@
     "status-in-review": 0.0,
     "report": 0.0,
     "acknowledge-continue": 0.0,
-    "refine-push": 0.0
+    "de-conflict": 0.0
   },
   "timeseries": {
     "weekly": [
@@ -2848,10 +10350,31 @@
       },
       {
         "week": "2026-06-01",
-        "created": 45,
-        "closed": 28,
-        "cum_closed": 93,
-        "backlog": 23
+        "created": 82,
+        "closed": 49,
+        "cum_closed": 114,
+        "backlog": 39
+      },
+      {
+        "week": "2026-06-08",
+        "created": 176,
+        "closed": 111,
+        "cum_closed": 225,
+        "backlog": 104
+      },
+      {
+        "week": "2026-06-15",
+        "created": 33,
+        "closed": 36,
+        "cum_closed": 261,
+        "backlog": 101
+      },
+      {
+        "week": "2026-06-22",
+        "created": 14,
+        "closed": 24,
+        "cum_closed": 285,
+        "backlog": 91
       }
     ]
   }

--- a/scorecard.json
+++ b/scorecard.json
@@ -1,51 +1,51 @@
 {
-  "generated_at": "2026-06-11T22:26:19.158457+00:00",
+  "generated_at": "2026-06-26T13:33:46.755710+00:00",
   "window": {
     "since": "2026-05-01",
-    "until": "2026-06-11"
+    "until": "2026-06-26"
   },
   "triad": {
-    "merged_clean": 99,
-    "merged_with_edits": 8,
-    "closed": 9,
-    "open": 2,
-    "merge_rate_pct": 92.2
+    "merged_clean": 151,
+    "merged_with_edits": 17,
+    "closed": 12,
+    "open": 0,
+    "merge_rate_pct": 93.3
   },
   "rework": {
-    "regression_count": 0,
-    "merged_factory_prs": 107,
-    "rework_rate_pct": 0.0
+    "regression_count": 28,
+    "merged_factory_prs": 168,
+    "rework_rate_pct": 16.7
   },
   "churn": {
-    "added_lines": 39724,
-    "surviving_lines": 34956,
-    "churn_pct": 12.0,
-    "commits_analyzed": 178,
-    "commits_too_young": 263
+    "added_lines": 163535,
+    "surviving_lines": 58280,
+    "churn_pct": 64.4,
+    "commits_analyzed": 538,
+    "commits_too_young": 128
   },
   "by_size": {
-    "S": {
-      "merged_clean": 22,
-      "merged_with_edits": 3,
-      "closed": 0,
-      "open": 1
-    },
-    "M": {
-      "merged_clean": 33,
-      "merged_with_edits": 3,
-      "closed": 0,
-      "open": 1
-    },
     "unknown": {
-      "merged_clean": 28,
+      "merged_clean": 48,
       "merged_with_edits": 2,
-      "closed": 8,
+      "closed": 10,
       "open": 0
     },
     "L": {
-      "merged_clean": 16,
-      "merged_with_edits": 0,
+      "merged_clean": 22,
+      "merged_with_edits": 3,
       "closed": 0,
+      "open": 0
+    },
+    "M": {
+      "merged_clean": 51,
+      "merged_with_edits": 8,
+      "closed": 0,
+      "open": 0
+    },
+    "S": {
+      "merged_clean": 30,
+      "merged_with_edits": 4,
+      "closed": 1,
       "open": 0
     },
     "XL": {
@@ -987,18 +987,514 @@
     {
       "number": 342,
       "title": "Implement trend_pullback daily scanner (trend-following pullback signals)",
-      "classification": "open",
+      "classification": "merged_clean",
       "issue": 299,
       "size": "M",
-      "merged_at": null
+      "merged_at": "2026-06-11T23:47:22Z"
     },
     {
       "number": 344,
       "title": "[dark-factory] Guard against OR-join trigger_rule regressions in the workflow DAG",
-      "classification": "open",
+      "classification": "merged_clean",
       "issue": 224,
       "size": "S",
+      "merged_at": "2026-06-11T23:48:18Z"
+    },
+    {
+      "number": 348,
+      "title": "[arch-v3][MED] Stage run_pre_market_scan into detect/enrich/persist pipeline (346-line function)",
+      "classification": "merged_clean",
+      "issue": 288,
+      "size": "unknown",
+      "merged_at": "2026-06-12T11:22:58Z"
+    },
+    {
+      "number": 351,
+      "title": "[arch-v3][MED] Add readiness probe (DB/Redis) + migration gate in deploy path",
+      "classification": "merged_clean",
+      "issue": 289,
+      "size": "unknown",
+      "merged_at": "2026-06-12T09:43:20Z"
+    },
+    {
+      "number": 352,
+      "title": "feat(infra): run backend container as non-root appuser (#258)",
+      "classification": "closed",
+      "issue": 258,
+      "size": "unknown",
       "merged_at": null
+    },
+    {
+      "number": 353,
+      "title": "[arch-v3][MED] Tweet-monitor cookie auth: expiry alerting or official API (3 reviews unticketed)",
+      "classification": "merged_clean",
+      "issue": 290,
+      "size": "unknown",
+      "merged_at": "2026-06-12T09:54:52Z"
+    },
+    {
+      "number": 354,
+      "title": "Baseline-green gate: smoke origin/main before any factory run",
+      "classification": "merged_clean",
+      "issue": 332,
+      "size": "S",
+      "merged_at": "2026-06-12T09:47:49Z"
+    },
+    {
+      "number": 356,
+      "title": "Run Record: one structured per-run record of every stage verdict (gen_ai.* to Seq + runs.jsonl)",
+      "classification": "merged_clean",
+      "issue": 333,
+      "size": "M",
+      "merged_at": "2026-06-12T09:57:36Z"
+    },
+    {
+      "number": 357,
+      "title": "Deepen the Gate seam: layered gate policy, judge calibration audit, blast-radius human gate",
+      "classification": "merged_clean",
+      "issue": 334,
+      "size": "L",
+      "merged_at": "2026-06-12T10:00:07Z"
+    },
+    {
+      "number": 358,
+      "title": "Failure-to-eval flywheel: post-mortem stage on circuit-break, failures become eval tasks",
+      "classification": "merged_clean",
+      "issue": 336,
+      "size": "M",
+      "merged_at": "2026-06-12T15:14:27Z"
+    },
+    {
+      "number": 359,
+      "title": "Replay benchmark: pass^k suite of replayed closed issues to regression-test the harness",
+      "classification": "merged_clean",
+      "issue": 335,
+      "size": "L",
+      "merged_at": "2026-06-12T14:54:50Z"
+    },
+    {
+      "number": 367,
+      "title": "[arch-v3][LOW] SQL aggregates in get_trade_stats + selectinload pagination fix",
+      "classification": "merged_clean",
+      "issue": 291,
+      "size": "unknown",
+      "merged_at": "2026-06-12T15:15:06Z"
+    },
+    {
+      "number": 399,
+      "title": "test(frontend): scope-correct PageLoader tests (not in spec #250)",
+      "classification": "closed",
+      "issue": 311,
+      "size": "unknown",
+      "merged_at": null
+    },
+    {
+      "number": 400,
+      "title": "test(frontend): scope-correct ScorecardDetail tests (spec #250 non-goal)",
+      "classification": "merged_clean",
+      "issue": 309,
+      "size": "unknown",
+      "merged_at": "2026-06-12T20:45:15Z"
+    },
+    {
+      "number": 401,
+      "title": "Implement automated database backups with retention",
+      "classification": "merged_clean",
+      "issue": 90,
+      "size": "M",
+      "merged_at": "2026-06-12T20:54:23Z"
+    },
+    {
+      "number": 405,
+      "title": "test(frontend): scope-correct AlertBadges tests (not in spec #250)",
+      "classification": "merged_clean",
+      "issue": 313,
+      "size": "unknown",
+      "merged_at": "2026-06-13T03:04:07Z"
+    },
+    {
+      "number": 406,
+      "title": "test(frontend): scope-correct ActiveWatchlist tests (not in spec #250)",
+      "classification": "merged_clean",
+      "issue": 312,
+      "size": "unknown",
+      "merged_at": "2026-06-13T03:03:30Z"
+    },
+    {
+      "number": 407,
+      "title": "test(frontend): scope-correct PreMarketMovers tests (not in spec #250)",
+      "classification": "merged_clean",
+      "issue": 314,
+      "size": "unknown",
+      "merged_at": "2026-06-13T03:20:32Z"
+    },
+    {
+      "number": 408,
+      "title": "test(frontend): scope-correct ScorecardOverview tests (not in spec #250)",
+      "classification": "merged_clean",
+      "issue": 315,
+      "size": "unknown",
+      "merged_at": "2026-06-13T03:21:15Z"
+    },
+    {
+      "number": 409,
+      "title": "test(frontend): scope-correct Settings tests (not in spec #250)",
+      "classification": "merged_clean",
+      "issue": 316,
+      "size": "unknown",
+      "merged_at": "2026-06-13T03:05:02Z"
+    },
+    {
+      "number": 410,
+      "title": "[security] F-AUTH-01: Swagger/openapi.json/metrics unauthenticated in production",
+      "classification": "merged_clean",
+      "issue": 369,
+      "size": "S",
+      "merged_at": "2026-06-13T03:33:40Z"
+    },
+    {
+      "number": 411,
+      "title": "feat(infra): run dark-factory container as non-root factory user",
+      "classification": "merged_clean",
+      "issue": 261,
+      "size": "unknown",
+      "merged_at": "2026-06-13T03:01:46Z"
+    },
+    {
+      "number": 412,
+      "title": "[arch-v3][LOW] Make Trivy block on HIGH/CRITICAL + add password min-length policy",
+      "classification": "merged_with_edits",
+      "issue": 293,
+      "size": "S",
+      "merged_at": "2026-06-13T03:21:45Z"
+    },
+    {
+      "number": 413,
+      "title": "feat(infra): run frontend container as non-root node user",
+      "classification": "merged_clean",
+      "issue": 259,
+      "size": "unknown",
+      "merged_at": "2026-06-13T13:36:49Z"
+    },
+    {
+      "number": 414,
+      "title": "test-infra: add postgres discovery fallback when testcontainers exec is blocked",
+      "classification": "merged_clean",
+      "issue": 360,
+      "size": "unknown",
+      "merged_at": "2026-06-13T19:38:20Z"
+    },
+    {
+      "number": 415,
+      "title": "[security] F-NET-01: Redis has no authentication (requirepass unset)",
+      "classification": "merged_with_edits",
+      "issue": 370,
+      "size": "M",
+      "merged_at": "2026-06-15T17:41:34Z"
+    },
+    {
+      "number": 416,
+      "title": "[arch-v3][LOW] Validate JSONB writes + enforce severity enum + channel_config schema",
+      "classification": "merged_with_edits",
+      "issue": 292,
+      "size": "M",
+      "merged_at": "2026-06-14T14:57:06Z"
+    },
+    {
+      "number": 417,
+      "title": "[arch-v3][LOW] Decompose frontend god files: api/scanner.ts (787) + QualityReportModal.tsx (753)",
+      "classification": "merged_clean",
+      "issue": 294,
+      "size": "M",
+      "merged_at": "2026-06-13T17:22:20Z"
+    },
+    {
+      "number": 418,
+      "title": "Update ARCHITECTURE.md to document /api/ready readiness endpoint",
+      "classification": "merged_clean",
+      "issue": 350,
+      "size": "unknown",
+      "merged_at": "2026-06-13T09:40:52Z"
+    },
+    {
+      "number": 420,
+      "title": "Single config interface: config.yaml as sole source of factory policy",
+      "classification": "merged_clean",
+      "issue": 338,
+      "size": "S",
+      "merged_at": "2026-06-13T09:39:39Z"
+    },
+    {
+      "number": 422,
+      "title": "factory: dedupe scope-enforcement findings before filing tickets",
+      "classification": "merged_clean",
+      "issue": 384,
+      "size": "M",
+      "merged_at": "2026-06-13T13:35:34Z"
+    },
+    {
+      "number": 423,
+      "title": "[security] F-FRONT-01: External-content URLs without allowlist; no CSP",
+      "classification": "merged_with_edits",
+      "issue": 381,
+      "size": "M",
+      "merged_at": "2026-06-13T18:47:29Z"
+    },
+    {
+      "number": 437,
+      "title": "Extract tested factory core from entrypoint/scheduler/de-conflict bash glue",
+      "classification": "merged_with_edits",
+      "issue": 337,
+      "size": "L",
+      "merged_at": "2026-06-13T18:56:15Z"
+    },
+    {
+      "number": 447,
+      "title": "Backtest harness core: daily-bar replay of TradingStrategy vs scan signals",
+      "classification": "merged_with_edits",
+      "issue": 301,
+      "size": "L",
+      "merged_at": "2026-06-14T15:27:39Z"
+    },
+    {
+      "number": 505,
+      "title": "ci: lint .archon/workflows when: expressions against Archon grammar",
+      "classification": "merged_clean",
+      "issue": 403,
+      "size": "S",
+      "merged_at": "2026-06-14T14:56:22Z"
+    },
+    {
+      "number": 510,
+      "title": "Plan stage implemented the full feature on the refine branch (#339) instead of stopping at the plan",
+      "classification": "merged_clean",
+      "issue": 390,
+      "size": "M",
+      "merged_at": "2026-06-14T20:16:22Z"
+    },
+    {
+      "number": 511,
+      "title": "test(frontend): quality-pass the 7 OOS test files from #250 (executes epic #383 decision)",
+      "classification": "merged_clean",
+      "issue": 396,
+      "size": "M",
+      "merged_at": "2026-06-14T20:06:46Z"
+    },
+    {
+      "number": 512,
+      "title": "observability: pre-market scan latency SLO \u2014 metrics + missed-slot alerts",
+      "classification": "merged_with_edits",
+      "issue": 391,
+      "size": "M",
+      "merged_at": "2026-06-15T12:11:57Z"
+    },
+    {
+      "number": 513,
+      "title": "[security] F-DOCKER-01: socket-proxy BUILD/POST + preview compose weak creds",
+      "classification": "merged_clean",
+      "issue": 379,
+      "size": "M",
+      "merged_at": "2026-06-15T01:13:28Z"
+    },
+    {
+      "number": 514,
+      "title": "[security] F-WS-01: WebSocket resource exhaustion (no conn/msg caps, per-conn pubsub)",
+      "classification": "merged_clean",
+      "issue": 377,
+      "size": "M",
+      "merged_at": "2026-06-15T01:14:26Z"
+    },
+    {
+      "number": 515,
+      "title": "feat: HMM regime detection stamps and filters scanner events (#106)",
+      "classification": "merged_with_edits",
+      "issue": 106,
+      "size": "L",
+      "merged_at": "2026-06-15T15:30:38Z"
+    },
+    {
+      "number": 519,
+      "title": "Preview env fails on every implement run: BuildKit 403 through docker-socket-proxy (+ EXEC:0 second wall)",
+      "classification": "merged_clean",
+      "issue": 436,
+      "size": "M",
+      "merged_at": "2026-06-15T01:32:01Z"
+    },
+    {
+      "number": 520,
+      "title": "Exclude untrusted events from trusted Scorecard metrics",
+      "classification": "merged_clean",
+      "issue": 497,
+      "size": "M",
+      "merged_at": "2026-06-15T01:33:16Z"
+    },
+    {
+      "number": 524,
+      "title": "Scheduler dependencies_met() strands issues whose dependency is closed but off-board",
+      "classification": "merged_clean",
+      "issue": 389,
+      "size": "S",
+      "merged_at": "2026-06-15T12:54:30Z"
+    },
+    {
+      "number": 562,
+      "title": "docs(docker): document root-user exception in Dockerfile.forecast",
+      "classification": "merged_clean",
+      "issue": 329,
+      "size": "unknown",
+      "merged_at": "2026-06-20T03:53:45Z"
+    },
+    {
+      "number": 563,
+      "title": "enhance(pg_discovery): guard isinstance(containers, list) on Docker API response",
+      "classification": "merged_clean",
+      "issue": 429,
+      "size": "unknown",
+      "merged_at": "2026-06-20T11:05:17Z"
+    },
+    {
+      "number": 565,
+      "title": "cleanup(dark-factory): factory-failures.jsonl accumulates OOS telemetry entries on feature branches",
+      "classification": "merged_clean",
+      "issue": 431,
+      "size": "unknown",
+      "merged_at": "2026-06-20T11:06:24Z"
+    },
+    {
+      "number": 566,
+      "title": "docs(architecture): ARCHITECTURE.md buildkit subgraph should be tracked as in-scope doc for #436",
+      "classification": "merged_clean",
+      "issue": 516,
+      "size": "unknown",
+      "merged_at": "2026-06-20T11:07:27Z"
+    },
+    {
+      "number": 567,
+      "title": "chore(codeindex): docs/codeindex-hotspots.md OOS line-count refreshes committed on feature branches",
+      "classification": "merged_clean",
+      "issue": 561,
+      "size": "unknown",
+      "merged_at": "2026-06-20T11:09:06Z"
+    },
+    {
+      "number": 568,
+      "title": "fix(dark-factory): unparseable when: fails the run loudly \u2014 pin Archon f83fb556 (#402)",
+      "classification": "merged_clean",
+      "issue": 402,
+      "size": "S",
+      "merged_at": "2026-06-20T14:50:51Z"
+    },
+    {
+      "number": 572,
+      "title": "feat(backtest): 5-scanner x strategy comparison run (#302)",
+      "classification": "merged_clean",
+      "issue": 302,
+      "size": "M",
+      "merged_at": "2026-06-20T14:53:09Z"
+    },
+    {
+      "number": 575,
+      "title": "Revisit dispatch ceiling (C9) \u2014 re-measure success-by-size/type",
+      "classification": "merged_clean",
+      "issue": 355,
+      "size": "M",
+      "merged_at": "2026-06-20T16:45:37Z"
+    },
+    {
+      "number": 580,
+      "title": "Outcome dashboard: per-scanner ScannerOutcomeSummary aggregates in UI",
+      "classification": "merged_clean",
+      "issue": 303,
+      "size": "M",
+      "merged_at": "2026-06-21T03:54:32Z"
+    },
+    {
+      "number": 583,
+      "title": "feat(notifications): generic system-notification path (email/push) for non-scanner events",
+      "classification": "closed",
+      "issue": 570,
+      "size": "S",
+      "merged_at": null
+    },
+    {
+      "number": 586,
+      "title": "Expose data quality gate preflight API",
+      "classification": "merged_clean",
+      "issue": 493,
+      "size": "M",
+      "merged_at": "2026-06-21T19:52:10Z"
+    },
+    {
+      "number": 589,
+      "title": "Revisit dispatch ceiling (C9) - re-measure success-by-size/type",
+      "classification": "merged_clean",
+      "issue": 394,
+      "size": "S",
+      "merged_at": "2026-06-21T19:53:18Z"
+    },
+    {
+      "number": 593,
+      "title": "data-quality: gap/staleness detection on aggregates + corporate-action handling",
+      "classification": "merged_clean",
+      "issue": 387,
+      "size": "L",
+      "merged_at": "2026-06-21T19:55:03Z"
+    },
+    {
+      "number": 597,
+      "title": "Add reusable data quality gate contract and service",
+      "classification": "merged_clean",
+      "issue": 492,
+      "size": "L",
+      "merged_at": "2026-06-21T21:15:32Z"
+    },
+    {
+      "number": 598,
+      "title": "scanner: nightly replay-diff \u2014 re-run yesterday's scans and diff vs live signals",
+      "classification": "merged_with_edits",
+      "issue": 392,
+      "size": "M",
+      "merged_at": "2026-06-22T13:03:31Z"
+    },
+    {
+      "number": 599,
+      "title": "feat: weekly restore drill \u2014 verify backups via throwaway postgres (#386)",
+      "classification": "merged_clean",
+      "issue": 386,
+      "size": "M",
+      "merged_at": "2026-06-22T02:00:02Z"
+    },
+    {
+      "number": 600,
+      "title": "chaos: IBKR gateway kill-test \u2014 verify live-scanner degradation and recovery",
+      "classification": "merged_clean",
+      "issue": 393,
+      "size": "M",
+      "merged_at": "2026-06-22T01:57:14Z"
+    },
+    {
+      "number": 603,
+      "title": "feat: apply advisory data quality gate to scanner runs (#494)",
+      "classification": "merged_clean",
+      "issue": 494,
+      "size": "L",
+      "merged_at": "2026-06-22T11:44:04Z"
+    },
+    {
+      "number": 604,
+      "title": "Show data quality trust status in scanner and quality UI",
+      "classification": "merged_clean",
+      "issue": 495,
+      "size": "L",
+      "merged_at": "2026-06-22T11:44:23Z"
+    },
+    {
+      "number": 605,
+      "title": "cleanup(dark-factory): orphaned seed files in dark-factory/seed/seed/ from prior failed run",
+      "classification": "merged_clean",
+      "issue": 518,
+      "size": "unknown",
+      "merged_at": "2026-06-22T11:44:17Z"
     }
   ]
 }


### PR DESCRIPTION
Regenerated `docs/pipeline-report.html` from current GitHub data (`scripts/generate.sh`) and added a v1→v2 comparison report.

**v1 (2026-06-04) → v2 (2026-06-26), ~22 days:**
| Metric | v1 | v2 | Δ |
|---|---|---|---|
| Issues tracked | 116 | 376 | ×3.2 |
| Shipped (closed) | 93 | 285 | ×3.1 |
| Autonomous | 35 (30.2%) | 162 (43.1%) | +12.9 pts |
| Total AI spend | $214.56 | $1,053.30 | ×4.9 |
| Avg $/ticket | $6.13 | $6.50 | ~flat |
| Median lead | 30.1h | 49.3h | +64% |
| p85 lead | 226h | 201h | −11% |

The factory scaled ~3× in throughput and stayed cost-efficient per ticket; the median slowed as new quality gates landed (cost shifted toward refine ×11, conformance ×9, plus new code-review/revise-advisory stages) while the worst-case tail tightened. Adds `docs/pipeline-report-comparison-2026-06-04-vs-2026-06-26.html` (self-contained, dark-factory skin). Doc-only.