### PR TITLE
fix(docker): allowlist restore-drill scripts in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,5 @@
 !docker/
 !scripts/backup.sh
 !scripts/backup-entrypoint.sh
+!scripts/restore-drill.sh
+!scripts/restore-drill-entrypoint.sh


### PR DESCRIPTION
The `db-restore-drill` weekly backup-verification sidecar could never build. `.dockerignore` is deny-all (`*`) + allowlist; only `scripts/backup.sh` + `scripts/backup-entrypoint.sh` were re-included, so `scripts/restore-drill.sh` and `scripts/restore-drill-entrypoint.sh` were stripped from the build context and `COPY` failed with `'/scripts/restore-drill-entrypoint.sh': not found` — a context exclusion, not a missing file. Two-line fix; verified the image builds end-to-end. (Surfaced while bringing the dev stack up to date post-merge; `db-backup` itself was unaffected.)