### PR TITLE
fix(providers): guard ib_insync import against Python 3.14 event-loop RuntimeError (clears false main-red)

### DIFF
--- a/backend/app/providers/ibkr.py
+++ b/backend/app/providers/ibkr.py
@@ -35,11 +35,21 @@ try:
     from ib_insync.contract import ContractDetails
 
     IB_INSYNC_AVAILABLE = True
-except ImportError:
+except (ImportError, RuntimeError) as _ib_insync_err:
+    # RuntimeError covers Python 3.14+ environments (e.g. the dark-factory
+    # image) where ib_insync's transitive dep eventkit calls
+    # asyncio.get_event_loop() at import time and raises
+    # "There is no current event loop in thread 'MainThread'." Importing
+    # app.main must not hard-fail just because this optional provider can't
+    # load — it degrades gracefully via IB_INSYNC_AVAILABLE instead. The
+    # IBKR symbols (IB/Future/...) are only referenced inside methods, so
+    # leaving them unbound here is safe until IBKR features are used.
     IB_INSYNC_AVAILABLE = False
     logger.warning(
-        "ib_insync not installed. IBKRDataProvider will be unavailable. "
-        "Run: pip install ib_insync"
+        "ib_insync unavailable (%s). IBKRDataProvider will be disabled. "
+        "Run: pip install ib_insync (requires a Python runtime compatible "
+        "with ib_insync/eventkit).",
+        _ib_insync_err,
     )
 
 


### PR DESCRIPTION
## Problem

The dark-factory scheduler's smoke gate (`dark-factory/smoke_gate.sh`) verifies `origin/main` is buildable before any per-ticket implement work by running `python -c "import app.main"`. The dark-factory image runs **Python 3.14**, where `eventkit` (a transitive dependency of `ib_insync`) calls `asyncio.get_event_loop()` at import time and raises:

```
RuntimeError: There is no current event loop in thread 'MainThread'.
```

`backend/app/providers/ibkr.py` already guards the `ib_insync` import, but only catches `ImportError` — so the `RuntimeError` escaped and `import app.main` hard-failed **in the factory environment only**. This made the smoke gate falsely flag main as red, writing the `main-is-red` sentinel and **pausing ALL implement dispatch** (auto-filed regression omniscient/markethawk#629, red since ~2026-06-26 11:50). Refine/plan kept running, but nothing could reach In review.

CI `build-backend` passes because the backend image runs an older Python where `ib_insync`/`eventkit` import fine — so the app itself is healthy; only the Py3.14 factory import path was broken.

## Fix

Broaden the import guard to also catch `RuntimeError`, degrading the optional IBKR provider gracefully (`IB_INSYNC_AVAILABLE = False`) instead of breaking the whole import graph. The `ib_insync` symbols (`IB`/`Future`/...) are only referenced inside method bodies (verified: no module-level / class-body / def-time-annotation usage — line 517's `-> Optional["IB"]` is a string forward-ref), so leaving them unbound is safe until IBKR features actually run.

## Validation

Under real Python 3.14.4 inside a live factory container:
- Before: `python -c "import app.main"` → `RuntimeError: There is no current event loop`.
- After (this change copied into the clone): `import app.main` imports cleanly; logs `ib_insync unavailable (...). IBKRDataProvider will be disabled.`

This is exactly the command the smoke gate runs, so the next "Recheck main" will go green, clear the sentinel, and auto-close omniscient/markethawk#629 — releasing implement dispatch.

Refs omniscient/markethawk#629, part of the Python 3.14 migration family (#536, omniscient/dark-factory#139).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
