### PR TITLE
architecture-v4: universe_export.py raises HTTPException from a service (SoC leak)

### DIFF
--- a/.archon/memory/backend-patterns.md
+++ b/.archon/memory/backend-patterns.md
@@ -78,7 +78,6 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 
 - [PATTERN] Pure-ASGI middleware classes (like `CSRFMiddleware`) should be defined at module level in `main.py`, not inside `create_app()` — module-level placement makes them importable by the test suite without triggering the full app factory. The `AuthMiddleware` is an exception because it closes over `EXEMPT_PREFIXES`. <!-- issue:#192 date:2026-06-05 expires:2026-12-05 source:implement -->
 
-- [PATTERN] CSRF_EXEMPT_PREFIXES and AUTH EXEMPT_PREFIXES serve different concerns and must remain separate tuples in `main.py`. Do not merge them — CSRF exempts pre-authentication paths; auth exempts docs/health/metrics paths that are unrelated to CSRF. <!-- issue:#192 date:2026-06-05 expires:2026-12-05 source:implement -->
 
 
 
@@ -106,3 +105,5 @@ Entries are advisory. If an entry conflicts with CLAUDE.md or ARCHITECTURE.md, f
 - [PROVISIONAL] `WebSocketException(code=1008)` raised inside the route handler body (not only from a FastAPI Dependency) is caught by Starlette and closes the connection before `websocket.accept()` returns to the client — so an `async with ws_connection_slot(user_id):` context manager in the handler body (before `await websocket.accept()`) correctly delivers 1008 without needing a separate Dependency. <!-- evidence:test-output issue:#377 date:2026-06-14 expires:2026-12-14 source:implement -->
 
 - [PROVISIONAL] To persist a Pydantic v2 model that contains `datetime` fields into a JSONB column, use `json.loads(json.dumps(model.model_dump(), default=str))` — `model.model_dump()` returns `datetime` objects which PostgreSQL's JSON encoder rejects; `default=str` coerces them to ISO strings and `json.loads` rebuilds a plain dict. <!-- evidence:test-output issue:#494 date:2026-06-22 expires:2026-12-22 source:implement -->
+- [AVOID] Never raise `HTTPException` from a service module (`app/services/`) — services have no HTTP context and become untestable without FastAPI. Raise domain exceptions (`UniverseValidationError`, `UniverseNotFoundError`, etc.) and convert to `HTTPException` in the router handler (`except UniverseValidationError as e: raise HTTPException(400, detail=str(e))`). `starlette.responses` types (e.g. `StreamingResponse`) are acceptable in services since they are data-format, not control-flow, concerns. <!-- issue:#631 date:2026-06-27 expires:2026-12-27 source:implement -->
+- [PATTERN] CSRF_EXEMPT_PREFIXES and AUTH EXEMPT_PREFIXES serve different concerns and must remain separate tuples in `main.py`. Do not merge them — CSRF exempts pre-authentication paths; auth exempts docs/health/metrics paths that are unrelated to CSRF. <!-- issue:#192 date:2026-06-05 expires:2026-12-05 source:implement -->

--- a/backend/app/routers/universe.py
+++ b/backend/app/routers/universe.py
@@ -341,6 +341,8 @@ def export_universe_aggregates(
         return universe_export.export_aggregates(universe_id, request, db)
     except UniverseNotFoundError:
         raise HTTPException(status_code=404, detail="Universe not found")
+    except UniverseValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 @router.get("/{universe_id}/stocks", response_model=List[MonitoredStockResponse])

--- a/backend/app/routers/universe.py
+++ b/backend/app/routers/universe.py
@@ -342,7 +342,7 @@ def export_universe_aggregates(
     except UniverseNotFoundError:
         raise HTTPException(status_code=404, detail="Universe not found")
     except UniverseValidationError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=e.args[0])
 
 
 @router.get("/{universe_id}/stocks", response_model=List[MonitoredStockResponse])
@@ -486,4 +486,4 @@ def trigger_normalization(
     except UniverseNotFoundError:
         raise HTTPException(status_code=404, detail="Universe not found")
     except UniverseValidationError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=e.args[0])

--- a/backend/app/services/universe_export.py
+++ b/backend/app/services/universe_export.py
@@ -8,11 +8,10 @@ import io
 import zipfile
 from datetime import datetime, timedelta
 
-from fastapi import HTTPException
-from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
+from starlette.responses import StreamingResponse
 
-from app.exceptions import UniverseNotFoundError
+from app.exceptions import UniverseNotFoundError, UniverseValidationError
 from app.models import StockUniverse, StockUniverseTicker
 from app.models.futures_aggregate import FuturesAggregate
 from app.models.stock_aggregate import StockAggregate
@@ -48,7 +47,7 @@ def export_aggregates(universe_id: int, request, db: Session) -> StreamingRespon
     request.multiplier, request.from_date, request.to_date, request.zip_format.
     ExportAggregatesRequest stays defined in routers/universe.py.
     Raises UniverseNotFoundError if the universe does not exist.
-    Raises HTTPException(400) if no tickers are provided.
+    Raises UniverseValidationError if no tickers are provided.
     """
     universe = db.query(StockUniverse).filter(StockUniverse.id == universe_id).first()
     if not universe:
@@ -56,7 +55,7 @@ def export_aggregates(universe_id: int, request, db: Session) -> StreamingRespon
 
     tickers = request.tickers
     if not tickers:
-        raise HTTPException(status_code=400, detail="No tickers selected")
+        raise UniverseValidationError("No tickers selected", universe_id=universe_id)
 
     futures_set = {
         row.ticker

--- a/backend/tests/services/test_universe_export_service.py
+++ b/backend/tests/services/test_universe_export_service.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.responses import StreamingResponse
+
+
+def _make_db(universe_obj=None):
+    db = MagicMock()
+    mock_q = MagicMock()
+    mock_q.filter.return_value = mock_q
+    mock_q.order_by.return_value = mock_q
+    mock_q.first.return_value = universe_obj
+    mock_q.all.return_value = []
+    mock_q.__iter__ = MagicMock(return_value=iter([]))
+    db.query.return_value = mock_q
+    return db
+
+
+def _make_request(**kwargs):
+    defaults = dict(
+        tickers=["AAPL"],
+        timespan="day",
+        multiplier=1,
+        from_date=None,
+        to_date=None,
+        zip_format="per_ticker",
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+class TestExportAggregates:
+    def test_universe_not_found_raises_domain_error(self):
+        from app.exceptions import UniverseNotFoundError
+        from app.services.universe_export import export_aggregates
+
+        db = _make_db(universe_obj=None)
+        with pytest.raises(UniverseNotFoundError):
+            export_aggregates(999, _make_request(), db)
+
+    def test_empty_tickers_raises_domain_error(self):
+        from app.exceptions import UniverseValidationError
+        from app.services.universe_export import export_aggregates
+
+        universe = MagicMock()
+        universe.name = "TestUniverse"
+        db = _make_db(universe_obj=universe)
+        with pytest.raises(UniverseValidationError):
+            export_aggregates(1, _make_request(tickers=[]), db)
+
+    def test_valid_request_returns_streaming_response(self):
+        from app.services.universe_export import export_aggregates
+
+        universe = MagicMock()
+        universe.name = "TestUniverse"
+        db = _make_db(universe_obj=universe)
+        result = export_aggregates(1, _make_request(tickers=["AAPL"]), db)
+        assert isinstance(result, StreamingResponse)

--- a/backend/tests/services/test_universe_export_service.py
+++ b/backend/tests/services/test_universe_export_service.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-from fastapi.responses import StreamingResponse
+from starlette.responses import StreamingResponse
 
 
 def _make_db(universe_obj=None):


### PR DESCRIPTION
Closes #631

## Summary
Automated implementation for issue #631.

## Preview
⚠️ _Preview environment failed to start (preview failed: docker compose up failed (migrate/boot — see preview_build.log tail below)) — endpoint validation was skipped; see the failure comment on the issue._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue #631"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue #631"
```

---
*Generated by MarketHawk Dark Factory*