### PR TITLE
Build read-through memory retrieval adapter for Dark Factory

### DIFF
--- a/dark-factory/evals/factory-failures.jsonl
+++ b/dark-factory/evals/factory-failures.jsonl
@@ -144,3 +144,4 @@
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:49:58Z"}
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:53:20Z"}
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:53:33Z"}
+{"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:56:54Z"}

--- a/dark-factory/evals/factory-failures.jsonl
+++ b/dark-factory/evals/factory-failures.jsonl
@@ -142,3 +142,4 @@
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"fix","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:45:52Z"}
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:49:43Z"}
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:49:58Z"}
+{"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:53:20Z"}

--- a/dark-factory/evals/factory-failures.jsonl
+++ b/dark-factory/evals/factory-failures.jsonl
@@ -143,3 +143,4 @@
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:49:43Z"}
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:49:58Z"}
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:53:20Z"}
+{"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:53:33Z"}

--- a/dark-factory/evals/factory-failures.jsonl
+++ b/dark-factory/evals/factory-failures.jsonl
@@ -138,3 +138,4 @@
 {"issue":650,"title":"unknown","phase":"fix","exit_code":1,"postmortem":"You've hit your session limit · resets 5pm (UTC) ","promoted_at":"2026-06-27T14:41:22Z"}
 {"issue":651,"title":"Add agent role and project scoping to Dark Factory memory calls","phase":"fix","exit_code":1,"postmortem":"You've hit your session limit · resets 5pm (UTC) ","promoted_at":"2026-06-27T14:54:17Z"}
 {"issue":651,"title":"Add agent role and project scoping to Dark Factory memory calls","phase":"fix","exit_code":1,"postmortem":"You've hit your session limit · resets 5pm (UTC) ","promoted_at":"2026-06-27T14:54:30Z"}
+{"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"fix","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:45:42Z"}

--- a/dark-factory/evals/factory-failures.jsonl
+++ b/dark-factory/evals/factory-failures.jsonl
@@ -145,3 +145,4 @@
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:53:20Z"}
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:53:33Z"}
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:56:54Z"}
+{"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:57:13Z"}

--- a/dark-factory/evals/factory-failures.jsonl
+++ b/dark-factory/evals/factory-failures.jsonl
@@ -139,3 +139,4 @@
 {"issue":651,"title":"Add agent role and project scoping to Dark Factory memory calls","phase":"fix","exit_code":1,"postmortem":"You've hit your session limit · resets 5pm (UTC) ","promoted_at":"2026-06-27T14:54:17Z"}
 {"issue":651,"title":"Add agent role and project scoping to Dark Factory memory calls","phase":"fix","exit_code":1,"postmortem":"You've hit your session limit · resets 5pm (UTC) ","promoted_at":"2026-06-27T14:54:30Z"}
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"fix","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:45:42Z"}
+{"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"fix","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:45:52Z"}

--- a/dark-factory/evals/factory-failures.jsonl
+++ b/dark-factory/evals/factory-failures.jsonl
@@ -141,3 +141,4 @@
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"fix","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:45:42Z"}
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"fix","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:45:52Z"}
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:49:43Z"}
+{"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:49:58Z"}

--- a/dark-factory/evals/factory-failures.jsonl
+++ b/dark-factory/evals/factory-failures.jsonl
@@ -140,3 +140,4 @@
 {"issue":651,"title":"Add agent role and project scoping to Dark Factory memory calls","phase":"fix","exit_code":1,"postmortem":"You've hit your session limit · resets 5pm (UTC) ","promoted_at":"2026-06-27T14:54:30Z"}
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"fix","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:45:42Z"}
 {"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"fix","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:45:52Z"}
+{"issue":646,"title":"Build read-through memory retrieval adapter for Dark Factory","phase":"continue","exit_code":1,"postmortem":"You've hit your session limit · resets 7pm (UTC) ","promoted_at":"2026-06-29T16:49:43Z"}

--- a/dark-factory/scripts/memory_import.py
+++ b/dark-factory/scripts/memory_import.py
@@ -318,9 +318,11 @@ def update_index(
     for record in records:
         if record.id not in existing_ids:
             agent_id = record.evidence[0].get("source") if record.evidence else None
+            created_at = record.evidence[0].get("date") if record.evidence else None
             compact = {
                 "id": record.id,
                 "agent_id": agent_id,
+                "created_at": created_at,
                 "kind": record.kind,
                 "scope": record.scope,
                 "path_prefixes": record.path_prefixes,

--- a/dark-factory/scripts/memory_import.py
+++ b/dark-factory/scripts/memory_import.py
@@ -317,8 +317,10 @@ def update_index(
     new_lines = []
     for record in records:
         if record.id not in existing_ids:
+            agent_id = record.evidence[0].get("source") if record.evidence else None
             compact = {
                 "id": record.id,
+                "agent_id": agent_id,
                 "kind": record.kind,
                 "scope": record.scope,
                 "path_prefixes": record.path_prefixes,

--- a/dark-factory/scripts/memory_import.py
+++ b/dark-factory/scripts/memory_import.py
@@ -317,8 +317,15 @@ def update_index(
     new_lines = []
     for record in records:
         if record.id not in existing_ids:
-            agent_id = record.evidence[0].get("source") if record.evidence else None
-            created_at = record.evidence[0].get("date") if record.evidence else None
+            # Collect agent_id and created_at across all evidence sources so that
+            # source-filtering in scan_index can match entries whose primary source
+            # is not at index 0.
+            agent_id = next(
+                (e.get("source") for e in record.evidence if e.get("source")), None
+            ) if record.evidence else None
+            created_at = next(
+                (e.get("date") for e in record.evidence if e.get("date")), None
+            ) if record.evidence else None
             compact = {
                 "id": record.id,
                 "agent_id": agent_id,

--- a/dark-factory/scripts/memory_retrieve.py
+++ b/dark-factory/scripts/memory_retrieve.py
@@ -224,10 +224,11 @@ def scan_index(memory_dir, area_files, files, allowed_sources):
         if not passes_path_filter(path_prefixes, files):
             continue
 
-        # Source filter: use agent_id from index entry (global files exempt)
+        # Source filter: use agent_id from index entry (global files exempt).
+        # Entries without agent_id pass unconditionally (backward compat with pre-import corpus).
         if source_file not in GLOBAL_FILES:
-            agent_id = entry.get("agent_id", "")
-            if agent_id not in allowed_sources:
+            agent_id = entry.get("agent_id") or ""
+            if agent_id and agent_id not in allowed_sources:
                 continue
 
         # Read record for full summary (fail-open: fallback to summary_snippet)
@@ -290,7 +291,10 @@ def retrieve_memory(memory_dir, phase, files):
 
     index_path = memory_dir / "index.jsonl"
     if index_path.exists():
-        candidates = scan_index(memory_dir, area_files, files, allowed_sources)
+        try:
+            candidates = scan_index(memory_dir, area_files, files, allowed_sources)
+        except OSError:
+            candidates = []
         if candidates:
             return format_index_output(candidates)
 

--- a/dark-factory/scripts/memory_retrieve.py
+++ b/dark-factory/scripts/memory_retrieve.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""
+memory_retrieve.py — Role-aware memory retrieval for Dark Factory workflows.
+
+Primary path: .archon/memory/index.jsonl + records/ (when index is present and non-empty)
+Fallback path: scan .archon/memory/*.md files directly
+
+Usage:
+    python memory_retrieve.py --phase implement [--files "path1\\npath2"] \\
+        [--issue 646] [--memory-dir .archon/memory]
+
+Stdout: markdown memory block for insertion into Archon command prompts.
+"""
+import argparse
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+GLOBAL_FILES = {"codebase-patterns.md", "architecture.md"}
+
+ALL_MEMORY_FILES = [
+    "codebase-patterns.md",
+    "architecture.md",
+    "backend-patterns.md",
+    "frontend-patterns.md",
+    "dark-factory-ops.md",
+]
+
+# Phase → allowed source tags (area-specific file entries only; global files exempt)
+PHASE_SOURCE_MAP = {
+    "refine": {"refine"},
+    "plan": {"refine"},
+    "implement": {"implement"},
+    "validate": {"conformance"},
+    "review": {"code-review"},
+}
+
+# File-path prefix → area memory file
+AREA_PREFIX_MAP = [
+    (("backend/",), "backend-patterns.md"),
+    (("frontend/",), "frontend-patterns.md"),
+    (("docker-compose", "Dockerfile", "dark-factory/", ".archon/"), "dark-factory-ops.md"),
+]
+
+# Only these kind tags are considered authoritative
+AUTHORITATIVE_KINDS = {"PATTERN", "AVOID", "FIX"}
+
+# Parse: - [TAG] body <!-- meta -->
+_ENTRY_RE = re.compile(
+    r"^- \[(?P<tag>[^\]]+)\]\s+(?P<body>.+?)(?:\s*<!--(?P<meta>[^>]*)-->)?\s*$"
+)
+# Parse key:value pairs in metadata comment
+_TAG_RE = re.compile(r"(\w+\d*):([^\s>]+)")
+
+
+# ── Area selection ─────────────────────────────────────────────────────────
+
+def select_area_files(files):
+    """Layer 1: select memory files relevant to the changed file set.
+
+    Returns a sublist of ALL_MEMORY_FILES in declaration order.
+    If files is empty, all five files are included.
+    """
+    if not files:
+        return list(ALL_MEMORY_FILES)
+
+    included = set(GLOBAL_FILES)
+    for file_path in files:
+        for prefixes, mem_file in AREA_PREFIX_MAP:
+            if any(file_path.startswith(p) for p in prefixes):
+                included.add(mem_file)
+
+    return [f for f in ALL_MEMORY_FILES if f in included]
+
+
+# ── Entry-level helpers ────────────────────────────────────────────────────
+
+def parse_meta(meta_str):
+    """Extract key:value pairs from a metadata comment string."""
+    if not meta_str:
+        return {}
+    return dict(_TAG_RE.findall(meta_str))
+
+
+def is_expired(expires_str, today=None):
+    """Return True if the expiry date is strictly in the past."""
+    if not expires_str:
+        return False
+    ref = today or date.today().isoformat()
+    try:
+        return expires_str < ref
+    except TypeError:
+        return False
+
+
+def path_specificity(path_prefixes, files):
+    """Return the length of the longest path prefix that matches any file in files."""
+    if not path_prefixes or not files:
+        return 0
+    best = 0
+    for prefix in path_prefixes:
+        for f in files:
+            if f.startswith(prefix):
+                best = max(best, len(prefix))
+    return best
+
+
+def passes_path_filter(path_prefixes, files):
+    """True if the entry's path prefixes match at least one file, or has no restriction."""
+    if not path_prefixes:
+        return True
+    if not files:
+        return True
+    return any(f.startswith(p) for p in path_prefixes for f in files)
+
+
+def passes_line_filters(tag, meta, source_file, files, allowed_sources):
+    """Layer 2 filter for a parsed markdown entry.
+
+    Excludes PROVISIONAL/INVALID/expired entries, applies source filter
+    (global files are exempt), and path-tag filter.
+    """
+    tag_upper = tag.upper()
+    if tag_upper == "PROVISIONAL" or tag_upper.startswith("INVALID"):
+        return False
+    if tag not in AUTHORITATIVE_KINDS:
+        return False
+    if is_expired(meta.get("expires", "")):
+        return False
+    if source_file not in GLOBAL_FILES:
+        src = meta.get("source", "")
+        if src not in allowed_sources:
+            return False
+    path_tag = meta.get("path", "")
+    if path_tag:
+        if files and not any(f.startswith(path_tag) for f in files):
+            return False
+    return True
+
+
+# ── Markdown fallback path ─────────────────────────────────────────────────
+
+def scan_markdown_files(memory_dir, area_files, files, allowed_sources):
+    """Scan .md files and return {source_file: [raw_line, ...]} for passing entries."""
+    results = {}
+    for fname in area_files:
+        fpath = Path(memory_dir) / fname
+        if not fpath.exists():
+            continue
+        try:
+            text = fpath.read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        entries = []
+        for line in text.splitlines():
+            if line.strip() == "---":
+                break
+            m = _ENTRY_RE.match(line)
+            if not m:
+                continue
+            tag = m.group("tag")
+            meta = parse_meta(m.group("meta") or "")
+            if passes_line_filters(tag, meta, fname, files, allowed_sources):
+                entries.append(line)
+
+        if entries:
+            results[fname] = entries
+
+    return results
+
+
+def format_markdown_output(results):
+    """Format scan_markdown_files output as a ### Memory: block string."""
+    parts = []
+    for fname in ALL_MEMORY_FILES:
+        if fname not in results:
+            continue
+        parts.append(f"### Memory: {fname}")
+        parts.extend(results[fname])
+        parts.append("")
+    return "\n".join(parts).rstrip()
+
+
+# ── Index primary path ─────────────────────────────────────────────────────
+
+def scan_index(memory_dir, area_files, files, allowed_sources):
+    """Scan index.jsonl and records/ to build ranked entry list.
+
+    Returns list of dicts: {source_file, text, specificity, expires_at}.
+    """
+    memory_dir = Path(memory_dir)
+    index_path = memory_dir / "index.jsonl"
+    records_dir = memory_dir / "records"
+    area_set = set(area_files)
+    today = date.today().isoformat()
+
+    candidates = []
+    for raw in index_path.read_text(encoding="utf-8").splitlines():
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+        if entry.get("kind") not in AUTHORITATIVE_KINDS:
+            continue
+        if is_expired(entry.get("expires_at", ""), today):
+            continue
+
+        source_file = entry.get("source_file", "")
+        if source_file not in area_set:
+            continue
+
+        path_prefixes = entry.get("path_prefixes") or []
+        if not passes_path_filter(path_prefixes, files):
+            continue
+
+        record_path = records_dir / f"{entry['id']}.json"
+        if record_path.exists():
+            try:
+                record = json.loads(record_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            summary = record.get("summary", entry.get("summary_snippet", ""))
+            evidence_sources = {e.get("source", "") for e in record.get("evidence") or []}
+        else:
+            summary = entry.get("summary_snippet", "")
+            evidence_sources = set()
+
+        if source_file not in GLOBAL_FILES:
+            if not (evidence_sources & allowed_sources):
+                continue
+
+        text = f"- [{entry['kind']}] {summary}"
+        spec = path_specificity(path_prefixes, files)
+        candidates.append({
+            "source_file": source_file,
+            "text": text,
+            "specificity": spec,
+            "expires_at": entry.get("expires_at", ""),
+        })
+
+    return candidates
+
+
+def format_index_output(candidates):
+    """Format scan_index output, grouped by source_file in ALL_MEMORY_FILES order.
+
+    Within each group: ranked by path specificity (desc) then expires_at (desc).
+    """
+    grouped = {}
+    for c in candidates:
+        grouped.setdefault(c["source_file"], []).append(c)
+
+    parts = []
+    for fname in ALL_MEMORY_FILES:
+        if fname not in grouped:
+            continue
+        entries = sorted(
+            grouped[fname],
+            key=lambda x: (x["specificity"], x.get("expires_at", "")),
+            reverse=True,
+        )
+        parts.append(f"### Memory: {fname}")
+        for e in entries:
+            parts.append(e["text"])
+        parts.append("")
+
+    return "\n".join(parts).rstrip()
+
+
+# ── Dispatch ───────────────────────────────────────────────────────────────
+
+def retrieve_memory(memory_dir, phase, files):
+    """Return a markdown memory block for the given phase and changed files."""
+    allowed_sources = PHASE_SOURCE_MAP.get(phase, set())
+    area_files = select_area_files(files)
+    memory_dir = Path(memory_dir)
+
+    index_path = memory_dir / "index.jsonl"
+    if index_path.exists():
+        candidates = scan_index(memory_dir, area_files, files, allowed_sources)
+        if candidates:
+            return format_index_output(candidates)
+
+    results = scan_markdown_files(memory_dir, area_files, files, allowed_sources)
+    return format_markdown_output(results)
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Retrieve Dark Factory memory entries for a workflow phase."
+    )
+    parser.add_argument(
+        "--phase",
+        required=True,
+        choices=list(PHASE_SOURCE_MAP),
+        help="Workflow phase (drives source filter and area selection)",
+    )
+    parser.add_argument(
+        "--files",
+        default="",
+        help="Newline-separated list of changed or anticipated file paths",
+    )
+    parser.add_argument("--issue", type=int, default=None, help="Issue number (informational)")
+    parser.add_argument("--labels", default="", help="Issue labels (reserved, unused)")
+    parser.add_argument(
+        "--memory-dir",
+        default=".archon/memory",
+        help="Path to the memory directory (default: .archon/memory)",
+    )
+    args = parser.parse_args()
+
+    memory_dir = Path(args.memory_dir)
+    if not memory_dir.exists():
+        sys.stderr.write(f"error: memory directory not found: {memory_dir}\n")
+        sys.exit(1)
+
+    files = [f.strip() for f in args.files.splitlines() if f.strip()]
+    output = retrieve_memory(memory_dir, args.phase, files)
+    if output:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/dark-factory/scripts/memory_retrieve.py
+++ b/dark-factory/scripts/memory_retrieve.py
@@ -123,17 +123,17 @@ def passes_line_filters(tag, meta, source_file, files, allowed_sources):
 
     Excludes PROVISIONAL/INVALID/expired entries, applies source filter
     (global files are exempt), and path-tag filter.
+    Entries without a source: tag pass the source filter unconditionally
+    (backward-compatible with pre-scoping corpus entries).
     """
     tag_upper = tag.upper()
     if tag_upper == "PROVISIONAL" or tag_upper.startswith("INVALID"):
-        return False
-    if tag not in AUTHORITATIVE_KINDS:
         return False
     if is_expired(meta.get("expires", "")):
         return False
     if source_file not in GLOBAL_FILES:
         src = meta.get("source", "")
-        if src not in allowed_sources:
+        if src and src not in allowed_sources:
             return False
     path_tag = meta.get("path", "")
     if path_tag:
@@ -244,7 +244,7 @@ def scan_index(memory_dir, area_files, files, allowed_sources):
             "source_file": source_file,
             "text": text,
             "specificity": spec,
-            "expires_at": entry.get("expires_at", ""),
+            "created_at": entry.get("created_at", ""),
         })
 
     return candidates
@@ -265,7 +265,7 @@ def format_index_output(candidates):
             continue
         entries = sorted(
             grouped[fname],
-            key=lambda x: (x["specificity"], x.get("expires_at", "")),
+            key=lambda x: (x["specificity"], x.get("created_at", "")),
             reverse=True,
         )
         parts.append(f"### Memory: {fname}")

--- a/dark-factory/scripts/memory_retrieve.py
+++ b/dark-factory/scripts/memory_retrieve.py
@@ -232,7 +232,10 @@ def scan_index(memory_dir, area_files, files, allowed_sources):
                 continue
 
         # Read record for full summary (fail-open: fallback to summary_snippet)
-        record_path = records_dir / f"{entry['id']}.json"
+        entry_id = entry.get("id")
+        if not entry_id:
+            continue
+        record_path = records_dir / f"{entry_id}.json"
         if record_path.exists():
             try:
                 record = json.loads(record_path.read_text(encoding="utf-8"))
@@ -258,7 +261,7 @@ def scan_index(memory_dir, area_files, files, allowed_sources):
 def format_index_output(candidates):
     """Format scan_index output, grouped by source_file in ALL_MEMORY_FILES order.
 
-    Within each group: ranked by path specificity (desc) then expires_at (desc).
+    Within each group: ranked by path specificity (desc) then created_at (desc).
     """
     grouped = {}
     for c in candidates:
@@ -270,7 +273,7 @@ def format_index_output(candidates):
             continue
         entries = sorted(
             grouped[fname],
-            key=lambda x: (x["specificity"], x.get("created_at", "")),
+            key=lambda x: (x["specificity"], x.get("created_at") or ""),
             reverse=True,
         )
         parts.append(f"### Memory: {fname}")
@@ -293,7 +296,7 @@ def retrieve_memory(memory_dir, phase, files):
     if index_path.exists():
         try:
             candidates = scan_index(memory_dir, area_files, files, allowed_sources)
-        except OSError:
+        except (OSError, ValueError):
             candidates = []
         if candidates:
             return format_index_output(candidates)

--- a/dark-factory/scripts/memory_retrieve.py
+++ b/dark-factory/scripts/memory_retrieve.py
@@ -191,7 +191,9 @@ def format_markdown_output(results):
 def scan_index(memory_dir, area_files, files, allowed_sources):
     """Scan index.jsonl and records/ to build ranked entry list.
 
-    Returns list of dicts: {source_file, text, specificity, expires_at}.
+    Returns list of dicts: {source_file, text, specificity, created_at}.
+    Source filter uses agent_id from the index entry per spec §6.
+    Record files are read for full summary text (implementation-time decision, spec Open Q #3).
     """
     memory_dir = Path(memory_dir)
     index_path = memory_dir / "index.jsonl"
@@ -209,7 +211,7 @@ def scan_index(memory_dir, area_files, files, allowed_sources):
         except json.JSONDecodeError:
             continue
 
-        if entry.get("kind") not in AUTHORITATIVE_KINDS:
+        if entry.get("status") in ("provisional", "invalid"):
             continue
         if is_expired(entry.get("expires_at", ""), today):
             continue
@@ -222,23 +224,25 @@ def scan_index(memory_dir, area_files, files, allowed_sources):
         if not passes_path_filter(path_prefixes, files):
             continue
 
+        # Source filter: use agent_id from index entry (global files exempt)
+        if source_file not in GLOBAL_FILES:
+            agent_id = entry.get("agent_id", "")
+            if agent_id not in allowed_sources:
+                continue
+
+        # Read record for full summary (fail-open: fallback to summary_snippet)
         record_path = records_dir / f"{entry['id']}.json"
         if record_path.exists():
             try:
                 record = json.loads(record_path.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
-                continue
-            summary = record.get("summary", entry.get("summary_snippet", ""))
-            evidence_sources = {e.get("source", "") for e in record.get("evidence") or []}
+                summary = entry.get("summary_snippet", "")
+            else:
+                summary = record.get("summary", entry.get("summary_snippet", ""))
         else:
             summary = entry.get("summary_snippet", "")
-            evidence_sources = set()
 
-        if source_file not in GLOBAL_FILES:
-            if not (evidence_sources & allowed_sources):
-                continue
-
-        text = f"- [{entry['kind']}] {summary}"
+        text = f"- [{entry.get('kind', 'PATTERN')}] {summary}"
         spec = path_specificity(path_prefixes, files)
         candidates.append({
             "source_file": source_file,

--- a/dark-factory/tests/test_memory_import.py
+++ b/dark-factory/tests/test_memory_import.py
@@ -278,6 +278,32 @@ def test_update_index_agent_id_none_when_no_source():
         assert line["agent_id"] is None
 
 
+def test_update_index_writes_created_at():
+    """update_index must write created_at from evidence[0]['date'] for ranking tiebreaker."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        index_path = Path(tmpdir) / "index.jsonl"
+        record = mi.parse_entry(
+            "- [PATTERN] Created-at check <!-- issue:#646 date:2026-06-30 expires:2026-12-30 source:implement -->",
+            "backend-patterns.md",
+        )
+        mi.update_index([record], index_path, dry_run=False)
+        line = json.loads(index_path.read_text().strip())
+        assert line["created_at"] == "2026-06-30"
+
+
+def test_update_index_created_at_none_when_no_date():
+    """Entries without a date: tag get created_at=null in the compact index."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        index_path = Path(tmpdir) / "index.jsonl"
+        record = mi.parse_entry(
+            "- [PATTERN] No date tag <!-- issue:#1 expires:2026-12-31 source:implement -->",
+            "codebase-patterns.md",
+        )
+        mi.update_index([record], index_path, dry_run=False)
+        line = json.loads(index_path.read_text().strip())
+        assert line["created_at"] is None
+
+
 # ---------------------------------------------------------------------------
 # Integration test (runs against real .archon/memory/)
 # ---------------------------------------------------------------------------

--- a/dark-factory/tests/test_memory_import.py
+++ b/dark-factory/tests/test_memory_import.py
@@ -249,6 +249,36 @@ def test_dry_run_writes_nothing():
 
 
 # ---------------------------------------------------------------------------
+# agent_id in compact index
+# ---------------------------------------------------------------------------
+
+def test_update_index_writes_agent_id():
+    """update_index must write agent_id to each compact line so scan_index can filter by source."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        index_path = Path(tmpdir) / "index.jsonl"
+        record = mi.parse_entry(
+            "- [PATTERN] Source filter check <!-- issue:#646 date:2026-06-30 expires:2026-12-30 source:implement -->",
+            "backend-patterns.md",
+        )
+        mi.update_index([record], index_path, dry_run=False)
+        line = json.loads(index_path.read_text().strip())
+        assert line["agent_id"] == "implement"
+
+
+def test_update_index_agent_id_none_when_no_source():
+    """Entries without a source: tag get agent_id=null in the compact index."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        index_path = Path(tmpdir) / "index.jsonl"
+        record = mi.parse_entry(
+            "- [PATTERN] No source tag <!-- issue:#1 date:2026-01-01 expires:2026-12-31 -->",
+            "codebase-patterns.md",
+        )
+        mi.update_index([record], index_path, dry_run=False)
+        line = json.loads(index_path.read_text().strip())
+        assert line["agent_id"] is None
+
+
+# ---------------------------------------------------------------------------
 # Integration test (runs against real .archon/memory/)
 # ---------------------------------------------------------------------------
 

--- a/dark-factory/tests/test_memory_retrieve.py
+++ b/dark-factory/tests/test_memory_retrieve.py
@@ -1,0 +1,738 @@
+"""
+Tests for dark-factory/scripts/memory_retrieve.py.
+
+All tests use in-memory data or tmp_path; no live .archon/memory/ reads.
+Monkeypatching patches Path.exists / Path.read_text to isolate file I/O.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import memory_retrieve as mr  # noqa: E402
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+FUTURE = "2099-12-31"
+PAST = "2000-01-01"
+
+
+def _make_index_line(**kwargs):
+    base = {
+        "id": "aabbccdd00112233",
+        "kind": "PATTERN",
+        "scope": "backend",
+        "source_file": "backend-patterns.md",
+        "path_prefixes": [],
+        "expires_at": FUTURE,
+        "confidence": 1.0,
+        "summary_snippet": "Short snippet.",
+    }
+    base.update(kwargs)
+    return json.dumps(base)
+
+
+def _make_record(summary="Full summary text.", sources=("implement",), path_prefixes=None):
+    return json.dumps({
+        "id": "aabbccdd00112233",
+        "kind": "PATTERN",
+        "summary": summary,
+        "evidence": [{"source": s, "date": "2026-06-01", "issue": 1} for s in sources],
+        "path_prefixes": path_prefixes or [],
+        "expires_at": FUTURE,
+        "confidence": 1.0,
+        "scope": "backend",
+        "source_file": "backend-patterns.md",
+    })
+
+
+# ── TestConstants ──────────────────────────────────────────────────────────
+
+class TestConstants:
+    def test_global_files_count(self):
+        assert len(mr.GLOBAL_FILES) == 2
+
+    def test_global_files_contents(self):
+        assert "codebase-patterns.md" in mr.GLOBAL_FILES
+        assert "architecture.md" in mr.GLOBAL_FILES
+
+    def test_all_memory_files_count(self):
+        assert len(mr.ALL_MEMORY_FILES) == 5
+
+    def test_all_memory_files_order(self):
+        assert mr.ALL_MEMORY_FILES[0] == "codebase-patterns.md"
+        assert mr.ALL_MEMORY_FILES[1] == "architecture.md"
+        assert mr.ALL_MEMORY_FILES[2] == "backend-patterns.md"
+        assert mr.ALL_MEMORY_FILES[3] == "frontend-patterns.md"
+        assert mr.ALL_MEMORY_FILES[4] == "dark-factory-ops.md"
+
+    def test_phase_source_map_count(self):
+        assert len(mr.PHASE_SOURCE_MAP) == 5
+
+    def test_phase_source_map_implement(self):
+        assert mr.PHASE_SOURCE_MAP["implement"] == {"implement"}
+
+    def test_phase_source_map_validate(self):
+        assert mr.PHASE_SOURCE_MAP["validate"] == {"conformance"}
+
+    def test_phase_source_map_review(self):
+        assert mr.PHASE_SOURCE_MAP["review"] == {"code-review"}
+
+    def test_phase_source_map_refine(self):
+        assert mr.PHASE_SOURCE_MAP["refine"] == {"refine"}
+
+    def test_phase_source_map_plan_same_as_refine(self):
+        assert mr.PHASE_SOURCE_MAP["plan"] == mr.PHASE_SOURCE_MAP["refine"]
+
+    def test_authoritative_kinds(self):
+        assert mr.AUTHORITATIVE_KINDS == {"PATTERN", "AVOID", "FIX"}
+
+
+# ── TestSelectAreaFiles ────────────────────────────────────────────────────
+
+class TestSelectAreaFiles:
+    def test_empty_files_returns_all_five(self):
+        result = mr.select_area_files([])
+        assert result == mr.ALL_MEMORY_FILES
+
+    def test_backend_file_adds_backend_patterns(self):
+        result = mr.select_area_files(["backend/app/services/scanner.py"])
+        assert "backend-patterns.md" in result
+        assert "codebase-patterns.md" in result
+        assert "architecture.md" in result
+
+    def test_backend_file_excludes_frontend_patterns(self):
+        result = mr.select_area_files(["backend/app/models/stock.py"])
+        assert "frontend-patterns.md" not in result
+
+    def test_frontend_file_adds_frontend_patterns(self):
+        result = mr.select_area_files(["frontend/src/pages/Scanner.tsx"])
+        assert "frontend-patterns.md" in result
+        assert "codebase-patterns.md" in result
+
+    def test_dark_factory_file_adds_ops_patterns(self):
+        result = mr.select_area_files(["dark-factory/scripts/foo.py"])
+        assert "dark-factory-ops.md" in result
+
+    def test_archon_file_adds_ops_patterns(self):
+        result = mr.select_area_files([".archon/commands/implement.md"])
+        assert "dark-factory-ops.md" in result
+
+    def test_dockerfile_adds_ops_patterns(self):
+        result = mr.select_area_files(["Dockerfile"])
+        assert "dark-factory-ops.md" in result
+
+    def test_docker_compose_adds_ops_patterns(self):
+        result = mr.select_area_files(["docker-compose.yml"])
+        assert "dark-factory-ops.md" in result
+
+    def test_unknown_file_returns_only_global_files(self):
+        result = mr.select_area_files(["some/unknown/path.txt"])
+        assert set(result) == mr.GLOBAL_FILES
+
+    def test_mixed_files_includes_multiple_area_files(self):
+        result = mr.select_area_files([
+            "backend/app/routers/scanner.py",
+            "frontend/src/pages/Dashboard.tsx",
+        ])
+        assert "backend-patterns.md" in result
+        assert "frontend-patterns.md" in result
+
+    def test_output_preserves_all_memory_files_order(self):
+        result = mr.select_area_files(["backend/app/foo.py", "frontend/src/bar.tsx"])
+        indices = [mr.ALL_MEMORY_FILES.index(f) for f in result]
+        assert indices == sorted(indices)
+
+    def test_global_files_always_included(self):
+        for phase_file in ["backend/x.py", "frontend/x.tsx", "dark-factory/x.sh"]:
+            result = mr.select_area_files([phase_file])
+            assert "codebase-patterns.md" in result
+            assert "architecture.md" in result
+
+
+# ── TestPassesLine ─────────────────────────────────────────────────────────
+
+class TestPassesLine:
+    ALLOWED = {"implement"}
+    FILES = ["backend/app/services/scanner.py"]
+
+    def _call(self, tag, meta, source_file="backend-patterns.md", files=None, allowed=None):
+        return mr.passes_line_filters(
+            tag,
+            meta,
+            source_file,
+            files if files is not None else self.FILES,
+            allowed if allowed is not None else self.ALLOWED,
+        )
+
+    # --- PROVISIONAL / INVALID exclusion ---
+    def test_provisional_excluded(self):
+        assert not self._call("PROVISIONAL", {"source": "implement", "expires": FUTURE})
+
+    def test_invalid_excluded(self):
+        assert not self._call("INVALID: some reason", {"source": "implement", "expires": FUTURE})
+
+    def test_invalid_with_colon_excluded(self):
+        assert not self._call("INVALID:old", {"source": "implement", "expires": FUTURE})
+
+    # --- Expiry ---
+    def test_expired_excluded(self):
+        assert not self._call("PATTERN", {"source": "implement", "expires": PAST})
+
+    def test_future_expiry_included(self):
+        assert self._call("PATTERN", {"source": "implement", "expires": FUTURE})
+
+    def test_no_expiry_field_included(self):
+        assert self._call("PATTERN", {"source": "implement"})
+
+    # --- Source filter for area-specific files ---
+    def test_correct_source_passes(self):
+        assert self._call("PATTERN", {"source": "implement", "expires": FUTURE})
+
+    def test_wrong_source_excluded(self):
+        assert not self._call("PATTERN", {"source": "conformance", "expires": FUTURE})
+
+    def test_missing_source_excluded(self):
+        assert not self._call("PATTERN", {"expires": FUTURE})
+
+    # --- Global-file exemption ---
+    def test_global_codebase_passes_any_source(self):
+        assert self._call("PATTERN", {"source": "conformance", "expires": FUTURE},
+                          source_file="codebase-patterns.md")
+
+    def test_global_architecture_passes_any_source(self):
+        assert self._call("FIX", {"source": "refine", "expires": FUTURE},
+                          source_file="architecture.md")
+
+    def test_global_file_still_excludes_provisional(self):
+        assert not self._call("PROVISIONAL", {"source": "implement", "expires": FUTURE},
+                               source_file="codebase-patterns.md")
+
+    def test_global_file_still_excludes_expired(self):
+        assert not self._call("PATTERN", {"source": "implement", "expires": PAST},
+                               source_file="architecture.md")
+
+    # --- Path-tag filter ---
+    def test_no_path_tag_always_passes(self):
+        assert self._call("PATTERN", {"source": "implement", "expires": FUTURE})
+
+    def test_matching_path_tag_passes(self):
+        meta = {"source": "implement", "expires": FUTURE, "path": "backend/app/"}
+        assert self._call("PATTERN", meta)
+
+    def test_mismatched_path_tag_excluded(self):
+        meta = {"source": "implement", "expires": FUTURE, "path": "frontend/src/"}
+        assert not self._call("PATTERN", meta)
+
+    def test_path_tag_with_empty_files_passes(self):
+        meta = {"source": "implement", "expires": FUTURE, "path": "frontend/src/"}
+        assert self._call("PATTERN", meta, files=[])
+
+    # --- Phase × source coverage ---
+    def test_refine_phase_passes_refine_source(self):
+        meta = {"source": "refine", "expires": FUTURE}
+        assert self._call("PATTERN", meta, allowed=mr.PHASE_SOURCE_MAP["refine"])
+
+    def test_validate_phase_passes_conformance_source(self):
+        meta = {"source": "conformance", "expires": FUTURE}
+        assert self._call("AVOID", meta, allowed=mr.PHASE_SOURCE_MAP["validate"])
+
+    def test_review_phase_passes_code_review_source(self):
+        meta = {"source": "code-review", "expires": FUTURE}
+        assert self._call("FIX", meta, allowed=mr.PHASE_SOURCE_MAP["review"])
+
+    def test_plan_phase_passes_refine_source(self):
+        meta = {"source": "refine", "expires": FUTURE}
+        assert self._call("PATTERN", meta, allowed=mr.PHASE_SOURCE_MAP["plan"])
+
+    def test_implement_phase_excludes_refine_source(self):
+        meta = {"source": "refine", "expires": FUTURE}
+        assert not self._call("PATTERN", meta, allowed=mr.PHASE_SOURCE_MAP["implement"])
+
+    # --- All authoritative kinds pass ---
+    def test_avoid_kind_passes(self):
+        assert self._call("AVOID", {"source": "implement", "expires": FUTURE})
+
+    def test_fix_kind_passes(self):
+        assert self._call("FIX", {"source": "implement", "expires": FUTURE})
+
+    def test_unknown_kind_excluded(self):
+        assert not self._call("NOTE", {"source": "implement", "expires": FUTURE})
+
+
+# ── TestScanMarkdownFiles ──────────────────────────────────────────────────
+
+SAMPLE_MD = """\
+# Backend Patterns
+
+- [PATTERN] Keep this one. <!-- issue:#1 date:2026-01-01 expires:{future} source:implement -->
+- [AVOID] Also keep. <!-- issue:#2 date:2026-01-01 expires:{future} source:implement -->
+- [PROVISIONAL] Skip me. <!-- evidence:x issue:#3 date:2026-01-01 expires:{future} source:implement -->
+- [PATTERN] Expired entry. <!-- issue:#4 date:2026-01-01 expires:{past} source:implement -->
+- [PATTERN] Wrong source. <!-- issue:#5 date:2026-01-01 expires:{future} source:conformance -->
+---
+<!-- PROVISIONAL -->
+- [PATTERN] In provisional section — skip. <!-- issue:#6 date:2026-01-01 expires:{future} source:implement -->
+""".format(future=FUTURE, past=PAST)
+
+GLOBAL_MD = """\
+# Codebase Patterns
+
+- [PATTERN] Global entry any-source. <!-- issue:#10 date:2026-01-01 expires:{future} source:conformance -->
+- [AVOID] Another global. <!-- issue:#11 date:2026-01-01 expires:{future} source:refine -->
+""".format(future=FUTURE)
+
+
+class TestScanMarkdownFiles:
+    def _build_dir(self, tmp_path, files):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        for fname, content in files.items():
+            (mem_dir / fname).write_text(content, encoding="utf-8")
+        return mem_dir
+
+    def test_returns_passing_entries_only(self, tmp_path):
+        mem_dir = self._build_dir(tmp_path, {"backend-patterns.md": SAMPLE_MD})
+        result = mr.scan_markdown_files(
+            mem_dir,
+            ["backend-patterns.md"],
+            files=["backend/app/foo.py"],
+            allowed_sources={"implement"},
+        )
+        assert "backend-patterns.md" in result
+        entries = result["backend-patterns.md"]
+        assert len(entries) == 2
+        assert "Keep this one" in entries[0]
+        assert "Also keep" in entries[1]
+
+    def test_provisional_entries_excluded(self, tmp_path):
+        mem_dir = self._build_dir(tmp_path, {"backend-patterns.md": SAMPLE_MD})
+        result = mr.scan_markdown_files(
+            mem_dir, ["backend-patterns.md"], files=[], allowed_sources={"implement"}
+        )
+        texts = " ".join(result.get("backend-patterns.md", []))
+        assert "Skip me" not in texts
+
+    def test_provisional_section_entries_excluded(self, tmp_path):
+        mem_dir = self._build_dir(tmp_path, {"backend-patterns.md": SAMPLE_MD})
+        result = mr.scan_markdown_files(
+            mem_dir, ["backend-patterns.md"], files=[], allowed_sources={"implement"}
+        )
+        texts = " ".join(result.get("backend-patterns.md", []))
+        assert "provisional section" not in texts
+
+    def test_expired_entries_excluded(self, tmp_path):
+        mem_dir = self._build_dir(tmp_path, {"backend-patterns.md": SAMPLE_MD})
+        result = mr.scan_markdown_files(
+            mem_dir, ["backend-patterns.md"], files=[], allowed_sources={"implement"}
+        )
+        texts = " ".join(result.get("backend-patterns.md", []))
+        assert "Expired entry" not in texts
+
+    def test_wrong_source_excluded_for_area_file(self, tmp_path):
+        mem_dir = self._build_dir(tmp_path, {"backend-patterns.md": SAMPLE_MD})
+        result = mr.scan_markdown_files(
+            mem_dir, ["backend-patterns.md"], files=[], allowed_sources={"implement"}
+        )
+        texts = " ".join(result.get("backend-patterns.md", []))
+        assert "Wrong source" not in texts
+
+    def test_global_file_passes_all_sources(self, tmp_path):
+        mem_dir = self._build_dir(tmp_path, {"codebase-patterns.md": GLOBAL_MD})
+        result = mr.scan_markdown_files(
+            mem_dir,
+            ["codebase-patterns.md"],
+            files=[],
+            allowed_sources={"implement"},
+        )
+        assert "codebase-patterns.md" in result
+        assert len(result["codebase-patterns.md"]) == 2
+
+    def test_missing_file_skipped_gracefully(self, tmp_path):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        result = mr.scan_markdown_files(
+            mem_dir, ["backend-patterns.md"], files=[], allowed_sources={"implement"}
+        )
+        assert result == {}
+
+    def test_empty_file_skipped(self, tmp_path):
+        mem_dir = self._build_dir(tmp_path, {"backend-patterns.md": ""})
+        result = mr.scan_markdown_files(
+            mem_dir, ["backend-patterns.md"], files=[], allowed_sources={"implement"}
+        )
+        assert result == {}
+
+    def test_path_tag_filter_applied(self, tmp_path):
+        content = (
+            "- [PATTERN] Frontend only. <!-- issue:#1 expires:{f} source:implement "
+            "path:frontend/src/ -->\n"
+            "- [PATTERN] No restriction. <!-- issue:#2 expires:{f} source:implement -->\n"
+        ).format(f=FUTURE)
+        mem_dir = self._build_dir(tmp_path, {"backend-patterns.md": content})
+        result = mr.scan_markdown_files(
+            mem_dir,
+            ["backend-patterns.md"],
+            files=["backend/app/foo.py"],
+            allowed_sources={"implement"},
+        )
+        entries = result.get("backend-patterns.md", [])
+        texts = " ".join(entries)
+        assert "Frontend only" not in texts
+        assert "No restriction" in texts
+
+    def test_returns_file_only_if_entries_non_empty(self, tmp_path):
+        content = "- [PROVISIONAL] Skip me. <!-- issue:#1 expires:{f} source:implement -->\n".format(f=FUTURE)
+        mem_dir = self._build_dir(tmp_path, {"backend-patterns.md": content})
+        result = mr.scan_markdown_files(
+            mem_dir, ["backend-patterns.md"], files=[], allowed_sources={"implement"}
+        )
+        assert "backend-patterns.md" not in result
+
+
+# ── TestFormatOutput ───────────────────────────────────────────────────────
+
+class TestFormatOutput:
+    def test_markdown_format_section_header(self):
+        results = {"backend-patterns.md": ["- [PATTERN] Foo."]}
+        out = mr.format_markdown_output(results)
+        assert "### Memory: backend-patterns.md" in out
+        assert "- [PATTERN] Foo." in out
+
+    def test_markdown_format_empty_results(self):
+        assert mr.format_markdown_output({}) == ""
+
+    def test_markdown_format_order_follows_all_memory_files(self):
+        results = {
+            "backend-patterns.md": ["- [PATTERN] B."],
+            "codebase-patterns.md": ["- [PATTERN] C."],
+        }
+        out = mr.format_markdown_output(results)
+        assert out.index("### Memory: codebase") < out.index("### Memory: backend")
+
+    def test_index_format_section_header(self):
+        candidates = [{"source_file": "backend-patterns.md", "text": "- [PATTERN] Foo.",
+                        "specificity": 0, "expires_at": FUTURE}]
+        out = mr.format_index_output(candidates)
+        assert "### Memory: backend-patterns.md" in out
+        assert "- [PATTERN] Foo." in out
+
+    def test_index_format_empty_candidates(self):
+        assert mr.format_index_output([]) == ""
+
+    def test_index_format_order_follows_all_memory_files(self):
+        candidates = [
+            {"source_file": "backend-patterns.md", "text": "- [PATTERN] B.",
+             "specificity": 0, "expires_at": FUTURE},
+            {"source_file": "codebase-patterns.md", "text": "- [PATTERN] C.",
+             "specificity": 0, "expires_at": FUTURE},
+        ]
+        out = mr.format_index_output(candidates)
+        assert out.index("### Memory: codebase") < out.index("### Memory: backend")
+
+    def test_index_format_sorts_by_specificity_descending(self):
+        candidates = [
+            {"source_file": "backend-patterns.md", "text": "- [PATTERN] Low.",
+             "specificity": 0, "expires_at": FUTURE},
+            {"source_file": "backend-patterns.md", "text": "- [PATTERN] High.",
+             "specificity": 10, "expires_at": FUTURE},
+        ]
+        out = mr.format_index_output(candidates)
+        assert out.index("High") < out.index("Low")
+
+    def test_index_format_sorts_by_expires_at_as_tiebreaker(self):
+        candidates = [
+            {"source_file": "backend-patterns.md", "text": "- [PATTERN] Older.",
+             "specificity": 5, "expires_at": "2026-06-01"},
+            {"source_file": "backend-patterns.md", "text": "- [PATTERN] Newer.",
+             "specificity": 5, "expires_at": "2027-01-01"},
+        ]
+        out = mr.format_index_output(candidates)
+        assert out.index("Newer") < out.index("Older")
+
+
+# ── TestScanIndex ──────────────────────────────────────────────────────────
+
+def _build_index_dir(tmp_path, index_lines, records):
+    mem_dir = tmp_path / "memory"
+    mem_dir.mkdir()
+    records_dir = mem_dir / "records"
+    records_dir.mkdir()
+    (mem_dir / "index.jsonl").write_text("\n".join(index_lines), encoding="utf-8")
+    for rec_id, rec_data in records.items():
+        (records_dir / f"{rec_id}.json").write_text(json.dumps(rec_data), encoding="utf-8")
+    return mem_dir
+
+
+class TestScanIndex:
+    def _basic_entry(self, **kwargs):
+        base = {
+            "id": "aabb0011",
+            "kind": "PATTERN",
+            "source_file": "backend-patterns.md",
+            "path_prefixes": [],
+            "expires_at": FUTURE,
+            "confidence": 1.0,
+            "summary_snippet": "Snippet.",
+        }
+        base.update(kwargs)
+        return base
+
+    def _basic_record(self, rec_id, summary="Full text.", sources=("implement",)):
+        return {
+            "id": rec_id,
+            "kind": "PATTERN",
+            "summary": summary,
+            "evidence": [{"source": s, "date": "2026-01-01", "issue": 1} for s in sources],
+            "path_prefixes": [],
+            "expires_at": FUTURE,
+        }
+
+    def test_provisional_kind_excluded(self, tmp_path):
+        entry = self._basic_entry(id="aabb0001", kind="PROVISIONAL")
+        mem_dir = _build_index_dir(
+            tmp_path,
+            [json.dumps(entry)],
+            {"aabb0001": self._basic_record("aabb0001")},
+        )
+        result = mr.scan_index(mem_dir, ["backend-patterns.md"], [], {"implement"})
+        assert result == []
+
+    def test_invalid_kind_excluded(self, tmp_path):
+        entry = self._basic_entry(id="aabb0002", kind="INVALID")
+        mem_dir = _build_index_dir(
+            tmp_path,
+            [json.dumps(entry)],
+            {"aabb0002": self._basic_record("aabb0002")},
+        )
+        result = mr.scan_index(mem_dir, ["backend-patterns.md"], [], {"implement"})
+        assert result == []
+
+    def test_expired_entry_excluded(self, tmp_path):
+        entry = self._basic_entry(id="aabb0003", expires_at=PAST)
+        mem_dir = _build_index_dir(
+            tmp_path,
+            [json.dumps(entry)],
+            {"aabb0003": self._basic_record("aabb0003")},
+        )
+        result = mr.scan_index(mem_dir, ["backend-patterns.md"], [], {"implement"})
+        assert result == []
+
+    def test_wrong_area_file_excluded(self, tmp_path):
+        entry = self._basic_entry(id="aabb0004", source_file="frontend-patterns.md")
+        mem_dir = _build_index_dir(
+            tmp_path,
+            [json.dumps(entry)],
+            {"aabb0004": self._basic_record("aabb0004")},
+        )
+        result = mr.scan_index(mem_dir, ["backend-patterns.md"], [], {"implement"})
+        assert result == []
+
+    def test_source_filter_applied_for_area_file(self, tmp_path):
+        entry = self._basic_entry(id="aabb0005")
+        mem_dir = _build_index_dir(
+            tmp_path,
+            [json.dumps(entry)],
+            {"aabb0005": self._basic_record("aabb0005", sources=("conformance",))},
+        )
+        result = mr.scan_index(mem_dir, ["backend-patterns.md"], [], {"implement"})
+        assert result == []
+
+    def test_correct_source_passes(self, tmp_path):
+        entry = self._basic_entry(id="aabb0006")
+        mem_dir = _build_index_dir(
+            tmp_path,
+            [json.dumps(entry)],
+            {"aabb0006": self._basic_record("aabb0006", sources=("implement",))},
+        )
+        result = mr.scan_index(mem_dir, ["backend-patterns.md"], [], {"implement"})
+        assert len(result) == 1
+        assert "Full text." in result[0]["text"]
+
+    def test_global_file_passes_any_source(self, tmp_path):
+        entry = self._basic_entry(id="aabb0007", source_file="codebase-patterns.md")
+        mem_dir = _build_index_dir(
+            tmp_path,
+            [json.dumps(entry)],
+            {"aabb0007": {**self._basic_record("aabb0007", sources=("refine",)),
+                          "source_file": "codebase-patterns.md"}},
+        )
+        result = mr.scan_index(
+            mem_dir, ["codebase-patterns.md", "backend-patterns.md"], [], {"implement"}
+        )
+        assert len(result) == 1
+
+    def test_path_prefix_filter(self, tmp_path):
+        entry = self._basic_entry(id="aabb0008", path_prefixes=["frontend/src/"])
+        mem_dir = _build_index_dir(
+            tmp_path,
+            [json.dumps(entry)],
+            {"aabb0008": self._basic_record("aabb0008")},
+        )
+        result = mr.scan_index(
+            mem_dir, ["backend-patterns.md"], ["backend/app/foo.py"], {"implement"}
+        )
+        assert result == []
+
+    def test_path_prefix_match_sets_specificity(self, tmp_path):
+        entry = self._basic_entry(id="aabb0009", path_prefixes=["backend/app/"])
+        mem_dir = _build_index_dir(
+            tmp_path,
+            [json.dumps(entry)],
+            {"aabb0009": self._basic_record("aabb0009")},
+        )
+        result = mr.scan_index(
+            mem_dir, ["backend-patterns.md"], ["backend/app/services/scanner.py"], {"implement"}
+        )
+        assert len(result) == 1
+        assert result[0]["specificity"] == len("backend/app/")
+
+    def test_zero_specificity_for_empty_path_prefixes(self, tmp_path):
+        entry = self._basic_entry(id="aabb0010")
+        mem_dir = _build_index_dir(
+            tmp_path,
+            [json.dumps(entry)],
+            {"aabb0010": self._basic_record("aabb0010")},
+        )
+        result = mr.scan_index(
+            mem_dir, ["backend-patterns.md"], ["backend/app/foo.py"], {"implement"}
+        )
+        assert len(result) == 1
+        assert result[0]["specificity"] == 0
+
+
+# ── TestRetrieveMemory ─────────────────────────────────────────────────────
+
+class TestRetrieveMemory:
+    def test_uses_index_when_present(self, tmp_path):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        records_dir = mem_dir / "records"
+        records_dir.mkdir()
+        rec = {
+            "id": "abc123",
+            "kind": "PATTERN",
+            "summary": "Index path summary.",
+            "evidence": [{"source": "implement", "date": "2026-01-01", "issue": 1}],
+            "path_prefixes": [],
+            "expires_at": FUTURE,
+        }
+        (records_dir / "abc123.json").write_text(json.dumps(rec), encoding="utf-8")
+        entry = {
+            "id": "abc123",
+            "kind": "PATTERN",
+            "source_file": "backend-patterns.md",
+            "path_prefixes": [],
+            "expires_at": FUTURE,
+            "confidence": 1.0,
+            "summary_snippet": "Index path summary.",
+        }
+        (mem_dir / "index.jsonl").write_text(json.dumps(entry), encoding="utf-8")
+
+        out = mr.retrieve_memory(mem_dir, "implement", ["backend/app/foo.py"])
+        assert "Index path summary" in out
+
+    def test_falls_back_to_markdown_when_no_index(self, tmp_path):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        content = "- [PATTERN] Markdown fallback. <!-- issue:#1 expires:{f} source:implement -->\n".format(f=FUTURE)
+        (mem_dir / "backend-patterns.md").write_text(content, encoding="utf-8")
+
+        out = mr.retrieve_memory(mem_dir, "implement", ["backend/app/foo.py"])
+        assert "Markdown fallback" in out
+
+    def test_falls_back_when_index_yields_zero_survivors(self, tmp_path):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        records_dir = mem_dir / "records"
+        records_dir.mkdir()
+        # Index entry that will be filtered out (wrong source)
+        rec = {
+            "id": "xyz999",
+            "kind": "PATTERN",
+            "summary": "Should not appear.",
+            "evidence": [{"source": "conformance", "date": "2026-01-01", "issue": 1}],
+            "path_prefixes": [],
+            "expires_at": FUTURE,
+        }
+        (records_dir / "xyz999.json").write_text(json.dumps(rec), encoding="utf-8")
+        entry = {
+            "id": "xyz999",
+            "kind": "PATTERN",
+            "source_file": "backend-patterns.md",
+            "path_prefixes": [],
+            "expires_at": FUTURE,
+            "confidence": 1.0,
+            "summary_snippet": "Should not appear.",
+        }
+        (mem_dir / "index.jsonl").write_text(json.dumps(entry), encoding="utf-8")
+        content = "- [PATTERN] Fallback appears. <!-- issue:#2 expires:{f} source:implement -->\n".format(f=FUTURE)
+        (mem_dir / "backend-patterns.md").write_text(content, encoding="utf-8")
+
+        out = mr.retrieve_memory(mem_dir, "implement", ["backend/app/foo.py"])
+        assert "Fallback appears" in out
+        assert "Should not appear" not in out
+
+
+# ── TestMainCLI ────────────────────────────────────────────────────────────
+
+class TestMainCLI:
+    def _run(self, args, memory_dir=None, tmp_path=None):
+        import subprocess
+        script = str(Path(__file__).resolve().parents[1] / "scripts" / "memory_retrieve.py")
+        cmd = [sys.executable, script] + args
+        if memory_dir:
+            cmd += ["--memory-dir", str(memory_dir)]
+        return subprocess.run(cmd, capture_output=True, text=True)
+
+    def _make_mem_dir(self, tmp_path):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        content = "- [PATTERN] CLI test. <!-- issue:#1 expires:{f} source:implement -->\n".format(f=FUTURE)
+        (mem_dir / "backend-patterns.md").write_text(content, encoding="utf-8")
+        return mem_dir
+
+    def test_missing_phase_exits_nonzero(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        result = self._run([], memory_dir=mem_dir)
+        assert result.returncode != 0
+
+    def test_invalid_phase_exits_nonzero(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        result = self._run(["--phase", "invalid"], memory_dir=mem_dir)
+        assert result.returncode != 0
+
+    def test_missing_memory_dir_exits_nonzero(self, tmp_path):
+        result = self._run(["--phase", "implement", "--memory-dir", str(tmp_path / "nonexistent")])
+        assert result.returncode != 0
+
+    def test_valid_call_exits_zero(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        result = self._run(["--phase", "implement", "--files", "backend/app/foo.py"],
+                           memory_dir=mem_dir)
+        assert result.returncode == 0
+
+    def test_output_contains_memory_section(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        result = self._run(["--phase", "implement", "--files", "backend/app/foo.py"],
+                           memory_dir=mem_dir)
+        assert "### Memory:" in result.stdout
+
+    def test_issue_flag_accepted(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        result = self._run(["--phase", "implement", "--issue", "646"], memory_dir=mem_dir)
+        assert result.returncode == 0
+
+    def test_labels_flag_accepted(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        result = self._run(["--phase", "implement", "--labels", "backend"], memory_dir=mem_dir)
+        assert result.returncode == 0
+
+    def test_all_phases_accepted(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        for phase in ["refine", "plan", "implement", "validate", "review"]:
+            result = self._run(["--phase", phase], memory_dir=mem_dir)
+            assert result.returncode == 0, f"Phase {phase!r} failed: {result.stderr}"

--- a/dark-factory/tests/test_memory_retrieve.py
+++ b/dark-factory/tests/test_memory_retrieve.py
@@ -687,7 +687,7 @@ class TestRetrieveMemory:
         mem_dir.mkdir()
         records_dir = mem_dir / "records"
         records_dir.mkdir()
-        # Index entry that will be filtered out (wrong source)
+        # Index entry filtered out by wrong agent_id (source filter)
         rec = {
             "id": "xyz999",
             "kind": "PATTERN",
@@ -701,6 +701,7 @@ class TestRetrieveMemory:
             "id": "xyz999",
             "kind": "PATTERN",
             "source_file": "backend-patterns.md",
+            "agent_id": "conformance",
             "path_prefixes": [],
             "expires_at": FUTURE,
             "confidence": 1.0,
@@ -713,6 +714,17 @@ class TestRetrieveMemory:
         out = mr.retrieve_memory(mem_dir, "implement", ["backend/app/foo.py"])
         assert "Fallback appears" in out
         assert "Should not appear" not in out
+
+    def test_falls_back_when_index_unreadable(self, tmp_path):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        # A directory named index.jsonl triggers OSError on read_text
+        (mem_dir / "index.jsonl").mkdir()
+        content = "- [PATTERN] Fallback appears. <!-- issue:#2 expires:{f} source:implement -->\n".format(f=FUTURE)
+        (mem_dir / "backend-patterns.md").write_text(content, encoding="utf-8")
+
+        out = mr.retrieve_memory(mem_dir, "implement", ["backend/app/foo.py"])
+        assert "Fallback appears" in out
 
 
 # ── TestMainCLI ────────────────────────────────────────────────────────────

--- a/dark-factory/tests/test_memory_retrieve.py
+++ b/dark-factory/tests/test_memory_retrieve.py
@@ -493,8 +493,8 @@ class TestScanIndex:
             "expires_at": FUTURE,
         }
 
-    def test_provisional_kind_excluded(self, tmp_path):
-        entry = self._basic_entry(id="aabb0001", kind="PROVISIONAL")
+    def test_provisional_status_excluded(self, tmp_path):
+        entry = self._basic_entry(id="aabb0001", status="provisional", agent_id="implement")
         mem_dir = _build_index_dir(
             tmp_path,
             [json.dumps(entry)],
@@ -503,8 +503,8 @@ class TestScanIndex:
         result = mr.scan_index(mem_dir, ["backend-patterns.md"], [], {"implement"})
         assert result == []
 
-    def test_invalid_kind_excluded(self, tmp_path):
-        entry = self._basic_entry(id="aabb0002", kind="INVALID")
+    def test_invalid_status_excluded(self, tmp_path):
+        entry = self._basic_entry(id="aabb0002", status="invalid", agent_id="implement")
         mem_dir = _build_index_dir(
             tmp_path,
             [json.dumps(entry)],
@@ -534,17 +534,17 @@ class TestScanIndex:
         assert result == []
 
     def test_source_filter_applied_for_area_file(self, tmp_path):
-        entry = self._basic_entry(id="aabb0005")
+        entry = self._basic_entry(id="aabb0005", agent_id="conformance")
         mem_dir = _build_index_dir(
             tmp_path,
             [json.dumps(entry)],
-            {"aabb0005": self._basic_record("aabb0005", sources=("conformance",))},
+            {"aabb0005": self._basic_record("aabb0005", sources=("implement",))},
         )
         result = mr.scan_index(mem_dir, ["backend-patterns.md"], [], {"implement"})
         assert result == []
 
     def test_correct_source_passes(self, tmp_path):
-        entry = self._basic_entry(id="aabb0006")
+        entry = self._basic_entry(id="aabb0006", agent_id="implement")
         mem_dir = _build_index_dir(
             tmp_path,
             [json.dumps(entry)],
@@ -568,7 +568,7 @@ class TestScanIndex:
         assert len(result) == 1
 
     def test_path_prefix_filter(self, tmp_path):
-        entry = self._basic_entry(id="aabb0008", path_prefixes=["frontend/src/"])
+        entry = self._basic_entry(id="aabb0008", path_prefixes=["frontend/src/"], agent_id="implement")
         mem_dir = _build_index_dir(
             tmp_path,
             [json.dumps(entry)],
@@ -580,7 +580,7 @@ class TestScanIndex:
         assert result == []
 
     def test_path_prefix_match_sets_specificity(self, tmp_path):
-        entry = self._basic_entry(id="aabb0009", path_prefixes=["backend/app/"])
+        entry = self._basic_entry(id="aabb0009", path_prefixes=["backend/app/"], agent_id="implement")
         mem_dir = _build_index_dir(
             tmp_path,
             [json.dumps(entry)],
@@ -593,7 +593,7 @@ class TestScanIndex:
         assert result[0]["specificity"] == len("backend/app/")
 
     def test_zero_specificity_for_empty_path_prefixes(self, tmp_path):
-        entry = self._basic_entry(id="aabb0010")
+        entry = self._basic_entry(id="aabb0010", agent_id="implement")
         mem_dir = _build_index_dir(
             tmp_path,
             [json.dumps(entry)],
@@ -604,6 +604,41 @@ class TestScanIndex:
         )
         assert len(result) == 1
         assert result[0]["specificity"] == 0
+
+    def test_index_non_authoritative_kind_passes(self, tmp_path):
+        """Spec §6 (index path): only status=provisional/invalid excluded, not by kind."""
+        entry = self._basic_entry(id="aabb0020", kind="NOTE", agent_id="implement")
+        mem_dir = _build_index_dir(
+            tmp_path,
+            [json.dumps(entry)],
+            {"aabb0020": self._basic_record("aabb0020")},
+        )
+        result = mr.scan_index(mem_dir, ["backend-patterns.md"], [], {"implement"})
+        assert len(result) == 1
+
+    def test_index_source_filter_uses_agent_id_not_evidence(self, tmp_path):
+        """Spec: agent_id from index entry drives source filter, not evidence[].source."""
+        entry = self._basic_entry(id="aabb0021", agent_id="implement")
+        rec = {
+            "id": "aabb0021", "kind": "PATTERN",
+            "summary": "Agent-id path.",
+            "evidence": [{"source": "conformance", "date": "2026-01-01", "issue": 1}],
+            "path_prefixes": [], "expires_at": FUTURE,
+        }
+        mem_dir = _build_index_dir(tmp_path, [json.dumps(entry)], {"aabb0021": rec})
+        result = mr.scan_index(mem_dir, ["backend-patterns.md"], [], {"implement"})
+        assert len(result) == 1
+
+    def test_index_source_filter_excludes_wrong_agent_id(self, tmp_path):
+        """Spec: index entry with wrong agent_id excluded even if record evidence matches."""
+        entry = self._basic_entry(id="aabb0022", agent_id="conformance")
+        mem_dir = _build_index_dir(
+            tmp_path,
+            [json.dumps(entry)],
+            {"aabb0022": self._basic_record("aabb0022", sources=("implement",))},
+        )
+        result = mr.scan_index(mem_dir, ["backend-patterns.md"], [], {"implement"})
+        assert result == []
 
 
 # ── TestRetrieveMemory ─────────────────────────────────────────────────────
@@ -627,6 +662,7 @@ class TestRetrieveMemory:
             "id": "abc123",
             "kind": "PATTERN",
             "source_file": "backend-patterns.md",
+            "agent_id": "implement",
             "path_prefixes": [],
             "expires_at": FUTURE,
             "confidence": 1.0,
@@ -775,3 +811,4 @@ class TestConformanceFixes:
         ]
         out = mr.format_index_output(candidates)
         assert out.index("Newer") < out.index("Older")
+

--- a/dark-factory/tests/test_memory_retrieve.py
+++ b/dark-factory/tests/test_memory_retrieve.py
@@ -195,8 +195,9 @@ class TestPassesLine:
     def test_wrong_source_excluded(self):
         assert not self._call("PATTERN", {"source": "conformance", "expires": FUTURE})
 
-    def test_missing_source_excluded(self):
-        assert not self._call("PATTERN", {"expires": FUTURE})
+    def test_missing_source_passes(self):
+        """Spec assumption: entries without source: tag pass unconditionally (backward compat)."""
+        assert self._call("PATTERN", {"expires": FUTURE})
 
     # --- Global-file exemption ---
     def test_global_codebase_passes_any_source(self):
@@ -259,8 +260,9 @@ class TestPassesLine:
     def test_fix_kind_passes(self):
         assert self._call("FIX", {"source": "implement", "expires": FUTURE})
 
-    def test_unknown_kind_excluded(self):
-        assert not self._call("NOTE", {"source": "implement", "expires": FUTURE})
+    def test_non_provisional_non_invalid_kind_passes(self):
+        """Spec §6 only excludes PROVISIONAL/INVALID; other kinds like NOTE pass through."""
+        assert self._call("NOTE", {"source": "implement", "expires": FUTURE})
 
 
 # ── TestScanMarkdownFiles ──────────────────────────────────────────────────
@@ -443,12 +445,12 @@ class TestFormatOutput:
         out = mr.format_index_output(candidates)
         assert out.index("High") < out.index("Low")
 
-    def test_index_format_sorts_by_expires_at_as_tiebreaker(self):
+    def test_index_format_sorts_by_created_at_as_tiebreaker(self):
         candidates = [
             {"source_file": "backend-patterns.md", "text": "- [PATTERN] Older.",
-             "specificity": 5, "expires_at": "2026-06-01"},
+             "specificity": 5, "created_at": "2026-01-01"},
             {"source_file": "backend-patterns.md", "text": "- [PATTERN] Newer.",
-             "specificity": 5, "expires_at": "2027-01-01"},
+             "specificity": 5, "created_at": "2027-01-01"},
         ]
         out = mr.format_index_output(candidates)
         assert out.index("Newer") < out.index("Older")
@@ -736,3 +738,40 @@ class TestMainCLI:
         for phase in ["refine", "plan", "implement", "validate", "review"]:
             result = self._run(["--phase", phase], memory_dir=mem_dir)
             assert result.returncode == 0, f"Phase {phase!r} failed: {result.stderr}"
+
+
+# ── Conformance fix verification tests ──────────────────────────────────────
+# These tests assert spec-correct behavior. They fail on the pre-fix code
+# and pass after the three material deviations are corrected.
+
+class TestConformanceFixes:
+    ALLOWED = {"implement"}
+    FILES = ["backend/app/services/scanner.py"]
+
+    def _call(self, tag, meta, source_file="backend-patterns.md", files=None, allowed=None):
+        return mr.passes_line_filters(
+            tag,
+            meta,
+            source_file,
+            files if files is not None else self.FILES,
+            allowed if allowed is not None else self.ALLOWED,
+        )
+
+    def test_missing_source_passes_backward_compat(self):
+        """Spec assumption: entries without source: tag pass unconditionally."""
+        assert self._call("PATTERN", {"expires": FUTURE})
+
+    def test_non_provisional_non_invalid_kind_passes(self):
+        """Spec §6 only excludes PROVISIONAL/INVALID; other kinds like NOTE should pass."""
+        assert self._call("NOTE", {"source": "implement", "expires": FUTURE})
+
+    def test_index_ranking_uses_created_at(self):
+        """Spec §7.3: tiebreak by created_at/updated_at descending, not expires_at."""
+        candidates = [
+            {"source_file": "backend-patterns.md", "text": "- [PATTERN] Older.",
+             "specificity": 5, "created_at": "2026-01-01"},
+            {"source_file": "backend-patterns.md", "text": "- [PATTERN] Newer.",
+             "specificity": 5, "created_at": "2027-01-01"},
+        ]
+        out = mr.format_index_output(candidates)
+        assert out.index("Newer") < out.index("Older")


### PR DESCRIPTION
Closes omniscient/dark-factory#143

## Summary
Automated implementation for issue omniscient/dark-factory#143.

## Preview
⚠️ _Preview environment failed to start (preview failed: docker compose up failed (migrate/boot — see preview_build.log tail below)) — endpoint validation was skipped; see the failure comment on the issue._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#143"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#143"
```

---
*Generated by MarketHawk Dark Factory*