### PR TITLE
fix(dark-factory): de-conflict node resolves cli.py via ${CLONE_DIR:-.} (recurring spurious-Blocked)

### DIFF
--- a/.archon/workflows/archon-dark-factory.yaml
+++ b/.archon/workflows/archon-dark-factory.yaml
@@ -415,7 +415,11 @@ nodes:
       ISSUE=$(jq -r '.resolved_number' "$ARTIFACTS_DIR/issue.json")
       ARTIFACTS_DIR="${ARTIFACTS_DIR:-/tmp/artifacts/${ISSUE}}"
       mkdir -p "$ARTIFACTS_DIR"
-      python3 "$CLONE_DIR/dark-factory/scripts/factory_core/cli.py" \
+      # $CLONE_DIR is not exported into archon DAG bash nodes (sibling nodes use
+      # paths relative to CWD, which is the clone root); fall back to "." so the
+      # deconflict CLI resolves instead of hitting a nonexistent /dark-factory/...
+      # path (exit 2). Recurring spurious-Blocked cause: #403/#391/#570/#394/#648.
+      python3 "${CLONE_DIR:-.}/dark-factory/scripts/factory_core/cli.py" \
         deconflict --issue "$ISSUE"
     depends_on: [regen-codeindex, setup-branch-resolve]
     # OR-join of mutually-exclusive branches (continue vs resolve); the always-skipped


### PR DESCRIPTION
## Problem
The factory **de-conflict** DAG node (`.archon/workflows/archon-dark-factory.yaml`) invoked `$CLONE_DIR/dark-factory/scripts/factory_core/cli.py`, but `$CLONE_DIR` is **not exported into archon DAG bash nodes** (every sibling node uses paths relative to CWD = the clone root). It therefore resolved to `/dark-factory/.../cli.py` — which doesn't exist in the container → exit 2 → the whole run exits 1 → the ticket trips to **Blocked**, even though implement/validate/conformance/code-review all succeeded.

This is a **long-standing, recurring spurious-Blocked** cause — `dark-factory/evals/factory-failures.jsonl` records it for omniscient/dark-factory#122, omniscient/markethawk#391, omniscient/markethawk#570, omniscient/dark-factory#119 — and it is currently blocking epic omniscient/dark-factory#140's **#648** (write adapter): the implementation and both high-sev code-review findings were resolved, but de-conflict failed because the branch conflicts with `main`.

## Fix
Fall back to `.` (the clone root, matching every sibling node) when `CLONE_DIR` is unset:
```diff
- python3 "$CLONE_DIR/dark-factory/scripts/factory_core/cli.py" \
+ python3 "${CLONE_DIR:-.}/dark-factory/scripts/factory_core/cli.py" \
```
`.archon/workflows/` is read from the fresh clone each run, so this takes effect on the next factory run with **no image rebuild**.

## Scope / safety
Pure path-restoring bugfix — no change to gate logic, thresholds, prompts, or DAG structure (de-conflict was *supposed* to run this CLI; now it can). YAML validated. The replay-bench gate targets behavioral DAG changes; this only repairs a broken path, so it should not need a bench run, but happy to run it if preferred.

Refs omniscient/dark-factory#140, omniscient/dark-factory#145, omniscient/dark-factory#122, omniscient/markethawk#391, omniscient/markethawk#570, omniscient/dark-factory#119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
