### PR TITLE
Add memory trace artifacts for every Dark Factory run

### DIFF
--- a/.archon/commands/dark-factory-implement.md
+++ b/.archon/commands/dark-factory-implement.md
@@ -39,7 +39,8 @@ MEMORY_CONTEXT=$(python3 "${REPO_ROOT}/dark-factory/scripts/memory_retrieve.py" 
   --phase implement \
   --files "$AFFECTED" \
   $ISSUE_ARG \
-  --memory-dir "${REPO_ROOT}/.archon/memory" 2>/dev/null || true)
+  --memory-dir "${REPO_ROOT}/.archon/memory" \
+  --emit-trace-to "$ARTIFACTS_DIR/memory-trace.json" 2>/dev/null || true)
 
 mkdir -p "$ARTIFACTS_DIR"
 printf '%s\n' "$MEMORY_CONTEXT" > "$ARTIFACTS_DIR/memory-context.md"

--- a/.archon/commands/dark-factory-plan.md
+++ b/.archon/commands/dark-factory-plan.md
@@ -39,7 +39,8 @@ MEMORY_CONTEXT=$(python3 "${REPO_ROOT}/dark-factory/scripts/memory_retrieve.py" 
   --phase plan \
   --files "$AFFECTED" \
   $ISSUE_ARG \
-  --memory-dir "${REPO_ROOT}/.archon/memory" 2>/dev/null || true)
+  --memory-dir "${REPO_ROOT}/.archon/memory" \
+  --emit-trace-to "$ARTIFACTS_DIR/memory-trace.json" 2>/dev/null || true)
 
 mkdir -p "$ARTIFACTS_DIR"
 printf '%s\n' "$MEMORY_CONTEXT" > "$ARTIFACTS_DIR/memory-context.md"

--- a/.archon/commands/dark-factory-refine.md
+++ b/.archon/commands/dark-factory-refine.md
@@ -47,7 +47,8 @@ MEMORY_CONTEXT=$(python3 "${REPO_ROOT}/dark-factory/scripts/memory_retrieve.py" 
   --phase refine \
   --files "$AFFECTED" \
   $ISSUE_ARG \
-  --memory-dir "${REPO_ROOT}/.archon/memory" 2>/dev/null || true)
+  --memory-dir "${REPO_ROOT}/.archon/memory" \
+  --emit-trace-to "$ARTIFACTS_DIR/memory-trace.json" 2>/dev/null || true)
 
 mkdir -p "$ARTIFACTS_DIR"
 printf '%s\n' "$MEMORY_CONTEXT" > "$ARTIFACTS_DIR/memory-context.md"

--- a/.archon/commands/dark-factory-validate.md
+++ b/.archon/commands/dark-factory-validate.md
@@ -114,7 +114,8 @@ MEMORY_CONTEXT=$(python3 "${REPO_ROOT}/dark-factory/scripts/memory_retrieve.py" 
   --phase validate \
   --files "$AFFECTED" \
   $ISSUE_ARG \
-  --memory-dir "${REPO_ROOT}/.archon/memory" 2>/dev/null || true)
+  --memory-dir "${REPO_ROOT}/.archon/memory" \
+  --emit-trace-to "$ARTIFACTS_DIR/memory-trace.json" 2>/dev/null || true)
 
 mkdir -p "$ARTIFACTS_DIR"
 printf '%s\n' "$MEMORY_CONTEXT" > "$ARTIFACTS_DIR/memory-context.md"

--- a/dark-factory/scripts/factory_core/run_record.py
+++ b/dark-factory/scripts/factory_core/run_record.py
@@ -299,6 +299,13 @@ def cmd_assemble(args) -> None:
         },
     }
 
+    trace_path = artifacts_dir / "memory-trace.json"
+    if trace_path.exists():
+        try:
+            run_record["memory_trace"] = json.loads(trace_path.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+
     out_file.parent.mkdir(parents=True, exist_ok=True)
     out_file.write_text(json.dumps(run_record, indent=2), encoding="utf-8")
 

--- a/dark-factory/scripts/memory_retrieve.py
+++ b/dark-factory/scripts/memory_retrieve.py
@@ -305,6 +305,68 @@ def retrieve_memory(memory_dir, phase, files):
     return format_markdown_output(results)
 
 
+# ── Trace emission ────────────────────────────────────────────────────────
+
+def _count_entries(fpath, files, allowed_sources, source_file_name):
+    """Count total and included entries in a memory .md file."""
+    try:
+        text = fpath.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    total = 0
+    included = 0
+    for line in text.splitlines():
+        if line.strip() == "---":
+            break
+        m = _ENTRY_RE.match(line)
+        if not m:
+            continue
+        total += 1
+        tag = m.group("tag")
+        meta = parse_meta(m.group("meta") or "")
+        if passes_line_filters(tag, meta, source_file_name, files, allowed_sources):
+            included += 1
+
+    return {"total": total, "included": included}
+
+
+def emit_memory_trace(trace_path, phase, files, memory_dir, area_files, allowed_sources):
+    """Write memory-trace.json to trace_path. Best-effort: never raises."""
+    try:
+        memory_dir = Path(memory_dir)
+        files_loaded = []
+        fallback_used = False
+
+        for fname in area_files:
+            fpath = memory_dir / fname
+            counts = _count_entries(fpath, files, allowed_sources, fname) if fpath.exists() else None
+            if counts is None:
+                fallback_used = True
+                continue
+            files_loaded.append({
+                "path": str(fpath),
+                "entries_total": counts["total"],
+                "entries_included": counts["included"],
+                "entries_filtered_out": counts["total"] - counts["included"],
+            })
+
+        trace = {
+            "schema_version": 1,
+            "retrieval_mechanism": "flatfile-pathtag",
+            "phase": phase,
+            "affected_files": list(files),
+            "files_loaded": files_loaded,
+            "fallback_used": fallback_used,
+        }
+
+        trace_path = Path(trace_path)
+        trace_path.parent.mkdir(parents=True, exist_ok=True)
+        trace_path.write_text(json.dumps(trace, indent=2), encoding="utf-8")
+    except Exception:
+        pass
+
+
 # ── CLI ────────────────────────────────────────────────────────────────────
 
 def main():
@@ -329,6 +391,12 @@ def main():
         default=".archon/memory",
         help="Path to the memory directory (default: .archon/memory)",
     )
+    parser.add_argument(
+        "--emit-trace-to",
+        default=None,
+        metavar="PATH",
+        help="Write memory-trace.json to this path (best-effort, non-blocking)",
+    )
     args = parser.parse_args()
 
     memory_dir = Path(args.memory_dir)
@@ -337,9 +405,15 @@ def main():
         sys.exit(1)
 
     files = [f.strip() for f in args.files.splitlines() if f.strip()]
+    allowed_sources = PHASE_SOURCE_MAP.get(args.phase, set())
+    area_files = select_area_files(files)
+
     output = retrieve_memory(memory_dir, args.phase, files)
     if output:
         print(output)
+
+    if args.emit_trace_to:
+        emit_memory_trace(args.emit_trace_to, args.phase, files, memory_dir, area_files, allowed_sources)
 
 
 if __name__ == "__main__":

--- a/dark-factory/scripts/memory_retrieve.py
+++ b/dark-factory/scripts/memory_retrieve.py
@@ -46,6 +46,14 @@ AREA_PREFIX_MAP = [
     (("docker-compose", "Dockerfile", "dark-factory/", ".archon/"), "dark-factory-ops.md"),
 ]
 
+PHASE_AGENT_ID = {
+    "refine":    "refine-agent",
+    "plan":      "plan-agent",
+    "implement": "implementation-agent",
+    "validate":  "validate-agent",
+    "review":    "review-agent",
+}
+
 # Only these kind tags are considered authoritative
 AUTHORITATIVE_KINDS = {"PATTERN", "AVOID", "FIX"}
 
@@ -331,7 +339,7 @@ def _count_entries(fpath, files, allowed_sources, source_file_name):
     return {"total": total, "included": included}
 
 
-def emit_memory_trace(trace_path, phase, files, memory_dir, area_files, allowed_sources):
+def emit_memory_trace(trace_path, phase, files, memory_dir, area_files, allowed_sources, issue=0, agent_id=None):
     """Write memory-trace.json to trace_path. Best-effort: never raises."""
     try:
         memory_dir = Path(memory_dir)
@@ -354,7 +362,10 @@ def emit_memory_trace(trace_path, phase, files, memory_dir, area_files, allowed_
         trace = {
             "schema_version": 1,
             "retrieval_mechanism": "flatfile-pathtag",
+            "issue": issue or 0,
             "phase": phase,
+            "agent_id": agent_id or PHASE_AGENT_ID.get(phase, phase + "-agent"),
+            "project": "markethawk",
             "affected_files": list(files),
             "files_loaded": files_loaded,
             "fallback_used": fallback_used,
@@ -413,7 +424,11 @@ def main():
         print(output)
 
     if args.emit_trace_to:
-        emit_memory_trace(args.emit_trace_to, args.phase, files, memory_dir, area_files, allowed_sources)
+        emit_memory_trace(
+            args.emit_trace_to, args.phase, files, memory_dir, area_files, allowed_sources,
+            issue=args.issue or 0,
+            agent_id=PHASE_AGENT_ID.get(args.phase, args.phase + "-agent"),
+        )
 
 
 if __name__ == "__main__":

--- a/dark-factory/tests/test_memory_retrieve.py
+++ b/dark-factory/tests/test_memory_retrieve.py
@@ -945,3 +945,56 @@ class TestEmitMemoryTrace:
         assert result.returncode == 0
         assert not trace_path.exists()
 
+    def test_emit_issue_field(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "memory-trace.json"
+        mr.emit_memory_trace(trace_path, "implement", [], mem_dir, mr.ALL_MEMORY_FILES, {"implement"}, issue=123)
+        data = json.loads(trace_path.read_text())
+        assert data["issue"] == 123
+
+    def test_emit_issue_defaults_to_zero(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "memory-trace.json"
+        mr.emit_memory_trace(trace_path, "implement", [], mem_dir, mr.ALL_MEMORY_FILES, {"implement"})
+        data = json.loads(trace_path.read_text())
+        assert data["issue"] == 0
+
+    def test_emit_agent_id_field(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "memory-trace.json"
+        mr.emit_memory_trace(trace_path, "implement", [], mem_dir, mr.ALL_MEMORY_FILES, {"implement"}, agent_id="implementation-agent")
+        data = json.loads(trace_path.read_text())
+        assert data["agent_id"] == "implementation-agent"
+
+    def test_emit_project_field(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "memory-trace.json"
+        mr.emit_memory_trace(trace_path, "implement", [], mem_dir, mr.ALL_MEMORY_FILES, {"implement"})
+        data = json.loads(trace_path.read_text())
+        assert data["project"] == "markethawk"
+
+    def test_phase_agent_id_map_exists(self, tmp_path):
+        assert hasattr(mr, "PHASE_AGENT_ID")
+        assert mr.PHASE_AGENT_ID["implement"] == "implementation-agent"
+        assert mr.PHASE_AGENT_ID["plan"] == "plan-agent"
+        assert mr.PHASE_AGENT_ID["refine"] == "refine-agent"
+        assert mr.PHASE_AGENT_ID["validate"] == "validate-agent"
+
+    def test_cli_includes_issue_agent_project(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "trace.json"
+        result = subprocess.run(
+            [sys.executable, str(Path(mr.__file__).resolve()),
+             "--phase", "implement",
+             "--memory-dir", str(mem_dir),
+             "--issue", "647",
+             "--emit-trace-to", str(trace_path)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert trace_path.exists()
+        data = json.loads(trace_path.read_text())
+        assert data["issue"] == 647
+        assert data["agent_id"] == "implementation-agent"
+        assert data["project"] == "markethawk"
+

--- a/dark-factory/tests/test_memory_retrieve.py
+++ b/dark-factory/tests/test_memory_retrieve.py
@@ -824,3 +824,124 @@ class TestConformanceFixes:
         out = mr.format_index_output(candidates)
         assert out.index("Newer") < out.index("Older")
 
+
+# ── TestEmitMemoryTrace ────────────────────────────────────────────────────
+
+import subprocess  # noqa: E402
+
+
+class TestEmitMemoryTrace:
+    """Tests for emit_memory_trace() and --emit-trace-to CLI flag (issue #647)."""
+
+    def _make_mem_dir(self, tmp_path, content="- [PATTERN] Foo. <!-- source:implement expires:2099-12-31 -->\n- [PATTERN] Bar. <!-- source:implement expires:2099-12-31 -->\n"):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        for fname in mr.ALL_MEMORY_FILES:
+            (mem_dir / fname).write_text(content)
+        return mem_dir
+
+    def test_emit_writes_valid_json(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "memory-trace.json"
+        mr.emit_memory_trace(trace_path, "implement", [], mem_dir, mr.ALL_MEMORY_FILES, {"implement"})
+        assert trace_path.exists()
+        data = json.loads(trace_path.read_text())
+        assert isinstance(data, dict)
+
+    def test_emit_schema_version(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "memory-trace.json"
+        mr.emit_memory_trace(trace_path, "implement", [], mem_dir, mr.ALL_MEMORY_FILES, {"implement"})
+        data = json.loads(trace_path.read_text())
+        assert data["schema_version"] == 1
+
+    def test_emit_retrieval_mechanism(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "memory-trace.json"
+        mr.emit_memory_trace(trace_path, "implement", [], mem_dir, mr.ALL_MEMORY_FILES, {"implement"})
+        data = json.loads(trace_path.read_text())
+        assert data["retrieval_mechanism"] == "flatfile-pathtag"
+
+    def test_emit_phase_field(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "memory-trace.json"
+        mr.emit_memory_trace(trace_path, "plan", [], mem_dir, mr.ALL_MEMORY_FILES, {"refine"})
+        data = json.loads(trace_path.read_text())
+        assert data["phase"] == "plan"
+
+    def test_emit_affected_files(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "memory-trace.json"
+        files = ["backend/app/services/scanner.py", "dark-factory/scripts/memory_retrieve.py"]
+        mr.emit_memory_trace(trace_path, "implement", files, mem_dir, mr.ALL_MEMORY_FILES, {"implement"})
+        data = json.loads(trace_path.read_text())
+        assert data["affected_files"] == files
+
+    def test_emit_files_loaded_structure(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "memory-trace.json"
+        mr.emit_memory_trace(trace_path, "implement", [], mem_dir, mr.ALL_MEMORY_FILES, {"implement"})
+        data = json.loads(trace_path.read_text())
+        assert "files_loaded" in data
+        assert isinstance(data["files_loaded"], list)
+        for entry in data["files_loaded"]:
+            assert "path" in entry
+            assert "entries_total" in entry
+            assert "entries_included" in entry
+            assert "entries_filtered_out" in entry
+
+    def test_emit_counts_match(self, tmp_path):
+        content = (
+            "- [PATTERN] P1. <!-- source:implement expires:2099-12-31 -->\n"
+            "- [PATTERN] P2. <!-- source:implement expires:2099-12-31 -->\n"
+            "- [PROVISIONAL] Skip. <!-- source:implement expires:2099-12-31 -->\n"
+        )
+        mem_dir = self._make_mem_dir(tmp_path, content=content)
+        trace_path = tmp_path / "memory-trace.json"
+        mr.emit_memory_trace(trace_path, "implement", [], mem_dir, ["backend-patterns.md"], {"implement"})
+        data = json.loads(trace_path.read_text())
+        entry = next(e for e in data["files_loaded"] if e["path"].endswith("backend-patterns.md"))
+        assert entry["entries_total"] == 3
+        assert entry["entries_included"] == 2
+        assert entry["entries_filtered_out"] == 1
+
+    def test_emit_fallback_false_on_success(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "memory-trace.json"
+        mr.emit_memory_trace(trace_path, "implement", [], mem_dir, mr.ALL_MEMORY_FILES, {"implement"})
+        data = json.loads(trace_path.read_text())
+        assert data["fallback_used"] is False
+
+    def test_emit_nonfatal_on_write_error(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        bad_path = Path("/nonexistent/directory/memory-trace.json")
+        # Should not raise
+        mr.emit_memory_trace(bad_path, "implement", [], mem_dir, mr.ALL_MEMORY_FILES, {"implement"})
+
+    def test_cli_emit_trace_to_flag_accepted(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "trace.json"
+        result = subprocess.run(
+            [sys.executable, str(Path(mr.__file__).resolve()),
+             "--phase", "implement",
+             "--memory-dir", str(mem_dir),
+             "--emit-trace-to", str(trace_path)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert trace_path.exists()
+        data = json.loads(trace_path.read_text())
+        assert data["schema_version"] == 1
+
+    def test_cli_no_trace_when_flag_absent(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "trace.json"
+        result = subprocess.run(
+            [sys.executable, str(Path(mr.__file__).resolve()),
+             "--phase", "implement",
+             "--memory-dir", str(mem_dir)],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert not trace_path.exists()
+

--- a/dark-factory/tests/test_run_record.py
+++ b/dark-factory/tests/test_run_record.py
@@ -283,3 +283,70 @@ def test_assemble_emits_jsonl_per_stage(tmp_path, monkeypatch):
     stages = [json.loads(l)["stage"] for l in lines]
     assert "validation" in stages
     assert "conformance" in stages
+
+
+# ── memory-trace pickup tests (issue #647) ─────────────────────────────────
+
+def test_assemble_picks_up_memory_trace(tmp_path, monkeypatch):
+    monkeypatch.setattr(rr, "JSONL_PATH", tmp_path / "runs.jsonl")
+    monkeypatch.setattr(rr, "_post_seq", lambda r: None)
+
+    trace = {
+        "schema_version": 1,
+        "retrieval_mechanism": "flatfile-pathtag",
+        "phase": "implement",
+        "affected_files": [],
+        "files_loaded": [],
+        "fallback_used": False,
+    }
+    (tmp_path / "memory-trace.json").write_text(json.dumps(trace))
+
+    out = tmp_path / "run-record.json"
+    args = _AssembleArgs(tmp_path, out)
+    rr.cmd_assemble(args)
+
+    rec = json.loads(out.read_text())
+    assert "memory_trace" in rec
+    assert rec["memory_trace"]["schema_version"] == 1
+    assert rec["memory_trace"]["retrieval_mechanism"] == "flatfile-pathtag"
+
+
+def test_assemble_no_memory_trace_key_when_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(rr, "JSONL_PATH", tmp_path / "runs.jsonl")
+    monkeypatch.setattr(rr, "_post_seq", lambda r: None)
+
+    out = tmp_path / "run-record.json"
+    args = _AssembleArgs(tmp_path, out)
+    rr.cmd_assemble(args)
+
+    rec = json.loads(out.read_text())
+    assert "memory_trace" not in rec
+
+
+def test_assemble_tolerates_malformed_memory_trace(tmp_path, monkeypatch):
+    monkeypatch.setattr(rr, "JSONL_PATH", tmp_path / "runs.jsonl")
+    monkeypatch.setattr(rr, "_post_seq", lambda r: None)
+
+    (tmp_path / "memory-trace.json").write_text("not valid json {{{")
+
+    out = tmp_path / "run-record.json"
+    args = _AssembleArgs(tmp_path, out)
+    rr.cmd_assemble(args)  # must not raise
+
+    rec = json.loads(out.read_text())
+    assert "memory_trace" not in rec
+
+
+def test_assemble_tolerates_unreadable_memory_trace(tmp_path, monkeypatch):
+    monkeypatch.setattr(rr, "JSONL_PATH", tmp_path / "runs.jsonl")
+    monkeypatch.setattr(rr, "_post_seq", lambda r: None)
+
+    # Create a directory where the file is expected — causes read failure
+    (tmp_path / "memory-trace.json").mkdir()
+
+    out = tmp_path / "run-record.json"
+    args = _AssembleArgs(tmp_path, out)
+    rr.cmd_assemble(args)  # must not raise
+
+    rec = json.loads(out.read_text())
+    assert "memory_trace" not in rec


### PR DESCRIPTION
Closes omniscient/dark-factory#144

## Summary
Automated implementation for issue omniscient/dark-factory#144.

## Preview
_No preview environment — this change does not affect the running app ('All changed files fall into non-runtime-affecting categories: .archon/ workflow config, dark-factory/scripts/ tooling, and dark-factory/tests/. No changes to backend/app, frontend/src, docker-compose, requirements.txt, or application code. Preview stack not needed.')._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#144"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#144"
```

---
*Generated by MarketHawk Dark Factory*