### PR TITLE
Add scenario-specific context packs for Dark Factory phases

### DIFF
--- a/dark-factory/scripts/context_pack.py
+++ b/dark-factory/scripts/context_pack.py
@@ -1,0 +1,327 @@
+"""CLI: assemble Dark Factory scenario context packs.
+
+Produces:
+  context-pack.md   — prompt-ready assembled content with ## <section_key> headers
+  context-pack.json — manifest with token budget, per-section status, over_budget flag
+
+Usage:
+  python3 context_pack.py --scenario implement --issue-num 42 --run-id abc123 \
+    --artifacts-dir /tmp/artifacts/42 --clone-dir /workspace/markethawk \
+    --issue-json /tmp/artifacts/42/issue.json \
+    --memory-file /tmp/artifacts/42/memory-context.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(__file__))
+import token_estimate as te
+import architecture_slice as aslice
+from context_budget import (
+    _SECTION_REGISTRY,
+    BUDGET_TOKENS,
+    DIFF_LINE_CAP,
+    _read_text,
+    _SKILL_PROMPT_DIR,
+    _SKILL_PROMPT_FILES,
+)
+
+
+def _included(text: str | None, file_path: str | None = None) -> tuple[dict, str | None]:
+    if not text or not text.strip():
+        return {"status": "dropped", "tokens": 0, "reason": "empty_or_missing"}, None
+    entry: dict = {"status": "included", "tokens": te.estimate_tokens(text)}
+    if file_path:
+        h = te.hash_file(file_path)
+        if h:
+            entry["file_hash"] = h
+    return entry, text
+
+
+def _dropped(reason: str) -> tuple[dict, None]:
+    return {"status": "dropped", "tokens": 0, "reason": reason}, None
+
+
+def _read_skill_prompts() -> tuple[dict, str | None]:
+    parts = []
+    for name in _SKILL_PROMPT_FILES:
+        txt = _read_text(os.path.join(_SKILL_PROMPT_DIR, name))
+        if txt:
+            parts.append(txt)
+    if not parts:
+        return {"status": "dropped", "tokens": 0, "reason": "container_mounted_not_found"}, None
+    combined = "\n".join(parts)
+    return {"status": "included", "tokens": te.estimate_tokens(combined)}, combined
+
+
+def _read_issue_context(issue_json: str | None) -> tuple[dict, str | None]:
+    raw = _read_text(issue_json)
+    if not raw:
+        return _dropped("empty_or_missing")
+    try:
+        body = json.loads(raw).get("body") or ""
+        return _included(body) if body.strip() else _dropped("empty_body")
+    except (json.JSONDecodeError, AttributeError):
+        return _dropped("invalid_json")
+
+
+def _read_comments(issue_json: str | None) -> tuple[dict, str | None]:
+    raw = _read_text(issue_json)
+    if not raw:
+        return _dropped("empty_or_missing")
+    try:
+        comments = json.loads(raw).get("comments") or []
+        combined = "\n".join(c.get("body", "") for c in comments if isinstance(c, dict))
+        return _included(combined) if combined.strip() else _dropped("no_comments")
+    except (json.JSONDecodeError, AttributeError):
+        return _dropped("invalid_json")
+
+
+def _read_pr_reviews(issue_json: str | None) -> tuple[dict, str | None]:
+    raw = _read_text(issue_json)
+    if not raw:
+        return _dropped("empty_or_missing")
+    try:
+        data = json.loads(raw)
+        pr = data.get("pr_reviews") or {}
+        inline = data.get("pr_inline_comments") or []
+        text = json.dumps(pr) + "\n" + json.dumps(inline)
+        return _included(text) if text.strip() else _dropped("no_pr_reviews")
+    except (json.JSONDecodeError, AttributeError):
+        return _dropped("invalid_json")
+
+
+def _read_diff(diff_file: str | None) -> tuple[dict, str | None]:
+    text = _read_text(diff_file)
+    if not text or not text.strip():
+        return _dropped("empty_or_missing")
+    lines = text.splitlines()
+    truncated = len(lines) > DIFF_LINE_CAP
+    effective = "\n".join(lines[:DIFF_LINE_CAP]) if truncated else text
+    entry: dict = {"tokens": te.estimate_tokens(effective)}
+    if truncated:
+        entry["status"] = "included_partial"
+        entry["truncated_at_lines"] = DIFF_LINE_CAP
+        content = effective + f"\n<!-- truncated at {DIFF_LINE_CAP} lines -->"
+    else:
+        entry["status"] = "included"
+        content = effective
+    if diff_file:
+        h = te.hash_file(diff_file)
+        if h:
+            entry["file_hash"] = h
+    return entry, content
+
+
+def assemble_pack(
+    scenario: str,
+    issue_num: int,
+    run_id: str,
+    clone_dir: str,
+    out_md: str,
+    out_json: str,
+    artifacts_dir: str | None = None,
+    spec_file: str | None = None,
+    memory_file: str | None = None,
+    issue_json: str | None = None,
+    impl_file: str | None = None,
+    diff_file: str | None = None,
+    spec_component: str | None = None,
+    changed_files: list[str] | None = None,
+    labels: list[str] | None = None,
+) -> None:
+    active = _SECTION_REGISTRY.get(scenario, [])
+    sections: dict[str, dict] = {}
+    source_hashes: dict[str, str] = {}
+    md_parts: list[str] = []
+
+    for sec in active:
+        status_entry: dict
+        content: str | None
+
+        if sec == "claude_md":
+            path = os.path.join(clone_dir, "CLAUDE.md")
+            status_entry, content = _included(_read_text(path), path)
+            h = te.hash_file(path)
+            if h:
+                source_hashes["CLAUDE.md"] = h
+
+        elif sec == "architecture_md":
+            arch_path = os.path.join(clone_dir, "ARCHITECTURE.md")
+            result = aslice.slice_architecture(
+                arch_path=arch_path,
+                scenario=scenario,
+                spec_component=spec_component,
+                spec_file=spec_file,
+                changed_files=changed_files,
+                labels=labels,
+                clone_dir=clone_dir,
+            )
+            # included_slice = targeted slice; included = full fallback
+            slice_status = "included" if result.fallback else "included_slice"
+            tokens = te.estimate_tokens(result.text)
+            status_entry = {
+                "status": slice_status,
+                "tokens": tokens,
+                "component": result.component,
+                "included_sections": result.included_sections,
+                "omitted_sections": result.omitted_sections,
+                "section_hashes": result.section_hashes,
+                "fallback": result.fallback,
+                "fallback_reason": result.fallback_reason,
+            }
+            content = result.text if result.text and result.text.strip() else None
+            h = te.hash_file(arch_path)
+            if h:
+                source_hashes["ARCHITECTURE.md"] = h
+
+        elif sec == "skill_prompts":
+            status_entry, content = _read_skill_prompts()
+
+        elif sec == "issue_context":
+            status_entry, content = _read_issue_context(issue_json)
+
+        elif sec == "comments":
+            status_entry, content = _read_comments(issue_json)
+
+        elif sec == "memory_context":
+            status_entry, content = _included(_read_text(memory_file), memory_file)
+            if memory_file and status_entry["status"] == "included":
+                h = te.hash_file(memory_file)
+                if h:
+                    source_hashes["memory-context.md"] = h
+
+        elif sec == "pr_reviews":
+            status_entry, content = _read_pr_reviews(issue_json)
+
+        elif sec == "spec":
+            status_entry, content = _included(_read_text(spec_file), spec_file)
+            if spec_file and status_entry["status"] == "included":
+                h = te.hash_file(spec_file)
+                if h:
+                    source_hashes["spec"] = h
+
+        elif sec == "implementation_md":
+            status_entry, content = _included(_read_text(impl_file), impl_file)
+            if impl_file and status_entry["status"] == "included":
+                h = te.hash_file(impl_file)
+                if h:
+                    source_hashes["implementation.md"] = h
+
+        elif sec == "diff":
+            status_entry, content = _read_diff(diff_file)
+            if diff_file and status_entry["status"] in ("included", "included_partial"):
+                h = te.hash_file(diff_file)
+                if h:
+                    source_hashes["diff"] = h
+
+        else:
+            status_entry, content = _dropped("unknown_section")
+
+        sections[sec] = status_entry
+        if content is not None:
+            md_parts.append(f"## {sec}\n\n{content}")
+
+    estimated = sum(v.get("tokens", 0) for v in sections.values())
+    utilization = round(estimated / BUDGET_TOKENS * 100, 1)
+    over_budget = estimated > BUDGET_TOKENS
+
+    if over_budget:
+        print(
+            f"WARNING: context pack for scenario '{scenario}' exceeds budget "
+            f"({estimated} > {BUDGET_TOKENS} tokens); sections not dropped",
+            file=sys.stderr,
+        )
+
+    # included_slice counts as included (content IS assembled into the MD)
+    included_sections = [
+        k for k, v in sections.items()
+        if v.get("status") in ("included", "included_partial", "included_slice")
+    ]
+    dropped_sections = [k for k, v in sections.items() if v.get("status") == "dropped"]
+
+    os.makedirs(os.path.dirname(os.path.abspath(out_md)), exist_ok=True)
+    with open(out_md, "w", encoding="utf-8") as f:
+        f.write("\n\n".join(md_parts))
+        if md_parts:
+            f.write("\n")
+
+    os.makedirs(os.path.dirname(os.path.abspath(out_json)), exist_ok=True)
+    artifact = {
+        "schema_version": 1,
+        "scenario": scenario,
+        "run_id": run_id,
+        "issue_number": issue_num,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "budget_tokens": BUDGET_TOKENS,
+        "estimated_input_tokens": estimated,
+        "utilization_pct": utilization,
+        "over_budget": over_budget,
+        "sections": sections,
+        "included_sections": included_sections,
+        "dropped_sections": dropped_sections,
+        "source_file_hashes": source_hashes,
+    }
+    with open(out_json, "w", encoding="utf-8") as f:
+        json.dump(artifact, f, indent=2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Assemble Dark Factory scenario context packs.")
+    parser.add_argument("--scenario", required=True,
+                        choices=list(_SECTION_REGISTRY.keys()),
+                        help="Phase scenario name")
+    parser.add_argument("--issue-num", required=True, type=int)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--artifacts-dir", required=True)
+    parser.add_argument("--clone-dir", required=True)
+    parser.add_argument("--spec-file")
+    parser.add_argument("--memory-file")
+    parser.add_argument("--issue-json")
+    parser.add_argument("--impl-file")
+    parser.add_argument("--diff-file")
+    parser.add_argument("--spec-component",
+                        help="Explicit component for architecture slicing "
+                             "(backend|frontend|dark-factory|infrastructure); inferred if omitted")
+    parser.add_argument("--changed-files", nargs="*", default=None,
+                        help="Changed file paths, used to infer the architecture-slice component")
+    parser.add_argument("--labels", nargs="*", default=None,
+                        help="Issue labels, used for architecture-slice component inference")
+    parser.add_argument("--out-md",
+                        help="Output path for context-pack.md "
+                             "(default: <artifacts-dir>/context-pack.md)")
+    parser.add_argument("--out-json",
+                        help="Output path for context-pack.json "
+                             "(default: <artifacts-dir>/context-pack.json)")
+    args = parser.parse_args()
+
+    out_md = args.out_md or os.path.join(args.artifacts_dir, "context-pack.md")
+    out_json = args.out_json or os.path.join(args.artifacts_dir, "context-pack.json")
+
+    assemble_pack(
+        scenario=args.scenario,
+        issue_num=args.issue_num,
+        run_id=args.run_id,
+        clone_dir=args.clone_dir,
+        out_md=out_md,
+        out_json=out_json,
+        artifacts_dir=args.artifacts_dir,
+        spec_file=args.spec_file,
+        memory_file=args.memory_file,
+        issue_json=args.issue_json,
+        impl_file=args.impl_file,
+        diff_file=args.diff_file,
+        spec_component=args.spec_component,
+        changed_files=args.changed_files,
+        labels=args.labels,
+    )
+    print(f"context-pack.md written to {out_md}", file=sys.stderr)
+    print(f"context-pack.json written to {out_json}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/dark-factory/scripts/context_pack.py
+++ b/dark-factory/scripts/context_pack.py
@@ -64,7 +64,11 @@ def _read_issue_context(issue_json: str | None) -> tuple[dict, str | None]:
         return _dropped("empty_or_missing")
     try:
         body = json.loads(raw).get("body") or ""
-        return _included(body) if body.strip() else _dropped("empty_body")
+        if not body.strip():
+            return _dropped("empty_body")
+        # Prefix with a blank line so any leading "## " in untrusted content
+        # does not inject a spurious section header into the assembled prompt.
+        return _included("\n" + body)
     except (json.JSONDecodeError, AttributeError):
         return _dropped("invalid_json")
 
@@ -76,7 +80,11 @@ def _read_comments(issue_json: str | None) -> tuple[dict, str | None]:
     try:
         comments = json.loads(raw).get("comments") or []
         combined = "\n".join(c.get("body", "") for c in comments if isinstance(c, dict))
-        return _included(combined) if combined.strip() else _dropped("no_comments")
+        if not combined.strip():
+            return _dropped("no_comments")
+        # Prefix with a blank line so any leading "## " in untrusted content
+        # does not inject a spurious section header into the assembled prompt.
+        return _included("\n" + combined)
     except (json.JSONDecodeError, AttributeError):
         return _dropped("invalid_json")
 
@@ -102,14 +110,16 @@ def _read_diff(diff_file: str | None) -> tuple[dict, str | None]:
     lines = text.splitlines()
     truncated = len(lines) > DIFF_LINE_CAP
     effective = "\n".join(lines[:DIFF_LINE_CAP]) if truncated else text
-    entry: dict = {"tokens": te.estimate_tokens(effective)}
     if truncated:
-        entry["status"] = "included_partial"
-        entry["truncated_at_lines"] = DIFF_LINE_CAP
         content = effective + f"\n<!-- truncated at {DIFF_LINE_CAP} lines -->"
+        entry: dict = {
+            "status": "included_partial",
+            "tokens": te.estimate_tokens(content),
+            "truncated_at_lines": DIFF_LINE_CAP,
+        }
     else:
-        entry["status"] = "included"
         content = effective
+        entry = {"status": "included", "tokens": te.estimate_tokens(content)}
     if diff_file:
         h = te.hash_file(diff_file)
         if h:
@@ -161,20 +171,41 @@ def assemble_pack(
                 labels=labels,
                 clone_dir=clone_dir,
             )
-            # included_slice = targeted slice; included = full fallback
-            slice_status = "included" if result.fallback else "included_slice"
-            tokens = te.estimate_tokens(result.text)
-            status_entry = {
-                "status": slice_status,
-                "tokens": tokens,
-                "component": result.component,
-                "included_sections": result.included_sections,
-                "omitted_sections": result.omitted_sections,
-                "section_hashes": result.section_hashes,
-                "fallback": result.fallback,
-                "fallback_reason": result.fallback_reason,
-            }
-            content = result.text if result.text and result.text.strip() else None
+            # Detect comment-only fallback text (e.g. "<!-- ... -->" with no real content).
+            _raw = result.text or ""
+            _non_comment_lines = [
+                ln for ln in _raw.splitlines()
+                if ln.strip() and not ln.strip().startswith("<!--") and not ln.strip().startswith("-->")
+            ]
+            _is_comment_only = bool(_raw.strip()) and not _non_comment_lines
+            if _is_comment_only or not _raw.strip():
+                status_entry = {
+                    "status": "dropped",
+                    "tokens": 0,
+                    "reason": "empty_fallback",
+                    "component": result.component,
+                    "included_sections": result.included_sections,
+                    "omitted_sections": result.omitted_sections,
+                    "section_hashes": result.section_hashes,
+                    "fallback": result.fallback,
+                    "fallback_reason": result.fallback_reason,
+                }
+                content = None
+            else:
+                # included_slice = targeted slice; included = full fallback
+                slice_status = "included" if result.fallback else "included_slice"
+                tokens = te.estimate_tokens(_raw)
+                status_entry = {
+                    "status": slice_status,
+                    "tokens": tokens,
+                    "component": result.component,
+                    "included_sections": result.included_sections,
+                    "omitted_sections": result.omitted_sections,
+                    "section_hashes": result.section_hashes,
+                    "fallback": result.fallback,
+                    "fallback_reason": result.fallback_reason,
+                }
+                content = _raw
             h = te.hash_file(arch_path)
             if h:
                 source_hashes["ARCHITECTURE.md"] = h

--- a/dark-factory/tests/test_context_pack.py
+++ b/dark-factory/tests/test_context_pack.py
@@ -1,0 +1,197 @@
+"""Tests for context_pack.py — scenario content assembler."""
+import io
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import context_pack as cp
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def make_issue_json(tmp_path, with_pr=False):
+    data = {
+        "resolved_number": 665,
+        "intent": "continue" if with_pr else "new",
+        "title": "Test issue",
+        "body": "Issue body text for pack assembly",
+        "comments": [{"body": "comment alpha"}, {"body": "comment beta"}],
+    }
+    if with_pr:
+        data["pr_reviews"] = {"reviews": [{"body": "lgtm"}], "comments": []}
+        data["pr_inline_comments"] = []
+    p = tmp_path / "issue.json"
+    p.write_text(json.dumps(data))
+    return str(p)
+
+
+def make_spec_file(tmp_path):
+    p = tmp_path / "spec.md"
+    p.write_text("# Spec\n\n" + "word " * 100)
+    return str(p)
+
+
+def make_impl_file(tmp_path):
+    p = tmp_path / "implementation.md"
+    p.write_text("## Changes\n\n" + "line " * 50)
+    return str(p)
+
+
+def make_diff_file(tmp_path, lines=10):
+    p = tmp_path / "review_diff.txt"
+    p.write_text("\n".join(f"+line {i}" for i in range(lines)))
+    return str(p)
+
+
+def run_pack(tmp_path, scenario, **kwargs):
+    out_md = str(tmp_path / "context-pack.md")
+    out_json = str(tmp_path / "context-pack.json")
+    cp.assemble_pack(
+        scenario=scenario,
+        issue_num=665,
+        run_id="test-run-cp-abc",
+        artifacts_dir=str(tmp_path),
+        clone_dir=str(tmp_path),
+        out_md=out_md,
+        out_json=out_json,
+        **kwargs,
+    )
+    manifest = json.loads(Path(out_json).read_text())
+    md_content = Path(out_md).read_text()
+    return manifest, md_content
+
+
+# ── JSON schema tests (refine scenario) ──────────────────────────────────────
+
+def test_required_json_fields_present(tmp_path):
+    manifest, _ = run_pack(tmp_path, "refine", issue_json=make_issue_json(tmp_path))
+    for field in (
+        "schema_version", "scenario", "run_id", "issue_number",
+        "generated_at", "budget_tokens", "estimated_input_tokens",
+        "utilization_pct", "over_budget", "sections", "included_sections",
+        "dropped_sections", "source_file_hashes",
+    ):
+        assert field in manifest, f"Missing required JSON field: {field}"
+
+
+def test_schema_version_is_1(tmp_path):
+    manifest, _ = run_pack(tmp_path, "refine", issue_json=make_issue_json(tmp_path))
+    assert manifest["schema_version"] == 1
+
+
+def test_budget_tokens_is_200000(tmp_path):
+    manifest, _ = run_pack(tmp_path, "refine", issue_json=make_issue_json(tmp_path))
+    assert manifest["budget_tokens"] == 200_000
+
+
+def test_over_budget_false_for_small_input(tmp_path):
+    manifest, _ = run_pack(tmp_path, "refine", issue_json=make_issue_json(tmp_path))
+    assert manifest["over_budget"] is False
+
+
+def test_refine_md_has_section_headers(tmp_path):
+    _, md = run_pack(tmp_path, "refine", issue_json=make_issue_json(tmp_path))
+    assert "## issue_context" in md
+    assert "## comments" in md
+
+
+def test_refine_md_contains_issue_body(tmp_path):
+    _, md = run_pack(tmp_path, "refine", issue_json=make_issue_json(tmp_path))
+    assert "Issue body text for pack assembly" in md
+
+
+# ── plan scenario — spec section included / dropped ───────────────────────────
+# The plan scenario includes spec; this verifies the content assembler handles
+# the include/drop distinction correctly.
+
+def test_plan_spec_included_when_file_supplied(tmp_path):
+    spec = make_spec_file(tmp_path)
+    manifest, md = run_pack(tmp_path, "plan",
+                            issue_json=make_issue_json(tmp_path),
+                            spec_file=spec)
+    assert manifest["sections"]["spec"]["status"] == "included"
+    assert manifest["sections"]["spec"]["tokens"] > 0
+    assert "## spec" in md
+
+
+def test_plan_spec_dropped_when_absent(tmp_path):
+    manifest, md = run_pack(tmp_path, "plan",
+                            issue_json=make_issue_json(tmp_path))
+    assert manifest["sections"]["spec"]["status"] == "dropped"
+    assert "## spec" not in md
+
+
+# ── code-review scenario — diff section with truncation ──────────────────────
+
+def test_code_review_diff_included_when_under_cap(tmp_path):
+    diff = make_diff_file(tmp_path, lines=50)
+    spec = make_spec_file(tmp_path)
+    manifest, md = run_pack(tmp_path, "code-review",
+                            issue_json=make_issue_json(tmp_path),
+                            spec_file=spec,
+                            diff_file=diff)
+    sec = manifest["sections"]["diff"]
+    assert sec["status"] == "included"
+    assert "truncated_at_lines" not in sec
+    assert "## diff" in md
+    assert "<!-- truncated" not in md
+
+
+def test_code_review_diff_partial_when_over_cap(tmp_path):
+    diff = make_diff_file(tmp_path, lines=1500)
+    spec = make_spec_file(tmp_path)
+    manifest, md = run_pack(tmp_path, "code-review",
+                            issue_json=make_issue_json(tmp_path),
+                            spec_file=spec,
+                            diff_file=diff)
+    sec = manifest["sections"]["diff"]
+    assert sec["status"] == "included_partial"
+    assert sec["truncated_at_lines"] == 1000
+    assert sec["tokens"] > 0
+    assert "<!-- truncated at 1000 lines -->" in md
+
+
+# ── over_budget flag ──────────────────────────────────────────────────────────
+
+def test_over_budget_true_and_stderr_warning_when_exceeds(tmp_path, monkeypatch):
+    # Temporarily reduce BUDGET_TOKENS so small content exceeds it
+    original = cp.BUDGET_TOKENS
+    monkeypatch.setattr(cp, "BUDGET_TOKENS", 1)
+    try:
+        captured = io.StringIO()
+        monkeypatch.setattr(sys, "stderr", captured)
+        manifest, _ = run_pack(tmp_path, "refine", issue_json=make_issue_json(tmp_path))
+    finally:
+        monkeypatch.setattr(cp, "BUDGET_TOKENS", original)
+
+    assert manifest["over_budget"] is True
+    warning = captured.getvalue()
+    assert "WARNING" in warning
+    assert "exceeds budget" in warning
+
+
+# ── graceful missing-file drop ────────────────────────────────────────────────
+
+def test_missing_source_files_drop_gracefully(tmp_path):
+    # No file-backed sources provided — spec, implementation_md, diff must all be dropped.
+    # skill_prompts is container-mounted (/opt/refinement-skills) so its status is env-dependent;
+    # we only assert on the file-path-backed sections.
+    manifest, _ = run_pack(tmp_path, "conformance",
+                           spec_file=None, impl_file=None, diff_file=None)
+    for sec_name in ("spec", "implementation_md", "diff"):
+        sec = manifest["sections"][sec_name]
+        assert sec["status"] == "dropped", (
+            f"Expected dropped for {sec_name!r}, got {sec['status']!r}"
+        )
+        assert "reason" in sec, f"Missing 'reason' for dropped section {sec_name!r}"
+
+
+def test_nonexistent_files_produce_dropped_with_reason(tmp_path):
+    manifest, _ = run_pack(tmp_path, "implement",
+                           issue_json="/nonexistent/issue.json",
+                           memory_file="/nonexistent/memory.md")
+    assert manifest["sections"]["issue_context"]["status"] == "dropped"
+    assert "reason" in manifest["sections"]["issue_context"]
+    assert manifest["sections"]["memory_context"]["status"] == "dropped"
+    assert "reason" in manifest["sections"]["memory_context"]

--- a/dark-factory/tests/test_context_pack.py
+++ b/dark-factory/tests/test_context_pack.py
@@ -126,10 +126,8 @@ def test_plan_spec_dropped_when_absent(tmp_path):
 
 def test_code_review_diff_included_when_under_cap(tmp_path):
     diff = make_diff_file(tmp_path, lines=50)
-    spec = make_spec_file(tmp_path)
     manifest, md = run_pack(tmp_path, "code-review",
                             issue_json=make_issue_json(tmp_path),
-                            spec_file=spec,
                             diff_file=diff)
     sec = manifest["sections"]["diff"]
     assert sec["status"] == "included"


### PR DESCRIPTION
Closes omniscient/dark-factory#154

## Summary
Automated implementation for issue omniscient/dark-factory#154.

## Preview
⚠️ _Preview environment failed to start (preview failed: docker compose up failed (migrate/boot — see preview_build.log tail below)) — endpoint validation was skipped; see the failure comment on the issue._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#154"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#154"
```

---
*Generated by MarketHawk Dark Factory*