### PR TITLE
Complete canonical signal replay engine

### DIFF
--- a/backend/app/alembic/versions/f1a2b3c4d5e6_add_replay_engine_tables.py
+++ b/backend/app/alembic/versions/f1a2b3c4d5e6_add_replay_engine_tables.py
@@ -1,0 +1,139 @@
+"""add_replay_engine_tables
+
+Revision ID: f1a2b3c4d5e6
+Revises: d4e5f6a7b8c9
+Create Date: 2026-07-01 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "f1a2b3c4d5e6"
+down_revision: Union[str, None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "replay_runs",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("uuid", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("celery_task_id", sa.String(length=64), nullable=True),
+        sa.Column("scanner_type", sa.String(length=50), nullable=False),
+        sa.Column(
+            "scanner_config_snapshot",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column("trading_strategy_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "strategy_snapshot",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("universe_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "universe_snapshot",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column("start_date", sa.Date(), nullable=False),
+        sa.Column("end_date", sa.Date(), nullable=False),
+        sa.Column("max_hold_days", sa.Integer(), nullable=False),
+        sa.Column("exit_fidelity", sa.String(length=20), nullable=False),
+        sa.Column("benchmark_symbol", sa.String(length=10), nullable=True),
+        sa.Column("data_hash", sa.String(length=64), nullable=True),
+        sa.Column("metrics", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("skipped_count", sa.Integer(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("signal_source", sa.String(length=20), nullable=True),
+        sa.Column("total_trades", sa.Integer(), nullable=True),
+        sa.Column("hit_rate", sa.Float(), nullable=True),
+        sa.Column("expectancy_r", sa.Float(), nullable=True),
+        sa.Column("profit_factor", sa.Float(), nullable=True),
+        sa.Column("max_drawdown_r", sa.Float(), nullable=True),
+        sa.Column("avg_bars_held", sa.Float(), nullable=True),
+        sa.Column("median_bars_held", sa.Float(), nullable=True),
+        sa.Column("avg_mfe_pct", sa.Float(), nullable=True),
+        sa.Column("avg_mae_pct", sa.Float(), nullable=True),
+        sa.Column("mfe_mae_ratio", sa.Float(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["trading_strategy_id"], ["trading_strategies.id"]),
+        sa.ForeignKeyConstraint(["universe_id"], ["stock_universes.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_replay_runs_id"), "replay_runs", ["id"], unique=False)
+    op.create_index(
+        op.f("ix_replay_runs_uuid"), "replay_runs", ["uuid"], unique=True
+    )
+    op.create_index(
+        op.f("ix_replay_runs_celery_task_id"),
+        "replay_runs",
+        ["celery_task_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "replay_trades",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("replay_run_id", sa.Integer(), nullable=False),
+        sa.Column("scanner_event_id", sa.Integer(), nullable=True),
+        sa.Column("ticker", sa.String(length=10), nullable=False),
+        sa.Column("signal_date", sa.Date(), nullable=False),
+        sa.Column("entry_date", sa.Date(), nullable=True),
+        sa.Column("entry_price", sa.Numeric(), nullable=True),
+        sa.Column("direction", sa.String(length=10), nullable=True),
+        sa.Column("stop_price", sa.Numeric(), nullable=True),
+        sa.Column("target_price", sa.Numeric(), nullable=True),
+        sa.Column("exit_date", sa.Date(), nullable=True),
+        sa.Column("exit_price", sa.Numeric(), nullable=True),
+        sa.Column("exit_reason", sa.String(length=30), nullable=True),
+        sa.Column("return_pct", sa.Numeric(), nullable=True),
+        sa.Column("return_r", sa.Numeric(), nullable=True),
+        sa.Column("mfe_pct", sa.Numeric(), nullable=True),
+        sa.Column("mae_pct", sa.Numeric(), nullable=True),
+        sa.Column("bars_held", sa.Integer(), nullable=True),
+        sa.Column("regime_trend", sa.String(length=20), nullable=True),
+        sa.Column("regime_vol", sa.String(length=20), nullable=True),
+        sa.Column("fill_source", sa.String(length=20), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["replay_run_id"], ["replay_runs.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["scanner_event_id"], ["scanner_events.id"], ondelete="SET NULL"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_replay_trades_id"), "replay_trades", ["id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_replay_trades_replay_run_id"),
+        "replay_trades",
+        ["replay_run_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_replay_trades_ticker"), "replay_trades", ["ticker"], unique=False
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_replay_trades_ticker"), table_name="replay_trades")
+    op.drop_index(
+        op.f("ix_replay_trades_replay_run_id"), table_name="replay_trades"
+    )
+    op.drop_index(op.f("ix_replay_trades_id"), table_name="replay_trades")
+    op.drop_table("replay_trades")
+    op.drop_index(op.f("ix_replay_runs_celery_task_id"), table_name="replay_runs")
+    op.drop_index(op.f("ix_replay_runs_uuid"), table_name="replay_runs")
+    op.drop_index(op.f("ix_replay_runs_id"), table_name="replay_runs")
+    op.drop_table("replay_runs")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -38,6 +38,7 @@ from app.routers import (
     live_data_router,
     news_router,
     outcomes_router,
+    replay_router,
     scanner_router,
     stocks_router,
     system_router,
@@ -443,6 +444,7 @@ def create_app() -> FastAPI:
     app.include_router(watchlist_router)
     app.include_router(auto_trading_router)
     app.include_router(outcomes_router)
+    app.include_router(replay_router)
     app.include_router(tweets_router)
     app.include_router(backtest_router)
     app.include_router(data_quality_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -18,6 +18,8 @@ from app.models.news_article import NewsArticle
 from app.models.news_preference import NewsPreference
 from app.models.push_subscription import PushSubscription
 from app.models.regime_model import RegimeModel
+from app.models.replay_run import ReplayRun
+from app.models.replay_trade import ReplayTrade
 from app.models.scanner_config import ScannerConfig
 from app.models.scanner_event import ScannerEvent
 from app.models.scanner_outcome_snapshot import ScannerOutcomeSnapshot
@@ -80,4 +82,6 @@ __all__ = [
     "TweetSignal",
     "User",
     "RegimeModel",
+    "ReplayRun",
+    "ReplayTrade",
 ]

--- a/backend/app/models/replay_run.py
+++ b/backend/app/models/replay_run.py
@@ -1,0 +1,57 @@
+"""ReplayRun model for reproducible signal replay executions."""
+
+import uuid
+
+from sqlalchemy import Column, Date, DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy import Uuid as UUID
+from sqlalchemy.dialects.postgresql import JSONB
+
+from app.core.database import Base
+from app.utils.time import utc_now
+
+
+class ReplayRun(Base):
+    """Anchor table for one canonical signal replay run."""
+
+    __tablename__ = "replay_runs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    uuid = Column(UUID(as_uuid=True), default=uuid.uuid4, unique=True, index=True)
+
+    status = Column(String(20), nullable=False, default="queued")
+    celery_task_id = Column(String(64), nullable=True, index=True)
+
+    scanner_type = Column(String(50), nullable=False)
+    scanner_config_snapshot = Column(JSONB, nullable=False)
+    trading_strategy_id = Column(
+        Integer, ForeignKey("trading_strategies.id"), nullable=True
+    )
+    strategy_snapshot = Column(JSONB, nullable=True)
+    universe_id = Column(Integer, ForeignKey("stock_universes.id"), nullable=False)
+    universe_snapshot = Column(JSONB, nullable=False)
+
+    start_date = Column(Date, nullable=False)
+    end_date = Column(Date, nullable=False)
+    max_hold_days = Column(Integer, nullable=False, default=10)
+    exit_fidelity = Column(String(20), nullable=False, default="intraday")
+    benchmark_symbol = Column(String(10), nullable=True, default="SPY")
+
+    data_hash = Column(String(64), nullable=True)
+    metrics = Column(JSONB, nullable=True)
+    skipped_count = Column(Integer, nullable=True, default=0)
+    error_message = Column(Text, nullable=True)
+    signal_source = Column(String(20), nullable=True)
+
+    total_trades = Column(Integer, nullable=True)
+    hit_rate = Column(Float, nullable=True)
+    expectancy_r = Column(Float, nullable=True)
+    profit_factor = Column(Float, nullable=True)
+    max_drawdown_r = Column(Float, nullable=True)
+    avg_bars_held = Column(Float, nullable=True)
+    median_bars_held = Column(Float, nullable=True)
+    avg_mfe_pct = Column(Float, nullable=True)
+    avg_mae_pct = Column(Float, nullable=True)
+    mfe_mae_ratio = Column(Float, nullable=True)
+
+    created_at = Column(DateTime, default=utc_now)
+    completed_at = Column(DateTime, nullable=True)

--- a/backend/app/models/replay_trade.py
+++ b/backend/app/models/replay_trade.py
@@ -1,0 +1,48 @@
+"""ReplayTrade model for one simulated trade in a replay run."""
+
+from sqlalchemy import Column, Date, DateTime, ForeignKey, Integer, Numeric, String
+
+from app.core.database import Base
+from app.utils.time import utc_now
+
+
+class ReplayTrade(Base):
+    """Per-signal ledger row produced by the replay engine."""
+
+    __tablename__ = "replay_trades"
+
+    id = Column(Integer, primary_key=True, index=True)
+    replay_run_id = Column(
+        Integer,
+        ForeignKey("replay_runs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    scanner_event_id = Column(
+        Integer,
+        ForeignKey("scanner_events.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    ticker = Column(String(10), nullable=False, index=True)
+    signal_date = Column(Date, nullable=False)
+    entry_date = Column(Date, nullable=True)
+    entry_price = Column(Numeric, nullable=True)
+    direction = Column(String(10), nullable=True)
+    stop_price = Column(Numeric, nullable=True)
+    target_price = Column(Numeric, nullable=True)
+
+    exit_date = Column(Date, nullable=True)
+    exit_price = Column(Numeric, nullable=True)
+    exit_reason = Column(String(30), nullable=True)
+    return_pct = Column(Numeric, nullable=True)
+    return_r = Column(Numeric, nullable=True)
+    mfe_pct = Column(Numeric, nullable=True)
+    mae_pct = Column(Numeric, nullable=True)
+    bars_held = Column(Integer, nullable=True)
+
+    regime_trend = Column(String(20), nullable=True)
+    regime_vol = Column(String(20), nullable=True)
+    fill_source = Column(String(20), nullable=True)
+
+    created_at = Column(DateTime, default=utc_now)

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -13,6 +13,7 @@ from app.routers.journal import router as journal_router
 from app.routers.live_data import router as live_data_router
 from app.routers.news import router as news_router
 from app.routers.outcomes import router as outcomes_router
+from app.routers.replay import router as replay_router
 from app.routers.scanner import router as scanner_router
 from app.routers.stocks import router as stocks_router
 from app.routers.system import router as system_router
@@ -34,6 +35,7 @@ __all__ = [
     "watchlist_router",
     "auto_trading_router",
     "outcomes_router",
+    "replay_router",
     "auth_router",
     "data_quality_router",
 ]

--- a/backend/app/routers/replay.py
+++ b/backend/app/routers/replay.py
@@ -1,0 +1,260 @@
+"""Replay API router."""
+
+from __future__ import annotations
+
+import itertools
+import uuid as _uuid
+from decimal import Decimal
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from app.core.database import get_db
+from app.models.scanner_config import ScannerConfig
+from app.models.replay_run import ReplayRun
+from app.models.replay_trade import ReplayTrade
+from app.models.stock_universe import StockUniverse
+from app.models.stock_universe_ticker import StockUniverseTicker
+from app.models.trading_strategy import TradingStrategy
+from app.schemas.replay import (
+    ReplayAnalyticsResponse,
+    ReplayCompareResponse,
+    ReplayRunRequest,
+    ReplayRunResponse,
+    ReplayTradesResponse,
+    RunCompareEntry,
+    RunPairComparison,
+)
+from app.tasks.replay import run_signal_replay
+from app.utils.time import utc_now
+
+router = APIRouter(prefix="/api/v1/replay", tags=["replay"])
+
+
+def _decimal_str(value) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return str(value)
+    return str(value)
+
+
+def _strategy_snapshot(strategy: TradingStrategy | None) -> dict | None:
+    if strategy is None:
+        return None
+    return {
+        "direction": strategy.direction,
+        "entry_type": strategy.entry_type,
+        "limit_offset_pct": _decimal_str(strategy.limit_offset_pct),
+        "stop_pct": _decimal_str(strategy.stop_pct),
+        "risk_reward_ratio": _decimal_str(strategy.risk_reward_ratio),
+        "max_slippage_pct": _decimal_str(strategy.max_slippage_pct),
+        "allowed_sessions": strategy.allowed_sessions,
+        "risk_per_trade_pct": _decimal_str(strategy.risk_per_trade_pct),
+        "max_position_usd": _decimal_str(strategy.max_position_usd),
+        "max_trades_per_day": strategy.max_trades_per_day,
+        "max_concurrent_positions": strategy.max_concurrent_positions,
+    }
+
+
+def _parse_uuid(value: str) -> _uuid.UUID:
+    try:
+        return _uuid.UUID(value)
+    except ValueError:
+        raise HTTPException(status_code=422, detail="Invalid UUID format")
+
+
+def _run_by_uuid(db: Session, run_uuid: str) -> ReplayRun:
+    parsed = _parse_uuid(run_uuid)
+    run = db.query(ReplayRun).filter(ReplayRun.uuid == parsed).first()
+    if run is None:
+        raise HTTPException(status_code=404, detail="Replay run not found")
+    return run
+
+
+@router.post("/runs", response_model=ReplayRunResponse, status_code=202)
+def create_replay_run(payload: ReplayRunRequest, db: Session = Depends(get_db)):
+    strategy = None
+    if payload.trading_strategy_id is not None:
+        strategy = (
+            db.query(TradingStrategy)
+            .filter(TradingStrategy.id == payload.trading_strategy_id)
+            .first()
+        )
+        if strategy is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"TradingStrategy id={payload.trading_strategy_id} not found",
+            )
+    universe = (
+        db.query(StockUniverse).filter(StockUniverse.id == payload.universe_id).first()
+    )
+    if universe is None:
+        raise HTTPException(
+            status_code=404, detail=f"StockUniverse id={payload.universe_id} not found"
+        )
+    scanner_config = (
+        db.query(ScannerConfig)
+        .filter(
+            ScannerConfig.scanner_type == payload.scanner_type,
+            ScannerConfig.universe_id == payload.universe_id,
+        )
+        .order_by(ScannerConfig.is_active.desc(), ScannerConfig.id.asc())
+        .first()
+    )
+    if scanner_config is None:
+        scanner_config_snapshot = {"scanner_type": payload.scanner_type}
+    else:
+        scanner_config_snapshot = {
+            "scanner_type": scanner_config.scanner_type,
+            "parameters": scanner_config.parameters or {},
+            "criteria": scanner_config.criteria or [],
+            "outcome_config": scanner_config.outcome_config,
+            "data_requirements": scanner_config.data_requirements,
+        }
+    tickers = sorted(
+        row[0]
+        for row in db.query(StockUniverseTicker.ticker)
+        .filter(StockUniverseTicker.universe_id == payload.universe_id)
+        .all()
+    )
+
+    run = ReplayRun(
+        uuid=_uuid.uuid4(),
+        status="queued",
+        scanner_type=payload.scanner_type,
+        scanner_config_snapshot=scanner_config_snapshot,
+        trading_strategy_id=payload.trading_strategy_id,
+        strategy_snapshot=_strategy_snapshot(strategy),
+        universe_id=payload.universe_id,
+        universe_snapshot={"universe_id": payload.universe_id, "tickers": tickers},
+        start_date=payload.start_date,
+        end_date=payload.end_date,
+        max_hold_days=payload.max_hold_days,
+        exit_fidelity=payload.exit_fidelity,
+        benchmark_symbol=payload.benchmark_symbol or "SPY",
+        created_at=utc_now(),
+    )
+    db.add(run)
+    db.commit()
+    db.refresh(run)
+
+    async_result = run_signal_replay.delay(run.id)
+    run.celery_task_id = async_result.id
+    db.commit()
+    db.refresh(run)
+    return run
+
+
+@router.get("/runs", response_model=List[ReplayRunResponse])
+def list_replay_runs(
+    scanner_type: Optional[str] = Query(default=None),
+    trading_strategy_id: Optional[int] = Query(default=None),
+    status: Optional[str] = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    db: Session = Depends(get_db),
+):
+    query = db.query(ReplayRun)
+    if scanner_type:
+        query = query.filter(ReplayRun.scanner_type == scanner_type)
+    if trading_strategy_id is not None:
+        query = query.filter(ReplayRun.trading_strategy_id == trading_strategy_id)
+    if status:
+        query = query.filter(ReplayRun.status == status)
+    return query.order_by(ReplayRun.created_at.desc()).offset(offset).limit(limit).all()
+
+
+@router.get("/runs/compare", response_model=ReplayCompareResponse)
+def compare_replay_runs(ids: str = Query(...), db: Session = Depends(get_db)):
+    raw_ids = [item.strip() for item in ids.split(",") if item.strip()]
+    if len(raw_ids) < 2 or len(raw_ids) > 5:
+        raise HTTPException(status_code=422, detail="compare requires 2 to 5 run IDs")
+    parsed_ids = [_parse_uuid(item) for item in raw_ids]
+    runs = db.query(ReplayRun).filter(ReplayRun.uuid.in_(parsed_ids)).all()
+    by_uuid = {run.uuid: run for run in runs}
+    missing = [str(run_uuid) for run_uuid in parsed_ids if run_uuid not in by_uuid]
+    if missing:
+        raise HTTPException(status_code=404, detail=f"Replay run not found: {missing[0]}")
+    ordered = [by_uuid[run_uuid] for run_uuid in parsed_ids]
+    comparisons = [
+        RunPairComparison(
+            a=a.uuid,
+            b=b.uuid,
+            data_hash_match=bool(a.data_hash and a.data_hash == b.data_hash),
+        )
+        for a, b in itertools.combinations(ordered, 2)
+    ]
+    return ReplayCompareResponse(
+        runs=[
+            RunCompareEntry(
+                uuid=run.uuid,
+                scanner_type=run.scanner_type,
+                start_date=run.start_date,
+                end_date=run.end_date,
+                status=run.status,
+                headline_metrics={
+                    "hit_rate": run.hit_rate,
+                    "expectancy_r": run.expectancy_r,
+                    "profit_factor": run.profit_factor,
+                    "max_drawdown_r": run.max_drawdown_r,
+                    "avg_bars_held": run.avg_bars_held,
+                    "total_trades": run.total_trades,
+                    "skipped_count": run.skipped_count,
+                },
+                data_hash=run.data_hash,
+            )
+            for run in ordered
+        ],
+        comparisons=comparisons,
+        all_hashes_match=all(item.data_hash_match for item in comparisons),
+    )
+
+
+@router.get("/runs/{run_uuid}", response_model=ReplayRunResponse)
+def get_replay_run(run_uuid: str, db: Session = Depends(get_db)):
+    return _run_by_uuid(db, run_uuid)
+
+
+@router.get("/runs/{run_uuid}/trades", response_model=ReplayTradesResponse)
+def get_replay_trades(
+    run_uuid: str,
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    sort: str = Query(default="signal_date"),
+    direction: str = Query(default="asc"),
+    db: Session = Depends(get_db),
+):
+    run = _run_by_uuid(db, run_uuid)
+    sort_columns = {
+        "signal_date": ReplayTrade.signal_date,
+        "return_r": ReplayTrade.return_r,
+        "ticker": ReplayTrade.ticker,
+        "return_pct": ReplayTrade.return_pct,
+    }
+    column = sort_columns.get(sort, ReplayTrade.signal_date)
+    query = db.query(ReplayTrade).filter(ReplayTrade.replay_run_id == run.id)
+    total = query.count()
+    order_by = column.desc() if direction == "desc" else column.asc()
+    trades = query.order_by(order_by).offset(offset).limit(limit).all()
+    return ReplayTradesResponse(trades=trades, total=total, limit=limit, offset=offset)
+
+
+@router.get("/runs/{run_uuid}/analytics", response_model=ReplayAnalyticsResponse)
+def get_replay_analytics(run_uuid: str, db: Session = Depends(get_db)):
+    run = _run_by_uuid(db, run_uuid)
+    if run.status != "completed":
+        return ReplayAnalyticsResponse(status=run.status)
+    metrics = run.metrics or {}
+    if not metrics:
+        from app.services.replay.metrics import MetricsComputer
+
+        metrics = MetricsComputer(db).compute(run.id).as_metrics_json()
+    return ReplayAnalyticsResponse(
+        status=run.status,
+        equity_curve=metrics.get("equity_curve", []),
+        calendar_decay=metrics.get("calendar_decay", []),
+        holding_period_decay=metrics.get("holding_period_decay", []),
+        regime_breakdown=metrics.get("regime_breakdown", []),
+    )

--- a/backend/app/routers/replay.py
+++ b/backend/app/routers/replay.py
@@ -11,9 +11,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
-from app.models.scanner_config import ScannerConfig
 from app.models.replay_run import ReplayRun
 from app.models.replay_trade import ReplayTrade
+from app.models.scanner_config import ScannerConfig
 from app.models.stock_universe import StockUniverse
 from app.models.stock_universe_ticker import StockUniverseTicker
 from app.models.trading_strategy import TradingStrategy

--- a/backend/app/schemas/replay.py
+++ b/backend/app/schemas/replay.py
@@ -1,0 +1,119 @@
+"""Pydantic schemas for the replay API."""
+
+from datetime import date, datetime
+from typing import Any, Dict, List, Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.common import BatchDateRange, Ticker
+
+
+class ReplayRunRequest(BatchDateRange):
+    model_config = ConfigDict(extra="forbid")
+
+    scanner_type: str
+    trading_strategy_id: Optional[int] = None
+    universe_id: int
+    max_hold_days: int = Field(default=10, ge=1, le=252)
+    exit_fidelity: Literal["intraday", "daily"] = "intraday"
+    benchmark_symbol: Optional[Ticker] = "SPY"
+
+
+class ReplayTradeResponse(BaseModel):
+    id: int
+    replay_run_id: int
+    scanner_event_id: Optional[int] = None
+    ticker: str
+    signal_date: date
+    entry_date: Optional[date] = None
+    entry_price: Optional[float] = None
+    direction: Optional[str] = None
+    stop_price: Optional[float] = None
+    target_price: Optional[float] = None
+    exit_date: Optional[date] = None
+    exit_price: Optional[float] = None
+    exit_reason: Optional[str] = None
+    return_pct: Optional[float] = None
+    return_r: Optional[float] = None
+    mfe_pct: Optional[float] = None
+    mae_pct: Optional[float] = None
+    bars_held: Optional[int] = None
+    regime_trend: Optional[str] = None
+    regime_vol: Optional[str] = None
+    fill_source: Optional[str] = None
+
+    model_config = {"from_attributes": True}
+
+
+class ReplayTradesResponse(BaseModel):
+    trades: List[ReplayTradeResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class ReplayRunResponse(BaseModel):
+    id: int
+    uuid: UUID
+    status: str
+    scanner_type: str
+    scanner_config_snapshot: Dict[str, Any]
+    trading_strategy_id: Optional[int] = None
+    strategy_snapshot: Optional[Dict[str, Any]] = None
+    universe_id: int
+    universe_snapshot: Dict[str, Any]
+    start_date: date
+    end_date: date
+    max_hold_days: int
+    exit_fidelity: str
+    benchmark_symbol: Optional[str] = None
+    data_hash: Optional[str] = None
+    metrics: Optional[Dict[str, Any]] = None
+    skipped_count: Optional[int] = None
+    error_message: Optional[str] = None
+    celery_task_id: Optional[str] = None
+    total_trades: Optional[int] = None
+    hit_rate: Optional[float] = None
+    expectancy_r: Optional[float] = None
+    profit_factor: Optional[float] = None
+    max_drawdown_r: Optional[float] = None
+    avg_bars_held: Optional[float] = None
+    median_bars_held: Optional[float] = None
+    avg_mfe_pct: Optional[float] = None
+    avg_mae_pct: Optional[float] = None
+    mfe_mae_ratio: Optional[float] = None
+    created_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+
+    model_config = {"from_attributes": True}
+
+
+class ReplayAnalyticsResponse(BaseModel):
+    status: str
+    equity_curve: List[Dict[str, Any]] = []
+    calendar_decay: List[Dict[str, Any]] = []
+    holding_period_decay: List[Dict[str, Any]] = []
+    regime_breakdown: List[Dict[str, Any]] = []
+
+
+class RunCompareEntry(BaseModel):
+    uuid: UUID
+    scanner_type: str
+    start_date: date
+    end_date: date
+    status: str
+    headline_metrics: Dict[str, Any]
+    data_hash: Optional[str]
+
+
+class RunPairComparison(BaseModel):
+    a: UUID
+    b: UUID
+    data_hash_match: bool
+
+
+class ReplayCompareResponse(BaseModel):
+    runs: List[RunCompareEntry]
+    comparisons: List[RunPairComparison]
+    all_hashes_match: bool

--- a/backend/app/services/replay/__init__.py
+++ b/backend/app/services/replay/__init__.py
@@ -1,0 +1,37 @@
+"""Replay engine services."""
+
+from app.services.replay.benchmark import BenchmarkIngestionError, BenchmarkIngestor
+from app.services.replay.classifier import (
+    RegimeClassifier,
+    ReplayRegime,
+    get_benchmark_regime,
+)
+from app.services.replay.manifest import (
+    ManifestResolver,
+    ResolvedManifest,
+    compute_data_hash,
+)
+from app.services.replay.metrics import MetricsComputer, MetricsResult
+from app.services.replay.protocols import (
+    ExitSimulator,
+    SignalRecord,
+    SimulatedTrade,
+    StrategyParams,
+)
+
+__all__ = [
+    "ExitSimulator",
+    "BenchmarkIngestionError",
+    "BenchmarkIngestor",
+    "ManifestResolver",
+    "MetricsComputer",
+    "MetricsResult",
+    "RegimeClassifier",
+    "ResolvedManifest",
+    "ReplayRegime",
+    "SignalRecord",
+    "SimulatedTrade",
+    "StrategyParams",
+    "compute_data_hash",
+    "get_benchmark_regime",
+]

--- a/backend/app/services/replay/benchmark.py
+++ b/backend/app/services/replay/benchmark.py
@@ -1,0 +1,101 @@
+"""Benchmark daily-bar ingestion for replay regime classification."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.exceptions import ProviderError
+from app.models.stock_aggregate import StockAggregate
+
+
+class BenchmarkIngestionError(Exception):
+    def __init__(self, symbol: str, start: date, end: date, cause: Exception):
+        super().__init__(f"Benchmark ingestion failed for {symbol} [{start}, {end}]: {cause}")
+        self.symbol = symbol
+        self.start = start
+        self.end = end
+        self.cause = cause
+
+
+def _weekdays(start: date, end: date) -> set[datetime]:
+    days: set[datetime] = set()
+    cursor = start
+    while cursor <= end:
+        if cursor.weekday() < 5:
+            days.add(datetime(cursor.year, cursor.month, cursor.day))
+        cursor += timedelta(days=1)
+    return days
+
+
+class BenchmarkIngestor:
+    """Gap-fill benchmark daily bars into `stock_aggregates`."""
+
+    def __init__(self, provider):
+        self._provider = provider
+
+    def ingest(self, symbol: str, start_date: date, end_date: date, db: Session) -> int:
+        start_dt = datetime(start_date.year, start_date.month, start_date.day)
+        end_dt = datetime(end_date.year, end_date.month, end_date.day, 23, 59, 59)
+        existing = {
+            row[0].replace(tzinfo=None)
+            for row in db.query(StockAggregate.timestamp)
+            .filter(
+                StockAggregate.ticker == symbol,
+                StockAggregate.timespan == "day",
+                StockAggregate.multiplier == 1,
+                StockAggregate.timestamp >= start_dt,
+                StockAggregate.timestamp <= end_dt,
+            )
+            .all()
+        }
+        missing = _weekdays(start_date, end_date) - existing
+        if not missing:
+            return 0
+
+        from_date = min(missing).date()
+        to_date = max(missing).date()
+        try:
+            bars = self._provider.get_bars(
+                symbol=symbol,
+                timespan="day",
+                multiplier=1,
+                from_date=str(from_date),
+                to_date=str(to_date),
+            )
+        except ProviderError as exc:
+            raise BenchmarkIngestionError(symbol, start_date, end_date, exc) from exc
+        except Exception as exc:
+            raise BenchmarkIngestionError(symbol, start_date, end_date, exc) from exc
+
+        new_rows = []
+        for bar in bars:
+            ts = bar["timestamp"].replace(tzinfo=None)
+            ts_day = datetime(ts.year, ts.month, ts.day)
+            if ts_day in existing:
+                continue
+            new_rows.append(
+                StockAggregate(
+                    ticker=symbol,
+                    timestamp=ts_day,
+                    multiplier=1,
+                    timespan="day",
+                    open=bar["open"],
+                    high=bar["high"],
+                    low=bar["low"],
+                    close=bar["close"],
+                    volume=bar["volume"],
+                    vwap=bar.get("vwap"),
+                    transactions=bar.get("transactions"),
+                    is_pre_market=False,
+                    is_after_market=False,
+                    provider="polygon",
+                )
+            )
+
+        if not new_rows:
+            return 0
+        db.bulk_save_objects(new_rows)
+        db.commit()
+        return len(new_rows)

--- a/backend/app/services/replay/classifier.py
+++ b/backend/app/services/replay/classifier.py
@@ -1,0 +1,100 @@
+"""Deterministic rule-based benchmark regime classifier."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import date, datetime
+
+from sqlalchemy.orm import Session
+
+from app.models.stock_aggregate import StockAggregate
+
+
+@dataclass(frozen=True)
+class ReplayRegime:
+    trend: str
+    vol: str
+
+
+class RegimeClassifier:
+    DEFAULT_VOL_THRESHOLDS = {"calm_below": 0.10, "turbulent_above": 0.20}
+
+    def __init__(self, symbol: str, vol_thresholds: dict[str, float] | None = None):
+        self.symbol = symbol
+        self.thresholds = self._validate_thresholds(
+            vol_thresholds or self.DEFAULT_VOL_THRESHOLDS
+        )
+        self.regime_map: dict[date, ReplayRegime] = {}
+
+    @staticmethod
+    def _validate_thresholds(thresholds: dict[str, float]) -> dict[str, float]:
+        required = {"calm_below", "turbulent_above"}
+        if set(thresholds.keys()) != required:
+            raise ValueError("vol_thresholds must contain calm_below and turbulent_above")
+        if thresholds["calm_below"] <= 0 or thresholds["turbulent_above"] <= 0:
+            raise ValueError("vol thresholds must be positive")
+        if thresholds["calm_below"] >= thresholds["turbulent_above"]:
+            raise ValueError("calm_below must be less than turbulent_above")
+        return dict(thresholds)
+
+    def classify(self, start_date: date, end_date: date, db: Session) -> None:
+        rows = (
+            db.query(StockAggregate.timestamp, StockAggregate.close)
+            .filter(
+                StockAggregate.ticker == self.symbol,
+                StockAggregate.timespan == "day",
+                StockAggregate.multiplier == 1,
+            )
+            .order_by(StockAggregate.timestamp.asc())
+            .all()
+        )
+        dates: list[date] = []
+        closes: list[float] = []
+        for row in rows:
+            ts = row.timestamp
+            dates.append(ts.date() if isinstance(ts, datetime) else ts)
+            closes.append(float(row.close))
+
+        self.regime_map = {}
+        log_returns: list[float | None] = [None]
+        for previous, current in zip(closes, closes[1:]):
+            log_returns.append(math.log(current / previous))
+
+        for index, current_date in enumerate(dates):
+            if not (start_date <= current_date <= end_date):
+                continue
+            trend = "unknown"
+            if index >= 199:
+                sma200 = sum(closes[index - 199 : index + 1]) / 200
+                trend = "bull" if closes[index] > sma200 else "bear"
+
+            vol = "normal"
+            if index >= 20:
+                window = [value for value in log_returns[index - 19 : index + 1] if value is not None]
+                if len(window) == 20:
+                    mean = sum(window) / len(window)
+                    variance = sum((value - mean) ** 2 for value in window) / (len(window) - 1)
+                    annualized = math.sqrt(variance) * math.sqrt(252)
+                    if annualized < self.thresholds["calm_below"]:
+                        vol = "calm"
+                    elif annualized > self.thresholds["turbulent_above"]:
+                        vol = "turbulent"
+
+            self.regime_map[current_date] = ReplayRegime(trend=trend, vol=vol)
+
+
+UNKNOWN_REGIME = ReplayRegime("unknown", "normal")
+
+
+def get_benchmark_regime(classifier: RegimeClassifier, lookup_date: date) -> ReplayRegime:
+    regime_map = classifier.regime_map
+    if not regime_map:
+        return UNKNOWN_REGIME
+    sorted_dates = sorted(regime_map)
+    if lookup_date < sorted_dates[0]:
+        return UNKNOWN_REGIME
+    for current in reversed(sorted_dates):
+        if current <= lookup_date:
+            return regime_map[current]
+    return UNKNOWN_REGIME

--- a/backend/app/services/replay/exit_simulator.py
+++ b/backend/app/services/replay/exit_simulator.py
@@ -1,0 +1,316 @@
+"""Pure intraday exit simulator for replay trades."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+
+from app.services.replay.protocols import SignalRecord, SimulatedTrade, StrategyParams
+
+EXIT_STOP = "stop"
+EXIT_TARGET = "target"
+EXIT_TIME = "time_exit"
+EXIT_NO_FILL = "eod-no-fill"
+EXIT_DATA_END = "delisted_or_data_end"
+
+
+def _as_decimal(value) -> Decimal:
+    return value if isinstance(value, Decimal) else Decimal(str(value))
+
+
+def _bar_date(bar) -> date:
+    ts = bar.timestamp
+    if isinstance(ts, datetime):
+        return ts.date()
+    return date(ts.year, ts.month, ts.day)
+
+
+def _is_regular_minute(bar) -> bool:
+    ts = bar.timestamp
+    is_after_open = not isinstance(ts, datetime) or ts.time() >= time(9, 30)
+    return (
+        getattr(bar, "timespan", None) == "minute"
+        and not getattr(bar, "is_pre_market", False)
+        and not getattr(bar, "is_after_market", False)
+        and is_after_open
+    )
+
+
+class IntradayExitSimulator:
+    """Resolve entries/exits by walking caller-supplied minute/daily bars."""
+
+    def simulate(
+        self,
+        signal: SignalRecord,
+        strategy: StrategyParams,
+        bars: list,
+        max_hold_days: int,
+    ) -> SimulatedTrade:
+        trade = SimulatedTrade(
+            ticker=signal.ticker,
+            signal_date=signal.signal_date,
+            source_event_id=signal.source_event_id,
+        )
+        is_short = strategy.direction == "short_only"
+
+        entry_day_bars = sorted(
+            [
+                bar
+                for bar in bars
+                if _bar_date(bar) == signal.signal_date and _is_regular_minute(bar)
+            ],
+            key=lambda bar: bar.timestamp,
+        )
+        if not entry_day_bars:
+            trade.exit_reason = EXIT_NO_FILL
+            return trade
+
+        entry_price = self._resolve_entry_price(
+            entry_day_bars=entry_day_bars,
+            signal=signal,
+            strategy=strategy,
+            is_short=is_short,
+        )
+        if entry_price is None:
+            trade.exit_reason = EXIT_NO_FILL
+            return trade
+
+        stop_price, target_price = self._levels(entry_price, strategy, is_short)
+        trade.entry_date = signal.signal_date
+        trade.entry_price = entry_price
+        trade.stop_price = stop_price
+        trade.target_price = target_price
+
+        hold_bars_by_date = self._hold_bars_by_date(bars, signal.signal_date)
+        return self._walk_exits(
+            trade=trade,
+            bars_by_date=hold_bars_by_date,
+            entry_date=signal.signal_date,
+            entry_price=entry_price,
+            stop_price=stop_price,
+            target_price=target_price,
+            max_hold_days=max_hold_days,
+            is_short=is_short,
+        )
+
+    def _resolve_entry_price(
+        self,
+        entry_day_bars: list,
+        signal: SignalRecord,
+        strategy: StrategyParams,
+        is_short: bool,
+    ) -> Decimal | None:
+        if strategy.entry_type != "limit":
+            return _as_decimal(entry_day_bars[0].open)
+
+        previous_close = signal.indicators.get("previous_close")
+        if previous_close is None:
+            return None
+        limit_price = _as_decimal(previous_close) * (
+            Decimal("1") + _as_decimal(strategy.limit_offset_pct) / Decimal("100")
+        )
+        for bar in entry_day_bars:
+            open_price = _as_decimal(bar.open)
+            if not is_short and _as_decimal(bar.low) <= limit_price:
+                return min(open_price, limit_price)
+            if is_short and _as_decimal(bar.high) >= limit_price:
+                return max(open_price, limit_price)
+        return None
+
+    def _levels(
+        self, entry_price: Decimal, strategy: StrategyParams, is_short: bool
+    ) -> tuple[Decimal, Decimal]:
+        stop_distance = entry_price * _as_decimal(strategy.stop_pct) / Decimal("100")
+        if is_short:
+            stop_price = entry_price + stop_distance
+            target_price = entry_price - (
+                abs(entry_price - stop_price) * _as_decimal(strategy.risk_reward_ratio)
+            )
+        else:
+            stop_price = entry_price - stop_distance
+            target_price = entry_price + (
+                abs(entry_price - stop_price) * _as_decimal(strategy.risk_reward_ratio)
+            )
+        return stop_price, target_price
+
+    def _hold_bars_by_date(self, bars: list, entry_date: date) -> dict[date, list]:
+        grouped: dict[date, list] = defaultdict(list)
+        for bar in bars:
+            day = _bar_date(bar)
+            if day <= entry_date:
+                continue
+            grouped[day].append(bar)
+        return {
+            day: sorted(day_bars, key=lambda bar: bar.timestamp)
+            for day, day_bars in sorted(grouped.items())
+        }
+
+    def _walk_exits(
+        self,
+        trade: SimulatedTrade,
+        bars_by_date: dict[date, list],
+        entry_date: date,
+        entry_price: Decimal,
+        stop_price: Decimal,
+        target_price: Decimal,
+        max_hold_days: int,
+        is_short: bool,
+    ) -> SimulatedTrade:
+        cutoff_date = entry_date + timedelta(days=max_hold_days)
+        mfe_pct = 0.0
+        mae_pct = 0.0
+        bars_walked = 0
+        used_daily_fallback = False
+        last_bar = None
+
+        for day, day_bars in bars_by_date.items():
+            minute_bars = [bar for bar in day_bars if _is_regular_minute(bar)]
+            daily_bars = [
+                bar
+                for bar in day_bars
+                if getattr(bar, "timespan", None) == "day"
+                and getattr(bar, "multiplier", 1) == 1
+            ]
+            if minute_bars:
+                bars_to_walk = minute_bars
+            elif daily_bars:
+                bars_to_walk = [daily_bars[0]]
+                used_daily_fallback = True
+            else:
+                continue
+
+            for bar in bars_to_walk:
+                if day >= cutoff_date:
+                    return self._finish(
+                        trade=trade,
+                        exit_date=day,
+                        exit_price=_as_decimal(bar.open),
+                        exit_reason=EXIT_TIME,
+                        bars_held=bars_walked,
+                        mfe_pct=mfe_pct,
+                        mae_pct=mae_pct,
+                        used_daily_fallback=used_daily_fallback,
+                        is_short=is_short,
+                    )
+
+                bars_walked += 1
+                last_bar = bar
+                high = _as_decimal(bar.high)
+                low = _as_decimal(bar.low)
+
+                if is_short:
+                    mfe_pct = max(
+                        mfe_pct, float((entry_price - low) / entry_price * 100)
+                    )
+                    mae_pct = max(
+                        mae_pct, float((high - entry_price) / entry_price * 100)
+                    )
+                    if high >= stop_price:
+                        return self._finish(
+                            trade,
+                            day,
+                            stop_price,
+                            EXIT_STOP,
+                            bars_walked,
+                            mfe_pct,
+                            mae_pct,
+                            used_daily_fallback,
+                            is_short,
+                        )
+                    if low <= target_price:
+                        return self._finish(
+                            trade,
+                            day,
+                            target_price,
+                            EXIT_TARGET,
+                            bars_walked,
+                            mfe_pct,
+                            mae_pct,
+                            used_daily_fallback,
+                            is_short,
+                        )
+                else:
+                    mfe_pct = max(
+                        mfe_pct, float((high - entry_price) / entry_price * 100)
+                    )
+                    mae_pct = max(
+                        mae_pct, float((entry_price - low) / entry_price * 100)
+                    )
+                    if low <= stop_price:
+                        return self._finish(
+                            trade,
+                            day,
+                            stop_price,
+                            EXIT_STOP,
+                            bars_walked,
+                            mfe_pct,
+                            mae_pct,
+                            used_daily_fallback,
+                            is_short,
+                        )
+                    if high >= target_price:
+                        return self._finish(
+                            trade,
+                            day,
+                            target_price,
+                            EXIT_TARGET,
+                            bars_walked,
+                            mfe_pct,
+                            mae_pct,
+                            used_daily_fallback,
+                            is_short,
+                        )
+
+        if last_bar is None:
+            trade.exit_reason = EXIT_DATA_END
+            trade.bars_held = 0
+            trade.fill_source = "daily-fallback" if used_daily_fallback else "intraday"
+            return trade
+
+        return self._finish(
+            trade=trade,
+            exit_date=_bar_date(last_bar),
+            exit_price=_as_decimal(last_bar.close),
+            exit_reason=EXIT_DATA_END,
+            bars_held=bars_walked,
+            mfe_pct=mfe_pct,
+            mae_pct=mae_pct,
+            used_daily_fallback=used_daily_fallback,
+            is_short=is_short,
+        )
+
+    def _finish(
+        self,
+        trade: SimulatedTrade,
+        exit_date: date,
+        exit_price: Decimal,
+        exit_reason: str,
+        bars_held: int,
+        mfe_pct: float,
+        mae_pct: float,
+        used_daily_fallback: bool,
+        is_short: bool,
+    ) -> SimulatedTrade:
+        trade.exit_date = exit_date
+        trade.exit_price = exit_price
+        trade.exit_reason = exit_reason
+        trade.bars_held = bars_held
+        trade.mfe_pct = mfe_pct
+        trade.mae_pct = mae_pct
+        trade.fill_source = "daily-fallback" if used_daily_fallback else "intraday"
+
+        if trade.entry_price is None or trade.stop_price is None:
+            return trade
+        direction_sign = Decimal("-1") if is_short else Decimal("1")
+        stop_distance = abs(trade.entry_price - trade.stop_price)
+        if stop_distance == 0:
+            trade.result_r = 0.0
+        else:
+            trade.result_r = float(
+                direction_sign * (exit_price - trade.entry_price) / stop_distance
+            )
+        trade.return_pct = float(
+            direction_sign * (exit_price - trade.entry_price) / trade.entry_price * 100
+        )
+        return trade

--- a/backend/app/services/replay/manifest.py
+++ b/backend/app/services/replay/manifest.py
@@ -6,7 +6,7 @@ import copy
 import hashlib
 import json
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from decimal import Decimal
 from typing import Any
 

--- a/backend/app/services/replay/manifest.py
+++ b/backend/app/services/replay/manifest.py
@@ -1,0 +1,222 @@
+"""Manifest freezing and market-data hashing for replay runs."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.scanner_config import ScannerConfig
+from app.models.stock_aggregate import StockAggregate
+from app.models.stock_split import StockSplit
+from app.models.stock_universe import StockUniverse
+from app.models.stock_universe_ticker import StockUniverseTicker
+from app.models.trading_strategy import TradingStrategy
+from app.utils.time import utc_now
+
+
+@dataclass(frozen=True)
+class ResolvedManifest:
+    scanner_type: str
+    scanner_config_snapshot: dict[str, Any]
+    strategy_snapshot: dict[str, Any] | None
+    universe_snapshot: dict[str, Any]
+
+
+def _decimal_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return str(value)
+    return str(value)
+
+
+def _date_range(start_date: date, end_date: date):
+    cursor = start_date
+    while cursor <= end_date:
+        yield cursor
+        cursor += timedelta(days=1)
+
+
+def _snapshot_scanner_config(config: ScannerConfig) -> dict[str, Any]:
+    return copy.deepcopy(
+        {
+            "scanner_type": config.scanner_type,
+            "parameters": config.parameters or {},
+            "criteria": config.criteria or {},
+            "outcome_config": config.outcome_config,
+            "data_requirements": config.data_requirements,
+        }
+    )
+
+
+def _snapshot_strategy(strategy: TradingStrategy | None) -> dict[str, Any] | None:
+    if strategy is None:
+        return None
+    return copy.deepcopy(
+        {
+            "direction": strategy.direction,
+            "entry_type": strategy.entry_type,
+            "limit_offset_pct": _decimal_str(strategy.limit_offset_pct),
+            "stop_pct": _decimal_str(strategy.stop_pct),
+            "risk_reward_ratio": _decimal_str(strategy.risk_reward_ratio),
+            "max_slippage_pct": _decimal_str(strategy.max_slippage_pct),
+            "allowed_sessions": strategy.allowed_sessions,
+            "risk_per_trade_pct": _decimal_str(strategy.risk_per_trade_pct),
+            "max_position_usd": _decimal_str(strategy.max_position_usd),
+            "max_trades_per_day": strategy.max_trades_per_day,
+            "max_concurrent_positions": strategy.max_concurrent_positions,
+        }
+    )
+
+
+class ManifestResolver:
+    """Freezes replay inputs into immutable JSON-compatible snapshots."""
+
+    def __init__(self, db: Session) -> None:
+        self._db = db
+
+    def resolve(
+        self,
+        scanner_config_id: int,
+        universe_id: int,
+        start_date: date,
+        end_date: date,
+        strategy_id: int | None = None,
+    ) -> ResolvedManifest:
+        config = (
+            self._db.query(ScannerConfig)
+            .filter(ScannerConfig.id == scanner_config_id)
+            .first()
+        )
+        if config is None:
+            raise ValueError(f"ScannerConfig id={scanner_config_id} not found")
+
+        universe = (
+            self._db.query(StockUniverse).filter(StockUniverse.id == universe_id).first()
+        )
+        if universe is None:
+            raise ValueError(f"StockUniverse id={universe_id} not found")
+
+        strategy = None
+        if strategy_id is not None:
+            strategy = (
+                self._db.query(TradingStrategy)
+                .filter(TradingStrategy.id == strategy_id)
+                .first()
+            )
+            if strategy is None:
+                raise ValueError(f"TradingStrategy id={strategy_id} not found")
+
+        tickers = sorted(
+            row[0]
+            for row in self._db.query(StockUniverseTicker.ticker)
+            .filter(StockUniverseTicker.universe_id == universe_id)
+            .all()
+        )
+
+        return ResolvedManifest(
+            scanner_type=config.scanner_type,
+            scanner_config_snapshot=_snapshot_scanner_config(config),
+            strategy_snapshot=_snapshot_strategy(strategy),
+            universe_snapshot={
+                "tickers": tickers,
+                "universe_id": universe_id,
+                "frozen_at": utc_now().isoformat(),
+            },
+        )
+
+    def compute_data_hash(
+        self,
+        tickers: list[str],
+        start_date: date,
+        end_date: date,
+    ) -> str:
+        return compute_data_hash(self._db, tickers, start_date, end_date)
+
+
+def _cell_for(db: Session, ticker: str, trading_day: date) -> dict[str, Any]:
+    bar = (
+        db.query(StockAggregate)
+        .filter(
+            StockAggregate.ticker == ticker,
+            StockAggregate.timespan == "day",
+            StockAggregate.multiplier == 1,
+            func.date(StockAggregate.timestamp) == trading_day,
+        )
+        .order_by(StockAggregate.timestamp.asc())
+        .first()
+    )
+    minute_count = (
+        db.query(func.count(StockAggregate.id))
+        .filter(
+            StockAggregate.ticker == ticker,
+            StockAggregate.timespan == "minute",
+            func.date(StockAggregate.timestamp) == trading_day,
+        )
+        .scalar()
+        or 0
+    )
+    applied_splits = (
+        db.query(StockSplit)
+        .filter(
+            StockSplit.ticker == ticker,
+            StockSplit.execution_date > trading_day,
+            StockSplit.adjustments_applied_at.isnot(None),
+        )
+        .order_by(StockSplit.execution_date.asc())
+        .all()
+    )
+
+    base: dict[str, Any] = {
+        "ticker": ticker,
+        "date": str(trading_day),
+        "minute_bar_count": int(minute_count),
+        "applied_splits": [
+            {
+                "execution_date": str(split.execution_date),
+                "from": _decimal_str(split.split_from),
+                "to": _decimal_str(split.split_to),
+            }
+            for split in applied_splits
+        ],
+    }
+
+    if bar is None:
+        base["missing"] = True
+        return base
+
+    base.update(
+        {
+            "open": _decimal_str(bar.open),
+            "high": _decimal_str(bar.high),
+            "low": _decimal_str(bar.low),
+            "close": _decimal_str(bar.close),
+            "volume": int(bar.volume),
+        }
+    )
+    return base
+
+
+def compute_data_hash(
+    db: Session,
+    tickers: list[str],
+    start_date: date,
+    end_date: date,
+) -> str:
+    """Return a stable SHA-256 fingerprint over bars, minute counts, and splits."""
+
+    cells = [
+        _cell_for(db, ticker, trading_day)
+        for ticker in sorted(tickers)
+        for trading_day in _date_range(start_date, end_date)
+    ]
+    canonical = json.dumps(cells, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/backend/app/services/replay/metrics.py
+++ b/backend/app/services/replay/metrics.py
@@ -1,0 +1,210 @@
+"""Replay ledger metrics and analytics."""
+
+from __future__ import annotations
+
+import statistics
+from collections import defaultdict
+from dataclasses import dataclass
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
+
+from app.models.replay_trade import ReplayTrade
+
+
+@dataclass
+class MetricsResult:
+    total_trades: int
+    hit_rate: float | None
+    expectancy_r: float | None
+    profit_factor: float | None
+    max_drawdown_r: float | None
+    avg_bars_held: float | None
+    median_bars_held: float | None
+    avg_mfe_pct: float | None
+    avg_mae_pct: float | None
+    mfe_mae_ratio: float | None
+    equity_curve: list[dict]
+    calendar_decay: list[dict]
+    holding_period_decay: list[dict]
+    regime_breakdown: list[dict]
+
+    def as_metrics_json(self) -> dict:
+        return {
+            "headline": {
+                "total_trades": self.total_trades,
+                "hit_rate": self.hit_rate,
+                "expectancy_r": self.expectancy_r,
+                "profit_factor": self.profit_factor,
+                "max_drawdown_r": self.max_drawdown_r,
+                "avg_bars_held": self.avg_bars_held,
+                "median_bars_held": self.median_bars_held,
+                "avg_mfe_pct": self.avg_mfe_pct,
+                "avg_mae_pct": self.avg_mae_pct,
+                "mfe_mae_ratio": self.mfe_mae_ratio,
+            },
+            "equity_curve": self.equity_curve,
+            "calendar_decay": self.calendar_decay,
+            "holding_period_decay": self.holding_period_decay,
+            "regime_breakdown": self.regime_breakdown,
+        }
+
+
+def _f(value) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return float(value)
+    return float(value)
+
+
+def _quarter(day) -> str:
+    return f"{day.year}-Q{((day.month - 1) // 3) + 1}"
+
+
+def _bucket_stats(trades: list[ReplayTrade]) -> dict:
+    values = [_f(trade.return_r) for trade in trades if trade.return_r is not None]
+    if not values:
+        return {
+            "n": len(trades),
+            "trades": len(trades),
+            "hit_rate": None,
+            "expectancy_r": None,
+            "profit_factor": None,
+            "avg_mfe_pct": None,
+        }
+    wins = [value for value in values if value > 0]
+    losses = [value for value in values if value < 0]
+    gross_profit = sum(wins)
+    gross_loss = abs(sum(losses))
+    profit_factor = gross_profit / gross_loss if gross_loss > 0 else None
+    mfes = [_f(trade.mfe_pct) for trade in trades if trade.mfe_pct is not None]
+    return {
+        "n": len(values),
+        "trades": len(values),
+        "hit_rate": len(wins) / len(values),
+        "expectancy_r": sum(values) / len(values),
+        "profit_factor": profit_factor,
+        "avg_mfe_pct": statistics.mean(mfes) if mfes else None,
+    }
+
+
+class MetricsComputer:
+    def __init__(self, db: Session):
+        self._db = db
+
+    def compute(self, run_id: int) -> MetricsResult:
+        trades = (
+            self._db.query(ReplayTrade)
+            .filter(ReplayTrade.replay_run_id == run_id)
+            .order_by(ReplayTrade.signal_date.asc(), ReplayTrade.id.asc())
+            .all()
+        )
+        values = [_f(trade.return_r) for trade in trades if trade.return_r is not None]
+        if not values:
+            return MetricsResult(
+                total_trades=0,
+                hit_rate=None,
+                expectancy_r=None,
+                profit_factor=None,
+                max_drawdown_r=None,
+                avg_bars_held=None,
+                median_bars_held=None,
+                avg_mfe_pct=None,
+                avg_mae_pct=None,
+                mfe_mae_ratio=None,
+                equity_curve=[],
+                calendar_decay=[],
+                holding_period_decay=[],
+                regime_breakdown=[],
+            )
+
+        wins = [value for value in values if value > 0]
+        losses = [value for value in values if value < 0]
+        gross_profit = sum(wins)
+        gross_loss = abs(sum(losses))
+        profit_factor = gross_profit / gross_loss if gross_loss > 0 else None
+        cumulative = 0.0
+        peak = 0.0
+        max_drawdown = 0.0
+        equity_curve = []
+        for trade, value in zip(
+            [trade for trade in trades if trade.return_r is not None], values
+        ):
+            cumulative += value
+            peak = max(peak, cumulative)
+            max_drawdown = max(max_drawdown, peak - cumulative)
+            equity_curve.append(
+                {"date": trade.signal_date.isoformat(), "cumulative_r": cumulative}
+            )
+
+        bars = [trade.bars_held for trade in trades if trade.bars_held is not None]
+        mfes = [_f(trade.mfe_pct) for trade in trades if trade.mfe_pct is not None]
+        maes = [_f(trade.mae_pct) for trade in trades if trade.mae_pct is not None]
+        avg_mfe = statistics.mean(mfes) if mfes else None
+        avg_mae = statistics.mean(maes) if maes else None
+
+        by_quarter: dict[str, list[ReplayTrade]] = defaultdict(list)
+        by_regime: dict[tuple[str, str], list[ReplayTrade]] = defaultdict(list)
+        max_hold = max(bars) if bars else 0
+        for trade in trades:
+            by_quarter[_quarter(trade.signal_date)].append(trade)
+            by_regime[
+                (trade.regime_trend or "unknown", trade.regime_vol or "normal")
+            ].append(trade)
+
+        calendar_decay = [
+            {"period": period, "bucket": period, **_bucket_stats(bucket)}
+            for period, bucket in sorted(by_quarter.items())
+        ]
+        holding_period_decay = []
+        for day in range(1, max_hold + 1):
+            open_trades = [
+                trade
+                for trade in trades
+                if trade.bars_held is not None and trade.bars_held >= day
+            ]
+            return_values = [
+                _f(trade.return_r)
+                for trade in open_trades
+                if trade.return_r is not None
+            ]
+            mfe_values = [
+                _f(trade.mfe_pct) for trade in open_trades if trade.mfe_pct is not None
+            ]
+            holding_period_decay.append(
+                {
+                    "day": day,
+                    "bars_held": day,
+                    "avg_return_r": statistics.mean(return_values)
+                    if return_values
+                    else None,
+                    "expectancy_r": statistics.mean(return_values)
+                    if return_values
+                    else None,
+                    "avg_mfe_pct": statistics.mean(mfe_values) if mfe_values else None,
+                    "n": len(return_values),
+                    "trades": len(return_values),
+                }
+            )
+        regime_breakdown = [
+            {"trend": trend, "vol": vol, "volatility": vol, **_bucket_stats(bucket)}
+            for (trend, vol), bucket in sorted(by_regime.items())
+        ]
+
+        return MetricsResult(
+            total_trades=len(values),
+            hit_rate=len(wins) / len(values),
+            expectancy_r=sum(values) / len(values),
+            profit_factor=profit_factor,
+            max_drawdown_r=max_drawdown,
+            avg_bars_held=statistics.mean(bars) if bars else None,
+            median_bars_held=float(statistics.median(bars)) if bars else None,
+            avg_mfe_pct=avg_mfe,
+            avg_mae_pct=avg_mae,
+            mfe_mae_ratio=(avg_mfe / avg_mae) if avg_mfe is not None and avg_mae else None,
+            equity_curve=equity_curve,
+            calendar_decay=calendar_decay,
+            holding_period_decay=holding_period_decay,
+            regime_breakdown=regime_breakdown,
+        )

--- a/backend/app/services/replay/protocols.py
+++ b/backend/app/services/replay/protocols.py
@@ -1,0 +1,60 @@
+"""Replay simulator protocol and shared dataclasses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Optional, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class SignalRecord:
+    ticker: str
+    signal_date: date
+    indicators: dict
+    source_event_id: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class StrategyParams:
+    entry_type: str
+    stop_pct: float
+    risk_reward_ratio: float
+    limit_offset_pct: float
+    direction: str
+
+
+@dataclass
+class SimulatedTrade:
+    ticker: str
+    signal_date: date
+    source_event_id: Optional[int]
+
+    entry_date: Optional[date] = None
+    entry_price: Optional[Decimal] = None
+    exit_date: Optional[date] = None
+    exit_price: Optional[Decimal] = None
+    exit_reason: Optional[str] = None
+    bars_held: Optional[int] = None
+
+    stop_price: Optional[Decimal] = None
+    target_price: Optional[Decimal] = None
+
+    return_pct: Optional[float] = None
+    result_r: Optional[float] = None
+    mfe_pct: Optional[float] = None
+    mae_pct: Optional[float] = None
+
+    fill_source: Optional[str] = None
+
+
+@runtime_checkable
+class ExitSimulator(Protocol):
+    def simulate(
+        self,
+        signal: SignalRecord,
+        strategy: StrategyParams,
+        bars: list,
+        max_hold_days: int,
+    ) -> SimulatedTrade: ...

--- a/backend/app/services/replay/signal_source.py
+++ b/backend/app/services/replay/signal_source.py
@@ -1,0 +1,36 @@
+"""Signal loading helpers for replay execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.models.scanner_event import ScannerEvent
+
+
+@dataclass
+class LoadedSignals:
+    signals: list[ScannerEvent]
+    signal_source: str
+    days_missing: int = 0
+    days_unsupported: int = 0
+
+
+class SignalSource:
+    def __init__(self, db: Session):
+        self._db = db
+
+    def load_existing(self, scanner_type: str, tickers: list[str], start_date, end_date) -> LoadedSignals:
+        signals = (
+            self._db.query(ScannerEvent)
+            .filter(
+                ScannerEvent.scanner_type == scanner_type,
+                ScannerEvent.ticker.in_(tickers),
+                ScannerEvent.event_date >= start_date,
+                ScannerEvent.event_date <= end_date,
+            )
+            .order_by(ScannerEvent.event_date.asc(), ScannerEvent.ticker.asc())
+            .all()
+        )
+        return LoadedSignals(signals=signals, signal_source="db")

--- a/backend/app/tasks/__init__.py
+++ b/backend/app/tasks/__init__.py
@@ -1,5 +1,4 @@
 from app.tasks.backtest import run_backtest
-from app.tasks.replay import run_signal_replay
 from app.tasks.quality import (
     analyze_signal_features,
     analyze_universe_quality,
@@ -7,6 +6,7 @@ from app.tasks.quality import (
     normalize_universe_quality,
 )
 from app.tasks.regime import backfill_regime_labels, update_regime_model
+from app.tasks.replay import run_signal_replay
 from app.tasks.scanning import (
     evaluate_scanner_alerts,
     run_liquidity_hunt_scheduled,

--- a/backend/app/tasks/__init__.py
+++ b/backend/app/tasks/__init__.py
@@ -1,4 +1,5 @@
 from app.tasks.backtest import run_backtest
+from app.tasks.replay import run_signal_replay
 from app.tasks.quality import (
     analyze_signal_features,
     analyze_universe_quality,
@@ -32,6 +33,7 @@ from app.tasks.trading import (
 __all__ = [
     # backtest
     "run_backtest",
+    "run_signal_replay",
     # sync
     "sync_tickers_batch",
     "sync_ticker_details",

--- a/backend/app/tasks/replay.py
+++ b/backend/app/tasks/replay.py
@@ -1,0 +1,211 @@
+"""Celery task for canonical signal replay runs."""
+
+from __future__ import annotations
+
+import logging
+import time as _time
+from datetime import datetime, time, timedelta
+from decimal import Decimal
+
+from app.core.celery_app import celery_app
+from app.core.database import SessionLocal
+from app.core.metrics import celery_task_duration_seconds, celery_tasks_total
+from app.utils.time import utc_now
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_STRATEGY = {
+    "direction": "long_only",
+    "entry_type": "market",
+    "limit_offset_pct": "0",
+    "stop_pct": "2",
+    "risk_reward_ratio": "2",
+}
+
+
+def _decimal(value) -> Decimal:
+    return value if isinstance(value, Decimal) else Decimal(str(value))
+
+
+def _strategy_params(snapshot: dict | None):
+    from app.services.replay.protocols import StrategyParams
+
+    data = {**DEFAULT_STRATEGY, **(snapshot or {})}
+    return StrategyParams(
+        direction=data.get("direction") or "long_only",
+        entry_type=data.get("entry_type") or "market",
+        limit_offset_pct=float(_decimal(data.get("limit_offset_pct", 0))),
+        stop_pct=float(_decimal(data.get("stop_pct", 2))),
+        risk_reward_ratio=float(_decimal(data.get("risk_reward_ratio", 2))),
+    )
+
+
+def _bar_window(signal_date, max_hold_days: int):
+    start = datetime.combine(signal_date, time.min)
+    end = datetime.combine(signal_date + timedelta(days=max_hold_days + 1), time.min)
+    return start, end
+
+
+def _load_bars(db, ticker: str, signal_date, max_hold_days: int) -> list:
+    from app.models.stock_aggregate import StockAggregate
+
+    start, end = _bar_window(signal_date, max_hold_days)
+    return (
+        db.query(StockAggregate)
+        .filter(
+            StockAggregate.ticker == ticker,
+            StockAggregate.timestamp >= start,
+            StockAggregate.timestamp < end,
+            StockAggregate.multiplier == 1,
+            StockAggregate.timespan.in_(["minute", "day"]),
+        )
+        .order_by(StockAggregate.timestamp.asc(), StockAggregate.timespan.desc())
+        .all()
+    )
+
+
+def _signal_record(event):
+    from app.services.replay.protocols import SignalRecord
+
+    indicators = dict(event.indicators or {})
+    if event.previous_close is not None:
+        indicators.setdefault("previous_close", str(event.previous_close))
+    return SignalRecord(
+        ticker=event.ticker,
+        signal_date=event.event_date,
+        indicators=indicators,
+        source_event_id=event.id,
+    )
+
+
+def _persist_trade(db, run, simulated, direction: str, regime) -> bool:
+    from app.models.replay_trade import ReplayTrade
+
+    db.add(
+        ReplayTrade(
+            replay_run_id=run.id,
+            scanner_event_id=simulated.source_event_id,
+            ticker=simulated.ticker,
+            signal_date=simulated.signal_date,
+            entry_date=simulated.entry_date,
+            entry_price=simulated.entry_price,
+            direction="short" if direction == "short_only" else "long",
+            stop_price=simulated.stop_price,
+            target_price=simulated.target_price,
+            exit_date=simulated.exit_date,
+            exit_price=simulated.exit_price,
+            exit_reason=simulated.exit_reason,
+            return_pct=simulated.return_pct,
+            return_r=simulated.result_r,
+            mfe_pct=simulated.mfe_pct,
+            mae_pct=simulated.mae_pct,
+            bars_held=simulated.bars_held,
+            regime_trend=regime.trend,
+            regime_vol=regime.vol,
+            fill_source=simulated.fill_source,
+        )
+    )
+    return simulated.entry_price is None
+
+
+def _execute_replay_run(run, db) -> None:
+    """Load canonical signals, simulate exits, persist trades, and cache metrics."""
+
+    from app.models.replay_trade import ReplayTrade
+    from app.services.replay.classifier import RegimeClassifier, get_benchmark_regime
+    from app.services.replay.exit_simulator import IntradayExitSimulator
+    from app.services.replay.manifest import compute_data_hash
+    from app.services.replay.metrics import MetricsComputer
+    from app.services.replay.signal_source import SignalSource
+
+    tickers = sorted((run.universe_snapshot or {}).get("tickers") or [])
+    hash_end = run.end_date + timedelta(days=run.max_hold_days)
+    run.data_hash = compute_data_hash(db, tickers, run.start_date, hash_end)
+
+    db.query(ReplayTrade).filter(ReplayTrade.replay_run_id == run.id).delete()
+
+    loaded = SignalSource(db).load_existing(
+        scanner_type=run.scanner_type,
+        tickers=tickers,
+        start_date=run.start_date,
+        end_date=run.end_date,
+    )
+    run.signal_source = loaded.signal_source
+
+    strategy = _strategy_params(run.strategy_snapshot)
+    simulator = IntradayExitSimulator()
+    classifier = RegimeClassifier(run.benchmark_symbol or "SPY")
+    classifier.classify(run.start_date, hash_end, db)
+
+    skipped = 0
+    for event in loaded.signals:
+        bars = _load_bars(db, event.ticker, event.event_date, run.max_hold_days)
+        simulated = simulator.simulate(
+            signal=_signal_record(event),
+            strategy=strategy,
+            bars=bars,
+            max_hold_days=run.max_hold_days,
+        )
+        regime = get_benchmark_regime(classifier, event.event_date)
+        if _persist_trade(db, run, simulated, strategy.direction, regime):
+            skipped += 1
+
+    run.skipped_count = skipped
+    db.flush()
+
+    result = MetricsComputer(db).compute(run.id)
+    run.total_trades = result.total_trades
+    run.hit_rate = result.hit_rate
+    run.expectancy_r = result.expectancy_r
+    run.profit_factor = result.profit_factor
+    run.max_drawdown_r = result.max_drawdown_r
+    run.avg_bars_held = result.avg_bars_held
+    run.median_bars_held = result.median_bars_held
+    run.avg_mfe_pct = result.avg_mfe_pct
+    run.avg_mae_pct = result.avg_mae_pct
+    run.mfe_mae_ratio = result.mfe_mae_ratio
+    run.metrics = result.as_metrics_json()
+
+
+@celery_app.task(bind=True, max_retries=0, name="app.tasks.run_signal_replay")
+def run_signal_replay(self, run_id: int):
+    from app.models.replay_run import ReplayRun
+
+    task_name = "run_signal_replay"
+    start = _time.monotonic()
+    db = SessionLocal()
+    try:
+        run = db.query(ReplayRun).filter(ReplayRun.id == run_id).first()
+        if not run:
+            logger.error("run_signal_replay: ReplayRun id=%s not found", run_id)
+            return
+
+        run.status = "running"
+        db.commit()
+
+        _execute_replay_run(run, db)
+
+        run.status = "completed"
+        run.completed_at = utc_now()
+        db.commit()
+        celery_tasks_total.labels(task_name=task_name, status="success").inc()
+        celery_task_duration_seconds.labels(task_name=task_name).observe(
+            _time.monotonic() - start
+        )
+    except Exception as exc:
+        logger.exception("run_signal_replay: run_id=%s failed: %s", run_id, exc)
+        try:
+            run = db.query(ReplayRun).filter(ReplayRun.id == run_id).first()
+            if run:
+                run.status = "failed"
+                run.error_message = str(exc)[:2000]
+                db.commit()
+        finally:
+            celery_tasks_total.labels(task_name=task_name, status="failure").inc()
+            celery_task_duration_seconds.labels(task_name=task_name).observe(
+                _time.monotonic() - start
+            )
+        raise
+    finally:
+        db.close()

--- a/backend/tests/api/test_replay.py
+++ b/backend/tests/api/test_replay.py
@@ -1,0 +1,173 @@
+"""Integration tests for replay API endpoints."""
+
+from datetime import date
+from decimal import Decimal
+from itertools import count
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.main import app
+
+client = TestClient(app)
+_name_counter = count(1)
+
+
+def _strategy_and_universe(db: Session):
+    from app.models.stock_universe import StockUniverse
+    from app.models.trading_strategy import TradingStrategy
+
+    universe = StockUniverse(
+        name=f"Replay API Universe {next(_name_counter)}",
+        description="Fixture universe",
+        criteria={},
+        is_active=True,
+    )
+    strategy = TradingStrategy(
+        name=f"Replay API Strategy {next(_name_counter)}",
+        direction="long_only",
+        entry_type="market",
+        stop_pct=Decimal("2"),
+        risk_reward_ratio=Decimal("2"),
+        limit_offset_pct=Decimal("0"),
+        max_slippage_pct=Decimal("0.5"),
+        allowed_sessions=["regular"],
+    )
+    db.add(universe)
+    db.add(strategy)
+    db.flush()
+    return strategy, universe
+
+
+def _run(db: Session, status: str = "completed", data_hash: str = "abc"):
+    from app.models.replay_run import ReplayRun
+
+    strategy, universe = _strategy_and_universe(db)
+    run = ReplayRun(
+        scanner_type="pre_market_volume_spike",
+        scanner_config_snapshot={"scanner_type": "pre_market_volume_spike"},
+        trading_strategy_id=strategy.id,
+        strategy_snapshot={"direction": "long_only"},
+        universe_id=universe.id,
+        universe_snapshot={"tickers": ["AAPL"]},
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 1, 31),
+        max_hold_days=10,
+        exit_fidelity="intraday",
+        benchmark_symbol="SPY",
+        status=status,
+        data_hash=data_hash,
+        total_trades=1,
+        hit_rate=1.0,
+        expectancy_r=2.0,
+        metrics={
+            "equity_curve": [{"date": "2026-01-02", "cumulative_r": 2.0}],
+            "calendar_decay": [],
+            "holding_period_decay": [],
+            "regime_breakdown": [],
+        },
+    )
+    db.add(run)
+    db.flush()
+    return run
+
+
+def test_create_replay_run_enqueues_task(db: Session):
+    strategy, universe = _strategy_and_universe(db)
+
+    with patch("app.routers.replay.run_signal_replay.delay") as delay:
+        delay.return_value.id = "task-1"
+        response = client.post(
+            "/api/v1/replay/runs",
+            json={
+                "scanner_type": "pre_market_volume_spike",
+                "trading_strategy_id": strategy.id,
+                "universe_id": universe.id,
+                "start_date": "2026-01-01",
+                "end_date": "2026-01-31",
+                "max_hold_days": 10,
+                "exit_fidelity": "intraday",
+                "benchmark_symbol": "SPY",
+            },
+        )
+
+    assert response.status_code == 202
+    data = response.json()
+    assert data["status"] == "queued"
+    assert data["celery_task_id"] == "task-1"
+    delay.assert_called_once()
+
+
+def test_list_and_get_replay_run(db: Session):
+    run = _run(db)
+
+    list_response = client.get("/api/v1/replay/runs?status=completed")
+    assert list_response.status_code == 200
+    assert list_response.json()[0]["uuid"] == str(run.uuid)
+
+    get_response = client.get(f"/api/v1/replay/runs/{run.uuid}")
+    assert get_response.status_code == 200
+    assert get_response.json()["metrics"]["equity_curve"][0]["cumulative_r"] == 2.0
+
+
+def test_replay_trades_endpoint_returns_paginated_ledger(db: Session):
+    from app.models.replay_trade import ReplayTrade
+
+    run = _run(db)
+    db.add(
+        ReplayTrade(
+            replay_run_id=run.id,
+            ticker="AAPL",
+            signal_date=date(2026, 1, 2),
+            return_r=Decimal("2"),
+            return_pct=Decimal("4"),
+            mfe_pct=Decimal("5"),
+            mae_pct=Decimal("1"),
+            bars_held=3,
+            exit_reason="target",
+        )
+    )
+    db.flush()
+
+    response = client.get(f"/api/v1/replay/runs/{run.uuid}/trades")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 1
+    assert data["trades"][0]["ticker"] == "AAPL"
+
+
+def test_replay_analytics_returns_empty_for_running_and_metrics_for_completed(db: Session):
+    running = _run(db, status="running")
+    completed = _run(db, status="completed")
+
+    running_response = client.get(f"/api/v1/replay/runs/{running.uuid}/analytics")
+    assert running_response.status_code == 200
+    assert running_response.json()["equity_curve"] == []
+
+    completed_response = client.get(f"/api/v1/replay/runs/{completed.uuid}/analytics")
+    assert completed_response.status_code == 200
+    assert completed_response.json()["equity_curve"][0]["cumulative_r"] == 2.0
+
+
+def test_replay_compare_validates_count_and_flags_hash_mismatch(db: Session):
+    first = _run(db, data_hash="aaa")
+    second = _run(db, data_hash="bbb")
+
+    invalid = client.get(f"/api/v1/replay/runs/compare?ids={first.uuid}")
+    assert invalid.status_code == 422
+
+    response = client.get(f"/api/v1/replay/runs/compare?ids={first.uuid},{second.uuid}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["all_hashes_match"] is False
+    assert data["comparisons"][0]["data_hash_match"] is False
+
+
+def test_replay_get_unknown_or_malformed_uuid(db: Session):
+    assert client.get("/api/v1/replay/runs/not-a-uuid").status_code == 422
+    assert (
+        client.get("/api/v1/replay/runs/00000000-0000-0000-0000-000000000001").status_code
+        == 404
+    )

--- a/backend/tests/services/test_replay_benchmark.py
+++ b/backend/tests/services/test_replay_benchmark.py
@@ -1,0 +1,104 @@
+"""Tests for benchmark daily-bar gap-fill ingestion."""
+
+from datetime import date, datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.exceptions import ProviderError
+
+
+def _provider(bars=None):
+    provider = MagicMock()
+    provider.get_bars.return_value = bars if bars is not None else []
+    return provider
+
+
+def _db(existing_timestamps=None):
+    db = MagicMock()
+    db.query.return_value.filter.return_value.all.return_value = [
+        (ts,) for ts in (existing_timestamps or [])
+    ]
+    return db
+
+
+def _bar(day: date, close: float = 500.0):
+    return {
+        "timestamp": datetime(day.year, day.month, day.day, tzinfo=timezone.utc),
+        "open": close - 1,
+        "high": close + 2,
+        "low": close - 2,
+        "close": close,
+        "volume": 10_000_000,
+        "vwap": close,
+        "transactions": 100_000,
+    }
+
+
+def test_benchmark_ingestor_inserts_missing_daily_bars():
+    from app.services.replay.benchmark import BenchmarkIngestor
+
+    provider = _provider([_bar(date(2026, 1, 5)), _bar(date(2026, 1, 6))])
+    db = _db()
+
+    count = BenchmarkIngestor(provider).ingest(
+        "SPY", date(2026, 1, 5), date(2026, 1, 6), db
+    )
+
+    assert count == 2
+    db.bulk_save_objects.assert_called_once()
+    db.commit.assert_called_once()
+
+
+def test_benchmark_ingestor_returns_zero_when_range_is_fully_present():
+    from app.services.replay.benchmark import BenchmarkIngestor
+
+    provider = _provider()
+    db = _db(
+        [
+            datetime(2026, 1, 5),
+            datetime(2026, 1, 6),
+            datetime(2026, 1, 7),
+        ]
+    )
+
+    count = BenchmarkIngestor(provider).ingest(
+        "QQQ", date(2026, 1, 5), date(2026, 1, 7), db
+    )
+
+    assert count == 0
+    provider.get_bars.assert_not_called()
+
+
+def test_benchmark_ingestor_detects_interior_gaps():
+    from app.services.replay.benchmark import BenchmarkIngestor
+
+    provider = _provider([_bar(date(2026, 1, 6)), _bar(date(2026, 1, 7))])
+    db = _db([datetime(2026, 1, 5), datetime(2026, 1, 8)])
+
+    count = BenchmarkIngestor(provider).ingest(
+        "SPY", date(2026, 1, 5), date(2026, 1, 8), db
+    )
+
+    assert count == 2
+    assert provider.get_bars.call_args.kwargs["from_date"] == "2026-01-06"
+    assert provider.get_bars.call_args.kwargs["to_date"] == "2026-01-07"
+
+
+def test_benchmark_ingestor_wraps_provider_errors():
+    from app.services.replay.benchmark import (
+        BenchmarkIngestionError,
+        BenchmarkIngestor,
+    )
+
+    provider = MagicMock()
+    provider.get_bars.side_effect = ProviderError(
+        "down", provider="polygon", endpoint="get_bars", is_retryable=True
+    )
+
+    with pytest.raises(BenchmarkIngestionError, match="SPY") as exc:
+        BenchmarkIngestor(provider).ingest(
+            "SPY", date(2026, 1, 5), date(2026, 1, 6), _db()
+        )
+
+    assert exc.value.symbol == "SPY"

--- a/backend/tests/services/test_replay_exit_simulator.py
+++ b/backend/tests/services/test_replay_exit_simulator.py
@@ -1,0 +1,192 @@
+"""Fixture tests for the pure replay intraday exit simulator."""
+
+from datetime import date, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+
+
+def _bar(
+    ts: datetime,
+    open_: str,
+    high: str,
+    low: str,
+    close: str,
+    timespan: str = "minute",
+    pre: bool = False,
+    post: bool = False,
+):
+    return SimpleNamespace(
+        timestamp=ts,
+        open=Decimal(open_),
+        high=Decimal(high),
+        low=Decimal(low),
+        close=Decimal(close),
+        timespan=timespan,
+        multiplier=1,
+        is_pre_market=pre,
+        is_after_market=post,
+    )
+
+
+def _signal(previous_close: str = "100"):
+    from app.services.replay.protocols import SignalRecord
+
+    return SignalRecord(
+        ticker="AAPL",
+        signal_date=date(2026, 1, 5),
+        indicators={"previous_close": previous_close},
+        source_event_id=42,
+    )
+
+
+def _strategy(**overrides):
+    from app.services.replay.protocols import StrategyParams
+
+    params = {
+        "entry_type": "market",
+        "stop_pct": 2.0,
+        "risk_reward_ratio": 2.0,
+        "limit_offset_pct": 0.0,
+        "direction": "long_only",
+    }
+    params.update(overrides)
+    return StrategyParams(**params)
+
+
+def _entry_bar():
+    return _bar(datetime(2026, 1, 5, 9, 30), "100", "101", "99", "100")
+
+
+def test_long_stop_first_on_minute_bar():
+    from app.services.replay.exit_simulator import IntradayExitSimulator
+
+    trade = IntradayExitSimulator().simulate(
+        _signal(),
+        _strategy(),
+        [
+            _entry_bar(),
+            _bar(datetime(2026, 1, 6, 9, 30), "100", "105", "97", "99"),
+        ],
+        max_hold_days=5,
+    )
+
+    assert trade.entry_price == Decimal("100")
+    assert trade.stop_price == Decimal("98.0")
+    assert trade.target_price == Decimal("104.00")
+    assert trade.exit_reason == "stop"
+    assert trade.exit_price == Decimal("98.0")
+    assert trade.result_r == -1.0
+    assert trade.return_pct == -2.0
+    assert trade.mfe_pct == 5.0
+    assert trade.mae_pct == 3.0
+    assert trade.bars_held == 1
+    assert trade.fill_source == "intraday"
+
+
+def test_long_target_first_on_minute_bar():
+    from app.services.replay.exit_simulator import IntradayExitSimulator
+
+    trade = IntradayExitSimulator().simulate(
+        _signal(),
+        _strategy(),
+        [
+            _entry_bar(),
+            _bar(datetime(2026, 1, 6, 9, 30), "100", "104.50", "99", "104"),
+        ],
+        max_hold_days=5,
+    )
+
+    assert trade.exit_reason == "target"
+    assert trade.exit_price == Decimal("104.00")
+    assert trade.result_r == 2.0
+    assert trade.return_pct == 4.0
+    assert trade.mfe_pct == 4.5
+    assert trade.mae_pct == 1.0
+
+
+def test_time_exit_uses_first_bar_on_or_after_cutoff():
+    from app.services.replay.exit_simulator import IntradayExitSimulator
+
+    trade = IntradayExitSimulator().simulate(
+        _signal(),
+        _strategy(),
+        [
+            _entry_bar(),
+            _bar(datetime(2026, 1, 6, 9, 30), "100", "101", "99", "100"),
+            _bar(datetime(2026, 1, 7, 9, 30), "101", "102", "100", "101"),
+        ],
+        max_hold_days=2,
+    )
+
+    assert trade.exit_reason == "time_exit"
+    assert trade.exit_date == date(2026, 1, 7)
+    assert trade.exit_price == Decimal("101")
+    assert trade.bars_held == 1
+    assert trade.result_r == 0.5
+
+
+def test_limit_entry_no_fill_returns_eod_no_fill():
+    from app.services.replay.exit_simulator import IntradayExitSimulator
+
+    trade = IntradayExitSimulator().simulate(
+        _signal(previous_close="100"),
+        _strategy(entry_type="limit", limit_offset_pct=-2.0),
+        [
+            _bar(datetime(2026, 1, 5, 9, 30), "100", "101", "99", "100"),
+            _bar(datetime(2026, 1, 5, 9, 31), "100", "101", "98.50", "100"),
+        ],
+        max_hold_days=5,
+    )
+
+    assert trade.exit_reason == "eod-no-fill"
+    assert trade.entry_price is None
+    assert trade.result_r is None
+
+
+def test_daily_fallback_stop_first_when_daily_bar_spans_stop_and_target():
+    from app.services.replay.exit_simulator import IntradayExitSimulator
+
+    trade = IntradayExitSimulator().simulate(
+        _signal(),
+        _strategy(),
+        [
+            _entry_bar(),
+            _bar(
+                datetime(2026, 1, 6),
+                "100",
+                "106",
+                "96",
+                "101",
+                timespan="day",
+            ),
+        ],
+        max_hold_days=5,
+    )
+
+    assert trade.exit_reason == "stop"
+    assert trade.exit_price == Decimal("98.0")
+    assert trade.fill_source == "daily-fallback"
+    assert trade.bars_held == 1
+
+
+def test_short_only_inverts_target_and_return_math():
+    from app.services.replay.exit_simulator import IntradayExitSimulator
+
+    trade = IntradayExitSimulator().simulate(
+        _signal(),
+        _strategy(direction="short_only"),
+        [
+            _entry_bar(),
+            _bar(datetime(2026, 1, 6, 9, 30), "100", "101", "95", "96"),
+        ],
+        max_hold_days=5,
+    )
+
+    assert trade.stop_price == Decimal("102.0")
+    assert trade.target_price == Decimal("96.00")
+    assert trade.exit_reason == "target"
+    assert trade.exit_price == Decimal("96.00")
+    assert trade.result_r == 2.0
+    assert trade.return_pct == 4.0
+    assert trade.mfe_pct == 5.0
+    assert trade.mae_pct == 1.0

--- a/backend/tests/services/test_replay_manifest.py
+++ b/backend/tests/services/test_replay_manifest.py
@@ -1,0 +1,221 @@
+"""Tests for replay manifest freezing and market-data hashing."""
+
+from datetime import date, datetime
+from decimal import Decimal
+
+
+def _seed_replay_inputs(db):
+    from app.models import ScannerConfig, StockUniverse, StockUniverseTicker
+    from app.models.trading_strategy import TradingStrategy
+
+    universe = StockUniverse(
+        name="Replay Universe",
+        description="Signals for replay tests",
+        criteria={"min_price": 5},
+        is_active=True,
+    )
+    db.add(universe)
+    db.flush()
+
+    db.add_all(
+        [
+            StockUniverseTicker(universe_id=universe.id, ticker="MSFT"),
+            StockUniverseTicker(universe_id=universe.id, ticker="AAPL"),
+        ]
+    )
+
+    scanner = ScannerConfig(
+        name="Replay Scanner",
+        scanner_type="pre_market_volume_spike",
+        parameters={"min_volume": 100000, "spike_ratio": 4.0},
+        criteria=[{"field": "volume_ratio", "op": ">=", "value": 4.0}],
+        outcome_config={"intervals": ["1d", "5d"]},
+        data_requirements={"intraday": "advisory"},
+        is_active=True,
+        universe_id=universe.id,
+    )
+    strategy = TradingStrategy(
+        name="Replay Strategy",
+        direction="long_only",
+        entry_type="limit",
+        limit_offset_pct=Decimal("1.5"),
+        stop_pct=Decimal("2.0"),
+        risk_reward_ratio=Decimal("2.5"),
+        max_slippage_pct=Decimal("0.5"),
+        allowed_sessions=["regular"],
+        risk_per_trade_pct=Decimal("1.0"),
+        max_position_usd=Decimal("5000"),
+        max_trades_per_day=3,
+        max_concurrent_positions=2,
+    )
+    db.add(scanner)
+    db.add(strategy)
+    db.flush()
+    return scanner, strategy, universe
+
+
+def _daily_bar(db, ticker: str, day: date, close: str = "102.00"):
+    from app.models.stock_aggregate import StockAggregate
+
+    bar = StockAggregate(
+        ticker=ticker,
+        timestamp=datetime(day.year, day.month, day.day),
+        multiplier=1,
+        timespan="day",
+        open=Decimal("100.00"),
+        high=Decimal("105.00"),
+        low=Decimal("99.00"),
+        close=Decimal(close),
+        volume=1_000_000,
+        vwap=Decimal("101.00"),
+        transactions=5000,
+    )
+    db.add(bar)
+    db.flush()
+    return bar
+
+
+def _minute_bar(db, ticker: str, ts: datetime):
+    from app.models.stock_aggregate import StockAggregate
+
+    bar = StockAggregate(
+        ticker=ticker,
+        timestamp=ts,
+        multiplier=1,
+        timespan="minute",
+        open=Decimal("100.00"),
+        high=Decimal("101.00"),
+        low=Decimal("99.50"),
+        close=Decimal("100.50"),
+        volume=10_000,
+        vwap=Decimal("100.25"),
+        transactions=100,
+    )
+    db.add(bar)
+    db.flush()
+    return bar
+
+
+def test_resolve_freezes_scanner_strategy_and_sorted_universe(db):
+    from app.services.replay.manifest import ManifestResolver
+
+    scanner, strategy, universe = _seed_replay_inputs(db)
+    resolver = ManifestResolver(db)
+
+    manifest = resolver.resolve(
+        scanner_config_id=scanner.id,
+        universe_id=universe.id,
+        start_date=date(2026, 1, 5),
+        end_date=date(2026, 1, 9),
+        strategy_id=strategy.id,
+    )
+
+    assert manifest.scanner_type == "pre_market_volume_spike"
+    assert manifest.scanner_config_snapshot == {
+        "scanner_type": "pre_market_volume_spike",
+        "parameters": {"min_volume": 100000, "spike_ratio": 4.0},
+        "criteria": [{"field": "volume_ratio", "op": ">=", "value": 4.0}],
+        "outcome_config": {"intervals": ["1d", "5d"]},
+        "data_requirements": {"intraday": "advisory"},
+    }
+    assert manifest.strategy_snapshot["direction"] == "long_only"
+    assert manifest.strategy_snapshot["limit_offset_pct"] == "1.5"
+    assert manifest.strategy_snapshot["risk_reward_ratio"] == "2.5"
+    assert manifest.universe_snapshot["tickers"] == ["AAPL", "MSFT"]
+    assert manifest.universe_snapshot["universe_id"] == universe.id
+    assert "frozen_at" in manifest.universe_snapshot
+
+    from app.models import StockUniverseTicker
+
+    scanner.parameters["min_volume"] = 999
+    strategy.direction = "short_only"
+    db.add(StockUniverseTicker(universe_id=universe.id, ticker="NVDA"))
+    db.flush()
+
+    assert manifest.scanner_config_snapshot["parameters"]["min_volume"] == 100000
+    assert manifest.strategy_snapshot["direction"] == "long_only"
+    assert manifest.universe_snapshot["tickers"] == ["AAPL", "MSFT"]
+
+
+def test_resolve_allows_scanner_only_manifest(db):
+    from app.services.replay.manifest import ManifestResolver
+
+    scanner, _strategy, universe = _seed_replay_inputs(db)
+    manifest = ManifestResolver(db).resolve(
+        scanner_config_id=scanner.id,
+        universe_id=universe.id,
+        start_date=date(2026, 1, 5),
+        end_date=date(2026, 1, 9),
+        strategy_id=None,
+    )
+
+    assert manifest.strategy_snapshot is None
+
+
+def test_compute_data_hash_is_stable_and_changes_when_daily_bar_mutates(db):
+    from app.services.replay.manifest import compute_data_hash
+
+    day = date(2026, 1, 5)
+    bar = _daily_bar(db, "AAPL", day, close="102.00")
+    first = compute_data_hash(db, ["AAPL"], day, day)
+    second = compute_data_hash(db, ["AAPL"], day, day)
+    assert first == second
+
+    bar.close = Decimal("103.00")
+    db.flush()
+
+    assert compute_data_hash(db, ["AAPL"], day, day) != first
+
+
+def test_compute_data_hash_changes_when_minute_count_changes(db):
+    from app.services.replay.manifest import compute_data_hash
+
+    day = date(2026, 1, 5)
+    _daily_bar(db, "AAPL", day)
+    first = compute_data_hash(db, ["AAPL"], day, day)
+
+    _minute_bar(db, "AAPL", datetime(2026, 1, 5, 9, 30))
+
+    assert compute_data_hash(db, ["AAPL"], day, day) != first
+
+
+def test_compute_data_hash_changes_when_applied_split_version_changes(db):
+    from app.models.stock_split import StockSplit
+    from app.services.replay.manifest import compute_data_hash
+
+    day = date(2026, 1, 5)
+    _daily_bar(db, "AAPL", day)
+    first = compute_data_hash(db, ["AAPL"], day, day)
+
+    db.add(
+        StockSplit(
+            ticker="AAPL",
+            execution_date=date(2026, 1, 20),
+            split_from=Decimal("1"),
+            split_to=Decimal("2"),
+            adjustments_applied_at=datetime(2026, 1, 21, 12, 0, 0),
+        )
+    )
+    db.flush()
+
+    assert compute_data_hash(db, ["AAPL"], day, day) != first
+
+
+def test_replay_run_defaults_and_nullable_strategy(db):
+    from app.models.replay_run import ReplayRun
+
+    run = ReplayRun(
+        scanner_type="pre_market_volume_spike",
+        scanner_config_snapshot={"scanner_type": "pre_market_volume_spike"},
+        trading_strategy_id=None,
+        strategy_snapshot=None,
+        universe_id=1,
+        universe_snapshot={"tickers": ["AAPL"]},
+        start_date=date(2026, 1, 5),
+        end_date=date(2026, 1, 9),
+        max_hold_days=10,
+    )
+
+    assert run.trading_strategy_id is None
+    assert run.metrics is None
+    assert run.status is None or run.status == "queued"

--- a/backend/tests/services/test_replay_metrics.py
+++ b/backend/tests/services/test_replay_metrics.py
@@ -1,0 +1,91 @@
+"""Tests for replay metrics computation."""
+
+from datetime import date
+from decimal import Decimal
+
+
+def _run(db):
+    from app.models.replay_run import ReplayRun
+    from app.models.stock_universe import StockUniverse
+
+    universe = StockUniverse(
+        name="Replay Metrics Universe",
+        description="Fixture universe",
+        criteria={},
+        is_active=True,
+    )
+    db.add(universe)
+    db.flush()
+
+    run = ReplayRun(
+        scanner_type="pre_market_volume_spike",
+        scanner_config_snapshot={"scanner_type": "pre_market_volume_spike"},
+        universe_id=universe.id,
+        universe_snapshot={"tickers": ["AAPL", "MSFT"]},
+        start_date=date(2026, 1, 1),
+        end_date=date(2026, 4, 30),
+        max_hold_days=5,
+        exit_fidelity="intraday",
+        benchmark_symbol="SPY",
+    )
+    db.add(run)
+    db.flush()
+    return run
+
+
+def _trade(db, run_id: int, ticker: str, signal_date: date, result_r: str, bars: int, trend: str, vol: str):
+    from app.models.replay_trade import ReplayTrade
+
+    trade = ReplayTrade(
+        replay_run_id=run_id,
+        ticker=ticker,
+        signal_date=signal_date,
+        entry_date=signal_date,
+        entry_price=Decimal("100"),
+        exit_date=signal_date,
+        exit_price=Decimal("100"),
+        exit_reason="target" if Decimal(result_r) > 0 else "stop",
+        return_pct=Decimal("1"),
+        return_r=Decimal(result_r),
+        mfe_pct=Decimal("4"),
+        mae_pct=Decimal("2"),
+        bars_held=bars,
+        regime_trend=trend,
+        regime_vol=vol,
+        fill_source="intraday",
+    )
+    db.add(trade)
+    db.flush()
+    return trade
+
+
+def test_metrics_computer_builds_headline_decay_regime_and_equity(db):
+    from app.services.replay.metrics import MetricsComputer
+
+    run = _run(db)
+    _trade(db, run.id, "AAPL", date(2026, 1, 5), "2.0", 2, "bull", "calm")
+    _trade(db, run.id, "MSFT", date(2026, 1, 6), "-1.0", 4, "bull", "calm")
+    _trade(db, run.id, "AAPL", date(2026, 2, 5), "0.0", 1, "bear", "normal")
+    _trade(db, run.id, "MSFT", date(2026, 4, 6), "1.0", 5, "bear", "normal")
+    _trade(db, run.id, "AAPL", date(2026, 4, 7), "-1.0", 3, "bear", "turbulent")
+
+    result = MetricsComputer(db).compute(run.id)
+
+    assert result.total_trades == 5
+    assert result.hit_rate == 0.4
+    assert result.expectancy_r == 0.2
+    assert result.profit_factor == 1.5
+    assert result.max_drawdown_r == 1.0
+    assert result.avg_bars_held == 3.0
+    assert result.median_bars_held == 3.0
+    assert result.avg_mfe_pct == 4.0
+    assert result.avg_mae_pct == 2.0
+    assert result.mfe_mae_ratio == 2.0
+    assert result.equity_curve[-1] == {"date": "2026-04-07", "cumulative_r": 1.0}
+    assert {row["period"] for row in result.calendar_decay} == {"2026-Q1", "2026-Q2"}
+    assert result.holding_period_decay[0]["day"] == 1
+    assert result.holding_period_decay[0]["avg_return_r"] == 0.2
+    assert any(
+        row["trend"] == "bull" and row["vol"] == "calm" and row["n"] == 2
+        for row in result.regime_breakdown
+    )

--- a/backend/tests/services/test_replay_regime_classifier.py
+++ b/backend/tests/services/test_replay_regime_classifier.py
@@ -1,0 +1,90 @@
+"""Tests for deterministic replay benchmark regime classification."""
+
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _rows(closes: list[float], start: date = date(2025, 1, 1)):
+    rows = []
+    day = start
+    for close in closes:
+        while day.weekday() >= 5:
+            day += timedelta(days=1)
+        rows.append(SimpleNamespace(timestamp=datetime(day.year, day.month, day.day), close=Decimal(str(close))))
+        day += timedelta(days=1)
+    return rows
+
+
+def _db_with_rows(rows):
+    db = MagicMock()
+    db.query.return_value.filter.return_value.order_by.return_value.all.return_value = rows
+    return db
+
+
+def test_regime_classifier_labels_bull_and_bear_by_sma200():
+    from app.services.replay.classifier import RegimeClassifier
+
+    rows = _rows([100.0] * 200 + [101.0, 99.0])
+    bull_day = rows[-2].timestamp.date()
+    bear_day = rows[-1].timestamp.date()
+    classifier = RegimeClassifier("SPY")
+    classifier.classify(bull_day, bear_day, _db_with_rows(rows))
+
+    assert classifier.regime_map[bull_day].trend == "bull"
+    assert classifier.regime_map[bear_day].trend == "bear"
+
+
+def test_regime_classifier_unknown_trend_before_warmup():
+    from app.services.replay.classifier import RegimeClassifier
+
+    rows = _rows([100.0] * 20)
+    day = rows[-1].timestamp.date()
+    classifier = RegimeClassifier("SPY")
+    classifier.classify(day, day, _db_with_rows(rows))
+
+    assert classifier.regime_map[day].trend == "unknown"
+
+
+def test_regime_classifier_vol_thresholds_are_overridable():
+    from app.services.replay.classifier import RegimeClassifier
+
+    closes = [100.0] * 220 + [100 + ((-1) ** i) * 0.1 for i in range(25)]
+    rows = _rows(closes)
+    day = rows[-1].timestamp.date()
+    classifier = RegimeClassifier(
+        "SPY", vol_thresholds={"calm_below": 0.5, "turbulent_above": 0.7}
+    )
+    classifier.classify(day, day, _db_with_rows(rows))
+
+    assert classifier.regime_map[day].vol == "calm"
+
+
+def test_regime_classifier_rejects_invalid_thresholds():
+    from app.services.replay.classifier import RegimeClassifier
+
+    with pytest.raises(ValueError, match="calm_below"):
+        RegimeClassifier(
+            "SPY", vol_thresholds={"calm_below": 0.3, "turbulent_above": 0.2}
+        )
+
+
+def test_get_benchmark_regime_carries_forward_non_trading_days():
+    from app.services.replay.classifier import (
+        RegimeClassifier,
+        ReplayRegime,
+        get_benchmark_regime,
+    )
+
+    classifier = RegimeClassifier.__new__(RegimeClassifier)
+    classifier.regime_map = {date(2026, 1, 2): ReplayRegime("bull", "normal")}
+
+    assert get_benchmark_regime(classifier, date(2026, 1, 3)) == ReplayRegime(
+        "bull", "normal"
+    )
+    assert get_benchmark_regime(classifier, date(2025, 12, 31)) == ReplayRegime(
+        "unknown", "normal"
+    )

--- a/backend/tests/tasks/test_replay_task.py
+++ b/backend/tests/tasks/test_replay_task.py
@@ -1,0 +1,144 @@
+"""Tests for replay Celery task status transitions."""
+
+from unittest.mock import MagicMock, patch
+
+
+def _db_with_run(run):
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = run
+    return db
+
+
+def test_run_signal_replay_marks_completed_on_success():
+    import app.tasks.replay as replay_module
+
+    run = MagicMock()
+    run.id = 1
+    db = _db_with_run(run)
+
+    with (
+        patch("app.tasks.replay.SessionLocal", return_value=db),
+        patch("app.tasks.replay._execute_replay_run") as execute,
+    ):
+        replay_module.run_signal_replay.run(run_id=1)
+
+    execute.assert_called_once_with(run, db)
+    assert run.status == "completed"
+    assert run.completed_at is not None
+    db.commit.assert_called()
+    db.close.assert_called_once()
+
+
+def test_run_signal_replay_records_failure_message():
+    import app.tasks.replay as replay_module
+
+    run = MagicMock()
+    run.id = 1
+    db = _db_with_run(run)
+
+    with (
+        patch("app.tasks.replay.SessionLocal", return_value=db),
+        patch("app.tasks.replay._execute_replay_run", side_effect=RuntimeError("bad replay")),
+    ):
+        try:
+            replay_module.run_signal_replay.run(run_id=1)
+        except RuntimeError:
+            pass
+
+    assert run.status == "failed"
+    assert run.error_message == "bad replay"
+    db.commit.assert_called()
+    db.close.assert_called_once()
+
+
+def test_execute_replay_run_persists_trades_and_metrics(db):
+    from datetime import date, datetime
+    from decimal import Decimal
+
+    from app.models.replay_run import ReplayRun
+    from app.models.replay_trade import ReplayTrade
+    from app.models.scanner_event import ScannerEvent
+    from app.models.stock_aggregate import StockAggregate
+    from app.models.stock_universe import StockUniverse
+    from app.tasks.replay import _execute_replay_run
+
+    universe = StockUniverse(
+        name="Replay Task Universe",
+        description="Task fixture",
+        criteria={},
+        is_active=True,
+    )
+    db.add(universe)
+    db.flush()
+
+    run = ReplayRun(
+        scanner_type="pre_market_volume_spike",
+        scanner_config_snapshot={"scanner_type": "pre_market_volume_spike"},
+        strategy_snapshot={
+            "direction": "long_only",
+            "entry_type": "market",
+            "stop_pct": "2",
+            "risk_reward_ratio": "2",
+            "limit_offset_pct": "0",
+        },
+        universe_id=universe.id,
+        universe_snapshot={"tickers": ["AAPL"]},
+        start_date=date(2026, 1, 2),
+        end_date=date(2026, 1, 2),
+        max_hold_days=3,
+        exit_fidelity="intraday",
+        benchmark_symbol="SPY",
+        status="running",
+    )
+    db.add(run)
+    db.flush()
+
+    db.add(
+        ScannerEvent(
+            ticker="AAPL",
+            event_date=date(2026, 1, 2),
+            scanner_type="pre_market_volume_spike",
+            previous_close=Decimal("99"),
+            indicators={},
+            criteria_met={},
+            metadata_={},
+        )
+    )
+    db.add_all(
+        [
+            StockAggregate(
+                ticker="AAPL",
+                timestamp=datetime(2026, 1, 2, 9, 30),
+                multiplier=1,
+                timespan="minute",
+                open=Decimal("100"),
+                high=Decimal("101"),
+                low=Decimal("99"),
+                close=Decimal("100"),
+                volume=1000,
+            ),
+            StockAggregate(
+                ticker="AAPL",
+                timestamp=datetime(2026, 1, 3, 9, 30),
+                multiplier=1,
+                timespan="minute",
+                open=Decimal("101"),
+                high=Decimal("105"),
+                low=Decimal("100"),
+                close=Decimal("104"),
+                volume=1000,
+            ),
+        ]
+    )
+    db.flush()
+
+    _execute_replay_run(run, db)
+
+    trade = db.query(ReplayTrade).filter(ReplayTrade.replay_run_id == run.id).one()
+    assert trade.ticker == "AAPL"
+    assert trade.exit_reason == "target"
+    assert float(trade.return_r) == 2.0
+    assert run.data_hash
+    assert run.total_trades == 1
+    assert run.hit_rate == 1.0
+    assert run.signal_source == "db"

--- a/docs/superpowers/plans/2026-07-01-canonical-signal-replay-engine.md
+++ b/docs/superpowers/plans/2026-07-01-canonical-signal-replay-engine.md
@@ -1,0 +1,154 @@
+# Canonical Signal Replay Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete Epic #483 by shipping the additive replay engine: reproducible manifests, intraday exit simulation, benchmark regimes, execution metrics, REST endpoints, and the `/replay` UI.
+
+**Architecture:** Add new `ReplayRun` and `ReplayTrade` tables beside the existing backtest tables. Keep replay services in `backend/app/services/replay/`, with pure simulation/metrics logic unit-tested separately from task/router orchestration. Expose a thin `/api/v1/replay` router and a React Query powered page that renders server-derived run analytics.
+
+**Tech Stack:** FastAPI, SQLAlchemy 2.0, Alembic, Celery, PostgreSQL JSONB, pytest, React 19, TypeScript, React Query, Recharts, Lightweight Charts.
+
+## Global Constraints
+
+- Do not modify or replace the existing `BacktestRun` / `BacktestTrade` feature.
+- Do not use Dark Factory; Epic #483 child tickets are reserved with `ready-for-human`.
+- Use TDD for production behavior: write failing tests before implementation code.
+- Reuse `StockAggregate` for benchmark bars; do not introduce a parallel benchmark table.
+- `exit_fidelity` values are `"intraday"` and `"daily"`.
+- `benchmark_symbol` is a manifest field and defaults to `"SPY"`.
+- Store reproducibility inputs as immutable JSON snapshots on `replay_runs`.
+- Keep headline metrics queryable as scalar columns and detailed analytics in `metrics` JSONB.
+- Frontend API calls go through `apiClient`; no raw `fetch`.
+
+---
+
+### Task 1: Models, Manifest Resolver, Data Hash (#484)
+
+**Files:**
+- Create: `backend/app/models/replay_run.py`
+- Create: `backend/app/models/replay_trade.py`
+- Create: `backend/app/services/replay/__init__.py`
+- Create: `backend/app/services/replay/manifest.py`
+- Create: `backend/app/alembic/versions/f1a2b3c4d5e6_add_replay_engine_tables.py`
+- Modify: `backend/app/models/__init__.py`
+- Test: `backend/tests/services/test_replay_manifest.py`
+
+**Interfaces:**
+- Produces `ReplayRun`, `ReplayTrade`, `ManifestResolver`, `ResolvedManifest`, `compute_data_hash`.
+- Later tasks consume `ReplayRun.universe_snapshot["tickers"]`, `strategy_snapshot`, `data_hash`, and `ReplayTrade` ledger fields.
+
+- [ ] Write failing manifest/data-hash tests:
+  - `ManifestResolver.resolve()` freezes scanner config, optional strategy, and sorted universe tickers.
+  - Mutating source objects after `resolve()` does not mutate returned snapshots.
+  - `compute_data_hash()` is stable for identical bars and changes when one OHLCV field changes.
+  - `compute_data_hash()` changes when minute-bar count or applied split version changes.
+  - `ReplayRun.metrics` is nullable until computed and `trading_strategy_id` accepts null.
+- [ ] Verify red with `python -m pytest tests/services/test_replay_manifest.py -q`.
+- [ ] Implement models, migration, manifest resolver, and package exports.
+- [ ] Verify green with targeted pytest and model import smoke test.
+
+### Task 2: Intraday Exit Simulator (#485)
+
+**Files:**
+- Create: `backend/app/services/replay/protocols.py`
+- Create: `backend/app/services/replay/exit_simulator.py`
+- Test: `backend/tests/services/test_replay_exit_simulator.py`
+
+**Interfaces:**
+- Produces `SignalRecord`, `StrategyParams`, `SimulatedTrade`, `ExitSimulator`, `IntradayExitSimulator`.
+- Later task consumes `IntradayExitSimulator.simulate(signal, strategy, bars, max_hold_days)`.
+
+- [ ] Write failing fixture tests for long stop-first, long target-first, time exit, EOD no-fill, daily fallback stop-first, and short-only inversion.
+- [ ] Verify red with `python -m pytest tests/services/test_replay_exit_simulator.py -q`.
+- [ ] Implement pure simulator with no DB access.
+- [ ] Verify green.
+
+### Task 3: Benchmark Ingestion and Regime Classifier (#486)
+
+**Files:**
+- Create: `backend/app/services/replay/benchmark.py`
+- Create: `backend/app/services/replay/classifier.py`
+- Modify: `backend/app/services/replay/__init__.py`
+- Test: `backend/tests/services/test_replay_benchmark.py`
+- Test: `backend/tests/services/test_replay_regime_classifier.py`
+
+**Interfaces:**
+- Produces `BenchmarkIngestor`, `BenchmarkIngestionError`, `ReplayRegime`, `RegimeClassifier`, `get_benchmark_regime`.
+- Execution task uses the ingestor and classifier to tag trades.
+
+- [ ] Write failing tests for idempotent gap-fill, interior gap detection, provider error wrapping, SMA200 trend labels, realized-vol buckets, threshold validation, and carry-forward lookup.
+- [ ] Verify red with targeted pytest.
+- [ ] Implement benchmark and classifier services.
+- [ ] Verify green.
+
+### Task 4: Execution Task and Metrics (#487)
+
+**Files:**
+- Create: `backend/app/services/replay/signal_source.py`
+- Create: `backend/app/services/replay/metrics.py`
+- Create: `backend/app/tasks/replay.py`
+- Modify: `backend/app/services/replay/__init__.py`
+- Test: `backend/tests/services/test_replay_metrics.py`
+- Test: `backend/tests/tasks/test_replay_task.py`
+
+**Interfaces:**
+- Produces `MetricsComputer.compute(run_id, db)` and Celery task `run_signal_replay`.
+- API uses cached scalar metrics and `metrics` JSONB.
+
+- [ ] Write failing metrics tests from a hand-computed trade ledger covering win/loss/flat trades, equity curve, quarter decay, holding-period decay, and regime breakdown.
+- [ ] Write failing task tests for completed run persistence and benchmark/signal-source failure setting `status="failed"`.
+- [ ] Implement signal source, metrics, and task orchestration.
+- [ ] Verify green.
+
+### Task 5: REST API (#488)
+
+**Files:**
+- Create: `backend/app/schemas/replay.py`
+- Create: `backend/app/routers/replay.py`
+- Modify: `backend/app/routers/__init__.py`
+- Modify: `backend/app/main.py`
+- Test: `backend/tests/api/test_replay.py`
+
+**Interfaces:**
+- Produces `/api/v1/replay/runs`, `/runs/{uuid}`, `/runs/{uuid}/trades`, `/runs/{uuid}/analytics`, `/runs/compare`.
+- Frontend consumes these endpoints.
+
+- [ ] Write failing API tests for create/list/get/trades/analytics/compare, malformed UUIDs, unknown runs, and compare count limits.
+- [ ] Implement schemas and router using the existing backtest router style.
+- [ ] Verify green.
+
+### Task 6: Frontend Replay Page (#489, #490)
+
+**Files:**
+- Create: `frontend/src/api/replay.ts`
+- Create: `frontend/src/pages/Replay/index.tsx`
+- Create: `frontend/src/pages/Replay/RunCreateForm.tsx`
+- Create: `frontend/src/pages/Replay/RunSummaryPanel.tsx`
+- Create: `frontend/src/pages/Replay/AnalyticsPanel.tsx`
+- Create: `frontend/src/utils/replayChartOverlays.ts`
+- Modify: `frontend/src/components/ui/StockChart.tsx`
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/components/Layout.tsx`
+- Test: `frontend/src/utils/replayChartOverlays.test.ts`
+
+**Interfaces:**
+- Consumes replay API types from `frontend/src/api/replay.ts`.
+- Extends `StockChart` with optional `replayMarkers` and `priceLines`.
+
+- [ ] Write failing utility tests for replay chart overlays.
+- [ ] Implement typed API client.
+- [ ] Implement run creation, polling, completed run analytics, trade table, chart modal, and comparison mode.
+- [ ] Add route and navigation entry.
+- [ ] Verify with `npx tsc --noEmit -p tsconfig.app.json` and targeted Vitest.
+
+### Task 7: Integration Verification and Issue Closure
+
+**Files:**
+- No new source files expected.
+
+- [ ] Run targeted backend replay tests.
+- [ ] Run frontend type-check and targeted Vitest.
+- [ ] Run Alembic upgrade head against a reachable database or document blocker.
+- [ ] Start the dev/demo stack if feasible and browser-check `/replay`.
+- [ ] Update/close #484-#490 and #483 according to actual completion state.
+- [ ] Commit, push `codex/epic-483-replay-engine`, and open a PR.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ const ActiveWatchlist = lazy(() => import('./pages/ActiveWatchlist'));
 const AutoTrading = lazy(() => import('./pages/AutoTrading'));
 const ScorecardOverview = lazy(() => import('./pages/ScorecardOverview'));
 const ScorecardDetail = lazy(() => import('./pages/ScorecardDetail'));
+const Replay = lazy(() => import('./pages/Replay'));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -68,6 +69,7 @@ function App() {
                         <Route path="/edge-explorer" element={<EdgeExplorer />} />
                         <Route path="/scorecard" element={<ScorecardOverview />} />
                         <Route path="/scorecard/:scannerType" element={<ScorecardDetail />} />
+                        <Route path="/replay" element={<Replay />} />
                         <Route path="/movers/pre-market" element={<PreMarketMovers />} />
                         <Route path="/watchlist" element={<ActiveWatchlist />} />
                         <Route path="/trading" element={<AutoTrading />} />

--- a/frontend/src/api/replay.ts
+++ b/frontend/src/api/replay.ts
@@ -1,0 +1,187 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from './client';
+
+export type ReplayRunStatus = 'queued' | 'running' | 'completed' | 'failed';
+export type ReplayExitFidelity = 'intraday' | 'daily';
+
+export interface ReplayRunCreateRequest {
+  scanner_type: string;
+  universe_id: number;
+  start_date: string;
+  end_date: string;
+  trading_strategy_id?: number | null;
+  max_hold_days?: number;
+  exit_fidelity?: ReplayExitFidelity;
+  benchmark_symbol?: string;
+}
+
+export interface ReplayRunSummary {
+  id: number;
+  uuid: string;
+  status: ReplayRunStatus;
+  celery_task_id: string | null;
+  scanner_type: string;
+  trading_strategy_id: number | null;
+  universe_id: number;
+  start_date: string;
+  end_date: string;
+  max_hold_days: number;
+  exit_fidelity: ReplayExitFidelity;
+  benchmark_symbol: string;
+  data_hash: string | null;
+  metrics: ReplayMetrics | null;
+  skipped_count: number;
+  error_message: string | null;
+  total_trades: number;
+  hit_rate: number | null;
+  expectancy_r: number | null;
+  profit_factor: number | null;
+  max_drawdown_r: number | null;
+  avg_bars_held: number | null;
+  median_bars_held: number | null;
+  avg_mfe_pct: number | null;
+  avg_mae_pct: number | null;
+  mfe_mae_ratio: number | null;
+  created_at: string;
+  completed_at: string | null;
+}
+
+export interface ReplayTrade {
+  id: number;
+  ticker: string;
+  signal_date: string;
+  entry_date: string | null;
+  entry_price: number | null;
+  direction: 'long' | 'short';
+  stop_price: number | null;
+  target_price: number | null;
+  exit_date: string | null;
+  exit_price: number | null;
+  exit_reason: string | null;
+  return_pct: number | null;
+  return_r: number | null;
+  mfe_pct: number | null;
+  mae_pct: number | null;
+  bars_held: number | null;
+  regime_trend: string | null;
+  regime_vol: string | null;
+  fill_source: string | null;
+}
+
+export interface ReplayTradesResponse {
+  trades: ReplayTrade[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface ReplayMetrics {
+  equity_curve?: Array<{ trade_index: number; equity_r: number }>;
+  calendar_decay?: Array<{ bucket: string; trades: number; expectancy_r: number | null }>;
+  holding_period_decay?: Array<{ bars_held: number; trades: number; expectancy_r: number | null }>;
+  regime_breakdown?: Array<{
+    trend: string;
+    volatility: string;
+    trades: number;
+    expectancy_r: number | null;
+    hit_rate: number | null;
+  }>;
+  [key: string]: unknown;
+}
+
+export interface ReplayCompareResponse {
+  runs: ReplayRunSummary[];
+  comparisons: Array<{
+    a: string;
+    b: string;
+    data_hash_match: boolean;
+  }>;
+}
+
+export interface ReplayRunListParams {
+  scanner_type?: string;
+  status?: ReplayRunStatus;
+  universe_id?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export const fetchReplayRuns = async (params?: ReplayRunListParams): Promise<ReplayRunSummary[]> => {
+  const response = await apiClient.get('/replay/runs', { params });
+  return response.data;
+};
+
+export const fetchReplayRun = async (uuid: string): Promise<ReplayRunSummary> => {
+  const response = await apiClient.get(`/replay/runs/${uuid}`);
+  return response.data;
+};
+
+export const createReplayRun = async (payload: ReplayRunCreateRequest): Promise<ReplayRunSummary> => {
+  const response = await apiClient.post('/replay/runs', payload);
+  return response.data;
+};
+
+export const fetchReplayTrades = async (
+  runUuid: string,
+  params?: { limit?: number; offset?: number; sort?: string; direction?: 'asc' | 'desc' },
+): Promise<ReplayTradesResponse> => {
+  const response = await apiClient.get(`/replay/runs/${runUuid}/trades`, { params });
+  return response.data;
+};
+
+export const fetchReplayAnalytics = async (runUuid: string): Promise<ReplayMetrics> => {
+  const response = await apiClient.get(`/replay/runs/${runUuid}/analytics`);
+  return response.data;
+};
+
+export const compareReplayRuns = async (ids: string[]): Promise<ReplayCompareResponse> => {
+  const response = await apiClient.get('/replay/runs/compare', { params: { ids: ids.join(',') } });
+  return response.data;
+};
+
+export const useReplayRuns = (params?: ReplayRunListParams) =>
+  useQuery({
+    queryKey: ['replay', 'runs', params],
+    queryFn: () => fetchReplayRuns(params),
+    refetchInterval: 15_000,
+  });
+
+export const useReplayRun = (uuid?: string | null) =>
+  useQuery({
+    queryKey: ['replay', 'run', uuid],
+    queryFn: () => fetchReplayRun(uuid as string),
+    enabled: Boolean(uuid),
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status === 'queued' || status === 'running' ? 5_000 : false;
+    },
+  });
+
+export const useReplayTrades = (runUuid?: string | null, sort = 'signal_date', direction: 'asc' | 'desc' = 'desc') =>
+  useQuery({
+    queryKey: ['replay', 'trades', runUuid, sort, direction],
+    queryFn: () => fetchReplayTrades(runUuid as string, { limit: 250, sort, direction }),
+    enabled: Boolean(runUuid),
+  });
+
+export const useReplayAnalytics = (runUuid?: string | null) =>
+  useQuery({
+    queryKey: ['replay', 'analytics', runUuid],
+    queryFn: () => fetchReplayAnalytics(runUuid as string),
+    enabled: Boolean(runUuid),
+  });
+
+export const useCreateReplayRun = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createReplayRun,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['replay', 'runs'] });
+    },
+  });
+};
+
+export const useCompareReplayRuns = () =>
+  useMutation({
+    mutationFn: compareReplayRuns,
+  });

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -13,6 +13,7 @@ import {
   Eye,
   Bot,
   Trophy,
+  History,
 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { getSystemStatus, MarketStatus } from '../api/system';
@@ -82,6 +83,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
     { name: 'Pre-market Movers', href: '/movers/pre-market', icon: TrendingUp },
     { name: 'Edge Explorer', href: '/edge-explorer', icon: BarChart3 },
     { name: 'Scorecard', href: '/scorecard', icon: Trophy },
+    { name: 'Signal Replay', href: '/replay', icon: History },
     { name: 'Universes', href: '/universes', icon: Database },
     { name: 'Watchlist', href: '/watchlist', icon: Eye },
     { name: 'Journal', href: '/journal', icon: BookOpen },

--- a/frontend/src/components/ui/StockChart.tsx
+++ b/frontend/src/components/ui/StockChart.tsx
@@ -15,6 +15,8 @@ import {
   HistogramSeries,
   createSeriesMarkers,
   SeriesMarker,
+  IPriceLine,
+  LineStyle,
 } from 'lightweight-charts';
 import { calculateDoubleSuperTrend } from '../../utils/indicators';
 import { ScannerEvent } from '../../api/scanner';
@@ -73,6 +75,8 @@ interface StockChartProps {
     wickDownColor?: string;
   };
   showDoubleSuperTrend?: boolean;
+  replayMarkers?: SeriesMarker<Time>[];
+  priceLines?: Array<{ value: number; color: string; label: string }>;
 }
 
 const StockChart: React.FC<StockChartProps> = ({
@@ -85,7 +89,9 @@ const StockChart: React.FC<StockChartProps> = ({
   symbol,
   liveData,
   colors = {},
-  showDoubleSuperTrend = false
+  showDoubleSuperTrend = false,
+  replayMarkers = [],
+  priceLines = [],
 }) => {
   // Helper to shift UTC timestamps to match the browser's local time labels
   const toLocalTime = (utcSeconds: number): number => {
@@ -109,6 +115,7 @@ const StockChart: React.FC<StockChartProps> = ({
   const stLine2SeriesRef = useRef<ISeriesApi<'Line'> | null>(null);
   const stCloudSeriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
   const markersPluginRef = useRef<ISeriesMarkersPluginApi<Time> | null>(null);
+  const priceLinesRef = useRef<IPriceLine[]>([]);
   const prevDataLengthRef = useRef<number>(0);
   const currentBarRef = useRef<{
     time: Time;
@@ -412,6 +419,10 @@ const StockChart: React.FC<StockChartProps> = ({
       }
 
       if (markersPluginRef.current) {
+        for (const marker of replayMarkers) {
+          allMarkers.push(marker);
+        }
+
         if (allMarkers.length > 0) {
           allMarkers.sort((a, b) =>
             typeof a.time === 'number' && typeof b.time === 'number'
@@ -453,6 +464,22 @@ const StockChart: React.FC<StockChartProps> = ({
 
       (seriesRef.current as unknown as ISeriesApi<'Line'>).setData(uniqueData as LineData[]);
     }
+
+    if (seriesRef.current) {
+      for (const line of priceLinesRef.current) {
+        seriesRef.current.removePriceLine(line);
+      }
+      priceLinesRef.current = priceLines.map((line) =>
+        seriesRef.current!.createPriceLine({
+          price: line.value,
+          color: line.color,
+          lineWidth: 1,
+          lineStyle: LineStyle.Dashed,
+          axisLabelVisible: true,
+          title: line.label,
+        }),
+      );
+    }
     
     // Only fit content on initial load or when data was previously empty
     // This prevents the chart from "jumping" when new historical data is backfilled
@@ -460,7 +487,7 @@ const StockChart: React.FC<StockChartProps> = ({
       chartRef.current?.timeScale().fitContent();
     }
     prevDataLengthRef.current = data.length;
-  }, [data, type, events, timespan, symbol, showDoubleSuperTrend]);
+  }, [data, type, events, timespan, symbol, showDoubleSuperTrend, replayMarkers, priceLines]);
 
   // Reset initialization flag when symbol or timespan changes to allow refitting
   useEffect(() => {

--- a/frontend/src/pages/Replay/AnalyticsPanel.tsx
+++ b/frontend/src/pages/Replay/AnalyticsPanel.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import Card from '../../components/ui/Card';
+import type { ReplayMetrics } from '../../api/replay';
+
+interface AnalyticsPanelProps {
+  metrics: ReplayMetrics | undefined;
+}
+
+const tooltipStyle = {
+  backgroundColor: '#111827',
+  border: '1px solid #374151',
+  borderRadius: '8px',
+  color: '#f9fafb',
+};
+
+const AnalyticsPanel: React.FC<AnalyticsPanelProps> = ({ metrics }) => {
+  const equityCurve = metrics?.equity_curve ?? [];
+  const calendarDecay = metrics?.calendar_decay ?? [];
+  const holdingDecay = metrics?.holding_period_decay ?? [];
+  const regimeBreakdown = metrics?.regime_breakdown ?? [];
+
+  return (
+    <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+      <Card title="Equity Curve">
+        <div className="h-72">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={equityCurve}>
+              <CartesianGrid stroke="#1f2937" vertical={false} />
+              <XAxis dataKey="trade_index" stroke="#6b7280" tick={{ fontSize: 11 }} />
+              <YAxis stroke="#6b7280" tick={{ fontSize: 11 }} />
+              <Tooltip contentStyle={tooltipStyle} />
+              <Line type="monotone" dataKey="equity_r" stroke="#38bdf8" strokeWidth={2} dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </Card>
+
+      <Card title="Calendar Decay">
+        <div className="h-72">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={calendarDecay}>
+              <CartesianGrid stroke="#1f2937" vertical={false} />
+              <XAxis dataKey="bucket" stroke="#6b7280" tick={{ fontSize: 11 }} />
+              <YAxis stroke="#6b7280" tick={{ fontSize: 11 }} />
+              <Tooltip contentStyle={tooltipStyle} />
+              <Bar dataKey="expectancy_r" fill="#22c55e" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </Card>
+
+      <Card title="Holding Period">
+        <div className="h-72">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={holdingDecay}>
+              <CartesianGrid stroke="#1f2937" vertical={false} />
+              <XAxis dataKey="bars_held" stroke="#6b7280" tick={{ fontSize: 11 }} />
+              <YAxis stroke="#6b7280" tick={{ fontSize: 11 }} />
+              <Tooltip contentStyle={tooltipStyle} />
+              <Bar dataKey="expectancy_r" fill="#f59e0b" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </Card>
+
+      <Card title="Regime Breakdown" noPadding>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-800">
+            <thead className="bg-gray-900/80">
+              <tr>
+                {['Trend', 'Volatility', 'Trades', 'Expectancy', 'Hit Rate'].map((header) => (
+                  <th key={header} className="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-gray-500">
+                    {header}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-800">
+              {regimeBreakdown.map((row) => (
+                <tr key={`${row.trend}-${row.volatility}`} className="hover:bg-gray-800/40">
+                  <td className="px-4 py-3 text-sm text-gray-200">{row.trend}</td>
+                  <td className="px-4 py-3 text-sm text-gray-300">{row.volatility}</td>
+                  <td className="px-4 py-3 text-sm text-gray-300">{row.trades}</td>
+                  <td className="px-4 py-3 text-sm text-gray-300">{row.expectancy_r == null ? '-' : `${row.expectancy_r.toFixed(2)}R`}</td>
+                  <td className="px-4 py-3 text-sm text-gray-300">{row.hit_rate == null ? '-' : `${(row.hit_rate * 100).toFixed(1)}%`}</td>
+                </tr>
+              ))}
+              {regimeBreakdown.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="px-4 py-10 text-center text-sm text-gray-500">No regime metrics yet.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default AnalyticsPanel;

--- a/frontend/src/pages/Replay/RunCreateForm.tsx
+++ b/frontend/src/pages/Replay/RunCreateForm.tsx
@@ -1,0 +1,189 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Play } from 'lucide-react';
+import Button from '../../components/ui/Button';
+import type { ScannerConfig } from '../../api/scanner';
+import type { TradingStrategy } from '../../api/trading';
+import type { StockUniverse } from '../../api/universe';
+import { useCreateReplayRun } from '../../api/replay';
+import type { ReplayRunSummary } from '../../api/replay';
+
+interface RunCreateFormProps {
+  scannerConfigs: ScannerConfig[];
+  strategies: TradingStrategy[];
+  universes: StockUniverse[];
+  onCreated: (run: ReplayRunSummary) => void;
+}
+
+const dateDaysAgo = (days: number): string => {
+  const date = new Date();
+  date.setDate(date.getDate() - days);
+  return date.toISOString().slice(0, 10);
+};
+
+const today = (): string => new Date().toISOString().slice(0, 10);
+
+const RunCreateForm: React.FC<RunCreateFormProps> = ({
+  scannerConfigs,
+  strategies,
+  universes,
+  onCreated,
+}) => {
+  const scannerOptions = useMemo(
+    () => Array.from(new Set(scannerConfigs.map((config) => config.scanner_type))).sort(),
+    [scannerConfigs],
+  );
+  const [scannerType, setScannerType] = useState(scannerOptions[0] ?? '');
+  const [universeId, setUniverseId] = useState<number | ''>(universes[0]?.id ?? '');
+  const [strategyId, setStrategyId] = useState<number | ''>('');
+  const [start, setStart] = useState(dateDaysAgo(90));
+  const [end, setEnd] = useState(today());
+  const [maxHoldDays, setMaxHoldDays] = useState(3);
+  const [exitFidelity, setExitFidelity] = useState<'intraday' | 'daily'>('intraday');
+  const [benchmarkSymbol, setBenchmarkSymbol] = useState('SPY');
+
+  const createRun = useCreateReplayRun();
+  const canSubmit = Boolean(scannerType.trim()) && universeId !== '' && start <= end && maxHoldDays > 0;
+
+  useEffect(() => {
+    if (!scannerType && scannerOptions.length > 0) {
+      setScannerType(scannerOptions[0]);
+    }
+  }, [scannerOptions, scannerType]);
+
+  useEffect(() => {
+    if (universeId === '' && universes.length > 0) {
+      setUniverseId(universes[0].id);
+    }
+  }, [universes, universeId]);
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    const selectedUniverseId = Number(universeId);
+
+    const run = await createRun.mutateAsync({
+      scanner_type: scannerType.trim(),
+      universe_id: selectedUniverseId,
+      trading_strategy_id: strategyId === '' ? null : strategyId,
+      start_date: start,
+      end_date: end,
+      max_hold_days: maxHoldDays,
+      exit_fidelity: exitFidelity,
+      benchmark_symbol: benchmarkSymbol.trim().toUpperCase() || 'SPY',
+    });
+    onCreated(run);
+  };
+
+  return (
+    <form onSubmit={submit} className="grid grid-cols-1 xl:grid-cols-12 gap-3">
+      <label className="xl:col-span-2">
+        <span className="block text-xs font-bold uppercase tracking-wider text-gray-500 mb-1">Scanner</span>
+        <input
+          list="replay-scanner-types"
+          value={scannerType}
+          onChange={(event) => setScannerType(event.target.value)}
+          className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:ring-1 focus:ring-financial-blue"
+          placeholder="scanner_type"
+          required
+        />
+        <datalist id="replay-scanner-types">
+          {scannerOptions.map((scanner) => (
+            <option key={scanner} value={scanner} />
+          ))}
+        </datalist>
+      </label>
+
+      <label className="xl:col-span-2">
+        <span className="block text-xs font-bold uppercase tracking-wider text-gray-500 mb-1">Universe</span>
+        <select
+          value={universeId}
+          onChange={(event) => setUniverseId(Number(event.target.value))}
+          className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:ring-1 focus:ring-financial-blue"
+          required
+        >
+          <option value="" disabled>Pick universe</option>
+          {universes.map((universe) => (
+            <option key={universe.id} value={universe.id}>{universe.name}</option>
+          ))}
+        </select>
+      </label>
+
+      <label className="xl:col-span-2">
+        <span className="block text-xs font-bold uppercase tracking-wider text-gray-500 mb-1">Strategy</span>
+        <select
+          value={strategyId}
+          onChange={(event) => setStrategyId(event.target.value ? Number(event.target.value) : '')}
+          className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:ring-1 focus:ring-financial-blue"
+        >
+          <option value="">Scanner defaults</option>
+          {strategies.map((strategy) => (
+            <option key={strategy.id} value={strategy.id}>{strategy.name}</option>
+          ))}
+        </select>
+      </label>
+
+      <label className="xl:col-span-1">
+        <span className="block text-xs font-bold uppercase tracking-wider text-gray-500 mb-1">Start</span>
+        <input
+          type="date"
+          value={start}
+          onChange={(event) => setStart(event.target.value)}
+          className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:ring-1 focus:ring-financial-blue"
+          required
+        />
+      </label>
+
+      <label className="xl:col-span-1">
+        <span className="block text-xs font-bold uppercase tracking-wider text-gray-500 mb-1">End</span>
+        <input
+          type="date"
+          value={end}
+          onChange={(event) => setEnd(event.target.value)}
+          className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:ring-1 focus:ring-financial-blue"
+          required
+        />
+      </label>
+
+      <label className="xl:col-span-1">
+        <span className="block text-xs font-bold uppercase tracking-wider text-gray-500 mb-1">Hold</span>
+        <input
+          type="number"
+          min={1}
+          max={30}
+          value={maxHoldDays}
+          onChange={(event) => setMaxHoldDays(Number(event.target.value))}
+          className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:ring-1 focus:ring-financial-blue"
+        />
+      </label>
+
+      <label className="xl:col-span-1">
+        <span className="block text-xs font-bold uppercase tracking-wider text-gray-500 mb-1">Fidelity</span>
+        <select
+          value={exitFidelity}
+          onChange={(event) => setExitFidelity(event.target.value as 'intraday' | 'daily')}
+          className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:ring-1 focus:ring-financial-blue"
+        >
+          <option value="intraday">Intraday</option>
+          <option value="daily">Daily</option>
+        </select>
+      </label>
+
+      <label className="xl:col-span-1">
+        <span className="block text-xs font-bold uppercase tracking-wider text-gray-500 mb-1">Benchmark</span>
+        <input
+          value={benchmarkSymbol}
+          onChange={(event) => setBenchmarkSymbol(event.target.value.toUpperCase())}
+          className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:ring-1 focus:ring-financial-blue"
+        />
+      </label>
+
+      <div className="xl:col-span-1 flex items-end">
+        <Button type="submit" icon={Play} loading={createRun.isPending} disabled={!canSubmit} fullWidth>
+          Run
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default RunCreateForm;

--- a/frontend/src/pages/Replay/RunCreateForm.tsx
+++ b/frontend/src/pages/Replay/RunCreateForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Play } from 'lucide-react';
 import Button from '../../components/ui/Button';
 import type { ScannerConfig } from '../../api/scanner';
@@ -42,27 +42,17 @@ const RunCreateForm: React.FC<RunCreateFormProps> = ({
   const [benchmarkSymbol, setBenchmarkSymbol] = useState('SPY');
 
   const createRun = useCreateReplayRun();
-  const canSubmit = Boolean(scannerType.trim()) && universeId !== '' && start <= end && maxHoldDays > 0;
-
-  useEffect(() => {
-    if (!scannerType && scannerOptions.length > 0) {
-      setScannerType(scannerOptions[0]);
-    }
-  }, [scannerOptions, scannerType]);
-
-  useEffect(() => {
-    if (universeId === '' && universes.length > 0) {
-      setUniverseId(universes[0].id);
-    }
-  }, [universes, universeId]);
+  const effectiveScannerType = scannerType || scannerOptions[0] || '';
+  const effectiveUniverseId = universeId === '' ? universes[0]?.id ?? null : universeId;
+  const canSubmit = Boolean(effectiveScannerType.trim()) && effectiveUniverseId !== null && start <= end && maxHoldDays > 0;
 
   const submit = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (!canSubmit) return;
-    const selectedUniverseId = Number(universeId);
+    if (!canSubmit || effectiveUniverseId === null) return;
+    const selectedUniverseId = effectiveUniverseId;
 
     const run = await createRun.mutateAsync({
-      scanner_type: scannerType.trim(),
+      scanner_type: effectiveScannerType.trim(),
       universe_id: selectedUniverseId,
       trading_strategy_id: strategyId === '' ? null : strategyId,
       start_date: start,
@@ -80,7 +70,7 @@ const RunCreateForm: React.FC<RunCreateFormProps> = ({
         <span className="block text-xs font-bold uppercase tracking-wider text-gray-500 mb-1">Scanner</span>
         <input
           list="replay-scanner-types"
-          value={scannerType}
+          value={effectiveScannerType}
           onChange={(event) => setScannerType(event.target.value)}
           className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:ring-1 focus:ring-financial-blue"
           placeholder="scanner_type"
@@ -96,7 +86,7 @@ const RunCreateForm: React.FC<RunCreateFormProps> = ({
       <label className="xl:col-span-2">
         <span className="block text-xs font-bold uppercase tracking-wider text-gray-500 mb-1">Universe</span>
         <select
-          value={universeId}
+          value={effectiveUniverseId ?? ''}
           onChange={(event) => setUniverseId(Number(event.target.value))}
           className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:ring-1 focus:ring-financial-blue"
           required

--- a/frontend/src/pages/Replay/RunSummaryPanel.tsx
+++ b/frontend/src/pages/Replay/RunSummaryPanel.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Activity, BarChart3, Percent, ShieldCheck, TrendingDown, Trophy } from 'lucide-react';
+import MetricCard from '../../components/ui/MetricCard';
+import type { ReplayRunSummary } from '../../api/replay';
+
+interface RunSummaryPanelProps {
+  run: ReplayRunSummary | null;
+}
+
+const formatPct = (value: number | null | undefined): string =>
+  value == null ? '-' : `${(value * 100).toFixed(1)}%`;
+
+const formatNumber = (value: number | null | undefined, digits = 2): string =>
+  value == null ? '-' : value.toFixed(digits);
+
+const statusClass = (status: ReplayRunSummary['status']): string => {
+  if (status === 'completed') return 'bg-green-500/10 text-green-400 border-green-500/30';
+  if (status === 'failed') return 'bg-red-500/10 text-red-400 border-red-500/30';
+  if (status === 'running') return 'bg-blue-500/10 text-blue-400 border-blue-500/30';
+  return 'bg-yellow-500/10 text-yellow-400 border-yellow-500/30';
+};
+
+const RunSummaryPanel: React.FC<RunSummaryPanelProps> = ({ run }) => {
+  if (!run) {
+    return (
+      <div className="h-full min-h-64 flex items-center justify-center border border-dashed border-gray-800 rounded-lg bg-gray-900/30">
+        <p className="text-sm text-gray-500">Select a replay run.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-3">
+            <h2 className="text-xl font-black text-financial-light">{run.scanner_type}</h2>
+            <span className={`px-2 py-1 rounded border text-[10px] font-bold uppercase tracking-widest ${statusClass(run.status)}`}>
+              {run.status}
+            </span>
+          </div>
+          <p className="text-xs text-gray-500 mt-1">
+            {run.start_date} to {run.end_date} · universe #{run.universe_id} · {run.exit_fidelity}
+          </p>
+        </div>
+        <div className="bg-gray-900 border border-gray-800 rounded-lg px-3 py-2 min-w-0">
+          <p className="text-[10px] uppercase tracking-widest text-gray-500 font-bold">Data hash</p>
+          <p className="font-mono text-xs text-gray-300 truncate max-w-[40rem]">{run.data_hash ?? 'pending'}</p>
+        </div>
+      </div>
+
+      {run.error_message && (
+        <div className="border border-red-500/30 bg-red-500/10 text-red-300 rounded-lg px-4 py-3 text-sm">
+          {run.error_message}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 2xl:grid-cols-6 gap-4">
+        <MetricCard title="Trades" value={run.total_trades} icon={BarChart3} color="blue" />
+        <MetricCard title="Hit Rate" value={formatPct(run.hit_rate)} icon={Percent} color="green" />
+        <MetricCard title="Expectancy" value={`${formatNumber(run.expectancy_r)}R`} icon={Trophy} color="purple" />
+        <MetricCard title="Profit Factor" value={formatNumber(run.profit_factor)} icon={ShieldCheck} color="yellow" />
+        <MetricCard title="Max Drawdown" value={`${formatNumber(run.max_drawdown_r)}R`} icon={TrendingDown} color="red" />
+        <MetricCard title="MFE/MAE" value={formatNumber(run.mfe_mae_ratio)} icon={Activity} color="blue" />
+      </div>
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {[
+          ['Avg Bars Held', formatNumber(run.avg_bars_held, 1)],
+          ['Median Bars Held', formatNumber(run.median_bars_held, 1)],
+          ['Avg MFE', `${formatNumber(run.avg_mfe_pct)}%`],
+          ['Avg MAE', `${formatNumber(run.avg_mae_pct)}%`],
+        ].map(([label, value]) => (
+          <div key={label} className="bg-gray-900/60 border border-gray-800 rounded-lg px-4 py-3">
+            <p className="text-[10px] uppercase tracking-widest text-gray-500 font-bold">{label}</p>
+            <p className="text-lg font-bold text-financial-light mt-1">{value}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RunSummaryPanel;

--- a/frontend/src/pages/Replay/index.tsx
+++ b/frontend/src/pages/Replay/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { BarChart3, GitCompare, History, RefreshCw } from 'lucide-react';
 import Card from '../../components/ui/Card';
@@ -48,17 +48,12 @@ const ReplayPage: React.FC = () => {
   const { data: strategies = [] } = useStrategies(true);
   const runsQuery = useReplayRuns({ limit: 50 });
   const runs = runsQuery.data ?? [];
-  const selectedRunQuery = useReplayRun(selectedRunUuid);
-  const selectedRun = selectedRunQuery.data ?? runs.find((run) => run.uuid === selectedRunUuid) ?? null;
-  const tradesQuery = useReplayTrades(selectedRunUuid);
-  const analyticsQuery = useReplayAnalytics(selectedRunUuid);
+  const effectiveRunUuid = selectedRunUuid ?? runs[0]?.uuid ?? null;
+  const selectedRunQuery = useReplayRun(effectiveRunUuid);
+  const selectedRun = selectedRunQuery.data ?? runs.find((run) => run.uuid === effectiveRunUuid) ?? null;
+  const tradesQuery = useReplayTrades(effectiveRunUuid);
+  const analyticsQuery = useReplayAnalytics(effectiveRunUuid);
   const compareRuns = useCompareReplayRuns();
-
-  useEffect(() => {
-    if (!selectedRunUuid && runs.length > 0) {
-      setSelectedRunUuid(runs[0].uuid);
-    }
-  }, [runs, selectedRunUuid]);
 
   const selectedTradeChart = useQuery({
     queryKey: ['replay', 'trade-chart', selectedTrade?.ticker],
@@ -128,7 +123,7 @@ const ReplayPage: React.FC = () => {
         >
           <div className="divide-y divide-gray-800">
             {runs.map((run) => {
-              const active = selectedRunUuid === run.uuid;
+              const active = effectiveRunUuid === run.uuid;
               return (
                 <div
                   key={run.uuid}

--- a/frontend/src/pages/Replay/index.tsx
+++ b/frontend/src/pages/Replay/index.tsx
@@ -1,0 +1,271 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { BarChart3, GitCompare, History, RefreshCw } from 'lucide-react';
+import Card from '../../components/ui/Card';
+import Button from '../../components/ui/Button';
+import Modal from '../../components/ui/Modal';
+import StockChart from '../../components/ui/StockChart';
+import { fetchScannerConfigs } from '../../api/scanner';
+import { fetchStockUniverses } from '../../api/universe';
+import { fetchHistoricalData } from '../../api/scanner';
+import { useStrategies } from '../../api/trading';
+import {
+  useCompareReplayRuns,
+  useReplayAnalytics,
+  useReplayRun,
+  useReplayRuns,
+  useReplayTrades,
+} from '../../api/replay';
+import type { ReplayRunSummary, ReplayTrade } from '../../api/replay';
+import RunCreateForm from './RunCreateForm';
+import RunSummaryPanel from './RunSummaryPanel';
+import AnalyticsPanel from './AnalyticsPanel';
+import { buildReplayMarkers, buildReplayPriceLines } from '../../utils/replayChartOverlays';
+
+const formatMetric = (value: number | null | undefined, suffix = ''): string =>
+  value == null ? '-' : `${value.toFixed(2)}${suffix}`;
+
+const statusClass = (status: ReplayRunSummary['status']): string => {
+  if (status === 'completed') return 'text-green-400';
+  if (status === 'failed') return 'text-red-400';
+  if (status === 'running') return 'text-blue-400';
+  return 'text-yellow-400';
+};
+
+const ReplayPage: React.FC = () => {
+  const [selectedRunUuid, setSelectedRunUuid] = useState<string | null>(null);
+  const [selectedTrade, setSelectedTrade] = useState<ReplayTrade | null>(null);
+  const [compareIds, setCompareIds] = useState<string[]>([]);
+
+  const { data: scannerConfigs = [] } = useQuery({
+    queryKey: ['scannerConfigs'],
+    queryFn: fetchScannerConfigs,
+  });
+  const { data: universes = [] } = useQuery({
+    queryKey: ['universes', 'replay'],
+    queryFn: () => fetchStockUniverses({ include_stats: true }),
+  });
+  const { data: strategies = [] } = useStrategies(true);
+  const runsQuery = useReplayRuns({ limit: 50 });
+  const runs = runsQuery.data ?? [];
+  const selectedRunQuery = useReplayRun(selectedRunUuid);
+  const selectedRun = selectedRunQuery.data ?? runs.find((run) => run.uuid === selectedRunUuid) ?? null;
+  const tradesQuery = useReplayTrades(selectedRunUuid);
+  const analyticsQuery = useReplayAnalytics(selectedRunUuid);
+  const compareRuns = useCompareReplayRuns();
+
+  useEffect(() => {
+    if (!selectedRunUuid && runs.length > 0) {
+      setSelectedRunUuid(runs[0].uuid);
+    }
+  }, [runs, selectedRunUuid]);
+
+  const selectedTradeChart = useQuery({
+    queryKey: ['replay', 'trade-chart', selectedTrade?.ticker],
+    queryFn: () => fetchHistoricalData(selectedTrade!.ticker, '6mo', 'day'),
+    enabled: Boolean(selectedTrade),
+  });
+
+  const compareSummary = useMemo(() => {
+    const comparisons = compareRuns.data?.comparisons ?? [];
+    if (comparisons.length === 0) return null;
+    const mismatches = comparisons.filter((comparison) => !comparison.data_hash_match).length;
+    return `${comparisons.length - mismatches}/${comparisons.length} hash pairs match`;
+  }, [compareRuns.data]);
+
+  const toggleCompare = (uuid: string) => {
+    setCompareIds((current) => {
+      if (current.includes(uuid)) return current.filter((id) => id !== uuid);
+      if (current.length >= 5) return current;
+      return [...current, uuid];
+    });
+  };
+
+  const runComparison = () => {
+    if (compareIds.length >= 2) {
+      compareRuns.mutate(compareIds);
+    }
+  };
+
+  return (
+    <div className="space-y-6 animate-fade-in">
+      <div className="flex flex-col xl:flex-row xl:items-center justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-black text-financial-light tracking-tight">SIGNAL REPLAY</h1>
+          <p className="text-gray-400 mt-1 font-medium">Canonical replay runs with reproducible manifests and trade-level audit trails</p>
+        </div>
+        <Button icon={RefreshCw} variant="secondary" onClick={() => runsQuery.refetch()}>
+          Refresh
+        </Button>
+      </div>
+
+      <Card title="Create Replay Run" icon={History}>
+        <RunCreateForm
+          scannerConfigs={scannerConfigs}
+          strategies={strategies}
+          universes={universes}
+          onCreated={(run) => setSelectedRunUuid(run.uuid)}
+        />
+      </Card>
+
+      <div className="grid grid-cols-1 2xl:grid-cols-[minmax(26rem,34rem)_1fr] gap-6">
+        <Card
+          title="Runs"
+          icon={BarChart3}
+          actions={
+            <Button
+              icon={GitCompare}
+              size="sm"
+              variant="secondary"
+              disabled={compareIds.length < 2}
+              loading={compareRuns.isPending}
+              onClick={runComparison}
+            >
+              Compare
+            </Button>
+          }
+          noPadding
+        >
+          <div className="divide-y divide-gray-800">
+            {runs.map((run) => {
+              const active = selectedRunUuid === run.uuid;
+              return (
+                <div
+                  key={run.uuid}
+                  className={`p-4 cursor-pointer transition-colors ${active ? 'bg-financial-blue/10' : 'hover:bg-gray-800/50'}`}
+                  onClick={() => setSelectedRunUuid(run.uuid)}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={compareIds.includes(run.uuid)}
+                          onChange={(event) => {
+                            event.stopPropagation();
+                            toggleCompare(run.uuid);
+                          }}
+                          onClick={(event) => event.stopPropagation()}
+                          className="h-4 w-4 rounded border-gray-700 bg-gray-900"
+                        />
+                        <p className="font-bold text-financial-light truncate">{run.scanner_type}</p>
+                      </div>
+                      <p className="text-xs text-gray-500 mt-1">
+                        {run.start_date} to {run.end_date} · {run.total_trades} trades
+                      </p>
+                      <p className="font-mono text-[10px] text-gray-500 mt-2 truncate">{run.data_hash ?? 'hash pending'}</p>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <p className={`text-xs font-bold uppercase ${statusClass(run.status)}`}>{run.status}</p>
+                      <p className="text-sm text-gray-300 mt-1">{formatMetric(run.expectancy_r)}R</p>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+            {runs.length === 0 && (
+              <div className="px-4 py-16 text-center text-sm text-gray-500">No replay runs yet.</div>
+            )}
+          </div>
+          {compareSummary && (
+            <div className="border-t border-gray-800 bg-gray-900/70 px-4 py-3 text-sm text-gray-300">
+              {compareSummary}
+            </div>
+          )}
+        </Card>
+
+        <Card title="Run Summary" icon={History}>
+          <RunSummaryPanel run={selectedRun} />
+        </Card>
+      </div>
+
+      <AnalyticsPanel metrics={analyticsQuery.data} />
+
+      <Card title="Trades" noPadding>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-800">
+            <thead className="bg-gray-900/80">
+              <tr>
+                {['Ticker', 'Signal', 'Direction', 'Entry', 'Exit', 'Reason', 'Return', 'R', 'Regime'].map((header) => (
+                  <th key={header} className="px-4 py-3 text-left text-[10px] font-bold uppercase tracking-widest text-gray-500">
+                    {header}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-800">
+              {(tradesQuery.data?.trades ?? []).map((trade) => (
+                <tr
+                  key={trade.id}
+                  onClick={() => setSelectedTrade(trade)}
+                  className="hover:bg-gray-800/50 cursor-pointer"
+                >
+                  <td className="px-4 py-3 font-bold text-financial-light">{trade.ticker}</td>
+                  <td className="px-4 py-3 text-sm text-gray-300">{trade.signal_date.slice(0, 10)}</td>
+                  <td className="px-4 py-3 text-sm text-gray-300 uppercase">{trade.direction}</td>
+                  <td className="px-4 py-3 text-sm text-gray-300">{formatMetric(trade.entry_price, '')}</td>
+                  <td className="px-4 py-3 text-sm text-gray-300">{formatMetric(trade.exit_price, '')}</td>
+                  <td className="px-4 py-3 text-sm text-gray-300">{trade.exit_reason ?? '-'}</td>
+                  <td className={`px-4 py-3 text-sm font-bold ${(trade.return_pct ?? 0) >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+                    {formatMetric(trade.return_pct, '%')}
+                  </td>
+                  <td className={`px-4 py-3 text-sm font-bold ${(trade.return_r ?? 0) >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+                    {formatMetric(trade.return_r, 'R')}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-300">
+                    {[trade.regime_trend, trade.regime_vol].filter(Boolean).join(' / ') || '-'}
+                  </td>
+                </tr>
+              ))}
+              {(tradesQuery.data?.trades ?? []).length === 0 && (
+                <tr>
+                  <td colSpan={9} className="px-4 py-16 text-center text-sm text-gray-500">No replay trades for this run.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+
+      <Modal
+        isOpen={Boolean(selectedTrade)}
+        onClose={() => setSelectedTrade(null)}
+        title={selectedTrade ? `${selectedTrade.ticker} Trade Drill-Down` : 'Trade Drill-Down'}
+        size="xl"
+      >
+        {selectedTrade && (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+              {[
+                ['Signal', selectedTrade.signal_date.slice(0, 10)],
+                ['Return', formatMetric(selectedTrade.return_r, 'R')],
+                ['MFE', formatMetric(selectedTrade.mfe_pct, '%')],
+                ['MAE', formatMetric(selectedTrade.mae_pct, '%')],
+              ].map(([label, value]) => (
+                <div key={label} className="bg-gray-950 border border-gray-800 rounded-lg px-4 py-3">
+                  <p className="text-[10px] uppercase tracking-widest text-gray-500 font-bold">{label}</p>
+                  <p className="text-lg font-bold text-financial-light mt-1">{value}</p>
+                </div>
+              ))}
+            </div>
+
+            <div className="border border-gray-800 rounded-lg overflow-hidden bg-gray-950">
+              <StockChart
+                data={selectedTradeChart.data?.data ?? []}
+                type="candlestick"
+                timespan="day"
+                height={420}
+                symbol={selectedTrade.ticker}
+                highlightDate={selectedTrade.signal_date}
+                replayMarkers={buildReplayMarkers(selectedTrade)}
+                priceLines={buildReplayPriceLines(selectedTrade)}
+              />
+            </div>
+          </div>
+        )}
+      </Modal>
+    </div>
+  );
+};
+
+export default ReplayPage;

--- a/frontend/src/utils/replayChartOverlays.test.ts
+++ b/frontend/src/utils/replayChartOverlays.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { buildReplayMarkers, buildReplayPriceLines } from './replayChartOverlays';
+import type { ReplayTrade } from '../api/replay';
+
+const baseTrade: ReplayTrade = {
+  id: 1,
+  ticker: 'AAPL',
+  signal_date: '2026-01-02',
+  entry_date: '2026-01-02T14:31:00Z',
+  entry_price: 100,
+  direction: 'long',
+  stop_price: 95,
+  target_price: 110,
+  exit_date: '2026-01-03T16:00:00Z',
+  exit_price: 110,
+  exit_reason: 'target',
+  return_pct: 10,
+  return_r: 2,
+  mfe_pct: 11,
+  mae_pct: -1,
+  bars_held: 390,
+  regime_trend: 'bullish',
+  regime_vol: 'normal',
+  fill_source: 'intraday',
+};
+
+describe('replay chart overlays', () => {
+  it('builds sorted signal, entry, and exit markers', () => {
+    const markers = buildReplayMarkers(baseTrade);
+
+    expect(markers).toHaveLength(3);
+    expect(markers.map((marker) => marker.text)).toEqual(['Signal', 'Entry', 'target']);
+    expect(markers[1].shape).toBe('arrowUp');
+    expect(markers[2].color).toBe('#22c55e');
+  });
+
+  it('uses short entry and losing exit directions', () => {
+    const markers = buildReplayMarkers({
+      ...baseTrade,
+      direction: 'short',
+      return_r: -1,
+      exit_reason: 'stop',
+    });
+
+    expect(markers[1].position).toBe('aboveBar');
+    expect(markers[1].shape).toBe('arrowDown');
+    expect(markers[2].color).toBe('#ef4444');
+  });
+
+  it('builds entry, stop, target, and exit price lines', () => {
+    expect(buildReplayPriceLines(baseTrade)).toEqual([
+      { value: 100, color: '#38bdf8', label: 'Entry' },
+      { value: 95, color: '#ef4444', label: 'Stop' },
+      { value: 110, color: '#22c55e', label: 'Target' },
+      { value: 110, color: '#f59e0b', label: 'Exit' },
+    ]);
+  });
+});

--- a/frontend/src/utils/replayChartOverlays.ts
+++ b/frontend/src/utils/replayChartOverlays.ts
@@ -1,0 +1,78 @@
+import type { SeriesMarker, Time } from 'lightweight-charts';
+import type { ReplayTrade } from '../api/replay';
+
+export interface ReplayPriceLine {
+  value: number;
+  color: string;
+  label: string;
+}
+
+const timeFromIso = (value: string | null): Time | null => {
+  if (!value) return null;
+  return value.split('T')[0].split(' ')[0] as Time;
+};
+
+export const buildReplayMarkers = (trade: ReplayTrade): SeriesMarker<Time>[] => {
+  const markers: SeriesMarker<Time>[] = [];
+  const signalTime = timeFromIso(trade.signal_date);
+  const entryTime = timeFromIso(trade.entry_date);
+  const exitTime = timeFromIso(trade.exit_date);
+
+  if (signalTime) {
+    markers.push({
+      time: signalTime,
+      position: 'belowBar',
+      color: '#f59e0b',
+      shape: 'circle',
+      size: 1,
+      text: 'Signal',
+    });
+  }
+
+  if (entryTime) {
+    markers.push({
+      time: entryTime,
+      position: trade.direction === 'short' ? 'aboveBar' : 'belowBar',
+      color: '#38bdf8',
+      shape: trade.direction === 'short' ? 'arrowDown' : 'arrowUp',
+      size: 1,
+      text: 'Entry',
+    });
+  }
+
+  if (exitTime) {
+    markers.push({
+      time: exitTime,
+      position: trade.return_r != null && trade.return_r < 0 ? 'belowBar' : 'aboveBar',
+      color: trade.return_r != null && trade.return_r < 0 ? '#ef4444' : '#22c55e',
+      shape: trade.return_r != null && trade.return_r < 0 ? 'arrowDown' : 'arrowUp',
+      size: 1,
+      text: trade.exit_reason ?? 'Exit',
+    });
+  }
+
+  return markers.sort((a, b) =>
+    typeof a.time === 'number' && typeof b.time === 'number'
+      ? a.time - b.time
+      : String(a.time).localeCompare(String(b.time)),
+  );
+};
+
+export const buildReplayPriceLines = (trade: ReplayTrade): ReplayPriceLine[] => {
+  const lines: ReplayPriceLine[] = [];
+
+  if (trade.entry_price != null) {
+    lines.push({ value: trade.entry_price, color: '#38bdf8', label: 'Entry' });
+  }
+  if (trade.stop_price != null) {
+    lines.push({ value: trade.stop_price, color: '#ef4444', label: 'Stop' });
+  }
+  if (trade.target_price != null) {
+    lines.push({ value: trade.target_price, color: '#22c55e', label: 'Target' });
+  }
+  if (trade.exit_price != null) {
+    lines.push({ value: trade.exit_price, color: '#f59e0b', label: 'Exit' });
+  }
+
+  return lines;
+};


### PR DESCRIPTION
## Summary
- Adds replay run/trade persistence, Alembic migration, manifest/data hashing, signal loading, intraday exit simulation, benchmark regime classification, replay metrics, and Celery execution.
- Adds `/api/v1/replay` run, trade, analytics, and compare endpoints with focused API/service/task tests.
- Adds the Signal Replay frontend console with run creation, hash comparison, analytics panels, trade table, and chart drill-down overlays.

## Verification
- `python -m pytest tests/services/test_replay_manifest.py tests/services/test_replay_exit_simulator.py tests/services/test_replay_benchmark.py tests/services/test_replay_regime_classifier.py tests/services/test_replay_metrics.py tests/tasks/test_replay_task.py tests/api/test_replay.py -q --no-cov` (31 passed)
- `npx tsc --noEmit -p tsconfig.app.json`
- `npx vitest run src/utils/replayChartOverlays.test.ts` (3 passed)
- `npm run build`
- `python -m alembic heads`
- `python -m pytest tests -x -q` currently stops during collection on Python 3.10 because `tests/test_coverage_config.py` imports stdlib `tomllib`.

Closes #483
Closes #484
Closes #485
Closes #486
Closes #487
Closes #488
Closes #489
Closes #490