### PR TITLE
fix(scheduler): exclude ready-for-human from orphaned-in-progress sweep

### DIFF
--- a/dark-factory/scheduler.sh
+++ b/dark-factory/scheduler.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 # --- Configuration (non-policy infrastructure) ---
-SKIP_LABELS="needs-discussion,epic"
+# ready-for-human marks a ticket a human has taken over; the factory must leave it alone
+# everywhere (dispatch, retry, rescue, and the orphaned-in-progress sweep) — an In-progress
+# ready-for-human ticket has no container because a HUMAN is on it, not because a run died.
+SKIP_LABELS="needs-discussion,epic,ready-for-human"
 SCHEDULER_STATE_DIR="${SCHEDULER_STATE_DIR:-/var/lib/dark-factory}"
 STATE_FILE="${SCHEDULER_STATE_DIR}/scheduler-state.json"
 RECHECK_STAMP_FILE="${SCHEDULER_STATE_DIR}/main-red-last-recheck"


### PR DESCRIPTION
## Bug

Tickets labelled **`ready-for-human`** that sit in **In progress** were being swept to **Blocked** with a `## Dark Factory — Orphaned Run Recovered` comment.

The orphaned-in-progress sweep (`scheduler.sh` ~L900) moves any In-progress item with **no running factory container** to Blocked, on the assumption the run died untrappably (host reboot / OOM / SIGKILL). It only exempts items via `has_skip_label`, and `SKIP_LABELS` was `"needs-discussion,epic"` — it did **not** include `ready-for-human`.

A `ready-for-human` + In-progress ticket has no container because a **human took it over**, not because a run died — so the sweep wrongly "recovered" it.

## Fix

Add `ready-for-human` to `SKIP_LABELS`. `has_skip_label` gates the factory across **every** priority (dispatch, retry, rescue, conflict-resolution, spec/plan advance, and the orphaned sweep), so this makes the factory uniformly leave human-owned tickets alone — the intended semantics of the label, and consistent with the existing sweep comment *"Skip-labels let a human park an item."*

One-line change (plus an explanatory comment). No tests reference the sweep (it is bash, not pytest-covered).

## Deployment note

`scheduler.sh` is baked into `markethawk-dark-factory:latest` (the running `backlog-scheduler` executes `/opt/dark-factory/scheduler.sh`). This PR makes the fix durable on `main`; the running scheduler was hot-patched (`docker cp` + restart) for immediate effect pending the next image rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
