### PR TITLE
Add top-k memory retrieval cap compatible with Dark Factory memory v2

### DIFF
--- a/dark-factory/scripts/context_budget.py
+++ b/dark-factory/scripts/context_budget.py
@@ -67,6 +67,17 @@ def _dropped(reason: str) -> dict:
     return {"status": "dropped", "tokens": 0, "reason": reason}
 
 
+def _read_json(path: str | None) -> dict | None:
+    """Read and parse a JSON file. Returns None on missing file, OSError, or parse error."""
+    raw = _read_text(path)
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
 def _probe_skill_prompts() -> dict:
     parts = []
     for name in _SKILL_PROMPT_FILES:
@@ -209,6 +220,14 @@ def build_budget(
                 h = te.hash_file(memory_file)
                 if h:
                     source_hashes["memory-context.md"] = h
+            # Best-effort: surface cap counts from memory-trace.json when available.
+            # Pre-run budget calls will not have the trace; post-run calls will.
+            if artifacts_dir:
+                trace_path = os.path.join(artifacts_dir, "memory-trace.json")
+                trace = _read_json(trace_path)
+                if trace:
+                    sections[sec]["entries_selected"] = trace.get("entries_selected_total", 0)
+                    sections[sec]["entries_dropped"] = trace.get("entries_dropped_by_cap_total", 0)
 
         elif sec == "pr_reviews":
             sections[sec] = _probe_pr_reviews(issue_json)

--- a/dark-factory/scripts/context_budget.py
+++ b/dark-factory/scripts/context_budget.py
@@ -68,14 +68,17 @@ def _dropped(reason: str) -> dict:
 
 
 def _read_json(path: str | None) -> dict | None:
-    """Read and parse a JSON file. Returns None on missing file, OSError, or parse error."""
+    """Read and parse a JSON file. Returns None on missing file, OSError, parse error, or non-object JSON."""
     raw = _read_text(path)
     if not raw:
         return None
     try:
-        return json.loads(raw)
+        parsed = json.loads(raw)
     except (json.JSONDecodeError, ValueError):
         return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
 
 
 def _probe_skill_prompts() -> dict:
@@ -222,7 +225,7 @@ def build_budget(
                     source_hashes["memory-context.md"] = h
             # Best-effort: surface cap counts from memory-trace.json when available.
             # Pre-run budget calls will not have the trace; post-run calls will.
-            if artifacts_dir:
+            if artifacts_dir and sections[sec]["status"] != "dropped":
                 trace_path = os.path.join(artifacts_dir, "memory-trace.json")
                 trace = _read_json(trace_path)
                 if trace:

--- a/dark-factory/scripts/memory_retrieve.py
+++ b/dark-factory/scripts/memory_retrieve.py
@@ -303,20 +303,18 @@ def scan_index(memory_dir, area_files, files, allowed_sources):
     return candidates
 
 
-def format_index_output(candidates, labels=None, cap_out=None):
+def format_index_output(candidates, labels=None, _cap_out=None):
     """Format scan_index output with dual cap and label-boost ranking.
 
     Sort key: (path_specificity + label_boost, created_at DESC) globally.
     Cap: stop at TOP_K_DEFAULT entries OR TOKEN_BUDGET_DEFAULT tokens, whichever first.
     Groups selected entries by source_file in ALL_MEMORY_FILES order.
 
-    cap_out: optional dict mutated in-place with cap telemetry keys:
+    _cap_out: optional dict mutated in-place with cap telemetry keys:
         entries_selected, entries_dropped_by_cap, per_file_selected, per_file_dropped.
         Prefer passing an empty dict and reading it after the call; a future refactor
         could return a (text, cap_counts) tuple instead.
     """
-    # Internal alias kept for back-compat with direct callers using _cap_out kwarg.
-    _cap_out = cap_out
     labels = labels or []
 
     # Tiebreaker: entries without created_at sort as "" which, under reverse=True,
@@ -387,7 +385,7 @@ def retrieve_memory(memory_dir, phase, files, labels=None, _cap_out=None):
         except (OSError, ValueError):
             candidates = []
         if candidates:
-            return format_index_output(candidates, labels=labels, cap_out=_cap_out)
+            return format_index_output(candidates, labels=labels, _cap_out=_cap_out)
 
     results = scan_markdown_files(memory_dir, area_files, files, allowed_sources)
     # Markdown fallback: populate _cap_out with zero counts so downstream consumers

--- a/dark-factory/scripts/memory_retrieve.py
+++ b/dark-factory/scripts/memory_retrieve.py
@@ -18,8 +18,12 @@ import sys
 from datetime import date
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent))
-import token_estimate as te  # 4 chars/token estimator
+try:
+    import token_estimate as te  # 4 chars/token estimator (package-relative)
+except ImportError:
+    # Fallback: add parent dir to sys.path when running as a standalone script.
+    sys.path.insert(0, str(Path(__file__).parent))
+    import token_estimate as te  # noqa: E402
 
 # ── Constants ──────────────────────────────────────────────────────────────
 
@@ -299,17 +303,25 @@ def scan_index(memory_dir, area_files, files, allowed_sources):
     return candidates
 
 
-def format_index_output(candidates, labels=None, _cap_out=None):
+def format_index_output(candidates, labels=None, cap_out=None):
     """Format scan_index output with dual cap and label-boost ranking.
 
     Sort key: (path_specificity + label_boost, created_at DESC) globally.
     Cap: stop at TOP_K_DEFAULT entries OR TOKEN_BUDGET_DEFAULT tokens, whichever first.
     Groups selected entries by source_file in ALL_MEMORY_FILES order.
-    _cap_out: if provided, populated with entries_selected, entries_dropped_by_cap,
-              per_file_selected, per_file_dropped.
+
+    cap_out: optional dict mutated in-place with cap telemetry keys:
+        entries_selected, entries_dropped_by_cap, per_file_selected, per_file_dropped.
+        Prefer passing an empty dict and reading it after the call; a future refactor
+        could return a (text, cap_counts) tuple instead.
     """
+    # Internal alias kept for back-compat with direct callers using _cap_out kwarg.
+    _cap_out = cap_out
     labels = labels or []
 
+    # Tiebreaker: entries without created_at sort as "" which, under reverse=True,
+    # ranks them last within equal specificity+boost (i.e. oldest/undated are lowest
+    # priority). This is intentional: undated entries lose recency tiebreaks.
     ranked = sorted(
         candidates,
         key=lambda c: (
@@ -324,7 +336,9 @@ def format_index_output(candidates, labels=None, _cap_out=None):
     token_total = 0
     for c in ranked:
         token_cost = te.estimate_tokens(c["text"])
-        if len(selected) >= TOP_K_DEFAULT or token_total + token_cost > TOKEN_BUDGET_DEFAULT:
+        # Always admit the first entry even if it alone exceeds the token budget,
+        # so a single large memory never silently yields an empty block.
+        if len(selected) >= TOP_K_DEFAULT or (selected and token_total + token_cost > TOKEN_BUDGET_DEFAULT):
             dropped.append(c)
         else:
             selected.append(c)
@@ -373,9 +387,17 @@ def retrieve_memory(memory_dir, phase, files, labels=None, _cap_out=None):
         except (OSError, ValueError):
             candidates = []
         if candidates:
-            return format_index_output(candidates, labels=labels, _cap_out=_cap_out)
+            return format_index_output(candidates, labels=labels, cap_out=_cap_out)
 
     results = scan_markdown_files(memory_dir, area_files, files, allowed_sources)
+    # Markdown fallback: populate _cap_out with zero counts so downstream consumers
+    # can distinguish "no cap applied" (fallback_used=True) from absent telemetry.
+    if _cap_out is not None:
+        _cap_out["entries_selected"] = 0
+        _cap_out["entries_dropped_by_cap"] = 0
+        _cap_out["per_file_selected"] = {}
+        _cap_out["per_file_dropped"] = {}
+        _cap_out["fallback_used"] = True
     return format_markdown_output(results)
 
 
@@ -476,7 +498,16 @@ def main():
         help="Newline-separated list of changed or anticipated file paths",
     )
     parser.add_argument("--issue", type=int, default=None, help="Issue number (informational)")
-    parser.add_argument("--labels", nargs="*", default=None, help="Issue labels for memory ranking label boost")
+    parser.add_argument(
+        "--labels",
+        nargs="*",
+        default=None,
+        # IMPORTANT: nargs="*" requires space-separated tokens, NOT comma-separated.
+        # Correct:   --labels backend frontend
+        # Wrong:     --labels "backend,frontend"  (treated as one label, matches nothing)
+        # All callers must pass individual tokens separated by spaces.
+        help="Issue labels for memory ranking label boost (space-separated, e.g. --labels backend frontend)",
+    )
     parser.add_argument(
         "--memory-dir",
         default=".archon/memory",

--- a/dark-factory/scripts/memory_retrieve.py
+++ b/dark-factory/scripts/memory_retrieve.py
@@ -340,6 +340,8 @@ def format_index_output(candidates, labels=None, _cap_out=None):
         token_cost = te.estimate_tokens(c["text"])
         # Always admit the first entry even if it alone exceeds the token budget,
         # so a single large memory never silently yields an empty block.
+        # Over-budget entries are skipped individually (not a hard stop); a later
+        # smaller entry may still be admitted if it fits within the remaining budget.
         if len(selected) >= TOP_K_DEFAULT or (selected and token_total + token_cost > TOKEN_BUDGET_DEFAULT):
             if selected and token_total + token_cost > TOKEN_BUDGET_DEFAULT and len(selected) < TOP_K_DEFAULT:
                 sys.stderr.write(
@@ -467,8 +469,6 @@ def emit_memory_trace(trace_path, phase, files, memory_dir, area_files, allowed_
         # cap_counts (which reflects the actual retrieval path) rather than the
         # markdown-file existence check above, so the two signals stay consistent.
         index_path_ran = cap_counts is not None and not cap_counts.get("fallback_used")
-        if index_path_ran:
-            fallback_used = cap_counts.get("fallback_used", False)
 
         trace = {
             "schema_version": 1,

--- a/dark-factory/scripts/memory_retrieve.py
+++ b/dark-factory/scripts/memory_retrieve.py
@@ -482,7 +482,7 @@ def emit_memory_trace(trace_path, phase, files, memory_dir, area_files, allowed_
             "fallback_used": fallback_used,
         }
 
-        if cap_counts is not None and not cap_counts.get("fallback_used"):
+        if cap_counts and not cap_counts.get("fallback_used"):
             trace["entries_selected_total"] = cap_counts.get("entries_selected", 0)
             trace["entries_dropped_by_cap_total"] = cap_counts.get("entries_dropped_by_cap", 0)
 

--- a/dark-factory/scripts/memory_retrieve.py
+++ b/dark-factory/scripts/memory_retrieve.py
@@ -68,7 +68,11 @@ AUTHORITATIVE_KINDS = {"PATTERN", "AVOID", "FIX"}
 TOP_K_DEFAULT = 8
 TOKEN_BUDGET_DEFAULT = 1500
 
-# Issue label → source_file boost mapping (mirrors architecture_slice._LABEL_COMPONENT_MAP)
+# Issue label → source_file boost mapping.
+# Intentionally independent from architecture_slice._LABEL_COMPONENT_MAP: that map
+# routes labels to component paths for code navigation, whereas this map routes labels
+# to memory source_file names for retrieval ranking. The keys and values deliberately
+# differ; do not merge or derive one from the other.
 _LABEL_SOURCE_BOOST_MAP = {
     "dark factory":     "dark-factory-ops.md",
     "dark-factory":     "dark-factory-ops.md",
@@ -337,6 +341,10 @@ def format_index_output(candidates, labels=None, _cap_out=None):
         # Always admit the first entry even if it alone exceeds the token budget,
         # so a single large memory never silently yields an empty block.
         if len(selected) >= TOP_K_DEFAULT or (selected and token_total + token_cost > TOKEN_BUDGET_DEFAULT):
+            if selected and token_total + token_cost > TOKEN_BUDGET_DEFAULT and len(selected) < TOP_K_DEFAULT:
+                sys.stderr.write(
+                    f"memory-cap: dropped oversized entry ({token_cost} tokens) from {c['source_file']}\n"
+                )
             dropped.append(c)
         else:
             selected.append(c)
@@ -455,6 +463,13 @@ def emit_memory_trace(trace_path, phase, files, memory_dir, area_files, allowed_
                 "entries_dropped_by_cap": per_file_dropped.get(fname, 0),
             })
 
+        # When the index path ran and provided cap_counts, use fallback_used from
+        # cap_counts (which reflects the actual retrieval path) rather than the
+        # markdown-file existence check above, so the two signals stay consistent.
+        index_path_ran = cap_counts is not None and not cap_counts.get("fallback_used")
+        if index_path_ran:
+            fallback_used = cap_counts.get("fallback_used", False)
+
         trace = {
             "schema_version": 1,
             "retrieval_mechanism": "flatfile-pathtag",
@@ -467,7 +482,7 @@ def emit_memory_trace(trace_path, phase, files, memory_dir, area_files, allowed_
             "fallback_used": fallback_used,
         }
 
-        if cap_counts:
+        if cap_counts is not None and not cap_counts.get("fallback_used"):
             trace["entries_selected_total"] = cap_counts.get("entries_selected", 0)
             trace["entries_dropped_by_cap_total"] = cap_counts.get("entries_dropped_by_cap", 0)
 

--- a/dark-factory/scripts/memory_retrieve.py
+++ b/dark-factory/scripts/memory_retrieve.py
@@ -18,6 +18,9 @@ import sys
 from datetime import date
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent))
+import token_estimate as te  # 4 chars/token estimator
+
 # ── Constants ──────────────────────────────────────────────────────────────
 
 GLOBAL_FILES = {"codebase-patterns.md", "architecture.md"}
@@ -57,12 +60,42 @@ PHASE_AGENT_ID = {
 # Only these kind tags are considered authoritative
 AUTHORITATIVE_KINDS = {"PATTERN", "AVOID", "FIX"}
 
+# Cap defaults for the index retrieval path
+TOP_K_DEFAULT = 8
+TOKEN_BUDGET_DEFAULT = 1500
+
+# Issue label → source_file boost mapping (mirrors architecture_slice._LABEL_COMPONENT_MAP)
+_LABEL_SOURCE_BOOST_MAP = {
+    "dark factory":     "dark-factory-ops.md",
+    "dark-factory":     "dark-factory-ops.md",
+    "frontend":         "frontend-patterns.md",
+    "backend":          "backend-patterns.md",
+}
+
 # Parse: - [TAG] body <!-- meta -->
 _ENTRY_RE = re.compile(
     r"^- \[(?P<tag>[^\]]+)\]\s+(?P<body>.+?)(?:\s*<!--(?P<meta>[^>]*)-->)?\s*$"
 )
 # Parse key:value pairs in metadata comment
 _TAG_RE = re.compile(r"(\w+\d*):([^\s>]+)")
+
+
+# ── Label boost ───────────────────────────────────────────────────────────
+
+def compute_label_boost(source_file, labels):
+    """Return +1 if source_file maps to a domain matched by any issue label; 0 otherwise.
+
+    Global files (codebase-patterns.md, architecture.md) are never boosted.
+    Match is case-insensitive: key in label.lower().
+    """
+    if not labels or source_file in GLOBAL_FILES:
+        return 0
+    for label_text in labels:
+        label_lower = label_text.lower()
+        for key, target_file in _LABEL_SOURCE_BOOST_MAP.items():
+            if key in label_lower and source_file == target_file:
+                return 1
+    return 0
 
 
 # ── Area selection ─────────────────────────────────────────────────────────
@@ -266,26 +299,59 @@ def scan_index(memory_dir, area_files, files, allowed_sources):
     return candidates
 
 
-def format_index_output(candidates):
-    """Format scan_index output, grouped by source_file in ALL_MEMORY_FILES order.
+def format_index_output(candidates, labels=None, _cap_out=None):
+    """Format scan_index output with dual cap and label-boost ranking.
 
-    Within each group: ranked by path specificity (desc) then created_at (desc).
+    Sort key: (path_specificity + label_boost, created_at DESC) globally.
+    Cap: stop at TOP_K_DEFAULT entries OR TOKEN_BUDGET_DEFAULT tokens, whichever first.
+    Groups selected entries by source_file in ALL_MEMORY_FILES order.
+    _cap_out: if provided, populated with entries_selected, entries_dropped_by_cap,
+              per_file_selected, per_file_dropped.
     """
-    grouped = {}
-    for c in candidates:
+    labels = labels or []
+
+    ranked = sorted(
+        candidates,
+        key=lambda c: (
+            c["specificity"] + compute_label_boost(c["source_file"], labels),
+            c.get("created_at") or "",
+        ),
+        reverse=True,
+    )
+
+    selected = []
+    dropped = []
+    token_total = 0
+    for c in ranked:
+        token_cost = te.estimate_tokens(c["text"])
+        if len(selected) >= TOP_K_DEFAULT or token_total + token_cost > TOKEN_BUDGET_DEFAULT:
+            dropped.append(c)
+        else:
+            selected.append(c)
+            token_total += token_cost
+
+    if _cap_out is not None:
+        per_file_selected: dict = {}
+        per_file_dropped: dict = {}
+        for c in selected:
+            per_file_selected[c["source_file"]] = per_file_selected.get(c["source_file"], 0) + 1
+        for c in dropped:
+            per_file_dropped[c["source_file"]] = per_file_dropped.get(c["source_file"], 0) + 1
+        _cap_out["entries_selected"] = len(selected)
+        _cap_out["entries_dropped_by_cap"] = len(dropped)
+        _cap_out["per_file_selected"] = per_file_selected
+        _cap_out["per_file_dropped"] = per_file_dropped
+
+    grouped: dict = {}
+    for c in selected:
         grouped.setdefault(c["source_file"], []).append(c)
 
     parts = []
     for fname in ALL_MEMORY_FILES:
         if fname not in grouped:
             continue
-        entries = sorted(
-            grouped[fname],
-            key=lambda x: (x["specificity"], x.get("created_at") or ""),
-            reverse=True,
-        )
         parts.append(f"### Memory: {fname}")
-        for e in entries:
+        for e in grouped[fname]:
             parts.append(e["text"])
         parts.append("")
 
@@ -294,7 +360,7 @@ def format_index_output(candidates):
 
 # ── Dispatch ───────────────────────────────────────────────────────────────
 
-def retrieve_memory(memory_dir, phase, files):
+def retrieve_memory(memory_dir, phase, files, labels=None, _cap_out=None):
     """Return a markdown memory block for the given phase and changed files."""
     allowed_sources = PHASE_SOURCE_MAP.get(phase, set())
     area_files = select_area_files(files)
@@ -307,7 +373,7 @@ def retrieve_memory(memory_dir, phase, files):
         except (OSError, ValueError):
             candidates = []
         if candidates:
-            return format_index_output(candidates)
+            return format_index_output(candidates, labels=labels, _cap_out=_cap_out)
 
     results = scan_markdown_files(memory_dir, area_files, files, allowed_sources)
     return format_markdown_output(results)
@@ -339,12 +405,20 @@ def _count_entries(fpath, files, allowed_sources, source_file_name):
     return {"total": total, "included": included}
 
 
-def emit_memory_trace(trace_path, phase, files, memory_dir, area_files, allowed_sources, issue=0, agent_id=None):
-    """Write memory-trace.json to trace_path. Best-effort: never raises."""
+def emit_memory_trace(trace_path, phase, files, memory_dir, area_files, allowed_sources, issue=0, agent_id=None, cap_counts=None):
+    """Write memory-trace.json to trace_path. Best-effort: never raises.
+
+    cap_counts: dict from format_index_output() _cap_out, containing:
+        entries_selected, entries_dropped_by_cap, per_file_selected, per_file_dropped.
+        Empty dict or None means markdown fallback ran (no cap applied).
+    """
     try:
         memory_dir = Path(memory_dir)
         files_loaded = []
         fallback_used = False
+
+        per_file_selected = (cap_counts or {}).get("per_file_selected", {})
+        per_file_dropped = (cap_counts or {}).get("per_file_dropped", {})
 
         for fname in area_files:
             fpath = memory_dir / fname
@@ -357,6 +431,8 @@ def emit_memory_trace(trace_path, phase, files, memory_dir, area_files, allowed_
                 "entries_total": counts["total"],
                 "entries_included": counts["included"],
                 "entries_filtered_out": counts["total"] - counts["included"],
+                "entries_selected": per_file_selected.get(fname, 0),
+                "entries_dropped_by_cap": per_file_dropped.get(fname, 0),
             })
 
         trace = {
@@ -370,6 +446,10 @@ def emit_memory_trace(trace_path, phase, files, memory_dir, area_files, allowed_
             "files_loaded": files_loaded,
             "fallback_used": fallback_used,
         }
+
+        if cap_counts:
+            trace["entries_selected_total"] = cap_counts.get("entries_selected", 0)
+            trace["entries_dropped_by_cap_total"] = cap_counts.get("entries_dropped_by_cap", 0)
 
         trace_path = Path(trace_path)
         trace_path.parent.mkdir(parents=True, exist_ok=True)
@@ -396,7 +476,7 @@ def main():
         help="Newline-separated list of changed or anticipated file paths",
     )
     parser.add_argument("--issue", type=int, default=None, help="Issue number (informational)")
-    parser.add_argument("--labels", default="", help="Issue labels (reserved, unused)")
+    parser.add_argument("--labels", nargs="*", default=None, help="Issue labels for memory ranking label boost")
     parser.add_argument(
         "--memory-dir",
         default=".archon/memory",
@@ -419,7 +499,9 @@ def main():
     allowed_sources = PHASE_SOURCE_MAP.get(args.phase, set())
     area_files = select_area_files(files)
 
-    output = retrieve_memory(memory_dir, args.phase, files)
+    labels = args.labels or []
+    cap_counts: dict = {}
+    output = retrieve_memory(memory_dir, args.phase, files, labels=labels, _cap_out=cap_counts)
     if output:
         print(output)
 
@@ -428,6 +510,7 @@ def main():
             args.emit_trace_to, args.phase, files, memory_dir, area_files, allowed_sources,
             issue=args.issue or 0,
             agent_id=PHASE_AGENT_ID.get(args.phase, args.phase + "-agent"),
+            cap_counts=cap_counts if cap_counts else None,
         )
 
 

--- a/dark-factory/tests/test_context_budget.py
+++ b/dark-factory/tests/test_context_budget.py
@@ -252,3 +252,70 @@ def test_architecture_md_fallback_status_when_component_unknown(tmp_path):
     assert sec["status"] == "included"
     assert sec["fallback"] is True
     assert sec["fallback_reason"] == "component_unresolved"
+
+
+# ── memory_context cap counts from trace ─────────────────────────────────────
+
+import json as _json
+from pathlib import Path as _Path
+
+
+def write_memory_trace(artifacts_dir, entries_selected, entries_dropped):
+    """Write a minimal memory-trace.json with run-level cap totals."""
+    trace = {
+        "schema_version": 1,
+        "entries_selected_total": entries_selected,
+        "entries_dropped_by_cap_total": entries_dropped,
+    }
+    (_Path(artifacts_dir) / "memory-trace.json").write_text(
+        _json.dumps(trace), encoding="utf-8"
+    )
+
+
+def make_memory_file(tmp_path, content="Memory block content here.\n"):
+    p = tmp_path / "memory-context.md"
+    p.write_text(content)
+    return str(p)
+
+
+class TestMemoryContextCapCounts:
+    def test_entries_selected_from_trace(self, tmp_path):
+        issue_json = make_issue_json(tmp_path)
+        mem_file = make_memory_file(tmp_path)
+        write_memory_trace(str(tmp_path), entries_selected=6, entries_dropped=10)
+        result = run_budget(tmp_path, "plan", issue_json=issue_json, memory_file=mem_file)
+        mc = result["sections"]["memory_context"]
+        assert mc.get("entries_selected") == 6
+
+    def test_entries_dropped_from_trace(self, tmp_path):
+        issue_json = make_issue_json(tmp_path)
+        mem_file = make_memory_file(tmp_path)
+        write_memory_trace(str(tmp_path), entries_selected=3, entries_dropped=25)
+        result = run_budget(tmp_path, "plan", issue_json=issue_json, memory_file=mem_file)
+        mc = result["sections"]["memory_context"]
+        assert mc.get("entries_dropped") == 25
+
+    def test_no_trace_no_cap_fields(self, tmp_path):
+        """When trace is absent, cap fields are absent (not 0)."""
+        issue_json = make_issue_json(tmp_path)
+        mem_file = make_memory_file(tmp_path)
+        result = run_budget(tmp_path, "plan", issue_json=issue_json, memory_file=mem_file)
+        mc = result["sections"]["memory_context"]
+        assert "entries_selected" not in mc
+        assert "entries_dropped" not in mc
+
+    def test_corrupt_trace_does_not_raise(self, tmp_path):
+        """Corrupt trace JSON → fail-open, no exception."""
+        issue_json = make_issue_json(tmp_path)
+        mem_file = make_memory_file(tmp_path)
+        (_Path(tmp_path) / "memory-trace.json").write_text("not valid json", encoding="utf-8")
+        result = run_budget(tmp_path, "plan", issue_json=issue_json, memory_file=mem_file)
+        assert "memory_context" in result["sections"]
+
+    def test_dropped_memory_file_no_trace_no_crash(self, tmp_path):
+        """When memory_file is missing (pre-run call), trace read is not attempted."""
+        issue_json = make_issue_json(tmp_path)
+        write_memory_trace(str(tmp_path), entries_selected=5, entries_dropped=3)
+        result = run_budget(tmp_path, "plan", issue_json=issue_json, memory_file=None)
+        mc = result["sections"]["memory_context"]
+        assert mc["status"] == "dropped"

--- a/dark-factory/tests/test_context_budget.py
+++ b/dark-factory/tests/test_context_budget.py
@@ -313,7 +313,7 @@ class TestMemoryContextCapCounts:
         assert "memory_context" in result["sections"]
 
     def test_dropped_memory_file_no_trace_no_crash(self, tmp_path):
-        """When memory_file is missing (pre-run call), trace read is not attempted."""
+        """When memory_file is None, the memory_context section is dropped (status=dropped)."""
         issue_json = make_issue_json(tmp_path)
         write_memory_trace(str(tmp_path), entries_selected=5, entries_dropped=3)
         result = run_budget(tmp_path, "plan", issue_json=issue_json, memory_file=None)

--- a/dark-factory/tests/test_memory_retrieve.py
+++ b/dark-factory/tests/test_memory_retrieve.py
@@ -90,6 +90,26 @@ class TestConstants:
     def test_authoritative_kinds(self):
         assert mr.AUTHORITATIVE_KINDS == {"PATTERN", "AVOID", "FIX"}
 
+    def test_top_k_default(self):
+        assert mr.TOP_K_DEFAULT == 8
+
+    def test_token_budget_default(self):
+        assert mr.TOKEN_BUDGET_DEFAULT == 1500
+
+    def test_label_source_boost_map_exists(self):
+        assert hasattr(mr, "_LABEL_SOURCE_BOOST_MAP")
+
+    def test_label_source_boost_map_dark_factory_keys(self):
+        assert mr._LABEL_SOURCE_BOOST_MAP.get("dark factory") == "dark-factory-ops.md"
+        assert mr._LABEL_SOURCE_BOOST_MAP.get("dark-factory") == "dark-factory-ops.md"
+
+    def test_label_source_boost_map_frontend_backend(self):
+        assert mr._LABEL_SOURCE_BOOST_MAP.get("frontend") == "frontend-patterns.md"
+        assert mr._LABEL_SOURCE_BOOST_MAP.get("backend") == "backend-patterns.md"
+
+    def test_label_source_boost_map_four_keys(self):
+        assert len(mr._LABEL_SOURCE_BOOST_MAP) == 4
+
 
 # ── TestSelectAreaFiles ────────────────────────────────────────────────────
 
@@ -998,3 +1018,306 @@ class TestEmitMemoryTrace:
         assert data["agent_id"] == "implementation-agent"
         assert data["project"] == "markethawk"
 
+
+# ── TestComputeLabelBoost ──────────────────────────────────────────────────
+
+class TestComputeLabelBoost:
+    def test_no_labels_returns_zero(self):
+        assert mr.compute_label_boost("backend-patterns.md", []) == 0
+
+    def test_none_labels_returns_zero(self):
+        assert mr.compute_label_boost("backend-patterns.md", None) == 0
+
+    def test_backend_label_boosts_backend_patterns(self):
+        assert mr.compute_label_boost("backend-patterns.md", ["backend"]) == 1
+
+    def test_frontend_label_boosts_frontend_patterns(self):
+        assert mr.compute_label_boost("frontend-patterns.md", ["frontend"]) == 1
+
+    def test_dark_factory_label_boosts_ops_patterns(self):
+        assert mr.compute_label_boost("dark-factory-ops.md", ["Dark Factory"]) == 1
+
+    def test_dark_factory_hyphen_label_boosts_ops_patterns(self):
+        assert mr.compute_label_boost("dark-factory-ops.md", ["dark-factory"]) == 1
+
+    def test_label_match_is_case_insensitive(self):
+        assert mr.compute_label_boost("backend-patterns.md", ["BACKEND"]) == 1
+
+    def test_label_no_map_match_returns_zero(self):
+        assert mr.compute_label_boost("backend-patterns.md", ["performance"]) == 0
+
+    def test_mismatched_file_returns_zero(self):
+        assert mr.compute_label_boost("codebase-patterns.md", ["backend"]) == 0
+
+    def test_global_file_never_boosted(self):
+        assert mr.compute_label_boost("codebase-patterns.md", ["frontend", "backend"]) == 0
+        assert mr.compute_label_boost("architecture.md", ["dark factory"]) == 0
+
+    def test_returns_one_not_more(self):
+        assert mr.compute_label_boost("dark-factory-ops.md", ["dark factory", "dark-factory"]) == 1
+
+    def test_multiple_labels_one_matching(self):
+        assert mr.compute_label_boost("frontend-patterns.md", ["performance", "frontend", "backend"]) == 1
+
+
+# ── TestMainCLI labels_nargs addition ──────────────────────────────────────
+
+class TestMainCLILabelNargs:
+    def _run(self, args, memory_dir=None):
+        import subprocess
+        script = str(Path(__file__).resolve().parents[1] / "scripts" / "memory_retrieve.py")
+        cmd = [sys.executable, script] + args
+        if memory_dir:
+            cmd += ["--memory-dir", str(memory_dir)]
+        return subprocess.run(cmd, capture_output=True, text=True)
+
+    def _make_mem_dir(self, tmp_path):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        content = "- [PATTERN] CLI test. <!-- issue:#1 expires:{f} source:implement -->\n".format(f=FUTURE)
+        (mem_dir / "backend-patterns.md").write_text(content, encoding="utf-8")
+        return mem_dir
+
+    def test_labels_nargs_accepts_multiple(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        result = self._run(
+            ["--phase", "implement", "--labels", "Dark Factory", "performance"],
+            memory_dir=mem_dir,
+        )
+        assert result.returncode == 0
+
+
+# ── TestFormatIndexOutputCap ───────────────────────────────────────────────
+
+class TestFormatIndexOutputCap:
+    """Tests for dual cap and label-boost sort in format_index_output()."""
+
+    def _make_candidate(self, text, specificity=0, created_at="2026-01-01", source_file="backend-patterns.md"):
+        return {
+            "source_file": source_file,
+            "text": f"- [PATTERN] {text}",
+            "specificity": specificity,
+            "created_at": created_at,
+        }
+
+    def _candidates(self, n, source_file="backend-patterns.md"):
+        return [self._make_candidate(f"Entry {i}", source_file=source_file) for i in range(n)]
+
+    def test_nine_candidates_capped_to_eight(self):
+        caps = {}
+        out = mr.format_index_output(self._candidates(9), _cap_out=caps)
+        assert caps["entries_selected"] == 8
+        assert caps["entries_dropped_by_cap"] == 1
+
+    def test_eight_candidates_no_drop(self):
+        caps = {}
+        mr.format_index_output(self._candidates(8), _cap_out=caps)
+        assert caps["entries_selected"] == 8
+        assert caps["entries_dropped_by_cap"] == 0
+
+    def test_two_candidates_no_drop(self):
+        caps = {}
+        mr.format_index_output(self._candidates(2), _cap_out=caps)
+        assert caps["entries_selected"] == 2
+        assert caps["entries_dropped_by_cap"] == 0
+
+    def test_token_budget_cap_stops_early(self):
+        long_text = "x" * 590
+        candidates = [self._make_candidate(long_text + f"_{i}") for i in range(20)]
+        caps = {}
+        mr.format_index_output(candidates, _cap_out=caps)
+        assert caps["entries_selected"] <= 10
+        assert caps["entries_dropped_by_cap"] >= 10
+
+    def test_count_cap_takes_priority_over_token_cap(self):
+        caps = {}
+        mr.format_index_output(self._candidates(12), _cap_out=caps)
+        assert caps["entries_selected"] == 8
+        assert caps["entries_dropped_by_cap"] == 4
+
+    def test_cap_out_none_no_error(self):
+        out = mr.format_index_output(self._candidates(2))
+        assert "### Memory:" in out
+
+    def test_cap_out_per_file_selected(self):
+        caps = {}
+        candidates = (
+            [self._make_candidate(f"B{i}", source_file="backend-patterns.md") for i in range(5)] +
+            [self._make_candidate(f"F{i}", source_file="frontend-patterns.md") for i in range(5)]
+        )
+        mr.format_index_output(candidates, _cap_out=caps)
+        assert caps["entries_selected"] == 8
+        total_per_file = sum(caps["per_file_selected"].values())
+        assert total_per_file == 8
+
+    def test_cap_out_per_file_dropped(self):
+        caps = {}
+        candidates = (
+            [self._make_candidate(f"B{i}", source_file="backend-patterns.md") for i in range(5)] +
+            [self._make_candidate(f"F{i}", source_file="frontend-patterns.md") for i in range(5)]
+        )
+        mr.format_index_output(candidates, _cap_out=caps)
+        total_dropped = sum(caps["per_file_dropped"].values())
+        assert total_dropped == 2
+
+    def test_label_boost_promotes_matching_file(self):
+        candidates = [
+            {"source_file": "backend-patterns.md", "text": "- [PATTERN] Low spec backend.",
+             "specificity": 0, "created_at": "2026-01-01"},
+            {"source_file": "frontend-patterns.md", "text": "- [PATTERN] High spec frontend.",
+             "specificity": 100, "created_at": "2026-01-01"},
+        ]
+        out = mr.format_index_output(candidates, labels=["backend"])
+        assert "Low spec backend" in out
+        assert "High spec frontend" in out
+
+    def test_only_selected_entries_in_output(self):
+        candidates = [
+            self._make_candidate(f"Entry {i}", specificity=9 - i) for i in range(9)
+        ]
+        out = mr.format_index_output(candidates)
+        assert "Entry 8" not in out
+
+    def test_markdown_fallback_unchanged_by_cap(self, tmp_path):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        lines = [
+            f"- [PATTERN] Entry {i}. <!-- source:implement expires:2099-12-31 -->"
+            for i in range(10)
+        ]
+        (mem_dir / "backend-patterns.md").write_text("\n".join(lines), encoding="utf-8")
+        out = mr.retrieve_memory(str(mem_dir), "implement", ["backend/app/foo.py"])
+        for i in range(10):
+            assert f"Entry {i}" in out
+
+
+# ── TestEmitMemoryTraceCap ─────────────────────────────────────────────────
+
+class TestEmitMemoryTraceCap:
+    """Tests for cap-count fields in emit_memory_trace()."""
+
+    def _make_mem_dir(self, tmp_path):
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        content = "- [PATTERN] Foo. <!-- source:implement expires:2099-12-31 -->\n"
+        for fname in mr.ALL_MEMORY_FILES:
+            (mem_dir / fname).write_text(content)
+        return mem_dir
+
+    def test_cap_counts_in_trace_root(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "trace.json"
+        cap_counts = {
+            "entries_selected": 6,
+            "entries_dropped_by_cap": 10,
+            "per_file_selected": {"backend-patterns.md": 3, "codebase-patterns.md": 3},
+            "per_file_dropped": {"frontend-patterns.md": 5, "dark-factory-ops.md": 5},
+        }
+        mr.emit_memory_trace(
+            trace_path, "implement", [], mem_dir, mr.ALL_MEMORY_FILES, {"implement"},
+            cap_counts=cap_counts,
+        )
+        data = json.loads(trace_path.read_text())
+        assert data["entries_selected_total"] == 6
+        assert data["entries_dropped_by_cap_total"] == 10
+
+    def test_per_file_selected_in_files_loaded(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "trace.json"
+        cap_counts = {
+            "entries_selected": 3,
+            "entries_dropped_by_cap": 0,
+            "per_file_selected": {"backend-patterns.md": 3},
+            "per_file_dropped": {},
+        }
+        mr.emit_memory_trace(
+            trace_path, "implement", [], mem_dir, mr.ALL_MEMORY_FILES, {"implement"},
+            cap_counts=cap_counts,
+        )
+        data = json.loads(trace_path.read_text())
+        backend_entry = next(
+            (e for e in data["files_loaded"] if e["path"].endswith("backend-patterns.md")), None
+        )
+        assert backend_entry is not None
+        assert backend_entry["entries_selected"] == 3
+        assert backend_entry["entries_dropped_by_cap"] == 0
+
+    def test_per_file_dropped_zero_when_not_in_cap_counts(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "trace.json"
+        cap_counts = {
+            "entries_selected": 0,
+            "entries_dropped_by_cap": 0,
+            "per_file_selected": {},
+            "per_file_dropped": {},
+        }
+        mr.emit_memory_trace(
+            trace_path, "implement", [], mem_dir, mr.ALL_MEMORY_FILES, {"implement"},
+            cap_counts=cap_counts,
+        )
+        data = json.loads(trace_path.read_text())
+        frontend_entry = next(
+            (e for e in data["files_loaded"] if e["path"].endswith("frontend-patterns.md")), None
+        )
+        if frontend_entry:
+            assert frontend_entry["entries_selected"] == 0
+            assert frontend_entry["entries_dropped_by_cap"] == 0
+
+    def test_empty_cap_counts_omits_root_totals(self, tmp_path):
+        mem_dir = self._make_mem_dir(tmp_path)
+        trace_path = tmp_path / "trace.json"
+        mr.emit_memory_trace(
+            trace_path, "implement", [], mem_dir, mr.ALL_MEMORY_FILES, {"implement"},
+            cap_counts={},
+        )
+        data = json.loads(trace_path.read_text())
+        assert "entries_selected_total" not in data
+        assert "entries_dropped_by_cap_total" not in data
+
+    def test_cli_cap_counts_in_trace_via_index_path(self, tmp_path):
+        """Integration: CLI with index path emits cap count fields in trace."""
+        mem_dir = tmp_path / "memory"
+        mem_dir.mkdir()
+        records_dir = mem_dir / "records"
+        records_dir.mkdir()
+        index_lines = []
+        for i in range(10):
+            entry_id = f"aabb{i:04d}"
+            entry = {
+                "id": entry_id,
+                "kind": "PATTERN",
+                "source_file": "backend-patterns.md",
+                "agent_id": "implement",
+                "path_prefixes": [],
+                "expires_at": "2099-12-31",
+                "created_at": f"2026-01-{i+1:02d}",
+                "confidence": 1.0,
+                "summary_snippet": f"Entry {i}.",
+            }
+            index_lines.append(json.dumps(entry))
+            record = {
+                "id": entry_id,
+                "kind": "PATTERN",
+                "summary": f"Entry {i} full summary.",
+                "evidence": [{"source": "implement", "date": "2026-01-01", "issue": 667}],
+                "path_prefixes": [],
+                "expires_at": "2099-12-31",
+            }
+            (records_dir / f"{entry_id}.json").write_text(json.dumps(record), encoding="utf-8")
+        (mem_dir / "index.jsonl").write_text("\n".join(index_lines), encoding="utf-8")
+
+        trace_path = tmp_path / "trace.json"
+        result = subprocess.run(
+            [
+                sys.executable, str(Path(mr.__file__).resolve()),
+                "--phase", "implement",
+                "--memory-dir", str(mem_dir),
+                "--emit-trace-to", str(trace_path),
+            ],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        assert trace_path.exists()
+        data = json.loads(trace_path.read_text())
+        assert data.get("entries_selected_total") == 8
+        assert data.get("entries_dropped_by_cap_total") == 2

--- a/docs/codeindex-hotspots.md
+++ b/docs/codeindex-hotspots.md
@@ -1,31 +1,31 @@
-Files with blast score ≥ 5.0  (44 found)
+Files with blast score ≥ 5.0  (47 found)
 
-    75.5  frontend/src/api/client.ts  (26d / 99t)  78 loc
-    64.0  backend/app/routers/auth.py  (2d / 124t)  213 loc
-    42.0  frontend/src/api/scanner/index.ts  (31d / 22t)  53 loc
-    31.5  frontend/src/api/scanner/types.ts  (5d / 53t)  333 loc
-    31.0  backend/app/routers/scanner.py  (4d / 54t)  731 loc
-    31.0  frontend/src/components/ui/Card.tsx  (21d / 20t)  44 loc
-    30.0  backend/app/routers/system.py  (2d / 56t)  141 loc
-    28.5  frontend/src/components/ui/Button.tsx  (21d / 15t)  66 loc
-    28.0  backend/app/routers/futures.py  (1d / 54t)  188 loc
-    28.0  services/tweet-monitor/app/main.py  (1d / 54t)  266 loc
-    27.5  frontend/src/api/scanner/configs.ts  (1d / 53t)  21 loc
-    27.5  frontend/src/api/scanner/misc.ts  (1d / 53t)  99 loc
-    27.5  frontend/src/api/scanner/results.ts  (1d / 53t)  22 loc
-    27.5  frontend/src/api/scanner/reviews.ts  (1d / 53t)  35 loc
-    27.5  frontend/src/api/scanner/runs.ts  (1d / 53t)  49 loc
-    27.5  frontend/src/api/scanner/ws.ts  (1d / 53t)  26 loc
+    79.5  frontend/src/api/client.ts  (27d / 105t)  78 loc
+    67.5  backend/app/routers/auth.py  (2d / 131t)  213 loc
+    44.0  frontend/src/api/scanner/index.ts  (33d / 22t)  53 loc
+    33.0  frontend/src/components/ui/Card.tsx  (23d / 20t)  44 loc
+    32.5  frontend/src/api/scanner/types.ts  (5d / 55t)  333 loc
+    32.0  backend/app/routers/scanner.py  (4d / 56t)  731 loc
+    31.0  backend/app/routers/system.py  (2d / 58t)  141 loc
+    30.5  frontend/src/components/ui/Button.tsx  (23d / 15t)  66 loc
+    29.0  backend/app/routers/futures.py  (1d / 56t)  188 loc
+    29.0  services/tweet-monitor/app/main.py  (1d / 56t)  266 loc
+    28.5  frontend/src/api/scanner/configs.ts  (1d / 55t)  21 loc
+    28.5  frontend/src/api/scanner/misc.ts  (1d / 55t)  99 loc
+    28.5  frontend/src/api/scanner/results.ts  (1d / 55t)  22 loc
+    28.5  frontend/src/api/scanner/reviews.ts  (1d / 55t)  35 loc
+    28.5  frontend/src/api/scanner/runs.ts  (1d / 55t)  49 loc
+    28.5  frontend/src/api/scanner/ws.ts  (1d / 55t)  26 loc
     23.0  frontend/src/test-utils/renderWithQuery.tsx  (23d / 0t)  29 loc
-    16.0  frontend/src/api/universe.ts  (14d / 4t)  317 loc
-    14.5  frontend/src/components/ui/Modal.tsx  (9d / 11t)  87 loc
+    18.0  frontend/src/api/universe.ts  (16d / 4t)  317 loc
+    15.5  frontend/src/components/ui/Modal.tsx  (10d / 11t)  87 loc
+    14.5  frontend/src/api/trading.ts  (11d / 7t)  244 loc
     14.0  frontend/src/components/Ticker.tsx  (6d / 16t)  80 loc
     12.5  frontend/src/api/outcomes.ts  (10d / 5t)  228 loc
-    12.5  frontend/src/api/trading.ts  (9d / 7t)  244 loc
-    10.0  backend/app/main.py  (1d / 18t)  533 loc
-    10.0  backend/app/routers/universe.py  (1d / 18t)  490 loc
-     9.0  backend/app/routers/auto_trading.py  (1d / 16t)  380 loc
-     9.0  frontend/src/components/ui/MetricCard.tsx  (6d / 6t)  71 loc
+    11.0  backend/app/main.py  (1d / 20t)  535 loc
+    11.0  backend/app/routers/universe.py  (1d / 20t)  490 loc
+    10.5  frontend/src/components/ui/MetricCard.tsx  (7d / 7t)  71 loc
+    10.0  backend/app/routers/auto_trading.py  (1d / 18t)  380 loc
      8.5  backend/app/routers/outcomes.py  (1d / 15t)  370 loc
      8.5  frontend/src/utils/url.ts  (3d / 11t)  36 loc
      8.0  frontend/src/hooks/useScorecard.ts  (5d / 6t)  98 loc
@@ -34,13 +34,16 @@ Files with blast score ≥ 5.0  (44 found)
      7.5  frontend/src/components/TrustGateSummary.tsx  (3d / 9t)  185 loc
      7.5  frontend/src/components/verdictConfig.ts  (2d / 11t)  13 loc
      7.5  frontend/src/hooks/useWatchlistLive.ts  (6d / 3t)  182 loc
+     7.0  frontend/src/api/replay.ts  (6d / 2t)  188 loc
      6.5  backend/app/routers/news.py  (1d / 11t)  137 loc
      6.5  frontend/src/api/news.ts  (2d / 9t)  46 loc
      6.5  frontend/src/hooks/useScannerState.ts  (4d / 5t)  109 loc
      6.0  frontend/src/api/alerts.ts  (4d / 4t)  199 loc
      6.0  frontend/src/hooks/useLiveStockData.ts  (4d / 4t)  115 loc
+     6.0  frontend/src/utils/indicators.ts  (2d / 8t)  106 loc
      5.5  frontend/src/components/QualityReportModal/GradeBadge.tsx  (3d / 5t)  35 loc
-     5.5  frontend/src/utils/indicators.ts  (2d / 7t)  106 loc
      5.0  backend/app/routers/alerts.py  (1d / 8t)  458 loc
+     5.0  backend/app/routers/replay.py  (1d / 8t)  261 loc
      5.0  frontend/src/api/system.ts  (3d / 4t)  55 loc
      5.0  frontend/src/api/watchlist.ts  (4d / 2t)  70 loc
+     5.0  frontend/src/components/ui/StockChart.tsx  (2d / 6t)  617 loc


### PR DESCRIPTION
Closes omniscient/dark-factory#156

## Summary
Automated implementation for issue omniscient/dark-factory#156.

## Preview
⚠️ _Preview environment failed to start (preview failed: docker compose up failed (migrate/boot — see preview_build.log tail below)) — endpoint validation was skipped; see the failure comment on the issue._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#156"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#156"
```

---
*Generated by MarketHawk Dark Factory*