### PR TITLE
Implement scanner explainability foundation

### DIFF
--- a/backend/app/alembic/versions/a2b3c4d5e6f7_add_scanner_event_explanation.py
+++ b/backend/app/alembic/versions/a2b3c4d5e6f7_add_scanner_event_explanation.py
@@ -1,0 +1,29 @@
+"""add_scanner_event_explanation
+
+Revision ID: a2b3c4d5e6f7
+Revises: f1a2b3c4d5e6
+Create Date: 2026-07-02 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "a2b3c4d5e6f7"
+down_revision: Union[str, None] = "f1a2b3c4d5e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scanner_events",
+        sa.Column("explanation", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("scanner_events", "explanation")

--- a/backend/app/models/scanner_event.py
+++ b/backend/app/models/scanner_event.py
@@ -52,6 +52,9 @@ class ScannerEvent(Base):
     # Enrichment metadata (catalysts, splits, float rotation, etc.)
     metadata_ = Column("metadata", JSONB, nullable=False, default=dict)
 
+    # Scanner-neutral explainability payload.
+    explanation = Column(JSONB, nullable=True)
+
     signal_cluster_id = Column(
         Integer, ForeignKey("signal_clusters.id"), nullable=True, index=True
     )

--- a/backend/app/routers/scanner.py
+++ b/backend/app/routers/scanner.py
@@ -15,6 +15,7 @@ from fastapi import (
     Request,
     WebSocket,
     WebSocketDisconnect,
+    status,
 )
 from sqlalchemy.orm import Session, selectinload
 
@@ -430,6 +431,21 @@ def get_scanner_results(
     results = query.limit(limit).offset(offset).all()
 
     return results
+
+
+@router.post("/explanations/backfill", status_code=status.HTTP_202_ACCEPTED)
+def queue_scanner_explanation_backfill(
+    scanner_type: Optional[str] = None,
+    limit: int = Query(500, ge=1, le=5000),
+):
+    """Queue a best-effort explanation backfill for historical scanner events."""
+    from app.tasks.explanations import backfill_scanner_explanations
+
+    task = backfill_scanner_explanations.delay(
+        scanner_type=scanner_type,
+        limit=limit,
+    )
+    return {"status": "queued", "task_id": task.id}
 
 
 @router.get("/signal-quality-distribution")

--- a/backend/app/schemas/event.py
+++ b/backend/app/schemas/event.py
@@ -35,6 +35,7 @@ class ScannerEventResponse(BaseModel):
     indicators: Dict[str, Any] = Field(default_factory=dict)
     criteria_met: Dict[str, Any] = Field(default_factory=dict)
     metadata: Dict[str, Any] = Field(default_factory=dict, alias="metadata_")
+    explanation: Optional[Dict[str, Any]] = None
 
     created_at: datetime
     updated_at: datetime

--- a/backend/app/schemas/scanner_explanation.py
+++ b/backend/app/schemas/scanner_explanation.py
@@ -1,0 +1,92 @@
+import re
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+SCANNER_EXPLANATION_SCHEMA_VERSION = "scanner_explanation.v1"
+
+_CRITERION_ID_RE = re.compile(r"^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$")
+_ALLOWED_OPERATORS = {">", ">=", "<", "<=", "==", "!=", "exists"}
+_WARNING_SEVERITY_MAP = {
+    "info": "low",
+    "low": "low",
+    "warning": "medium",
+    "medium": "medium",
+    "error": "high",
+    "critical": "high",
+    "high": "high",
+}
+
+
+class CriterionExplanation(BaseModel):
+    label: str
+    observed: Any = None
+    threshold: Any = None
+    operator: str
+    unit: Optional[str] = None
+    source: Optional[str] = None
+    lookback: Optional[str] = None
+    importance: Optional[float] = Field(default=None, ge=0, le=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("operator")
+    @classmethod
+    def validate_operator(cls, value: str) -> str:
+        if value not in _ALLOWED_OPERATORS:
+            raise ValueError(f"operator must be one of {sorted(_ALLOWED_OPERATORS)}")
+        return value
+
+
+class DataQualityWarning(BaseModel):
+    code: str
+    severity: Literal["low", "medium", "high"]
+    message: str
+    affected_inputs: List[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("severity", mode="before")
+    @classmethod
+    def normalize_severity(cls, value: Any) -> str:
+        normalized = _WARNING_SEVERITY_MAP.get(str(value).lower())
+        if normalized is None:
+            raise ValueError("severity must be low, medium, or high")
+        return normalized
+
+
+class ExplanationEvidence(BaseModel):
+    reconstructed: bool
+    reconstruction_quality: Optional[Literal["best_effort", "partial"]] = None
+    generated_at: Optional[datetime] = None
+    generator_version: str = "explanation_builder.v1"
+    market_data_asof: Optional[datetime] = None
+    provider: Optional[str] = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ScannerExplanation(BaseModel):
+    schema_version: Literal["scanner_explanation.v1"]
+    why: List[str] = Field(min_length=1)
+    criteria_passed: Dict[str, CriterionExplanation] = Field(default_factory=dict)
+    criteria_failed: Dict[str, CriterionExplanation] = Field(default_factory=dict)
+    confidence_inputs: Dict[str, Any] = Field(default_factory=dict)
+    data_quality_warnings: List[DataQualityWarning] = Field(default_factory=list)
+    evidence: ExplanationEvidence
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def validate_criterion_ids(self) -> "ScannerExplanation":
+        for key in [*self.criteria_passed.keys(), *self.criteria_failed.keys()]:
+            if not _CRITERION_ID_RE.match(key):
+                raise ValueError(
+                    f"criterion id '{key}' must be scanner-qualified, like premarket.volume_spike"
+                )
+        return self
+
+
+def validate_scanner_explanation(payload: Dict[str, Any]) -> Dict[str, Any]:
+    return ScannerExplanation.model_validate(payload).model_dump(mode="json")

--- a/backend/app/services/alert_service.py
+++ b/backend/app/services/alert_service.py
@@ -383,6 +383,7 @@ def save_event(
     closing_price: float = None,
     ranker_config: Optional[Dict[str, Any]] = None,
     gate_metadata: Optional[Dict[str, Any]] = None,
+    explanation: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Persist a ScannerEvent and enqueue alert evaluation for new events."""
     from app.services.event_helpers import (
@@ -402,6 +403,8 @@ def save_event(
     _validate_jsonb_dict(indicators, "indicators")
     _validate_jsonb_dict(criteria_met, "criteria_met")
     _validate_jsonb_dict(enrichment, "enrichment")
+    if explanation is not None:
+        _validate_jsonb_dict(explanation, "explanation")
 
     score = None
     if ranker_config and ranker_config.get("enabled") and ranker_config.get("weights"):
@@ -432,6 +435,8 @@ def save_event(
         "signal_quality_score": score,
         "regime": regime,
     }
+    if explanation is not None:
+        event_dict["explanation"] = explanation
 
     existing = (
         db.query(ScannerEvent)

--- a/backend/app/services/pre_market_scan.py
+++ b/backend/app/services/pre_market_scan.py
@@ -412,9 +412,25 @@ def _persist(
     gate_metadata: Optional[Dict[str, Any]] = None,
 ) -> list[Dict[str, Any]]:
     from app.services.scanner import ScannerService
+    from app.services.scanner_explanations import build_pre_market_volume_explanation
+    from app.services.signal_ranker import compute_signal_quality_score
 
     results = []
     for signal in enriched:
+        signal_quality_score = None
+        if (
+            ranker_config
+            and ranker_config.get("enabled")
+            and ranker_config.get("weights")
+        ):
+            signal_quality_score = compute_signal_quality_score(
+                signal.indicators, ranker_config["weights"]
+            )
+        explanation = build_pre_market_volume_explanation(
+            signal,
+            signal_quality_score=signal_quality_score,
+            gate_metadata=gate_metadata,
+        )
         event_dict = ScannerService._save_event(
             db=db,
             ticker=signal.raw.ticker,
@@ -428,6 +444,7 @@ def _persist(
             closing_price=signal.day_metrics.get("closing_price"),
             ranker_config=ranker_config,
             gate_metadata=gate_metadata,
+            explanation=explanation,
         )
         results.append(event_dict)
         scanner_events_total.labels(scanner_type="pre_market_volume_spike").inc()

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -143,6 +143,7 @@ class ScannerService:
         closing_price: float = None,
         ranker_config: Optional[Dict[str, Any]] = None,
         gate_metadata: Optional[Dict[str, Any]] = None,
+        explanation: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         from app.services.alert_service import save_event
 
@@ -159,6 +160,7 @@ class ScannerService:
             closing_price=closing_price,
             ranker_config=ranker_config,
             gate_metadata=gate_metadata,
+            explanation=explanation,
         )
 
     # ------------------------------------------------------------------ #

--- a/backend/app/services/scanner_explanations.py
+++ b/backend/app/services/scanner_explanations.py
@@ -1,0 +1,222 @@
+from typing import Any, Dict, Optional
+
+from app.models.scanner_event import ScannerEvent
+from app.schemas.scanner_explanation import validate_scanner_explanation
+from app.utils.time import utc_now
+
+
+def _criterion(
+    label: str,
+    observed: Any,
+    threshold: Any,
+    operator: str,
+    unit: Optional[str] = None,
+    source: Optional[str] = None,
+    lookback: Optional[str] = None,
+    importance: Optional[float] = None,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "label": label,
+        "observed": observed,
+        "threshold": threshold,
+        "operator": operator,
+    }
+    if unit is not None:
+        payload["unit"] = unit
+    if source is not None:
+        payload["source"] = source
+    if lookback is not None:
+        payload["lookback"] = lookback
+    if importance is not None:
+        payload["importance"] = importance
+    return payload
+
+
+def _split_criteria(criteria_met: Dict[str, Any], criteria: Dict[str, Dict[str, Any]]):
+    passed: Dict[str, Dict[str, Any]] = {}
+    failed: Dict[str, Dict[str, Any]] = {}
+    for raw_key, explanation in criteria.items():
+        target = passed if bool(criteria_met.get(raw_key)) else failed
+        target[f"premarket.{raw_key}"] = explanation
+    return passed, failed
+
+
+def _quality_warnings(gate_metadata: Optional[Dict[str, Any]]) -> list[Dict[str, Any]]:
+    warnings = []
+    for warning in (gate_metadata or {}).get("warnings", []) or []:
+        warnings.append(
+            {
+                "code": warning.get("code", "quality_gate_warning"),
+                "severity": warning.get("severity", "medium"),
+                "message": warning.get("message", "Data quality warning."),
+                "affected_inputs": warning.get("affected_inputs", []),
+            }
+        )
+    return warnings
+
+
+def build_pre_market_volume_explanation(
+    signal: Any,
+    signal_quality_score: Optional[float] = None,
+    gate_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    raw = signal.raw
+    indicators = signal.indicators or {}
+    criteria_met = raw.criteria_met or {}
+
+    threshold = (
+        indicators.get("volume_anomaly_score")
+        if raw.threshold_method == "timesfm"
+        else 4.0
+    )
+    threshold_unit = "z" if raw.threshold_method == "timesfm" else "x"
+    observed_spike = (
+        indicators.get("volume_anomaly_score")
+        if raw.threshold_method == "timesfm"
+        else indicators.get("volume_spike_ratio", raw.relative_volume)
+    )
+
+    criteria = {
+        "volume_spike": _criterion(
+            "Volume spike",
+            observed_spike,
+            threshold,
+            ">=",
+            unit=threshold_unit,
+            source="minute_aggregates",
+            lookback="20d",
+            importance=1.0,
+        ),
+        "minimum_volume": _criterion(
+            "Minimum pre-market volume",
+            indicators.get("pre_market_volume", raw.pre_market_volume),
+            100000,
+            ">",
+            unit="shares",
+            source="minute_aggregates",
+            importance=0.8,
+        ),
+        "liquidity": _criterion(
+            "Baseline liquidity",
+            indicators.get("avg_volume_20d", raw.avg_volume_20d),
+            500000,
+            ">",
+            unit="shares",
+            source="daily_aggregates",
+            lookback="20d",
+            importance=0.7,
+        ),
+    }
+    passed, failed = _split_criteria(criteria_met, criteria)
+
+    why = [
+        (
+            f"Pre-market volume was {indicators.get('volume_spike_ratio', raw.relative_volume):.2f}x "
+            "the 20-day average."
+        )
+    ]
+    if indicators.get("gap_pct") is not None:
+        why.append(f"Opening gap was {indicators['gap_pct']}%.")
+    if indicators.get("has_news_catalyst"):
+        why.append("A news catalyst was present in enrichment data.")
+
+    payload = {
+        "schema_version": "scanner_explanation.v1",
+        "why": why,
+        "criteria_passed": passed,
+        "criteria_failed": failed,
+        "confidence_inputs": {
+            "signal_quality_score": signal_quality_score,
+            "threshold_method": raw.threshold_method,
+            "relative_volume": raw.relative_volume,
+            "anomaly_score": raw.anomaly_score,
+            "has_news_catalyst": indicators.get("has_news_catalyst"),
+        },
+        "data_quality_warnings": _quality_warnings(gate_metadata),
+        "evidence": {
+            "reconstructed": False,
+            "generated_at": utc_now(),
+            "generator_version": "explanation_builder.v1",
+            "provider": "polygon",
+        },
+    }
+    return validate_scanner_explanation(payload)
+
+
+def reconstruct_explanation_for_event(event: ScannerEvent) -> Dict[str, Any]:
+    indicators = event.indicators or {}
+    criteria_met = event.criteria_met or {}
+    if event.scanner_type == "pre_market_volume_spike":
+        criteria = {
+            "volume_spike": _criterion(
+                "Volume spike",
+                indicators.get("volume_spike_ratio")
+                or indicators.get("relative_volume"),
+                4.0,
+                ">=",
+                unit="x",
+                source="scanner_event.indicators",
+                lookback="20d",
+                importance=1.0,
+            ),
+            "minimum_volume": _criterion(
+                "Minimum pre-market volume",
+                indicators.get("pre_market_volume"),
+                100000,
+                ">",
+                unit="shares",
+                source="scanner_event.indicators",
+                importance=0.8,
+            ),
+            "liquidity": _criterion(
+                "Baseline liquidity",
+                indicators.get("avg_volume_20d"),
+                500000,
+                ">",
+                unit="shares",
+                source="scanner_event.indicators",
+                lookback="20d",
+                importance=0.7,
+            ),
+        }
+        passed, failed = _split_criteria(criteria_met, criteria)
+    else:
+        scanner_prefix = event.scanner_type.replace("_", ".")
+        passed = {}
+        failed = {}
+        for key, value in criteria_met.items():
+            target = passed if bool(value) else failed
+            target[f"{scanner_prefix}.{key}"] = _criterion(
+                key.replace("_", " ").title(),
+                value,
+                True,
+                "==",
+                source="scanner_event.criteria_met",
+            )
+
+    ratio = indicators.get("volume_spike_ratio") or indicators.get("relative_volume")
+    why = ["Historical scanner event reconstructed from stored indicators."]
+    if ratio is not None:
+        why = [f"Stored indicators show {ratio}x pre-market relative volume."]
+
+    payload = {
+        "schema_version": "scanner_explanation.v1",
+        "why": why,
+        "criteria_passed": passed,
+        "criteria_failed": failed,
+        "confidence_inputs": {
+            "signal_quality_score": event.signal_quality_score,
+            "scanner_type": event.scanner_type,
+        },
+        "data_quality_warnings": _quality_warnings(
+            (event.metadata_ or {}).get("quality_gate")
+        ),
+        "evidence": {
+            "reconstructed": True,
+            "reconstruction_quality": "best_effort",
+            "generated_at": utc_now(),
+            "generator_version": "explanation_backfill.v1",
+            "provider": "stored_scanner_event",
+        },
+    }
+    return validate_scanner_explanation(payload)

--- a/backend/app/tasks/__init__.py
+++ b/backend/app/tasks/__init__.py
@@ -1,4 +1,5 @@
 from app.tasks.backtest import run_backtest
+from app.tasks.explanations import backfill_scanner_explanations
 from app.tasks.quality import (
     analyze_signal_features,
     analyze_universe_quality,
@@ -34,6 +35,7 @@ __all__ = [
     # backtest
     "run_backtest",
     "run_signal_replay",
+    "backfill_scanner_explanations",
     # sync
     "sync_tickers_batch",
     "sync_ticker_details",

--- a/backend/app/tasks/explanations.py
+++ b/backend/app/tasks/explanations.py
@@ -1,0 +1,71 @@
+import logging
+import time as _time
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+
+from app.core.celery_app import celery_app
+from app.core.database import SessionLocal
+from app.core.metrics import celery_task_duration_seconds, celery_tasks_total
+from app.models.scanner_event import ScannerEvent
+from app.services.scanner_explanations import reconstruct_explanation_for_event
+
+logger = logging.getLogger(__name__)
+
+
+def _backfill_scanner_explanations_logic(
+    db: Session,
+    scanner_type: Optional[str] = None,
+    limit: int = 500,
+) -> dict:
+    base_query = db.query(ScannerEvent)
+    if scanner_type:
+        base_query = base_query.filter(ScannerEvent.scanner_type == scanner_type)
+
+    missing_explanation = sa.or_(
+        ScannerEvent.explanation.is_(None),
+        ScannerEvent.explanation == sa.JSON.NULL,
+    )
+    skipped = base_query.filter(sa.not_(missing_explanation)).count()
+    events = (
+        base_query.filter(missing_explanation)
+        .order_by(ScannerEvent.event_date.desc(), ScannerEvent.id.desc())
+        .limit(limit)
+        .all()
+    )
+
+    updated = 0
+    for event in events:
+        event.explanation = reconstruct_explanation_for_event(event)
+        updated += 1
+    db.commit()
+    return {"updated": updated, "skipped": skipped}
+
+
+@celery_app.task(name="app.tasks.backfill_scanner_explanations")
+def backfill_scanner_explanations(
+    scanner_type: Optional[str] = None,
+    limit: int = 500,
+) -> dict:
+    _task_name = "backfill_scanner_explanations"
+    _start = _time.monotonic()
+    db: Session = SessionLocal()
+    try:
+        result = _backfill_scanner_explanations_logic(
+            db,
+            scanner_type=scanner_type,
+            limit=limit,
+        )
+        celery_tasks_total.labels(task_name=_task_name, status="success").inc()
+        return result
+    except Exception:
+        celery_tasks_total.labels(task_name=_task_name, status="failure").inc()
+        logger.exception("backfill_scanner_explanations failed")
+        db.rollback()
+        raise
+    finally:
+        celery_task_duration_seconds.labels(task_name=_task_name).observe(
+            _time.monotonic() - _start
+        )
+        db.close()

--- a/backend/tests/api/test_scanner.py
+++ b/backend/tests/api/test_scanner.py
@@ -37,6 +37,26 @@ def test_results_returns_all_events(db: Session):
     assert all("scanner_type" in e for e in data)
 
 
+def test_results_returns_explanation_payload(db: Session):
+    event = seed_scanner_events(db, tickers=["AAPL"])[0]
+    event.explanation = {
+        "schema_version": "scanner_explanation.v1",
+        "why": ["Pre-market volume was 5.2x the 20-day average."],
+        "criteria_passed": {},
+        "criteria_failed": {},
+        "confidence_inputs": {},
+        "data_quality_warnings": [],
+        "evidence": {"reconstructed": False},
+    }
+    db.flush()
+
+    response = client.get("/api/v1/scanner/results?ticker=AAPL&limit=1")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["explanation"]["schema_version"] == "scanner_explanation.v1"
+
+
 def test_results_filter_by_ticker(db: Session):
     seed_scanner_events(db)
 
@@ -107,6 +127,21 @@ def test_results_accepts_allowlisted_sort_by(db: Session):
     response = client.get("/api/v1/scanner/results?sort_by=ticker")
 
     assert response.status_code == 200
+
+
+def test_explanation_backfill_endpoint_queues_task(db: Session):
+    from unittest.mock import patch
+
+    with patch("app.tasks.explanations.backfill_scanner_explanations.delay") as delay:
+        delay.return_value.id = "task-123"
+        response = client.post(
+            "/api/v1/scanner/explanations/backfill"
+            "?scanner_type=pre_market_volume_spike&limit=25"
+        )
+
+    assert response.status_code == 202
+    assert response.json() == {"status": "queued", "task_id": "task-123"}
+    delay.assert_called_once_with(scanner_type="pre_market_volume_spike", limit=25)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/models/test_scanner_event_explanation.py
+++ b/backend/tests/models/test_scanner_event_explanation.py
@@ -1,0 +1,32 @@
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+from app.models.scanner_event import ScannerEvent
+
+
+def test_scanner_event_persists_explanation_payload(db: Session):
+    event = ScannerEvent(
+        ticker="AAPL",
+        event_date=date(2026, 6, 2),
+        scanner_type="pre_market_volume_spike",
+        indicators={},
+        criteria_met={},
+        metadata_={},
+        explanation={
+            "schema_version": "scanner_explanation.v1",
+            "why": ["Volume was elevated."],
+            "criteria_passed": {},
+            "criteria_failed": {},
+            "confidence_inputs": {},
+            "data_quality_warnings": [],
+            "evidence": {"reconstructed": False},
+        },
+    )
+    db.add(event)
+    db.flush()
+    db.expire(event)
+
+    loaded = db.query(ScannerEvent).filter_by(id=event.id).one()
+
+    assert loaded.explanation["schema_version"] == "scanner_explanation.v1"

--- a/backend/tests/schemas/test_scanner_explanation.py
+++ b/backend/tests/schemas/test_scanner_explanation.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.scanner_explanation import ScannerExplanation
+
+
+def _payload():
+    return {
+        "schema_version": "scanner_explanation.v1",
+        "why": ["Pre-market volume was 5.2x the 20-day average."],
+        "criteria_passed": {
+            "premarket.volume_spike": {
+                "label": "Volume spike",
+                "observed": 5.2,
+                "threshold": 4.0,
+                "operator": ">=",
+                "unit": "x",
+                "source": "minute_aggregates",
+            }
+        },
+        "criteria_failed": {},
+        "confidence_inputs": {"signal_quality_score": 82.5},
+        "data_quality_warnings": [
+            {
+                "code": "stale_bars",
+                "severity": "medium",
+                "message": "Some bars are older than expected.",
+                "affected_inputs": ["minute_aggregates"],
+            }
+        ],
+        "evidence": {
+            "reconstructed": False,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "generator_version": "explanation_builder.v1",
+            "provider": "polygon",
+        },
+    }
+
+
+def test_scanner_explanation_accepts_v1_payload():
+    explanation = ScannerExplanation.model_validate(_payload())
+
+    assert explanation.schema_version == "scanner_explanation.v1"
+    assert "premarket.volume_spike" in explanation.criteria_passed
+    assert explanation.data_quality_warnings[0].severity == "medium"
+
+
+def test_scanner_explanation_rejects_unknown_schema_version():
+    payload = _payload()
+    payload["schema_version"] = "scanner_explanation.v2"
+
+    with pytest.raises(ValidationError):
+        ScannerExplanation.model_validate(payload)
+
+
+def test_scanner_explanation_rejects_unqualified_criterion_id():
+    payload = _payload()
+    payload["criteria_passed"] = {"volume_spike": payload["criteria_passed"]["premarket.volume_spike"]}
+
+    with pytest.raises(ValidationError, match="criterion id"):
+        ScannerExplanation.model_validate(payload)
+
+
+def test_scanner_explanation_rejects_unknown_operator():
+    payload = _payload()
+    payload["criteria_passed"]["premarket.volume_spike"]["operator"] = "around"
+
+    with pytest.raises(ValidationError):
+        ScannerExplanation.model_validate(payload)

--- a/backend/tests/services/test_alert_service.py
+++ b/backend/tests/services/test_alert_service.py
@@ -216,3 +216,31 @@ def test_save_event_accepts_valid_payload(mock_trigger, db: Session):
     assert "id" in result
     assert result["ticker"] == "AAPL"
     mock_trigger.assert_called_once_with(result["id"])
+
+
+@patch("app.services.alert_service.trigger_scanner_alert")
+def test_save_event_persists_explanation_payload(mock_trigger, db: Session):
+    explanation = {
+        "schema_version": "scanner_explanation.v1",
+        "why": ["Pre-market volume was 5.2x the 20-day average."],
+        "criteria_passed": {},
+        "criteria_failed": {},
+        "confidence_inputs": {},
+        "data_quality_warnings": [],
+        "evidence": {"reconstructed": False},
+    }
+
+    result = save_event(
+        db,
+        ticker="AAPL",
+        event_date=date.today(),
+        scanner_type="pre_market_volume_spike",
+        indicators={"relative_volume": 5.0},
+        criteria_met={"volume_ok": True},
+        enrichment={"source": "test"},
+        explanation=explanation,
+    )
+
+    event = db.query(ScannerEvent).filter(ScannerEvent.id == result["id"]).one()
+    assert event.explanation == explanation
+    mock_trigger.assert_called_once_with(result["id"])

--- a/backend/tests/services/test_scanner_explanations.py
+++ b/backend/tests/services/test_scanner_explanations.py
@@ -1,0 +1,95 @@
+from datetime import date, datetime
+
+from app.models.scanner_event import ScannerEvent
+from app.services.pre_market_scan import EnrichedSignal, RawSignal
+from app.services.scanner_explanations import (
+    build_pre_market_volume_explanation,
+    reconstruct_explanation_for_event,
+)
+
+
+def _raw_signal(criteria_met=None):
+    return RawSignal(
+        ticker="AAPL",
+        daily_bars=[],
+        pre_market_volume=650000,
+        volumes=[1000000] * 20,
+        closes=[100.0] * 20,
+        avg_volume_20d=125000,
+        avg_volume_50d=None,
+        previous_close=100.0,
+        relative_volume=5.2,
+        forecast={"p50": 100000, "p90": 350000},
+        anomaly_score=2.4,
+        threshold_method="timesfm",
+        criteria_met=criteria_met
+        or {"volume_spike": True, "minimum_volume": True, "liquidity": False},
+    )
+
+
+def _enriched_signal(criteria_met=None):
+    return EnrichedSignal(
+        raw=_raw_signal(criteria_met=criteria_met),
+        day_metrics={"opening_price": 104.0, "closing_price": 106.0},
+        indicators={
+            "pre_market_volume": 650000,
+            "avg_volume_20d": 125000,
+            "relative_volume": 5.2,
+            "volume_spike_ratio": 5.2,
+            "volume_anomaly_score": 2.4,
+            "volume_threshold_method": "timesfm",
+            "gap_pct": 4.0,
+            "has_news_catalyst": True,
+        },
+        enrichment={"quality_warnings": []},
+    )
+
+
+def test_build_pre_market_volume_explanation_splits_passed_and_failed_criteria():
+    explanation = build_pre_market_volume_explanation(
+        _enriched_signal(),
+        signal_quality_score=88.0,
+        gate_metadata={
+            "tier": "warning",
+            "warnings": [
+                {
+                    "code": "stale_bars",
+                    "severity": "warning",
+                    "message": "Some bars are stale.",
+                }
+            ],
+        },
+    )
+
+    assert explanation["schema_version"] == "scanner_explanation.v1"
+    assert "premarket.volume_spike" in explanation["criteria_passed"]
+    assert "premarket.liquidity" in explanation["criteria_failed"]
+    assert explanation["confidence_inputs"]["signal_quality_score"] == 88.0
+    assert explanation["data_quality_warnings"][0]["severity"] == "medium"
+    assert explanation["evidence"]["reconstructed"] is False
+
+
+def test_reconstruct_explanation_for_existing_event_marks_best_effort():
+    event = ScannerEvent(
+        ticker="AAPL",
+        event_date=date(2026, 6, 2),
+        scanner_type="pre_market_volume_spike",
+        indicators={
+            "pre_market_volume": 650000,
+            "avg_volume_20d": 125000,
+            "relative_volume": 5.2,
+            "volume_spike_ratio": 5.2,
+        },
+        criteria_met={"volume_spike": True, "liquidity": True},
+        metadata_={"quality_gate": {"tier": "trusted", "warnings": []}},
+        signal_quality_score=81.0,
+        created_at=datetime(2026, 6, 2),
+        updated_at=datetime(2026, 6, 2),
+    )
+
+    explanation = reconstruct_explanation_for_event(event)
+
+    assert explanation["schema_version"] == "scanner_explanation.v1"
+    assert explanation["evidence"]["reconstructed"] is True
+    assert explanation["evidence"]["reconstruction_quality"] == "best_effort"
+    assert explanation["confidence_inputs"]["signal_quality_score"] == 81.0

--- a/backend/tests/tasks/test_explanation_backfill_task.py
+++ b/backend/tests/tasks/test_explanation_backfill_task.py
@@ -1,0 +1,46 @@
+from datetime import date
+
+from sqlalchemy.orm import Session
+
+from app.models.scanner_event import ScannerEvent
+from app.tasks.explanations import _backfill_scanner_explanations_logic
+
+
+def _event(ticker: str, explanation=None):
+    return ScannerEvent(
+        ticker=ticker,
+        event_date=date(2026, 6, 2),
+        scanner_type="pre_market_volume_spike",
+        indicators={"pre_market_volume": 650000, "avg_volume_20d": 125000},
+        criteria_met={"volume_spike": True, "minimum_volume": True, "liquidity": True},
+        metadata_={},
+        explanation=explanation,
+    )
+
+
+def test_backfill_scanner_explanations_populates_missing_payloads(db: Session):
+    missing = _event("AAPL")
+    existing = _event(
+        "MSFT",
+        explanation={
+            "schema_version": "scanner_explanation.v1",
+            "why": ["Already present."],
+            "criteria_passed": {},
+            "criteria_failed": {},
+            "confidence_inputs": {},
+            "data_quality_warnings": [],
+            "evidence": {"reconstructed": False},
+        },
+    )
+    db.add_all([missing, existing])
+    db.flush()
+
+    result = _backfill_scanner_explanations_logic(
+        db,
+        scanner_type="pre_market_volume_spike",
+        limit=100,
+    )
+
+    assert result == {"updated": 1, "skipped": 1}
+    assert missing.explanation["evidence"]["reconstructed"] is True
+    assert existing.explanation["why"] == ["Already present."]

--- a/docs/superpowers/plans/2026-07-02-scanner-explainability-foundation.md
+++ b/docs/superpowers/plans/2026-07-02-scanner-explainability-foundation.md
@@ -1,0 +1,37 @@
+# Scanner Explainability Foundation Implementation Plan
+
+Epic: GitHub #448, "Epic: Explainability Foundation for scanner events"
+
+Worktree: `C:\Users\Frank\.codex\worktrees\b8e4\MarketHawk`
+
+Branch: `codex/epic-448-explainability-foundation`
+
+## Scope
+
+- Add a nullable `scanner_events.explanation` JSONB column.
+- Define and validate `scanner_explanation.v1` payloads.
+- Generate explanations for the reference `pre_market_volume_spike` scanner.
+- Return explanations through the existing scanner results API.
+- Render compact explanation details in the existing scanner results surface.
+- Add a backfill task and API trigger for historical events.
+
+## Steps
+
+1. Add backend tests for the new model column, schema validation, builder output, alert persistence, API serialization, and backfill task.
+2. Add the Alembic migration and SQLAlchemy model field.
+3. Add `backend/app/schemas/scanner_explanation.py` with strict scanner-neutral validation.
+4. Add `backend/app/services/scanner_explanations.py` with the pre-market builder and reconstruction helper.
+5. Thread optional `explanation` through alert persistence and pre-market scanner event saving.
+6. Add API response field and backfill endpoint wired to a Celery task.
+7. Add frontend types and a compact `ScannerExplanationPanel` in `ScannerResults`.
+8. Run focused backend and frontend tests, then repo lint/type/build checks.
+
+## Verification
+
+- `ruff check .`
+- Focused backend pytest for schema/service/API/task coverage.
+- `python -m alembic heads`
+- `npx tsc --noEmit -p tsconfig.app.json`
+- `npx eslint . --report-unused-disable-directives-severity error`
+- `npx vitest run src/components/ScannerResults.test.tsx`
+- `npm run build`

--- a/frontend/src/api/scanner/types.ts
+++ b/frontend/src/api/scanner/types.ts
@@ -20,10 +20,48 @@ export interface ScannerEvent {
   indicators: Record<string, unknown>;
   criteria_met: Record<string, unknown>;
   metadata: Record<string, unknown>;
+  explanation?: ScannerExplanation | null;
 
   created_at: string;
   updated_at: string;
   latest_review?: SignalReview | null;
+}
+
+export interface ScannerCriterionExplanation {
+  label: string;
+  observed?: unknown;
+  threshold?: unknown;
+  operator: '>' | '>=' | '<' | '<=' | '==' | '!=' | 'exists';
+  unit?: string | null;
+  source?: string | null;
+  lookback?: string | null;
+  importance?: number | null;
+}
+
+export interface ScannerDataQualityWarning {
+  code: string;
+  severity: 'low' | 'medium' | 'high';
+  message: string;
+  affected_inputs: string[];
+}
+
+export interface ScannerExplanationEvidence {
+  reconstructed: boolean;
+  reconstruction_quality?: 'best_effort' | 'partial' | null;
+  generated_at?: string | null;
+  generator_version?: string | null;
+  market_data_asof?: string | null;
+  provider?: string | null;
+}
+
+export interface ScannerExplanation {
+  schema_version: 'scanner_explanation.v1';
+  why: string[];
+  criteria_passed: Record<string, ScannerCriterionExplanation>;
+  criteria_failed: Record<string, ScannerCriterionExplanation>;
+  confidence_inputs: Record<string, unknown>;
+  data_quality_warnings: ScannerDataQualityWarning[];
+  evidence: ScannerExplanationEvidence;
 }
 
 export interface SignalReview {

--- a/frontend/src/components/ScannerExplanationPanel.tsx
+++ b/frontend/src/components/ScannerExplanationPanel.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { AlertTriangle, CheckCircle2, History, XCircle } from 'lucide-react';
+import type { ScannerExplanation, ScannerCriterionExplanation } from '../api/scanner';
+
+interface ScannerExplanationPanelProps {
+  explanation?: ScannerExplanation | null;
+}
+
+const formatValue = (value: unknown, unit?: string | null): string => {
+  if (value == null) return 'n/a';
+  const suffix = unit ? unit : '';
+  if (typeof value === 'number') {
+    return `${Number.isInteger(value) ? value.toLocaleString() : value.toFixed(2)}${suffix}`;
+  }
+  return `${String(value)}${suffix}`;
+};
+
+const CriteriaPill: React.FC<{
+  criterion: ScannerCriterionExplanation;
+  passed: boolean;
+}> = ({ criterion, passed }) => {
+  const Icon = passed ? CheckCircle2 : XCircle;
+  const tone = passed
+    ? 'border-emerald-500/25 bg-emerald-500/10 text-emerald-300'
+    : 'border-rose-500/25 bg-rose-500/10 text-rose-300';
+  const observed = formatValue(criterion.observed, criterion.unit);
+  const threshold =
+    criterion.operator === 'exists'
+      ? 'exists'
+      : `${criterion.operator} ${formatValue(criterion.threshold, criterion.unit)}`;
+
+  return (
+    <span
+      className={`inline-flex max-w-full items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-semibold ${tone}`}
+      title={`${criterion.label}: ${observed} ${threshold}`}
+    >
+      <Icon className="h-3 w-3 shrink-0" />
+      <span className="truncate">{criterion.label}</span>
+      <span className="font-mono text-[9px] opacity-80">{observed}</span>
+    </span>
+  );
+};
+
+const ScannerExplanationPanel: React.FC<ScannerExplanationPanelProps> = ({ explanation }) => {
+  if (!explanation) return null;
+
+  const passed = Object.values(explanation.criteria_passed || {}).slice(0, 2);
+  const failed = Object.values(explanation.criteria_failed || {}).slice(0, 2);
+  const warnings = explanation.data_quality_warnings || [];
+
+  return (
+    <div className="mt-2 space-y-2 rounded-md border border-gray-700/70 bg-gray-900/55 p-2">
+      <div className="flex items-start justify-between gap-2">
+        <p className="min-w-0 text-xs leading-5 text-gray-300">{explanation.why[0]}</p>
+        {explanation.evidence.reconstructed && (
+          <span
+            className="inline-flex shrink-0 items-center gap-1 rounded border border-blue-500/25 bg-blue-500/10 px-1.5 py-0.5 text-[10px] font-bold uppercase text-blue-300"
+            title={explanation.evidence.reconstruction_quality ?? 'reconstructed'}
+          >
+            <History className="h-3 w-3" />
+            Rebuilt
+          </span>
+        )}
+      </div>
+
+      {(passed.length > 0 || failed.length > 0) && (
+        <div className="flex max-w-full flex-wrap gap-1.5">
+          {passed.map((criterion) => (
+            <CriteriaPill
+              key={`passed-${criterion.label}`}
+              criterion={criterion}
+              passed
+            />
+          ))}
+          {failed.map((criterion) => (
+            <CriteriaPill
+              key={`failed-${criterion.label}`}
+              criterion={criterion}
+              passed={false}
+            />
+          ))}
+        </div>
+      )}
+
+      {warnings.length > 0 && (
+        <div className="flex items-start gap-1.5 text-[11px] leading-4 text-amber-300">
+          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+          <span>{warnings[0].message}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ScannerExplanationPanel;

--- a/frontend/src/components/ScannerResults.test.tsx
+++ b/frontend/src/components/ScannerResults.test.tsx
@@ -75,6 +75,55 @@ describe('ScannerResults', () => {
     fireEvent.click(screen.getByText(/^date$/i));
     expect(onSort).toHaveBeenCalledWith('event_date');
   });
+
+  it('renders scanner explanation evidence when present', () => {
+    const explainedEvent = makeEvent({
+      explanation: {
+        schema_version: 'scanner_explanation.v1',
+        why: ['Pre-market volume was 5.20x the 20-day average.'],
+        criteria_passed: {
+          'premarket.volume_spike': {
+            label: 'Volume spike',
+            observed: 5.2,
+            threshold: 4,
+            operator: '>=',
+            unit: 'x',
+          },
+        },
+        criteria_failed: {
+          'premarket.liquidity': {
+            label: 'Baseline liquidity',
+            observed: 125000,
+            threshold: 500000,
+            operator: '>',
+            unit: 'shares',
+          },
+        },
+        confidence_inputs: {},
+        data_quality_warnings: [
+          {
+            code: 'stale_bars',
+            severity: 'medium',
+            message: 'Some bars are older than expected.',
+            affected_inputs: ['minute_aggregates'],
+          },
+        ],
+        evidence: {
+          reconstructed: true,
+          reconstruction_quality: 'best_effort',
+        },
+      },
+    });
+    const results = { ...emptyResults, events_detected: 1, events: [explainedEvent] };
+
+    renderWithQuery(<ScannerResults results={results} />);
+
+    expect(screen.getByText('Pre-market volume was 5.20x the 20-day average.')).toBeInTheDocument();
+    expect(screen.getByText('Volume spike')).toBeInTheDocument();
+    expect(screen.getByText('Baseline liquidity')).toBeInTheDocument();
+    expect(screen.getByText('Rebuilt')).toBeInTheDocument();
+    expect(screen.getByText('Some bars are older than expected.')).toBeInTheDocument();
+  });
 });
 
 const makeGate = (overrides: Partial<QualityGateAssessment> = {}): QualityGateAssessment => ({

--- a/frontend/src/components/ScannerResults.tsx
+++ b/frontend/src/components/ScannerResults.tsx
@@ -11,6 +11,7 @@ import {
 import Card from './ui/Card';
 import Ticker from './Ticker';
 import ReviewControls from './ReviewControls';
+import ScannerExplanationPanel from './ScannerExplanationPanel';
 import TrustGateBanner from './TrustGateBanner';
 import { ScannerEvent, ScannerDiagnostics, QualityGateAssessment } from '../api/scanner';
 import { safeExternalUrl } from '../utils/url';
@@ -298,6 +299,7 @@ const ScannerResults: React.FC<ScannerResultsProps> = ({
                     <p className="text-sm font-medium text-gray-200 line-clamp-1" title={event.summary}>
                       {event.summary}
                     </p>
+                    <ScannerExplanationPanel explanation={event.explanation ?? null} />
                   </td>
                   <td className="py-4 px-4 bg-gray-800">
                     <div className="flex flex-wrap gap-2 text-[10px] font-bold">


### PR DESCRIPTION
## Summary
- Add `scanner_events.explanation` JSONB storage, API serialization, and `scanner_explanation.v1` validation.
- Generate explanations for `pre_market_volume_spike` signals and add best-effort historical backfill via Celery/API.
- Render compact explanation evidence in Scanner Results with passed/failed criteria and quality warnings.

## Verification
- `ruff check .`
- `python -m alembic heads`
- `$env:PYTEST_ADDOPTS='--no-cov'; python -m pytest backend/tests/schemas/test_scanner_explanation.py backend/tests/services/test_scanner_explanations.py backend/tests/models/test_scanner_event_explanation.py backend/tests/services/test_alert_service.py::test_save_event_persists_explanation_payload backend/tests/tasks/test_explanation_backfill_task.py backend/tests/api/test_scanner.py::test_results_returns_explanation_payload backend/tests/api/test_scanner.py::test_explanation_backfill_endpoint_queues_task -q`
- `npx tsc --noEmit -p tsconfig.app.json`
- `npx eslint . --report-unused-disable-directives-severity error` (0 errors; existing fast-refresh warnings remain)
- `npx vitest run src/components/ScannerResults.test.tsx`
- `npm run build`

Implements #448.