### PR TITLE
Migrate liquidity hunt explanations

### DIFF
--- a/backend/app/services/liquidity_hunt.py
+++ b/backend/app/services/liquidity_hunt.py
@@ -34,6 +34,7 @@ from app.models.stock_split import StockSplit
 from app.models.ticker_reference import TickerReference
 from app.services.alert_service import save_event as _save_event
 from app.services.catalyst_parser import CatalystParser
+from app.services.scanner_explanations import build_liquidity_hunt_explanation
 from app.utils.session import get_market_today
 from app.utils.time import to_utc_naive
 
@@ -553,6 +554,13 @@ async def run_liquidity_hunt_scan(
                             opening_price=session_metrics["regular_open"],
                             closing_price=session_metrics["regular_close"],
                             gate_metadata=gate_metadata,
+                            explanation=build_liquidity_hunt_explanation(
+                                scanner_type="liquidity_hunt_pre",
+                                indicators=indicators_pre,
+                                criteria_met=criteria_pre,
+                                gate_metadata=gate_metadata,
+                                config=config,
+                            ),
                         )
                         results.append(event_dict)
                         counts["fired_pre"] += 1
@@ -596,6 +604,13 @@ async def run_liquidity_hunt_scan(
                                 opening_price=session_metrics["regular_open"],
                                 closing_price=session_metrics["regular_close"],
                                 gate_metadata=gate_metadata,
+                                explanation=build_liquidity_hunt_explanation(
+                                    scanner_type="liquidity_hunt_post",
+                                    indicators=indicators_post,
+                                    criteria_met=criteria_post,
+                                    gate_metadata=gate_metadata,
+                                    config=config,
+                                ),
                             )
                             results.append(event_dict)
                             counts["fired_post"] += 1

--- a/backend/app/services/scanner_explanations.py
+++ b/backend/app/services/scanner_explanations.py
@@ -4,6 +4,15 @@ from app.models.scanner_event import ScannerEvent
 from app.schemas.scanner_explanation import validate_scanner_explanation
 from app.utils.time import utc_now
 
+LIQUIDITY_HUNT_DEFAULT_CONFIG: dict[str, float] = {
+    "volume_ratio_min": 4.0,
+    "volume_pct_of_daily_min": 0.30,
+    "spike_pct_min": 0.10,
+    "regular_vol_ratio_max": 1000.0,
+    "regular_range_ratio_max": 1.50,
+    "session_volume_floor": 50_000,
+}
+
 
 def _criterion(
     label: str,
@@ -32,12 +41,16 @@ def _criterion(
     return payload
 
 
-def _split_criteria(criteria_met: Dict[str, Any], criteria: Dict[str, Dict[str, Any]]):
+def _split_criteria(
+    criteria_met: Dict[str, Any],
+    criteria: Dict[str, Dict[str, Any]],
+    prefix: str,
+):
     passed: Dict[str, Dict[str, Any]] = {}
     failed: Dict[str, Dict[str, Any]] = {}
     for raw_key, explanation in criteria.items():
         target = passed if bool(criteria_met.get(raw_key)) else failed
-        target[f"premarket.{raw_key}"] = explanation
+        target[f"{prefix}.{raw_key}"] = explanation
     return passed, failed
 
 
@@ -107,7 +120,7 @@ def build_pre_market_volume_explanation(
             importance=0.7,
         ),
     }
-    passed, failed = _split_criteria(criteria_met, criteria)
+    passed, failed = _split_criteria(criteria_met, criteria, "premarket")
 
     why = [
         (
@@ -131,6 +144,123 @@ def build_pre_market_volume_explanation(
             "relative_volume": raw.relative_volume,
             "anomaly_score": raw.anomaly_score,
             "has_news_catalyst": indicators.get("has_news_catalyst"),
+        },
+        "data_quality_warnings": _quality_warnings(gate_metadata),
+        "evidence": {
+            "reconstructed": False,
+            "generated_at": utc_now(),
+            "generator_version": "explanation_builder.v1",
+            "provider": "polygon",
+        },
+    }
+    return validate_scanner_explanation(payload)
+
+
+def _pct(value: Any) -> Optional[float]:
+    return round(float(value) * 100, 2) if value is not None else None
+
+
+def _liquidity_hunt_criteria(
+    indicators: Dict[str, Any],
+    config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Dict[str, Any]]:
+    cfg = {**LIQUIDITY_HUNT_DEFAULT_CONFIG, **(config or {})}
+    return {
+        "volume_ratio": _criterion(
+            "Off-hours volume ratio",
+            indicators.get("session_volume_ratio"),
+            cfg["volume_ratio_min"],
+            ">=",
+            unit="x",
+            source="minute_aggregates",
+            lookback="20d",
+            importance=1.0,
+        ),
+        "volume_materiality": _criterion(
+            "Off-hours share of daily volume",
+            _pct(indicators.get("session_volume_pct_of_daily")),
+            _pct(cfg["volume_pct_of_daily_min"]),
+            ">=",
+            unit="%",
+            source="minute_aggregates",
+            lookback="20d",
+            importance=0.8,
+        ),
+        "session_spike": _criterion(
+            "Off-hours price spike",
+            _pct(indicators.get("session_spike_pct")),
+            _pct(cfg["spike_pct_min"]),
+            ">=",
+            unit="%",
+            source="minute_aggregates",
+            importance=0.9,
+        ),
+        "quiet_regular_vol": _criterion(
+            "Regular-session volume restraint",
+            indicators.get("regular_volume_ratio"),
+            cfg["regular_vol_ratio_max"],
+            "<=",
+            unit="x",
+            source="minute_aggregates",
+            lookback="20d",
+            importance=0.4,
+        ),
+        "quiet_regular_range": _criterion(
+            "Regular-session range restraint",
+            indicators.get("regular_range_ratio"),
+            cfg["regular_range_ratio_max"],
+            "<=",
+            unit="x",
+            source="minute_aggregates",
+            lookback="20d",
+            importance=0.8,
+        ),
+        "volume_floor": _criterion(
+            "Absolute off-hours volume floor",
+            indicators.get("session_volume"),
+            cfg["session_volume_floor"],
+            ">=",
+            unit="shares",
+            source="minute_aggregates",
+            importance=0.6,
+        ),
+    }
+
+
+def build_liquidity_hunt_explanation(
+    scanner_type: str,
+    indicators: Dict[str, Any],
+    criteria_met: Dict[str, Any],
+    gate_metadata: Optional[Dict[str, Any]] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    criteria = _liquidity_hunt_criteria(indicators, config=config)
+    passed, failed = _split_criteria(criteria_met, criteria, scanner_type)
+
+    session_label = "pre-market" if indicators.get("session") == "pre" else "post-market"
+    why = [f"{session_label.title()} liquidity matched the hunt criteria."]
+    if indicators.get("session_volume_ratio") is not None:
+        why[0] = (
+            f"{session_label.title()} volume was "
+            f"{float(indicators['session_volume_ratio']):.2f}x its 20-day session baseline."
+        )
+    if indicators.get("session_spike_pct") is not None:
+        why.append(
+            f"Session high was {_pct(indicators['session_spike_pct']):.2f}% above reference close."
+        )
+
+    payload = {
+        "schema_version": "scanner_explanation.v1",
+        "why": why,
+        "criteria_passed": passed,
+        "criteria_failed": failed,
+        "confidence_inputs": {
+            "scanner_type": scanner_type,
+            "session": indicators.get("session"),
+            "session_volume": indicators.get("session_volume"),
+            "session_volume_ratio": indicators.get("session_volume_ratio"),
+            "session_spike_pct": indicators.get("session_spike_pct"),
+            "float_rotation_pct": indicators.get("float_rotation_pct"),
         },
         "data_quality_warnings": _quality_warnings(gate_metadata),
         "evidence": {
@@ -179,7 +309,10 @@ def reconstruct_explanation_for_event(event: ScannerEvent) -> Dict[str, Any]:
                 importance=0.7,
             ),
         }
-        passed, failed = _split_criteria(criteria_met, criteria)
+        passed, failed = _split_criteria(criteria_met, criteria, "premarket")
+    elif event.scanner_type in {"liquidity_hunt_pre", "liquidity_hunt_post"}:
+        criteria = _liquidity_hunt_criteria(indicators)
+        passed, failed = _split_criteria(criteria_met, criteria, event.scanner_type)
     else:
         scanner_prefix = event.scanner_type.replace("_", ".")
         passed = {}

--- a/backend/tests/services/test_liquidity_hunt.py
+++ b/backend/tests/services/test_liquidity_hunt.py
@@ -554,6 +554,63 @@ def test_scan_fires_both_variants():
     assert "liquidity_hunt_post" in saved_types
 
 
+def test_scan_persists_explanations_for_both_liquidity_hunt_variants():
+    """Both saved events carry scanner_explanation.v1 payloads."""
+    db = MagicMock()
+    with (
+        patch(
+            "app.services.liquidity_hunt._get_session_metrics",
+            return_value=_CLEAN_METRICS,
+        ),
+        patch("app.services.liquidity_hunt._get_prior_day_close", return_value=11.00),
+        patch(
+            "app.services.liquidity_hunt._get_event_date_regular_close",
+            return_value=11.10,
+        ),
+        patch(
+            "app.services.liquidity_hunt._get_rolling_baselines",
+            return_value=_SCAN_BASELINES,
+        ),
+        patch(
+            "app.services.liquidity_hunt._get_enrichment",
+            return_value=_mock_enrichment(),
+        ),
+        patch(
+            "app.services.liquidity_hunt._save_event", return_value={"id": 1}
+        ) as mock_save,
+    ):
+        _run(
+            run_liquidity_hunt_scan(
+                ["TEST"],
+                db,
+                start_date=EVENT_DATE,
+                end_date=EVENT_DATE,
+                gate_metadata={
+                    "tier": "warning",
+                    "warnings": [
+                        {
+                            "code": "provider_gaps",
+                            "severity": "warning",
+                            "message": "Provider gaps were detected.",
+                        }
+                    ],
+                },
+            )
+        )
+
+    by_type = {c.kwargs["scanner_type"]: c.kwargs for c in mock_save.call_args_list}
+    pre_explanation = by_type["liquidity_hunt_pre"]["explanation"]
+    post_explanation = by_type["liquidity_hunt_post"]["explanation"]
+
+    assert pre_explanation["schema_version"] == "scanner_explanation.v1"
+    assert "liquidity_hunt_pre.volume_ratio" in pre_explanation["criteria_passed"]
+    assert "Provider gaps were detected." in [
+        warning["message"] for warning in pre_explanation["data_quality_warnings"]
+    ]
+    assert post_explanation["schema_version"] == "scanner_explanation.v1"
+    assert "liquidity_hunt_post.session_spike" in post_explanation["criteria_passed"]
+
+
 def test_scan_skips_ticker_when_sparse_history():
     """No events emitted when _get_rolling_baselines returns None."""
     db = MagicMock()

--- a/backend/tests/services/test_scanner_explanations.py
+++ b/backend/tests/services/test_scanner_explanations.py
@@ -3,6 +3,7 @@ from datetime import date, datetime
 from app.models.scanner_event import ScannerEvent
 from app.services.pre_market_scan import EnrichedSignal, RawSignal
 from app.services.scanner_explanations import (
+    build_liquidity_hunt_explanation,
     build_pre_market_volume_explanation,
     reconstruct_explanation_for_event,
 )
@@ -69,6 +70,53 @@ def test_build_pre_market_volume_explanation_splits_passed_and_failed_criteria()
     assert explanation["evidence"]["reconstructed"] is False
 
 
+def test_build_liquidity_hunt_explanation_splits_variant_criteria():
+    indicators = {
+        "session": "pre",
+        "session_volume": 350000,
+        "avg_session_volume_20d": 35000,
+        "session_volume_ratio": 10.0,
+        "session_volume_pct_of_daily": 0.35,
+        "session_high": 12.11,
+        "reference_close": 11.0,
+        "session_spike_pct": 0.1009,
+        "regular_volume_ratio": 0.9474,
+        "regular_range_ratio": 1.3575,
+        "float_rotation_pct": 0.7,
+    }
+    criteria_met = {
+        "volume_ratio": True,
+        "volume_materiality": True,
+        "session_spike": True,
+        "quiet_regular_vol": True,
+        "quiet_regular_range": False,
+        "volume_floor": True,
+    }
+
+    explanation = build_liquidity_hunt_explanation(
+        scanner_type="liquidity_hunt_pre",
+        indicators=indicators,
+        criteria_met=criteria_met,
+        gate_metadata={
+            "tier": "warning",
+            "warnings": [
+                {
+                    "code": "provider_gaps",
+                    "severity": "warning",
+                    "message": "Provider gaps were detected.",
+                }
+            ],
+        },
+    )
+
+    assert explanation["schema_version"] == "scanner_explanation.v1"
+    assert "liquidity_hunt_pre.volume_ratio" in explanation["criteria_passed"]
+    assert "liquidity_hunt_pre.quiet_regular_range" in explanation["criteria_failed"]
+    assert explanation["confidence_inputs"]["session"] == "pre"
+    assert explanation["data_quality_warnings"][0]["severity"] == "medium"
+    assert explanation["evidence"]["reconstructed"] is False
+
+
 def test_reconstruct_explanation_for_existing_event_marks_best_effort():
     event = ScannerEvent(
         ticker="AAPL",
@@ -93,3 +141,30 @@ def test_reconstruct_explanation_for_existing_event_marks_best_effort():
     assert explanation["evidence"]["reconstructed"] is True
     assert explanation["evidence"]["reconstruction_quality"] == "best_effort"
     assert explanation["confidence_inputs"]["signal_quality_score"] == 81.0
+
+
+def test_reconstruct_liquidity_hunt_event_uses_named_criteria():
+    event = ScannerEvent(
+        ticker="AAPL",
+        event_date=date(2026, 6, 2),
+        scanner_type="liquidity_hunt_pre",
+        indicators={
+            "session": "pre",
+            "session_volume_ratio": 10.0,
+            "session_spike_pct": 0.1009,
+            "session_volume_pct_of_daily": 0.35,
+        },
+        criteria_met={"volume_ratio": True, "quiet_regular_range": False},
+        metadata_={"quality_gate": {"tier": "trusted", "warnings": []}},
+        created_at=datetime(2026, 6, 2),
+        updated_at=datetime(2026, 6, 2),
+    )
+
+    explanation = reconstruct_explanation_for_event(event)
+
+    assert "liquidity_hunt_pre.volume_ratio" in explanation["criteria_passed"]
+    assert "liquidity_hunt_pre.quiet_regular_range" in explanation["criteria_failed"]
+    assert (
+        explanation["criteria_passed"]["liquidity_hunt_pre.volume_ratio"]["label"]
+        == "Off-hours volume ratio"
+    )


### PR DESCRIPTION
## Summary
- Add a liquidity-hunt explanation builder for pre/post variants using `scanner_explanation.v1`.
- Thread explanation payloads into `liquidity_hunt_pre` and `liquidity_hunt_post` event persistence.
- Improve historical reconstruction for liquidity hunt events to use named criteria instead of generic boolean labels.

## Verification
- `ruff check .`
- `$env:PYTEST_ADDOPTS='--no-cov'; python -m pytest backend/tests/services/test_liquidity_hunt.py backend/tests/services/test_scanner_explanations.py backend/tests/tasks/test_explanation_backfill_task.py backend/tests/api/test_scanner.py::test_results_returns_explanation_payload -q`
- `npx tsc --noEmit -p tsconfig.app.json`
- `npx eslint . --report-unused-disable-directives-severity error` (0 errors; existing fast-refresh warnings remain)
- `npm run build`

Closes #459.