### PR TITLE
Migrate oversold and pocket pivot explanations

### DIFF
--- a/backend/app/services/oversold_bounce_scan.py
+++ b/backend/app/services/oversold_bounce_scan.py
@@ -17,6 +17,7 @@ from app.core.metrics import (
 from app.exceptions import DataFetchError, ProviderError, ScanError
 from app.models.stock_aggregate import StockAggregate
 from app.services.scan_orchestrator import ScannerDescriptor, register
+from app.services.scanner_explanations import build_oversold_bounce_explanation
 from app.utils.session import get_market_today
 from app.utils.time import to_utc_naive
 
@@ -193,6 +194,11 @@ async def run_oversold_bounce_scan(
                         closing_price=float(today["Close"]),
                         ranker_config=ranker_config,
                         gate_metadata=gate_metadata,
+                        explanation=build_oversold_bounce_explanation(
+                            indicators=indicators,
+                            criteria_met=criteria_met,
+                            gate_metadata=gate_metadata,
+                        ),
                     )
                     results.append(event_dict)
                     scanner_events_total.labels(scanner_type="oversold_bounce").inc()

--- a/backend/app/services/pocket_pivot.py
+++ b/backend/app/services/pocket_pivot.py
@@ -31,6 +31,7 @@ from app.models.stock_split import StockSplit
 from app.models.ticker_reference import TickerReference
 from app.services.alert_service import save_event as _save_event
 from app.services.catalyst_parser import CatalystParser
+from app.services.scanner_explanations import build_pocket_pivot_explanation
 from app.utils.session import get_market_today
 from app.utils.time import to_utc_naive
 
@@ -323,6 +324,11 @@ async def run_pocket_pivot_scan(
                         previous_close=prior_close,
                         closing_price=today["close"],
                         gate_metadata=gate_metadata,
+                        explanation=build_pocket_pivot_explanation(
+                            indicators=indicators,
+                            criteria_met=criteria_met,
+                            gate_metadata=gate_metadata,
+                        ),
                     )
                     results.append(event_dict)
                     counts["fired"] += 1

--- a/backend/app/services/scanner_explanations.py
+++ b/backend/app/services/scanner_explanations.py
@@ -273,6 +273,189 @@ def build_liquidity_hunt_explanation(
     return validate_scanner_explanation(payload)
 
 
+def _oversold_bounce_criteria(
+    indicators: Dict[str, Any],
+) -> Dict[str, Dict[str, Any]]:
+    return {
+        "volume_ma_3_ok": _criterion(
+            "3-day volume average",
+            indicators.get("vol_ma_3"),
+            500000,
+            ">=",
+            unit="shares",
+            source="daily_aggregates",
+            lookback="3d",
+            importance=0.7,
+        ),
+        "price_ge_5": _criterion(
+            "Price floor",
+            indicators.get("previous_close") or indicators.get("closing_price"),
+            5,
+            ">=",
+            unit="$",
+            source="daily_aggregates",
+            importance=0.5,
+        ),
+        "rsi_2_crossed": _criterion(
+            "RSI-2 recovery cross",
+            indicators.get("rsi_2"),
+            15,
+            ">=",
+            source="daily_aggregates",
+            lookback="2d",
+            importance=1.0,
+        ),
+        "rsi_5_crossed": _criterion(
+            "RSI-5 recovery cross",
+            indicators.get("rsi_5"),
+            27,
+            ">=",
+            source="daily_aggregates",
+            lookback="5d",
+            importance=0.9,
+        ),
+        "no_gap_down": _criterion(
+            "No gap below prior low",
+            True,
+            True,
+            "==",
+            source="daily_aggregates",
+            importance=0.6,
+        ),
+    }
+
+
+def build_oversold_bounce_explanation(
+    indicators: Dict[str, Any],
+    criteria_met: Dict[str, Any],
+    gate_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    criteria = _oversold_bounce_criteria(indicators)
+    passed, failed = _split_criteria(criteria_met, criteria, "oversold_bounce")
+
+    why = ["RSI-2 and RSI-5 recovered from oversold levels."]
+    if indicators.get("rsi_2") is not None and indicators.get("rsi_5") is not None:
+        why[0] = (
+            f"RSI-2 recovered to {float(indicators['rsi_2']):.2f} and "
+            f"RSI-5 recovered to {float(indicators['rsi_5']):.2f}."
+        )
+    if indicators.get("vol_ma_3") is not None:
+        why.append(f"3-day average volume was {int(indicators['vol_ma_3']):,} shares.")
+
+    payload = {
+        "schema_version": "scanner_explanation.v1",
+        "why": why,
+        "criteria_passed": passed,
+        "criteria_failed": failed,
+        "confidence_inputs": {
+            "scanner_type": "oversold_bounce",
+            "rsi_2": indicators.get("rsi_2"),
+            "rsi_5": indicators.get("rsi_5"),
+            "vol_ma_3": indicators.get("vol_ma_3"),
+            "relative_volume": indicators.get("relative_volume"),
+            "avg_liquidity_5d": indicators.get("avg_liquidity_5d"),
+            "gap_pct": indicators.get("gap_pct"),
+        },
+        "data_quality_warnings": _quality_warnings(gate_metadata),
+        "evidence": {
+            "reconstructed": False,
+            "generated_at": utc_now(),
+            "generator_version": "explanation_builder.v1",
+            "provider": "polygon",
+        },
+    }
+    return validate_scanner_explanation(payload)
+
+
+def _pocket_pivot_criteria(
+    indicators: Dict[str, Any],
+) -> Dict[str, Dict[str, Any]]:
+    return {
+        "up_day": _criterion(
+            "Up day",
+            _pct(indicators.get("up_day_pct")),
+            0,
+            ">=",
+            unit="%",
+            source="daily_aggregates",
+            importance=0.7,
+        ),
+        "volume_over_max_down": _criterion(
+            "Volume exceeds highest down-day volume",
+            indicators.get("today_volume"),
+            indicators.get("max_down_day_vol"),
+            ">",
+            unit="shares",
+            source="daily_aggregates",
+            lookback=f"{indicators.get('lookback_days_available', 'n/a')}d",
+            importance=1.0,
+        ),
+        "price_floor": _criterion(
+            "Price floor",
+            indicators.get("today_close"),
+            indicators.get("price_floor", 5.0),
+            ">=",
+            unit="$",
+            source="daily_aggregates",
+            importance=0.5,
+        ),
+        "volume_floor": _criterion(
+            "Volume floor",
+            indicators.get("today_volume"),
+            indicators.get("volume_floor", 100000),
+            ">=",
+            unit="shares",
+            source="daily_aggregates",
+            importance=0.5,
+        ),
+    }
+
+
+def build_pocket_pivot_explanation(
+    indicators: Dict[str, Any],
+    criteria_met: Dict[str, Any],
+    gate_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    criteria = _pocket_pivot_criteria(indicators)
+    passed, failed = _split_criteria(criteria_met, criteria, "pocket_pivot")
+
+    why = ["Daily volume exceeded the highest down-day volume in the lookback."]
+    if (
+        indicators.get("today_volume") is not None
+        and indicators.get("max_down_day_vol") is not None
+    ):
+        why[0] = (
+            f"Volume was {int(indicators['today_volume']):,} shares versus "
+            f"{int(indicators['max_down_day_vol']):,} on the highest down day."
+        )
+    if indicators.get("up_day_pct") is not None:
+        why.append(f"Close was {_pct(indicators['up_day_pct']):.2f}% above prior close.")
+
+    payload = {
+        "schema_version": "scanner_explanation.v1",
+        "why": why,
+        "criteria_passed": passed,
+        "criteria_failed": failed,
+        "confidence_inputs": {
+            "scanner_type": "pocket_pivot",
+            "today_volume": indicators.get("today_volume"),
+            "max_down_day_vol": indicators.get("max_down_day_vol"),
+            "volume_over_max_down_pct": indicators.get("volume_over_max_down_pct"),
+            "down_days_in_lookback": indicators.get("down_days_in_lookback"),
+            "lookback_days_available": indicators.get("lookback_days_available"),
+            "split_in_lookback": indicators.get("split_in_lookback"),
+        },
+        "data_quality_warnings": _quality_warnings(gate_metadata),
+        "evidence": {
+            "reconstructed": False,
+            "generated_at": utc_now(),
+            "generator_version": "explanation_builder.v1",
+            "provider": "polygon",
+        },
+    }
+    return validate_scanner_explanation(payload)
+
+
 def reconstruct_explanation_for_event(event: ScannerEvent) -> Dict[str, Any]:
     indicators = event.indicators or {}
     criteria_met = event.criteria_met or {}
@@ -313,6 +496,12 @@ def reconstruct_explanation_for_event(event: ScannerEvent) -> Dict[str, Any]:
     elif event.scanner_type in {"liquidity_hunt_pre", "liquidity_hunt_post"}:
         criteria = _liquidity_hunt_criteria(indicators)
         passed, failed = _split_criteria(criteria_met, criteria, event.scanner_type)
+    elif event.scanner_type == "oversold_bounce":
+        criteria = _oversold_bounce_criteria(indicators)
+        passed, failed = _split_criteria(criteria_met, criteria, "oversold_bounce")
+    elif event.scanner_type == "pocket_pivot":
+        criteria = _pocket_pivot_criteria(indicators)
+        passed, failed = _split_criteria(criteria_met, criteria, "pocket_pivot")
     else:
         scanner_prefix = event.scanner_type.replace("_", ".")
         passed = {}

--- a/backend/tests/services/test_pocket_pivot.py
+++ b/backend/tests/services/test_pocket_pivot.py
@@ -129,6 +129,26 @@ def test_clean_pocket_pivot_fires():
     assert mock_save.call_args.kwargs["scanner_type"] == "pocket_pivot"
 
 
+def test_clean_pocket_pivot_persists_explanation():
+    today = {"close": 14.72, "volume": 350_000}
+    _, _, mock_save = _run_scan(
+        today,
+        prior_close=14.15,
+        lookback_bars=_STANDARD_LOOKBACK,
+        enrichment={
+            **_EMPTY_ENRICHMENT,
+            "catalyst_tags": ["earnings"],
+        },
+    )
+
+    explanation = mock_save.call_args.kwargs["explanation"]
+
+    assert explanation["schema_version"] == "scanner_explanation.v1"
+    assert "pocket_pivot.volume_over_max_down" in explanation["criteria_passed"]
+    assert explanation["confidence_inputs"]["down_days_in_lookback"] == 4
+    assert explanation["evidence"]["reconstructed"] is False
+
+
 # ---------------------------------------------------------------------------
 # Scenario 2: Down day — up-day check fails
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_scanner_explanations.py
+++ b/backend/tests/services/test_scanner_explanations.py
@@ -4,6 +4,8 @@ from app.models.scanner_event import ScannerEvent
 from app.services.pre_market_scan import EnrichedSignal, RawSignal
 from app.services.scanner_explanations import (
     build_liquidity_hunt_explanation,
+    build_oversold_bounce_explanation,
+    build_pocket_pivot_explanation,
     build_pre_market_volume_explanation,
     reconstruct_explanation_for_event,
 )
@@ -117,6 +119,70 @@ def test_build_liquidity_hunt_explanation_splits_variant_criteria():
     assert explanation["evidence"]["reconstructed"] is False
 
 
+def test_build_oversold_bounce_explanation_uses_named_criteria():
+    indicators = {
+        "rsi_2": 21.4,
+        "rsi_5": 31.2,
+        "vol_ma_3": 800000,
+        "avg_liquidity_5d": 42_000_000,
+        "gap_pct": 0.0,
+        "relative_volume": 1.25,
+    }
+    criteria_met = {
+        "volume_ma_3_ok": True,
+        "price_ge_5": True,
+        "rsi_2_crossed": True,
+        "rsi_5_crossed": True,
+        "no_gap_down": True,
+    }
+
+    explanation = build_oversold_bounce_explanation(
+        indicators=indicators,
+        criteria_met=criteria_met,
+    )
+
+    assert explanation["schema_version"] == "scanner_explanation.v1"
+    assert "oversold_bounce.rsi_2_crossed" in explanation["criteria_passed"]
+    assert explanation["criteria_passed"]["oversold_bounce.rsi_2_crossed"]["label"] == "RSI-2 recovery cross"
+    assert explanation["confidence_inputs"]["rsi_2"] == 21.4
+    assert explanation["evidence"]["reconstructed"] is False
+
+
+def test_build_pocket_pivot_explanation_uses_named_criteria():
+    indicators = {
+        "today_close": 14.72,
+        "prior_close": 14.15,
+        "up_day_pct": 0.0403,
+        "today_volume": 350000,
+        "max_down_day_vol": 280000,
+        "volume_over_max_down_pct": 0.25,
+        "down_days_in_lookback": 4,
+        "lookback_days_available": 10,
+        "volume_floor": 100000,
+        "price_floor": 5.0,
+    }
+    criteria_met = {
+        "up_day": True,
+        "volume_over_max_down": True,
+        "price_floor": True,
+        "volume_floor": True,
+    }
+
+    explanation = build_pocket_pivot_explanation(
+        indicators=indicators,
+        criteria_met=criteria_met,
+    )
+
+    assert explanation["schema_version"] == "scanner_explanation.v1"
+    assert "pocket_pivot.volume_over_max_down" in explanation["criteria_passed"]
+    assert (
+        explanation["criteria_passed"]["pocket_pivot.volume_over_max_down"]["label"]
+        == "Volume exceeds highest down-day volume"
+    )
+    assert explanation["confidence_inputs"]["down_days_in_lookback"] == 4
+    assert explanation["evidence"]["reconstructed"] is False
+
+
 def test_reconstruct_explanation_for_existing_event_marks_best_effort():
     event = ScannerEvent(
         ticker="AAPL",
@@ -167,4 +233,50 @@ def test_reconstruct_liquidity_hunt_event_uses_named_criteria():
     assert (
         explanation["criteria_passed"]["liquidity_hunt_pre.volume_ratio"]["label"]
         == "Off-hours volume ratio"
+    )
+
+
+def test_reconstruct_oversold_bounce_event_uses_named_criteria():
+    event = ScannerEvent(
+        ticker="AAPL",
+        event_date=date(2026, 6, 2),
+        scanner_type="oversold_bounce",
+        indicators={"rsi_2": 21.4, "rsi_5": 31.2, "vol_ma_3": 800000},
+        criteria_met={"rsi_2_crossed": True, "no_gap_down": True},
+        metadata_={},
+        created_at=datetime(2026, 6, 2),
+        updated_at=datetime(2026, 6, 2),
+    )
+
+    explanation = reconstruct_explanation_for_event(event)
+
+    assert "oversold_bounce.rsi_2_crossed" in explanation["criteria_passed"]
+    assert (
+        explanation["criteria_passed"]["oversold_bounce.rsi_2_crossed"]["label"]
+        == "RSI-2 recovery cross"
+    )
+
+
+def test_reconstruct_pocket_pivot_event_uses_named_criteria():
+    event = ScannerEvent(
+        ticker="AAPL",
+        event_date=date(2026, 6, 2),
+        scanner_type="pocket_pivot",
+        indicators={
+            "today_volume": 350000,
+            "max_down_day_vol": 280000,
+            "volume_over_max_down_pct": 0.25,
+        },
+        criteria_met={"volume_over_max_down": True, "volume_floor": True},
+        metadata_={},
+        created_at=datetime(2026, 6, 2),
+        updated_at=datetime(2026, 6, 2),
+    )
+
+    explanation = reconstruct_explanation_for_event(event)
+
+    assert "pocket_pivot.volume_over_max_down" in explanation["criteria_passed"]
+    assert (
+        explanation["criteria_passed"]["pocket_pivot.volume_over_max_down"]["label"]
+        == "Volume exceeds highest down-day volume"
     )

--- a/backend/tests/services/test_scanner_refactor.py
+++ b/backend/tests/services/test_scanner_refactor.py
@@ -223,6 +223,10 @@ def test_oversold_bounce_detects_rsi_crossover():
 
     mock_save.assert_called_once()
     assert len(results) == 1
+    explanation = mock_save.call_args.kwargs["explanation"]
+    assert explanation["schema_version"] == "scanner_explanation.v1"
+    assert "oversold_bounce.rsi_2_crossed" in explanation["criteria_passed"]
+    assert explanation["confidence_inputs"]["rsi_2"] >= 15
 
 
 def test_oversold_bounce_skips_with_insufficient_bars():


### PR DESCRIPTION
## Summary
- add explanation-contract builders for oversold bounce and pocket pivot scanner events
- persist structured explanations from both scanner implementations
- cover direct builders, event reconstruction, and scanner persistence with focused tests

## Verification
- PYTEST_ADDOPTS='--no-cov' python -m pytest backend/tests/services/test_scanner_explanations.py::test_build_oversold_bounce_explanation_uses_named_criteria backend/tests/services/test_scanner_explanations.py::test_build_pocket_pivot_explanation_uses_named_criteria backend/tests/services/test_scanner_explanations.py::test_reconstruct_oversold_bounce_event_uses_named_criteria backend/tests/services/test_scanner_explanations.py::test_reconstruct_pocket_pivot_event_uses_named_criteria backend/tests/services/test_pocket_pivot.py::test_clean_pocket_pivot_persists_explanation backend/tests/services/test_scanner_refactor.py::test_oversold_bounce_detects_rsi_crossover -q
- PYTEST_ADDOPTS='--no-cov' python -m pytest backend/tests/services/test_pocket_pivot.py backend/tests/services/test_scanner_refactor.py::test_oversold_bounce_detects_rsi_crossover backend/tests/services/test_scanner_refactor.py::test_oversold_bounce_skips_with_insufficient_bars backend/tests/services/test_oversold_bounce_scan_module.py backend/tests/services/test_scanner_explanations.py backend/tests/tasks/test_explanation_backfill_task.py backend/tests/api/test_scanner.py::test_results_returns_explanation_payload -q
- ruff check .
- npx tsc --noEmit -p tsconfig.app.json
- npx eslint . --report-unused-disable-directives-severity error
- npm run build

Closes #460