### PR TITLE
Migrate trend pullback explanations

### DIFF
--- a/backend/app/services/scanner_explanations.py
+++ b/backend/app/services/scanner_explanations.py
@@ -456,6 +456,129 @@ def build_pocket_pivot_explanation(
     return validate_scanner_explanation(payload)
 
 
+def _trend_pullback_criteria(
+    indicators: Dict[str, Any],
+) -> Dict[str, Dict[str, Any]]:
+    return {
+        "uptrend": _criterion(
+            "SMA trend structure",
+            {
+                "close": indicators.get("close"),
+                "sma50": indicators.get("sma50"),
+                "sma200": indicators.get("sma200"),
+            },
+            "close > SMA50 > SMA200 and SMA50 rising",
+            "==",
+            source="daily_aggregates",
+            lookback="200d",
+            importance=1.0,
+        ),
+        "near_high": _criterion(
+            "Near 252-day high",
+            indicators.get("pct_off_252d_high"),
+            15,
+            "<=",
+            unit="%",
+            source="daily_aggregates",
+            lookback="252d",
+            importance=0.7,
+        ),
+        "pullback_in_progress": _criterion(
+            "SMA20 pullback tag",
+            {
+                "low_near_sma20": indicators.get("sma20"),
+                "consecutive_days_above_sma20": indicators.get(
+                    "consecutive_days_above_sma20"
+                ),
+            },
+            "low within configured SMA20 tolerance after prior closes above SMA20",
+            "==",
+            source="daily_aggregates",
+            lookback="60d",
+            importance=0.9,
+        ),
+        "orderly_pullback": _criterion(
+            "Orderly pullback depth",
+            indicators.get("pullback_depth_pct"),
+            "configured depth range with no SMA50 breakdown",
+            "==",
+            unit="%",
+            source="daily_aggregates",
+            lookback="20d",
+            importance=1.0,
+        ),
+        "rsi_reset": _criterion(
+            "RSI-5 reset",
+            indicators.get("rsi5"),
+            40,
+            "<",
+            source="daily_aggregates",
+            lookback="5d",
+            importance=0.8,
+        ),
+        "liquidity": _criterion(
+            "Dollar-volume liquidity floor",
+            indicators.get("avg_dollar_vol_20d"),
+            5_000_000,
+            ">=",
+            unit="$",
+            source="daily_aggregates",
+            lookback="20d",
+            importance=0.6,
+        ),
+    }
+
+
+def build_trend_pullback_explanation(
+    indicators: Dict[str, Any],
+    criteria_met: Dict[str, Any],
+    gate_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    criteria = _trend_pullback_criteria(indicators)
+    passed, failed = _split_criteria(criteria_met, criteria, "trend_pullback")
+
+    why = ["Trend pullback criteria were met."]
+    if indicators.get("pullback_depth_pct") is not None:
+        why[0] = (
+            f"Pullback depth was {float(indicators['pullback_depth_pct']):.2f}% "
+            "from the recent swing high."
+        )
+    if indicators.get("rsi5") is not None:
+        why.append(f"RSI-5 reset to {float(indicators['rsi5']):.2f}.")
+    if indicators.get("atr14") is not None:
+        why.append(f"ATR-14 was {float(indicators['atr14']):.2f}.")
+
+    payload = {
+        "schema_version": "scanner_explanation.v1",
+        "why": why,
+        "criteria_passed": passed,
+        "criteria_failed": failed,
+        "confidence_inputs": {
+            "scanner_type": "trend_pullback",
+            "close": indicators.get("close"),
+            "sma20": indicators.get("sma20"),
+            "sma50": indicators.get("sma50"),
+            "sma200": indicators.get("sma200"),
+            "rsi5": indicators.get("rsi5"),
+            "pct_off_252d_high": indicators.get("pct_off_252d_high"),
+            "pullback_depth_pct": indicators.get("pullback_depth_pct"),
+            "consecutive_days_above_sma20": indicators.get(
+                "consecutive_days_above_sma20"
+            ),
+            "atr14": indicators.get("atr14"),
+            "avg_dollar_vol_20d": indicators.get("avg_dollar_vol_20d"),
+        },
+        "data_quality_warnings": _quality_warnings(gate_metadata),
+        "evidence": {
+            "reconstructed": False,
+            "generated_at": utc_now(),
+            "generator_version": "explanation_builder.v1",
+            "provider": "polygon",
+        },
+    }
+    return validate_scanner_explanation(payload)
+
+
 def reconstruct_explanation_for_event(event: ScannerEvent) -> Dict[str, Any]:
     indicators = event.indicators or {}
     criteria_met = event.criteria_met or {}
@@ -502,6 +625,9 @@ def reconstruct_explanation_for_event(event: ScannerEvent) -> Dict[str, Any]:
     elif event.scanner_type == "pocket_pivot":
         criteria = _pocket_pivot_criteria(indicators)
         passed, failed = _split_criteria(criteria_met, criteria, "pocket_pivot")
+    elif event.scanner_type == "trend_pullback":
+        criteria = _trend_pullback_criteria(indicators)
+        passed, failed = _split_criteria(criteria_met, criteria, "trend_pullback")
     else:
         scanner_prefix = event.scanner_type.replace("_", ".")
         passed = {}

--- a/backend/app/services/trend_pullback_scan.py
+++ b/backend/app/services/trend_pullback_scan.py
@@ -28,6 +28,7 @@ from app.core.metrics import (
 )
 from app.models.stock_aggregate import StockAggregate
 from app.services.alert_service import save_event as _save_event
+from app.services.scanner_explanations import build_trend_pullback_explanation
 from app.utils.session import get_market_today
 
 _ET = ZoneInfo("America/New_York")
@@ -338,6 +339,11 @@ async def run_trend_pullback_scan(
                         previous_close=None,
                         closing_price=close_today,
                         gate_metadata=gate_metadata,
+                        explanation=build_trend_pullback_explanation(
+                            indicators=indicators,
+                            criteria_met=criteria_met,
+                            gate_metadata=gate_metadata,
+                        ),
                     )
                     results.append(event_dict)
                     counts["fired"] += 1

--- a/backend/tests/services/test_scanner_explanations.py
+++ b/backend/tests/services/test_scanner_explanations.py
@@ -7,6 +7,7 @@ from app.services.scanner_explanations import (
     build_oversold_bounce_explanation,
     build_pocket_pivot_explanation,
     build_pre_market_volume_explanation,
+    build_trend_pullback_explanation,
     reconstruct_explanation_for_event,
 )
 
@@ -183,6 +184,44 @@ def test_build_pocket_pivot_explanation_uses_named_criteria():
     assert explanation["evidence"]["reconstructed"] is False
 
 
+def test_build_trend_pullback_explanation_uses_named_criteria():
+    indicators = {
+        "close": 65.8,
+        "sma20": 66.1,
+        "sma50": 63.4,
+        "sma200": 51.9,
+        "rsi5": 28.5,
+        "pct_off_252d_high": 7.2,
+        "pullback_depth_pct": 6.4,
+        "consecutive_days_above_sma20": 9,
+        "atr14": 1.37,
+        "avg_dollar_vol_20d": 18_000_000,
+    }
+    criteria_met = {
+        "uptrend": True,
+        "near_high": True,
+        "pullback_in_progress": True,
+        "orderly_pullback": True,
+        "rsi_reset": True,
+        "liquidity": True,
+    }
+
+    explanation = build_trend_pullback_explanation(
+        indicators=indicators,
+        criteria_met=criteria_met,
+    )
+
+    assert explanation["schema_version"] == "scanner_explanation.v1"
+    assert "trend_pullback.uptrend" in explanation["criteria_passed"]
+    assert "trend_pullback.orderly_pullback" in explanation["criteria_passed"]
+    assert (
+        explanation["criteria_passed"]["trend_pullback.uptrend"]["label"]
+        == "SMA trend structure"
+    )
+    assert explanation["confidence_inputs"]["atr14"] == 1.37
+    assert explanation["evidence"]["reconstructed"] is False
+
+
 def test_reconstruct_explanation_for_existing_event_marks_best_effort():
     event = ScannerEvent(
         ticker="AAPL",
@@ -279,4 +318,35 @@ def test_reconstruct_pocket_pivot_event_uses_named_criteria():
     assert (
         explanation["criteria_passed"]["pocket_pivot.volume_over_max_down"]["label"]
         == "Volume exceeds highest down-day volume"
+    )
+
+
+def test_reconstruct_trend_pullback_event_uses_named_criteria():
+    event = ScannerEvent(
+        ticker="AAPL",
+        event_date=date(2026, 6, 2),
+        scanner_type="trend_pullback",
+        indicators={
+            "close": 65.8,
+            "sma20": 66.1,
+            "sma50": 63.4,
+            "sma200": 51.9,
+            "rsi5": 28.5,
+            "pullback_depth_pct": 6.4,
+            "atr14": 1.37,
+            "avg_dollar_vol_20d": 18_000_000,
+        },
+        criteria_met={"uptrend": True, "orderly_pullback": True, "liquidity": True},
+        metadata_={},
+        created_at=datetime(2026, 6, 2),
+        updated_at=datetime(2026, 6, 2),
+    )
+
+    explanation = reconstruct_explanation_for_event(event)
+
+    assert "trend_pullback.uptrend" in explanation["criteria_passed"]
+    assert "trend_pullback.orderly_pullback" in explanation["criteria_passed"]
+    assert (
+        explanation["criteria_passed"]["trend_pullback.orderly_pullback"]["label"]
+        == "Orderly pullback depth"
     )

--- a/backend/tests/services/test_trend_pullback_scan.py
+++ b/backend/tests/services/test_trend_pullback_scan.py
@@ -115,6 +115,23 @@ def _pullback_bars(
     return bars
 
 
+def _clean_trend_pullback_bars() -> list[MagicMock]:
+    bars = []
+    early_bars = 234
+    for i in range(early_bars):
+        c = 50.0 + 10.0 * (i / (early_bars - 1))
+        bars.append(_bar(c, volume=2_000_000))
+    for i in range(20):
+        c = 60.0 + 10.0 * ((i + 1) / 20)
+        bars.append(_bar(c, volume=2_000_000))
+    for j in range(5):
+        c = 70.0 * (1 - 0.001 * j)
+        bars.append(_bar(c, volume=2_000_000))
+    close = 70.0 * 0.97
+    bars.append(_bar(close, low=close * 0.995, high=close * 1.005, volume=500_000))
+    return bars
+
+
 # ---------------------------------------------------------------------------
 # Scenario 1: Module import
 # ---------------------------------------------------------------------------
@@ -242,6 +259,19 @@ def test_low_dollar_volume_does_not_fire():
     results, diag, _ = _run_scan(lambda db, t, d, lb: bars)
     assert results == []
     assert diag["fired"] == 0
+
+
+def test_clean_trend_pullback_persists_explanation():
+    bars = _clean_trend_pullback_bars()
+    results, diag, mock_save = _run_scan(lambda db, t, d, lb: bars)
+
+    assert results == [{"ticker": "AAPL"}]
+    assert diag["fired"] == 1
+    explanation = mock_save.call_args.kwargs["explanation"]
+    assert explanation["schema_version"] == "scanner_explanation.v1"
+    assert "trend_pullback.uptrend" in explanation["criteria_passed"]
+    assert "trend_pullback.rsi_reset" in explanation["criteria_passed"]
+    assert explanation["confidence_inputs"]["scanner_type"] == "trend_pullback"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add trend pullback explanation-contract builder with stable criterion IDs
- persist v1 explanations from trend pullback scanner events
- support best-effort reconstruction/backfill for historical trend pullback rows

## Verification
- PYTEST_ADDOPTS='--no-cov' python -m pytest backend/tests/services/test_scanner_explanations.py::test_build_trend_pullback_explanation_uses_named_criteria backend/tests/services/test_scanner_explanations.py::test_reconstruct_trend_pullback_event_uses_named_criteria backend/tests/services/test_trend_pullback_scan.py::test_clean_trend_pullback_persists_explanation -q
- PYTEST_ADDOPTS='--no-cov' python -m pytest backend/tests/services/test_trend_pullback_scan.py backend/tests/services/test_scanner_explanations.py backend/tests/tasks/test_explanation_backfill_task.py backend/tests/api/test_scanner.py::test_results_returns_explanation_payload -q
- ruff check .
- npx tsc --noEmit -p tsconfig.app.json
- npx eslint . --report-unused-disable-directives-severity error
- npm run build

Closes #461