### PR TITLE
Migrate live and social explanations

### DIFF
--- a/backend/app/services/scanner_explanations.py
+++ b/backend/app/services/scanner_explanations.py
@@ -579,6 +579,234 @@ def build_trend_pullback_explanation(
     return validate_scanner_explanation(payload)
 
 
+def _live_volume_spike_criteria(
+    indicators: Dict[str, Any],
+) -> Dict[str, Dict[str, Any]]:
+    return {
+        "volume_spike_4x": _criterion(
+            "Projected volume spike",
+            indicators.get("volume_spike_ratio"),
+            4,
+            ">=",
+            unit="x",
+            source="live_scanner",
+            lookback="intraday",
+            importance=1.0,
+        ),
+        "sufficient_avg_volume": _criterion(
+            "Average daily volume floor",
+            indicators.get("avg_daily_volume"),
+            50_000,
+            ">=",
+            unit="shares",
+            source="live_scanner",
+            lookback="daily_baseline",
+            importance=0.6,
+        ),
+    }
+
+
+def build_live_volume_spike_explanation(
+    indicators: Dict[str, Any],
+    criteria_met: Dict[str, Any],
+    gate_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    criteria = _live_volume_spike_criteria(indicators)
+    passed, failed = _split_criteria(criteria_met, criteria, "live_volume_spike")
+
+    why = ["Live projected volume exceeded the spike threshold."]
+    if indicators.get("volume_spike_ratio") is not None:
+        why[0] = (
+            f"Projected volume was {float(indicators['volume_spike_ratio']):.2f}x "
+            "average daily volume."
+        )
+    if indicators.get("minutes_elapsed") is not None:
+        why.append(
+            f"Signal fired after {float(indicators['minutes_elapsed']):.1f} minutes."
+        )
+
+    payload = {
+        "schema_version": "scanner_explanation.v1",
+        "why": why,
+        "criteria_passed": passed,
+        "criteria_failed": failed,
+        "confidence_inputs": {
+            "scanner_type": "live_volume_spike",
+            "volume_spike_ratio": indicators.get("volume_spike_ratio"),
+            "session_volume": indicators.get("session_volume"),
+            "avg_daily_volume": indicators.get("avg_daily_volume"),
+            "projected_volume": indicators.get("projected_volume"),
+            "minutes_elapsed": indicators.get("minutes_elapsed"),
+            "session": indicators.get("session"),
+        },
+        "data_quality_warnings": _quality_warnings(gate_metadata),
+        "evidence": {
+            "reconstructed": False,
+            "generated_at": utc_now(),
+            "generator_version": "explanation_builder.v1",
+            "provider": "live_scanner",
+        },
+    }
+    return validate_scanner_explanation(payload)
+
+
+def _live_price_move_criteria(
+    indicators: Dict[str, Any],
+) -> Dict[str, Dict[str, Any]]:
+    return {
+        "price_move_1pct": _criterion(
+            "Live price move",
+            abs(float(indicators.get("price_move_pct") or 0)),
+            1,
+            ">=",
+            unit="%",
+            source="live_scanner",
+            lookback="prior_close",
+            importance=1.0,
+        ),
+    }
+
+
+def build_live_price_move_explanation(
+    indicators: Dict[str, Any],
+    criteria_met: Dict[str, Any],
+    gate_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    criteria = _live_price_move_criteria(indicators)
+    passed, failed = _split_criteria(criteria_met, criteria, "live_price_move")
+
+    why = ["Live price moved beyond the configured threshold."]
+    if indicators.get("price_move_pct") is not None:
+        why[0] = f"Price moved {float(indicators['price_move_pct']):+.2f}% from prior close."
+    if (
+        indicators.get("prior_close") is not None
+        and indicators.get("current_price") is not None
+    ):
+        why.append(
+            f"Price moved from ${float(indicators['prior_close']):.2f} "
+            f"to ${float(indicators['current_price']):.2f}."
+        )
+
+    payload = {
+        "schema_version": "scanner_explanation.v1",
+        "why": why,
+        "criteria_passed": passed,
+        "criteria_failed": failed,
+        "confidence_inputs": {
+            "scanner_type": "live_price_move",
+            "price_move_pct": indicators.get("price_move_pct"),
+            "current_price": indicators.get("current_price"),
+            "prior_close": indicators.get("prior_close"),
+            "session": indicators.get("session"),
+        },
+        "data_quality_warnings": _quality_warnings(gate_metadata),
+        "evidence": {
+            "reconstructed": False,
+            "generated_at": utc_now(),
+            "generator_version": "explanation_builder.v1",
+            "provider": "live_scanner",
+        },
+    }
+    return validate_scanner_explanation(payload)
+
+
+def _social_callout_criteria(
+    indicators: Dict[str, Any],
+) -> Dict[str, Dict[str, Any]]:
+    return {
+        "has_cashtag": _criterion(
+            "Cashtag extracted",
+            bool(indicators.get("ticker") or indicators.get("tickers")),
+            True,
+            "==",
+            source="tweet_monitor",
+            importance=0.7,
+        ),
+        "has_price_level": _criterion(
+            "Price level extracted",
+            bool(
+                indicators.get("price_entry")
+                or indicators.get("price_target")
+                or indicators.get("price_stop")
+            ),
+            True,
+            "==",
+            source="tweet_monitor",
+            importance=0.6,
+        ),
+        "above_confidence_threshold": _criterion(
+            "Classifier confidence",
+            indicators.get("confidence"),
+            0.7,
+            ">=",
+            source="tweet_monitor",
+            importance=1.0,
+        ),
+    }
+
+
+def build_social_callout_explanation(
+    indicators: Dict[str, Any],
+    criteria_met: Dict[str, Any],
+    gate_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    criteria = _social_callout_criteria(indicators)
+    passed, failed = _split_criteria(criteria_met, criteria, "social_callout")
+
+    account = indicators.get("source_account") or "unknown"
+    why = [f"@{account} posted a classified social callout."]
+    if indicators.get("confidence") is not None:
+        why.append(f"Classifier confidence was {float(indicators['confidence']):.0%}.")
+    if indicators.get("price_entry") is not None:
+        why.append(f"Entry level extracted at ${float(indicators['price_entry']):.2f}.")
+
+    payload = {
+        "schema_version": "scanner_explanation.v1",
+        "why": why,
+        "criteria_passed": passed,
+        "criteria_failed": failed,
+        "confidence_inputs": {
+            "scanner_type": "social_callout",
+            "confidence": indicators.get("confidence"),
+            "source_account": indicators.get("source_account"),
+            "direction": indicators.get("direction"),
+            "price_entry": indicators.get("price_entry"),
+            "price_target": indicators.get("price_target"),
+            "price_stop": indicators.get("price_stop"),
+            "tweet_id": indicators.get("tweet_id"),
+        },
+        "data_quality_warnings": _quality_warnings(gate_metadata),
+        "evidence": {
+            "reconstructed": False,
+            "generated_at": utc_now(),
+            "generator_version": "explanation_builder.v1",
+            "provider": "tweet_monitor",
+        },
+    }
+    return validate_scanner_explanation(payload)
+
+
+def build_live_event_explanation(
+    scanner_type: str,
+    indicators: Dict[str, Any],
+    criteria_met: Dict[str, Any],
+    gate_metadata: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    if scanner_type == "live_volume_spike":
+        return build_live_volume_spike_explanation(
+            indicators=indicators,
+            criteria_met=criteria_met,
+            gate_metadata=gate_metadata,
+        )
+    if scanner_type == "live_price_move":
+        return build_live_price_move_explanation(
+            indicators=indicators,
+            criteria_met=criteria_met,
+            gate_metadata=gate_metadata,
+        )
+    raise ValueError(f"Unsupported live scanner type: {scanner_type}")
+
+
 def reconstruct_explanation_for_event(event: ScannerEvent) -> Dict[str, Any]:
     indicators = event.indicators or {}
     criteria_met = event.criteria_met or {}
@@ -628,6 +856,15 @@ def reconstruct_explanation_for_event(event: ScannerEvent) -> Dict[str, Any]:
     elif event.scanner_type == "trend_pullback":
         criteria = _trend_pullback_criteria(indicators)
         passed, failed = _split_criteria(criteria_met, criteria, "trend_pullback")
+    elif event.scanner_type == "live_volume_spike":
+        criteria = _live_volume_spike_criteria(indicators)
+        passed, failed = _split_criteria(criteria_met, criteria, "live_volume_spike")
+    elif event.scanner_type == "live_price_move":
+        criteria = _live_price_move_criteria(indicators)
+        passed, failed = _split_criteria(criteria_met, criteria, "live_price_move")
+    elif event.scanner_type == "social_callout":
+        criteria = _social_callout_criteria(indicators)
+        passed, failed = _split_criteria(criteria_met, criteria, "social_callout")
     else:
         scanner_prefix = event.scanner_type.replace("_", ".")
         passed = {}

--- a/backend/live_scanner/publisher.py
+++ b/backend/live_scanner/publisher.py
@@ -24,6 +24,7 @@ from app.models.scanner_event import ScannerEvent
 from app.schemas.event import SeverityLiteral
 from app.services.alert_service import _validate_jsonb_dict
 from app.services.event_helpers import compute_event_severity, generate_event_summary
+from app.services.scanner_explanations import build_live_event_explanation
 from app.services.signal_ranker import compute_signal_quality_score, load_ranker_config
 from live_scanner.bar_aggregator import ET, MinuteBar
 from live_scanner.conditions import ConditionResult
@@ -260,6 +261,11 @@ class LivePublisher:
             indicators=condition.indicators,
             criteria_met=condition.criteria_met,
             metadata_={"source": "live_scanner", "session": bar.session},
+            explanation=build_live_event_explanation(
+                scanner_type=condition.scanner_type,
+                indicators=condition.indicators,
+                criteria_met=condition.criteria_met,
+            ),
             signal_quality_score=score,
         )
 

--- a/backend/tests/live_scanner/test_publisher.py
+++ b/backend/tests/live_scanner/test_publisher.py
@@ -1,5 +1,6 @@
 import inspect
 import json
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock
 
 import pytest
@@ -71,3 +72,72 @@ async def test_publish_feed_recovered_sends_to_watchlist_alerts():
     msg = json.loads(raw)
     assert msg["type"] == "feed_recovered"
     assert "timestamp" in msg
+
+
+def test_write_scanner_event_persists_explanation(monkeypatch):
+    from live_scanner.bar_aggregator import MinuteBar
+    from live_scanner.conditions import ConditionResult
+    from live_scanner.publisher import LivePublisher
+
+    captured = {}
+
+    class FakeSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def add(self, event):
+            captured["event"] = event
+
+        def commit(self):
+            captured["event"].id = 42
+
+        def refresh(self, event):
+            event.id = 42
+
+    monkeypatch.setattr(pub_mod, "SessionLocal", lambda: FakeSession())
+    monkeypatch.setattr(
+        pub_mod, "load_ranker_config", lambda session: {"enabled": False}
+    )
+
+    bar = MinuteBar(
+        minute_ts=datetime(2026, 6, 2, 14, 31, tzinfo=timezone.utc),
+        symbol="AAPL",
+        open=100.0,
+        high=103.0,
+        low=99.5,
+        close=102.5,
+        volume=25000,
+        vwap=101.8,
+        bar_count=12,
+        session="regular",
+        session_volume=250000,
+        minutes_elapsed=30.0,
+        prior_close=100.0,
+        avg_daily_volume=500000,
+    )
+    condition = ConditionResult(
+        scanner_type="live_price_move",
+        indicators={
+            "price_move_pct": 2.5,
+            "current_price": 102.5,
+            "prior_close": 100.0,
+            "session": "regular",
+        },
+        criteria_met={"price_move_1pct": True},
+    )
+
+    event_id = LivePublisher("redis://localhost:6379")._write_scanner_event(
+        bar=bar,
+        condition=condition,
+        summary="AAPL live price move",
+        severity="medium",
+    )
+
+    assert event_id == 42
+    explanation = captured["event"].explanation
+    assert explanation["schema_version"] == "scanner_explanation.v1"
+    assert "live_price_move.price_move_1pct" in explanation["criteria_passed"]
+    assert explanation["confidence_inputs"]["scanner_type"] == "live_price_move"

--- a/backend/tests/services/test_scanner_explanations.py
+++ b/backend/tests/services/test_scanner_explanations.py
@@ -4,9 +4,12 @@ from app.models.scanner_event import ScannerEvent
 from app.services.pre_market_scan import EnrichedSignal, RawSignal
 from app.services.scanner_explanations import (
     build_liquidity_hunt_explanation,
+    build_live_price_move_explanation,
+    build_live_volume_spike_explanation,
     build_oversold_bounce_explanation,
     build_pocket_pivot_explanation,
     build_pre_market_volume_explanation,
+    build_social_callout_explanation,
     build_trend_pullback_explanation,
     reconstruct_explanation_for_event,
 )
@@ -222,6 +225,88 @@ def test_build_trend_pullback_explanation_uses_named_criteria():
     assert explanation["evidence"]["reconstructed"] is False
 
 
+def test_build_live_volume_spike_explanation_uses_named_criteria():
+    indicators = {
+        "volume_spike_ratio": 6.4,
+        "session_volume": 128000,
+        "avg_daily_volume": 500000,
+        "projected_volume": 3200000,
+        "minutes_elapsed": 12.0,
+        "session": "regular",
+    }
+    criteria_met = {"volume_spike_4x": True, "sufficient_avg_volume": True}
+
+    explanation = build_live_volume_spike_explanation(
+        indicators=indicators,
+        criteria_met=criteria_met,
+    )
+
+    assert explanation["schema_version"] == "scanner_explanation.v1"
+    assert "live_volume_spike.volume_spike_4x" in explanation["criteria_passed"]
+    assert (
+        explanation["criteria_passed"]["live_volume_spike.volume_spike_4x"]["label"]
+        == "Projected volume spike"
+    )
+    assert explanation["confidence_inputs"]["session"] == "regular"
+    assert explanation["evidence"]["provider"] == "live_scanner"
+
+
+def test_build_live_price_move_explanation_uses_named_criteria():
+    indicators = {
+        "price_move_pct": -3.25,
+        "current_price": 96.75,
+        "prior_close": 100.0,
+        "session": "pre",
+    }
+    criteria_met = {"price_move_1pct": True}
+
+    explanation = build_live_price_move_explanation(
+        indicators=indicators,
+        criteria_met=criteria_met,
+    )
+
+    assert explanation["schema_version"] == "scanner_explanation.v1"
+    assert "live_price_move.price_move_1pct" in explanation["criteria_passed"]
+    assert (
+        explanation["criteria_passed"]["live_price_move.price_move_1pct"]["label"]
+        == "Live price move"
+    )
+    assert explanation["confidence_inputs"]["price_move_pct"] == -3.25
+    assert explanation["evidence"]["provider"] == "live_scanner"
+
+
+def test_build_social_callout_explanation_uses_tweet_facts():
+    indicators = {
+        "confidence": 0.92,
+        "source_account": "market_pro",
+        "direction": "long",
+        "price_entry": 185.0,
+        "price_target": 195.0,
+        "tweet_id": "12345",
+    }
+    criteria_met = {
+        "has_cashtag": True,
+        "has_price_level": True,
+        "above_confidence_threshold": True,
+    }
+
+    explanation = build_social_callout_explanation(
+        indicators=indicators,
+        criteria_met=criteria_met,
+    )
+
+    assert explanation["schema_version"] == "scanner_explanation.v1"
+    assert "social_callout.above_confidence_threshold" in explanation["criteria_passed"]
+    assert (
+        explanation["criteria_passed"]["social_callout.above_confidence_threshold"][
+            "label"
+        ]
+        == "Classifier confidence"
+    )
+    assert explanation["confidence_inputs"]["tweet_id"] == "12345"
+    assert explanation["evidence"]["provider"] == "tweet_monitor"
+
+
 def test_reconstruct_explanation_for_existing_event_marks_best_effort():
     event = ScannerEvent(
         ticker="AAPL",
@@ -350,3 +435,44 @@ def test_reconstruct_trend_pullback_event_uses_named_criteria():
         explanation["criteria_passed"]["trend_pullback.orderly_pullback"]["label"]
         == "Orderly pullback depth"
     )
+
+
+def test_reconstruct_live_and_social_events_use_named_criteria():
+    live_event = ScannerEvent(
+        ticker="AAPL",
+        event_date=date(2026, 6, 2),
+        scanner_type="live_price_move",
+        indicators={
+            "price_move_pct": 2.4,
+            "current_price": 102.4,
+            "prior_close": 100.0,
+            "session": "regular",
+        },
+        criteria_met={"price_move_1pct": True},
+        metadata_={"source": "live_scanner"},
+        created_at=datetime(2026, 6, 2),
+        updated_at=datetime(2026, 6, 2),
+    )
+    social_event = ScannerEvent(
+        ticker="AAPL",
+        event_date=date(2026, 6, 2),
+        scanner_type="social_callout",
+        indicators={
+            "confidence": 0.88,
+            "source_account": "market_pro",
+            "direction": "long",
+            "tweet_id": "12345",
+        },
+        criteria_met={"above_confidence_threshold": True},
+        metadata_={"source": "tweet_monitor"},
+        created_at=datetime(2026, 6, 2),
+        updated_at=datetime(2026, 6, 2),
+    )
+
+    live_explanation = reconstruct_explanation_for_event(live_event)
+    social_explanation = reconstruct_explanation_for_event(social_event)
+
+    assert "live_price_move.price_move_1pct" in live_explanation["criteria_passed"]
+    assert "social_callout.above_confidence_threshold" in social_explanation[
+        "criteria_passed"
+    ]

--- a/services/tweet-monitor/app/models.py
+++ b/services/tweet-monitor/app/models.py
@@ -9,10 +9,10 @@ from datetime import datetime, timezone
 
 from sqlalchemy import (
     Boolean, Column, DateTime, Float, ForeignKey, Index, Integer,
-    String, Text, UniqueConstraint, create_engine
+    String, Text, UniqueConstraint
 )
 from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.orm import DeclarativeBase, relationship, Session
+from sqlalchemy.orm import DeclarativeBase, relationship
 
 
 class Base(DeclarativeBase):
@@ -94,6 +94,7 @@ class ScannerEvent(Base):
     indicators = Column(JSONB, default=dict)
     criteria_met = Column(JSONB, default=dict)
     metadata_ = Column("metadata", JSONB, default=dict)
+    explanation = Column(JSONB, nullable=True)
     signal_quality_score = Column(Float, nullable=True)
     created_at = Column(DateTime)
     updated_at = Column(DateTime)

--- a/services/tweet-monitor/app/pipeline.py
+++ b/services/tweet-monitor/app/pipeline.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 
 import redis
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -30,6 +30,103 @@ _redis = redis.from_url(settings.redis_url, decode_responses=True)
 
 # Celery task name for alert evaluation (matches backend task registration)
 _ALERT_TASK = "app.tasks.evaluate_scanner_alerts"
+
+
+def _criterion(
+    label: str,
+    observed: Any,
+    threshold: Any,
+    operator: str,
+    source: str = "tweet_monitor",
+    importance: float | None = None,
+) -> dict[str, Any]:
+    payload = {
+        "label": label,
+        "observed": observed,
+        "threshold": threshold,
+        "operator": operator,
+        "source": source,
+    }
+    if importance is not None:
+        payload["importance"] = importance
+    return payload
+
+
+def _split_criteria(
+    criteria_met: dict[str, Any],
+    criteria: dict[str, dict[str, Any]],
+) -> tuple[dict[str, dict[str, Any]], dict[str, dict[str, Any]]]:
+    passed = {}
+    failed = {}
+    for key, explanation in criteria.items():
+        target = passed if bool(criteria_met.get(key)) else failed
+        target[f"social_callout.{key}"] = explanation
+    return passed, failed
+
+
+def _build_social_callout_explanation(
+    indicators: dict[str, Any],
+    criteria_met: dict[str, Any],
+) -> dict[str, Any]:
+    criteria = {
+        "has_cashtag": _criterion(
+            "Cashtag extracted",
+            bool(indicators.get("ticker")),
+            True,
+            "==",
+            importance=0.7,
+        ),
+        "has_price_level": _criterion(
+            "Price level extracted",
+            bool(
+                indicators.get("price_entry")
+                or indicators.get("price_target")
+                or indicators.get("price_stop")
+            ),
+            True,
+            "==",
+            importance=0.6,
+        ),
+        "above_confidence_threshold": _criterion(
+            "Classifier confidence",
+            indicators.get("confidence"),
+            0.7,
+            ">=",
+            importance=1.0,
+        ),
+    }
+    passed, failed = _split_criteria(criteria_met, criteria)
+
+    account = indicators.get("source_account") or "unknown"
+    why = [f"@{account} posted a classified social callout."]
+    if indicators.get("confidence") is not None:
+        why.append(f"Classifier confidence was {float(indicators['confidence']):.0%}.")
+    if indicators.get("price_entry") is not None:
+        why.append(f"Entry level extracted at ${float(indicators['price_entry']):.2f}.")
+
+    return {
+        "schema_version": "scanner_explanation.v1",
+        "why": why,
+        "criteria_passed": passed,
+        "criteria_failed": failed,
+        "confidence_inputs": {
+            "scanner_type": "social_callout",
+            "confidence": indicators.get("confidence"),
+            "source_account": indicators.get("source_account"),
+            "direction": indicators.get("direction"),
+            "price_entry": indicators.get("price_entry"),
+            "price_target": indicators.get("price_target"),
+            "price_stop": indicators.get("price_stop"),
+            "tweet_id": indicators.get("tweet_id"),
+        },
+        "data_quality_warnings": [],
+        "evidence": {
+            "reconstructed": False,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "generator_version": "explanation_builder.v1",
+            "provider": "tweet_monitor",
+        },
+    }
 
 
 class SignalPipeline:
@@ -102,6 +199,9 @@ class SignalPipeline:
             "confidence": signal.confidence,
             "source_account": signal.account.handle if signal.account else "",
             "direction": signal.direction,
+            "ticker": ticker,
+            "tweet_id": signal.tweet_id,
+            "tweet_url": signal.tweet_url,
         }
         if ind.get("entry"):
             indicators["price_entry"] = ind["entry"]
@@ -113,6 +213,12 @@ class SignalPipeline:
         severity = "high" if signal.confidence > 0.9 else "medium"
         summary = self._build_summary(indicators)
 
+        criteria_met = {
+            "has_cashtag": bool(signal.tickers),
+            "has_price_level": bool(signal.price_levels),
+            "above_confidence_threshold": True,
+        }
+
         event = ScannerEvent(
             uuid=str(uuid_mod.uuid4()),
             ticker=ticker,
@@ -121,11 +227,7 @@ class SignalPipeline:
             summary=summary,
             severity=severity,
             indicators=indicators,
-            criteria_met={
-                "has_cashtag": bool(signal.tickers),
-                "has_price_level": bool(signal.price_levels),
-                "above_confidence_threshold": True,
-            },
+            criteria_met=criteria_met,
             metadata_={
                 "tweet_id": signal.tweet_id,
                 "tweet_url": signal.tweet_url,
@@ -133,6 +235,7 @@ class SignalPipeline:
                 "tweet_signal_id": signal.id,
                 "source": "tweet_monitor",
             },
+            explanation=_build_social_callout_explanation(indicators, criteria_met),
             signal_quality_score=signal.confidence,
             created_at=datetime.now(timezone.utc).replace(tzinfo=None),
             updated_at=datetime.now(timezone.utc).replace(tzinfo=None),

--- a/services/tweet-monitor/tests/test_pipeline.py
+++ b/services/tweet-monitor/tests/test_pipeline.py
@@ -1,0 +1,52 @@
+"""Unit tests for SignalPipeline promotion behavior."""
+
+import os
+import sys
+from datetime import datetime
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from app.pipeline import SignalPipeline
+
+
+def test_promote_persists_social_callout_explanation():
+    captured = {}
+
+    class FakeDb:
+        def add(self, event):
+            captured["event"] = event
+
+        def flush(self):
+            captured["event"].id = 42
+
+        def rollback(self):
+            raise AssertionError("rollback should not be called")
+
+    signal = SimpleNamespace(
+        id=7,
+        tweet_id="12345",
+        tweet_url="https://x.example/status/12345",
+        posted_at=datetime(2026, 6, 2, 13, 30),
+        full_text="$AAPL long entry 185 target 195",
+        confidence=0.92,
+        account=SimpleNamespace(handle="market_pro"),
+        direction="long",
+        tickers=["AAPL"],
+        price_levels={"AAPL": {"entry": 185.0, "target": 195.0}},
+        promoted=False,
+        scanner_event_id=None,
+        promotion_reason=None,
+    )
+
+    event_id = SignalPipeline(promotion_threshold=0.7)._promote(
+        FakeDb(), signal, "AAPL"
+    )
+
+    assert event_id == 42
+    explanation = captured["event"].explanation
+    assert explanation["schema_version"] == "scanner_explanation.v1"
+    assert "social_callout.above_confidence_threshold" in explanation[
+        "criteria_passed"
+    ]
+    assert explanation["confidence_inputs"]["tweet_id"] == "12345"


### PR DESCRIPTION
## Summary
- add v1 explanation builders for live volume spikes, live price moves, and social callouts
- persist explanations from the direct live-scanner ScannerEvent writer
- persist social callout explanations from tweet-monitor promotion writes
- cover builder/reconstruction behavior plus live and social event creation paths

## Verification
- PYTEST_ADDOPTS='--no-cov' python -m pytest backend/tests/services/test_scanner_explanations.py::test_build_live_volume_spike_explanation_uses_named_criteria backend/tests/services/test_scanner_explanations.py::test_build_live_price_move_explanation_uses_named_criteria backend/tests/services/test_scanner_explanations.py::test_build_social_callout_explanation_uses_tweet_facts backend/tests/services/test_scanner_explanations.py::test_reconstruct_live_and_social_events_use_named_criteria backend/tests/live_scanner/test_publisher.py::test_write_scanner_event_persists_explanation -q
- python -m pytest tests/test_pipeline.py::test_promote_persists_social_callout_explanation -q (from services/tweet-monitor)
- PYTEST_ADDOPTS='--no-cov' python -m pytest backend/tests/services/test_scanner_explanations.py backend/tests/tasks/test_explanation_backfill_task.py backend/tests/live_scanner/test_publisher.py backend/tests/services/test_alert_service.py::test_save_event_persists_explanation_payload -q
- python -m pytest tests -q (from services/tweet-monitor)
- PYTEST_ADDOPTS='--no-cov' python -m pytest backend/tests/live_scanner -q
- PYTEST_ADDOPTS='--no-cov' python -m pytest backend/tests/services/test_auto_trade_service.py::test_determine_side_long_only_blocks_short -q
- ruff check . (from backend)
- ruff check services/tweet-monitor/app/models.py services/tweet-monitor/app/pipeline.py services/tweet-monitor/tests/test_pipeline.py
- python -m compileall app (from services/tweet-monitor)
- npx tsc --noEmit -p tsconfig.app.json
- npx eslint . --report-unused-disable-directives-severity error
- npm run build

Note: a whole-service tweet-monitor ruff run still reports pre-existing unused imports in unrelated files.

Closes #462