### PR TITLE
Phase 4b T2: raise arch-slice token cap from p90 data + recalibrate

### DIFF
--- a/.claude/skills/refinement/config.yaml
+++ b/.claude/skills/refinement/config.yaml
@@ -123,8 +123,8 @@ token_optimization:
   architecture:
     enabled: true             # false = skip slicing, load full ARCHITECTURE.md; env: TOKEN_OPTIMIZATION_ARCHITECTURE_ENABLED overrides
     mode: slice               # slice = emit only the changed file excerpt + its direct callers
-    max_tokens: 3000          # token ceiling for architecture context per scenario (baked — no env override)
-    min_tokens: 1500          # floor for budget_enforce.py proportional distribution (50% of max_tokens)
+    max_tokens: 5000          # token ceiling for architecture context per scenario (baked — no env override)
+    min_tokens: 2500          # floor for budget_enforce.py proportional distribution (50% of max_tokens)
   memory:
     enabled: true             # false = skip top-k cap, emit all matching entries; env: TOKEN_OPTIMIZATION_MEMORY_ENABLED overrides
     mode: top_k               # top_k = emit only the K highest-scored memory entries

--- a/dark-factory/evals/reports/budget-calibration-scorecard-2026-07-03.md
+++ b/dark-factory/evals/reports/budget-calibration-scorecard-2026-07-03.md
@@ -1,13 +1,11 @@
 # Budget Calibration Scorecard — 2026-07-03
 
-**Issue:** [#730](https://github.com/omniscient/markethawk/issues/730)
+**Issue:** [#718](https://github.com/omniscient/markethawk/issues/718)
 **Script:** `dark-factory/evals/token_opt_eval.py --calibrate`
 
 ---
 
 ## Per-Scenario Token Distribution (opt_tokens)
-
-Note: "p90 (tok)" below is the p90 of total `opt_tokens` across all issues — not the uncapped `architecture_md` slice size. See the dedicated section below for uncapped arch-slice p90 values.
 
 | Scenario | p50 (tok) | p90 (tok) | p90×1.1 advisory |
 |----------|-----------|-----------|------------------|
@@ -19,30 +17,16 @@ Note: "p90 (tok)" below is the p90 of total `opt_tokens` across all issues — n
 
 ---
 
-## p90 Uncapped `architecture_md` Slice Size (sliced issues only, fallback=False)
-
-These values are the p90 of the pre-cap `architecture_md` slice token count, restricted to issues where architecture slicing was applied (not the full-doc fallback). Required by acceptance criterion 4 as input for the cap-raise ticket.
-
-| Scenario | p90 uncapped arch-slice (tok) | Sliced issue count | Sliced issue IDs |
-|----------|-------------------------------|--------------------|-----------------|
-| refine | 4,645 | 5 | 224, 332, 276, 215, 697 |
-| plan | 4,644 | 5 | 224, 332, 276, 215, 697 |
-| implement | 4,645 | 5 | 224, 332, 276, 215, 697 |
-| conformance | n/a | 0 | no sliced samples |
-| code-review | n/a | 0 | no sliced samples |
-
----
-
 ## Over-Budget Rate and Section-at-Risk Rate per Scenario × Budget
 
 | Scenario | Metric | 22,000 | 24,000 | 26,000 | 28,000 | 30,000 | 32,000 | 36,000 | 40,000 |
 |----------|--------|--------|--------|--------|--------|--------|--------|--------|--------|
 | refine | over_budget_rate | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% |
-| refine | section_at_risk_rate | 14% | 14% | 14% | 14% | 14% | 14% | 14% | 14% |
+| refine | section_at_risk_rate | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% |
 | plan | over_budget_rate | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% |
-| plan | section_at_risk_rate | 14% | 14% | 14% | 14% | 14% | 14% | 14% | 14% |
+| plan | section_at_risk_rate | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% |
 | implement | over_budget_rate | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% |
-| implement | section_at_risk_rate | 14% | 14% | 14% | 14% | 14% | 14% | 14% | 14% |
+| implement | section_at_risk_rate | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% |
 | conformance | over_budget_rate | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% |
 | conformance | section_at_risk_rate | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% |
 | code-review | over_budget_rate | 0% | 0% | 0% | 0% | 0% | 0% | 0% | 0% |
@@ -56,9 +40,9 @@ Criteria: `section_at_risk_rate == 0%` AND `over_budget_rate ≤ 10%`
 
 | Scenario | Recommended Budget |
 |----------|--------------------|
-| refine | none — widen --budgets |
-| plan | none — widen --budgets |
-| implement | none — widen --budgets |
+| refine | 22000 |
+| plan | 22000 |
+| implement | 22000 |
 | conformance | 22000 |
 | code-review | 22000 |
 

--- a/dark-factory/evals/results/token-opt-eval-2026-07-03.json
+++ b/dark-factory/evals/results/token-opt-eval-2026-07-03.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-03T15:24:14.519324+00:00",
+  "generated_at": "2026-07-03T17:31:46.312517+00:00",
   "results": [
     {
       "issue": 224,
@@ -3675,9 +3675,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 17589,
       "opt_tokens": 12067
@@ -3689,9 +3689,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 19589,
       "opt_tokens": 12067
@@ -3703,9 +3703,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 21589,
       "opt_tokens": 12067
@@ -3717,9 +3717,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 23589,
       "opt_tokens": 12067
@@ -3731,9 +3731,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 25589,
       "opt_tokens": 12067
@@ -3745,9 +3745,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 27589,
       "opt_tokens": 12067
@@ -3759,9 +3759,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 31589,
       "opt_tokens": 12067
@@ -3773,9 +3773,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 35589,
       "opt_tokens": 12067
@@ -3787,9 +3787,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 17589,
       "opt_tokens": 12066
@@ -3801,9 +3801,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 19589,
       "opt_tokens": 12066
@@ -3815,9 +3815,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 21589,
       "opt_tokens": 12066
@@ -3829,9 +3829,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 23589,
       "opt_tokens": 12066
@@ -3843,9 +3843,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 25589,
       "opt_tokens": 12066
@@ -3857,9 +3857,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 27589,
       "opt_tokens": 12066
@@ -3871,9 +3871,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 31589,
       "opt_tokens": 12066
@@ -3885,9 +3885,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 35589,
       "opt_tokens": 12066
@@ -3899,9 +3899,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 17589,
       "opt_tokens": 7808
@@ -3913,9 +3913,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 19589,
       "opt_tokens": 7808
@@ -3927,9 +3927,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 21589,
       "opt_tokens": 7808
@@ -3941,9 +3941,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 23589,
       "opt_tokens": 7808
@@ -3955,9 +3955,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 25589,
       "opt_tokens": 7808
@@ -3969,9 +3969,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 27589,
       "opt_tokens": 7808
@@ -3983,9 +3983,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 31589,
       "opt_tokens": 7808
@@ -3997,9 +3997,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 35589,
       "opt_tokens": 7808
@@ -4203,9 +4203,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 17589,
       "opt_tokens": 11758
@@ -4217,9 +4217,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 19589,
       "opt_tokens": 11758
@@ -4231,9 +4231,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 21589,
       "opt_tokens": 11758
@@ -4245,9 +4245,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 23589,
       "opt_tokens": 11758
@@ -4259,9 +4259,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 25589,
       "opt_tokens": 11758
@@ -4273,9 +4273,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 27589,
       "opt_tokens": 11758
@@ -4287,9 +4287,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 31589,
       "opt_tokens": 11758
@@ -4301,9 +4301,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 35589,
       "opt_tokens": 11758
@@ -4315,9 +4315,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 17589,
       "opt_tokens": 11757
@@ -4329,9 +4329,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 19589,
       "opt_tokens": 11757
@@ -4343,9 +4343,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 21589,
       "opt_tokens": 11757
@@ -4357,9 +4357,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 23589,
       "opt_tokens": 11757
@@ -4371,9 +4371,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 25589,
       "opt_tokens": 11757
@@ -4385,9 +4385,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 27589,
       "opt_tokens": 11757
@@ -4399,9 +4399,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 31589,
       "opt_tokens": 11757
@@ -4413,9 +4413,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 35589,
       "opt_tokens": 11757
@@ -4427,9 +4427,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 17589,
       "opt_tokens": 7499
@@ -4441,9 +4441,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 19589,
       "opt_tokens": 7499
@@ -4455,9 +4455,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 21589,
       "opt_tokens": 7499
@@ -4469,9 +4469,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 23589,
       "opt_tokens": 7499
@@ -4483,9 +4483,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 25589,
       "opt_tokens": 7499
@@ -4497,9 +4497,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 27589,
       "opt_tokens": 7499
@@ -4511,9 +4511,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 31589,
       "opt_tokens": 7499
@@ -4525,9 +4525,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 35589,
       "opt_tokens": 7499
@@ -6171,9 +6171,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 17589,
       "opt_tokens": 11684
@@ -6185,9 +6185,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 19589,
       "opt_tokens": 11684
@@ -6199,9 +6199,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 21589,
       "opt_tokens": 11684
@@ -6213,9 +6213,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 23589,
       "opt_tokens": 11684
@@ -6227,9 +6227,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 25589,
       "opt_tokens": 11684
@@ -6241,9 +6241,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 27589,
       "opt_tokens": 11684
@@ -6255,9 +6255,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 31589,
       "opt_tokens": 11684
@@ -6269,9 +6269,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 35589,
       "opt_tokens": 11684
@@ -6283,9 +6283,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 17589,
       "opt_tokens": 11683
@@ -6297,9 +6297,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 19589,
       "opt_tokens": 11683
@@ -6311,9 +6311,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 21589,
       "opt_tokens": 11683
@@ -6325,9 +6325,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 23589,
       "opt_tokens": 11683
@@ -6339,9 +6339,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 25589,
       "opt_tokens": 11683
@@ -6353,9 +6353,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 27589,
       "opt_tokens": 11683
@@ -6367,9 +6367,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 31589,
       "opt_tokens": 11683
@@ -6381,9 +6381,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 35589,
       "opt_tokens": 11683
@@ -6395,9 +6395,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 17589,
       "opt_tokens": 7425
@@ -6409,9 +6409,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 19589,
       "opt_tokens": 7425
@@ -6423,9 +6423,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 21589,
       "opt_tokens": 7425
@@ -6437,9 +6437,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 23589,
       "opt_tokens": 7425
@@ -6451,9 +6451,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 25589,
       "opt_tokens": 7425
@@ -6465,9 +6465,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 27589,
       "opt_tokens": 7425
@@ -6479,9 +6479,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 31589,
       "opt_tokens": 7425
@@ -6493,9 +6493,9 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
-      "section_at_risk": true,
+      "section_at_risk": false,
       "reserved_tokens": 4411,
       "allowance": 35589,
       "opt_tokens": 7425
@@ -7179,7 +7179,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7193,7 +7193,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7207,7 +7207,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7221,7 +7221,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7235,7 +7235,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7249,7 +7249,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7263,7 +7263,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7277,7 +7277,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7291,7 +7291,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7305,7 +7305,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7319,7 +7319,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7333,7 +7333,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7347,7 +7347,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7361,7 +7361,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7375,7 +7375,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7389,7 +7389,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7403,7 +7403,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7417,7 +7417,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7431,7 +7431,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7445,7 +7445,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7459,7 +7459,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7473,7 +7473,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7487,7 +7487,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -7501,7 +7501,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12507,7 +12507,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12521,7 +12521,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12535,7 +12535,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12549,7 +12549,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12563,7 +12563,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12577,7 +12577,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12591,7 +12591,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12605,7 +12605,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12619,7 +12619,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12633,7 +12633,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12647,7 +12647,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12661,7 +12661,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12675,7 +12675,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12689,7 +12689,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12703,7 +12703,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12717,7 +12717,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12731,7 +12731,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12745,7 +12745,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12759,7 +12759,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12773,7 +12773,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12787,7 +12787,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12801,7 +12801,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12815,7 +12815,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -12829,7 +12829,7 @@
       "over_budget": false,
       "would_trim": false,
       "derived_caps": {
-        "architecture_md": 3000
+        "architecture_md": 5000
       },
       "section_at_risk": false,
       "reserved_tokens": 4411,
@@ -14468,12 +14468,5 @@
       "allowance": 38000,
       "opt_tokens": 4542
     }
-  ],
-  "p90_uncapped_arch_slice_tokens_per_scenario": {
-    "refine": {"p90_tokens": 4645, "sliced_issue_count": 5, "sliced_issues": [224, 332, 276, 215, 697]},
-    "plan": {"p90_tokens": 4644, "sliced_issue_count": 5, "sliced_issues": [224, 332, 276, 215, 697]},
-    "implement": {"p90_tokens": 4645, "sliced_issue_count": 5, "sliced_issues": [224, 332, 276, 215, 697]},
-    "conformance": {"p90_tokens": null, "sliced_issue_count": 0, "note": "no sliced samples"},
-    "code-review": {"p90_tokens": null, "sliced_issue_count": 0, "note": "no sliced samples"}
-  }
+  ]
 }

--- a/dark-factory/scripts/budget_enforce.py
+++ b/dark-factory/scripts/budget_enforce.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass
 _HARDCODED = {
     "token_optimization": {
         "issue_context": {"reserve_tokens": 2000},
-        "architecture": {"max_tokens": 3000, "min_tokens": 1500},
+        "architecture": {"max_tokens": 5000, "min_tokens": 2500},
         "memory": {"max_tokens": 1500, "min_tokens": 750},
         "comments": {"max_tokens": 2000, "min_tokens": 1000},
         "diff": {"max_review_tokens": 6000, "min_review_tokens": 3000},

--- a/dark-factory/tests/test_budget_enforce.py
+++ b/dark-factory/tests/test_budget_enforce.py
@@ -567,3 +567,26 @@ def test_writeback_preserves_existing_fields(tmp_path):
     assert data["estimated_input_tokens"] == 42000
     assert data["savings_tokens"] == 1200
     assert data["savings_pct"] == 5
+
+
+# ── Test 33: guard — _HARDCODED arch caps match config.yaml ──────────────────
+
+def test_hardcoded_arch_caps_match_config_yaml():
+    """Guard: _HARDCODED architecture values must stay in sync with config.yaml.
+
+    If this test fails, update _HARDCODED in budget_enforce.py (or config.yaml)
+    so both sources agree — never let them drift silently.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    config_path = repo_root / ".claude" / "skills" / "refinement" / "config.yaml"
+    config = be._load_config(str(config_path))
+    arch_cfg = config["token_optimization"]["architecture"]
+    arch_hc = be._HARDCODED["token_optimization"]["architecture"]
+    assert arch_hc["max_tokens"] == arch_cfg["max_tokens"], (
+        f"_HARDCODED max_tokens ({arch_hc['max_tokens']}) != "
+        f"config.yaml max_tokens ({arch_cfg['max_tokens']})"
+    )
+    assert arch_hc["min_tokens"] == arch_cfg["min_tokens"], (
+        f"_HARDCODED min_tokens ({arch_hc['min_tokens']}) != "
+        f"config.yaml min_tokens ({arch_cfg['min_tokens']})"
+    )

--- a/dark-factory/tests/test_budget_enforce.py
+++ b/dark-factory/tests/test_budget_enforce.py
@@ -15,7 +15,7 @@ import budget_enforce as be
 DEFAULT_CONFIG = {
     "token_optimization": {
         "issue_context": {"reserve_tokens": 2000},
-        "architecture": {"max_tokens": 3000, "min_tokens": 1500},
+        "architecture": {"max_tokens": 5000, "min_tokens": 2500},
         "memory": {"max_tokens": 1500, "min_tokens": 750},
         "comments": {"max_tokens": 2000, "min_tokens": 1000},
         "diff": {"max_review_tokens": 6000, "min_review_tokens": 3000},
@@ -166,9 +166,9 @@ def test_proportional_distribution_normal():
     )
     result = be.derive_caps(sections, budget=30000, arch_fallback=False, config=DEFAULT_CONFIG)
     # All 4 optimizable sections present; allowance = 30000 - 2000 = 28000
-    # Sum of defaults = 3000 + 1500 + 2000 + 6000 = 12500
-    # Each should be at its default (28000 >> 12500)
-    assert result.derived_caps.get("architecture_md") == 3000
+    # Sum of defaults = 5000 + 1500 + 2000 + 6000 = 14500
+    # Each should be at its default (28000 >> 14500)
+    assert result.derived_caps.get("architecture_md") == 5000
     assert result.derived_caps.get("memory_context") == 1500
     assert result.derived_caps.get("comments") == 2000
     assert result.derived_caps.get("diff") == 6000
@@ -183,10 +183,10 @@ def test_proportional_distribution_floor_clamp():
         arch_fallback=False,
     )
     # allowance = 1000 - 2000 = 0... need budget > reserve
-    # budget=3000, reserve=2000, allowance=1000 (much less than sum of floors=6250)
+    # budget=3000, reserve=2000, allowance=1000 (much less than sum of floors=7250)
     result = be.derive_caps(sections, budget=3000, arch_fallback=False, config=DEFAULT_CONFIG)
     # Each section should be clamped to its floor
-    assert result.derived_caps.get("architecture_md") == 1500
+    assert result.derived_caps.get("architecture_md") == 2500
     assert result.derived_caps.get("memory_context") == 750
     assert result.derived_caps.get("comments") == 1000
     assert result.derived_caps.get("diff") == 3000
@@ -200,10 +200,10 @@ def test_proportional_distribution_default_clamp():
         issue_context_tokens=0,
         arch_fallback=False,
     )
-    # budget=200000, reserve=2000 (floor), allowance=198000 >> 12500 (sum of defaults)
+    # budget=200000, reserve=2000 (floor), allowance=198000 >> 14500 (sum of defaults)
     result = be.derive_caps(sections, budget=200000, arch_fallback=False, config=DEFAULT_CONFIG)
     # Each capped at default
-    assert result.derived_caps.get("architecture_md") == 3000
+    assert result.derived_caps.get("architecture_md") == 5000
     assert result.derived_caps.get("memory_context") == 1500
     assert result.derived_caps.get("comments") == 2000
     assert result.derived_caps.get("diff") == 6000
@@ -376,8 +376,8 @@ def test_missing_config_uses_hardcoded_defaults():
     config = be._load_config("/nonexistent/path/config.yaml")
     # Should return defaults without error
     assert config is not None
-    assert config["token_optimization"]["architecture"]["max_tokens"] == 3000
-    assert config["token_optimization"]["architecture"]["min_tokens"] == 1500
+    assert config["token_optimization"]["architecture"]["max_tokens"] == 5000
+    assert config["token_optimization"]["architecture"]["min_tokens"] == 2500
 
 
 # ── Test 25: comment_digest (continue scenario) maps to COMMENTS env var ──────


### PR DESCRIPTION
Closes omniscient/dark-factory#173

## Summary
Automated implementation for issue omniscient/dark-factory#173.

## Preview
_No preview environment — this change does not affect the running app ('All changes are non-runtime-affecting: factory config (.claude/**), documentation (*.md), evaluation results, and dark-factory test/script infrastructure. No changes to backend/app, frontend/src, migrations, dependencies, or container/compose files.')._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#173"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#173"
```

---
*Generated by MarketHawk Dark Factory*