### PR TITLE
Phase 4b T3: flip budget enforcement for refine + plan

### DIFF
--- a/.claude/skills/refinement/config.yaml
+++ b/.claude/skills/refinement/config.yaml
@@ -113,8 +113,8 @@ token_optimization:
     conformance: 22000         # provisional from T5 smoke run; recalibrate per runbook Follow-up Path (docs/agents/dark-factory-token-optimization.md)
     code-review: 22000         # provisional from T5 smoke run; recalibrate per runbook Follow-up Path (docs/agents/dark-factory-token-optimization.md)
   enforce:
-    refine: false
-    plan: false
+    refine: true               # T3b: enforcement live — #731 scorecard: 0% section_at_risk
+    plan: true                 # T3b: enforcement live — #731 scorecard: 0% section_at_risk
     implement: false
     conformance: true          # T6: enforcement live — 0% section_at_risk in T5 calibration
     code-review: true          # T6: enforcement live — 0% section_at_risk in T5 calibration

--- a/.claude/skills/refinement/config.yaml
+++ b/.claude/skills/refinement/config.yaml
@@ -113,8 +113,8 @@ token_optimization:
     conformance: 22000         # provisional from T5 smoke run; recalibrate per runbook Follow-up Path (docs/agents/dark-factory-token-optimization.md)
     code-review: 22000         # provisional from T5 smoke run; recalibrate per runbook Follow-up Path (docs/agents/dark-factory-token-optimization.md)
   enforce:
-    refine: true               # T3b: enforcement live — #731 scorecard: 0% section_at_risk
-    plan: true                 # T3b: enforcement live — #731 scorecard: 0% section_at_risk
+    refine: true               # T3b: enforcement live — #733 via #731 scorecard: 0% section_at_risk
+    plan: true                 # T3b: enforcement live — #733 via #731 scorecard: 0% section_at_risk
     implement: false
     conformance: true          # T6: enforcement live — 0% section_at_risk in T5 calibration
     code-review: true          # T6: enforcement live — 0% section_at_risk in T5 calibration

--- a/dark-factory/tests/test_budget_enforce_dag.py
+++ b/dark-factory/tests/test_budget_enforce_dag.py
@@ -78,14 +78,14 @@ def test_config_enforce_has_all_scenarios():
 def test_config_enforce_t6_state():
     enforce = _tok_opt().get("enforce", {})
     expected = {
-        "refine": False,
-        "plan": False,
+        "refine": True,
+        "plan": True,
         "implement": False,
         "conformance": True,
         "code-review": True,
     }
     assert enforce == expected, (
-        f"enforce must match the T6 intended state {expected}, got {enforce}"
+        f"enforce must match the T3b intended state {expected}, got {enforce}"
     )
 
 

--- a/docs/agents/dark-factory-token-optimization.md
+++ b/docs/agents/dark-factory-token-optimization.md
@@ -8,7 +8,7 @@ independently disabled via config flags or environment variable overrides.
 
 Rollout phases 1–3 (observe, low-risk optimization, implementation/conformance) landed
 via issues #664–#671. Phase 4 (budget enforcement) shipped via #713–#719.
-**As of T6 (#719), enforcement is live for conformance and code-review.**
+**As of T3b (#733), enforcement is live for conformance, code-review, refine, and plan.**
 
 ---
 
@@ -32,14 +32,14 @@ token_optimization:
   enabled: true
   enforce_budgets: true    # T6 live — master enforcement gate
   budgets:                 # per-scenario token budgets (provisional from T5 smoke run)
-    refine: 30000          # observe-only — enforce: false
-    plan: 30000            # observe-only — enforce: false
+    refine: 30000          # enforced — T3b go-live (#733)
+    plan: 30000            # enforced — T3b go-live (#733)
     implement: 30000       # observe-only — enforce: false
     conformance: 22000     # enforced — T6 go-live
     code-review: 22000     # enforced — T6 go-live
   enforce:
-    refine: false          # deferred; see Follow-up Path below
-    plan: false            # deferred; see Follow-up Path below
+    refine: true           # T3b live — #731 scorecard: 0% section_at_risk
+    plan: true             # T3b live — #731 scorecard: 0% section_at_risk
     implement: false       # deferred; see Follow-up Path below
     conformance: true      # T6 live
     code-review: true      # T6 live
@@ -181,19 +181,20 @@ The `context-budget.json` artifact (in `$ARTIFACTS_DIR`) includes per-section sa
 
 ## Budget Enforcement (Phase 4 — Live)
 
-As of T6 (#719), budget enforcement is **active** for `conformance` and `code-review`.
+As of T3b (#733), budget enforcement is **active** for `conformance`, `code-review`, `refine`, and `plan`.
 
 | Scenario | Enforce | Budget | Status |
 |----------|---------|--------|--------|
-| refine | false | 30 000 | observe-only |
-| plan | false | 30 000 | observe-only |
+| refine | **true** | **30 000** | **enforced (T3b)** |
+| plan | **true** | **30 000** | **enforced (T3b)** |
 | implement | false | 30 000 | observe-only |
 | conformance | **true** | **22 000** | **enforced (T6)** |
 | code-review | **true** | **22 000** | **enforced (T6)** |
 
-Budgets for conformance and code-review are **provisional** — derived from a 2-issue
-T5 smoke run. Run the full-corpus calibration (`dark-factory/evals/token_opt_eval.py
---calibrate`) after accumulating ≥ 10 bench issues to confirm or adjust.
+Budgets for refine and plan were validated by the full-corpus calibration in #731 (Phase 4b T2)
+with 0% `section_at_risk_rate` at the 30k budget. Budgets for conformance and code-review were
+derived from the T5 smoke run — run `dark-factory/evals/token_opt_eval.py --calibrate` after
+accumulating ≥ 10 bench issues to confirm or adjust.
 
 ### How enforcement works
 
@@ -255,14 +256,15 @@ planned `architecture.max_tokens` cap before flipping.
 
 ## Path to Phase 4 — Current Status
 
-Phase 4 (budget enforcement) is **partially live** as of T6 (#719):
-- **Conformance and code-review**: enforcement active (see Budget Enforcement section).
-- **Refine, plan, implement**: observe-only — deferred pending calibration.
+Phase 4 (budget enforcement) is **mostly live** as of T3b (#733):
+- **Conformance and code-review**: enforcement active since T6 (#719).
+- **Refine and plan**: enforcement active since T3b (#733) — #731 scorecard gated go-live.
+- **Implement**: observe-only — deferred pending calibration.
 
-### Follow-up Path for deferred scenarios (refine / plan / implement)
+### Follow-up Path for deferred scenario (implement)
 
 **Why deferred:** T5 calibration showed `section_at_risk_rate == 50%` at ALL tested
-budgets (22k–40k) for refine/plan/implement. Root cause: `architecture.max_tokens: 3000`
+budgets (22k–40k) for implement. Root cause: `architecture.max_tokens: 3000`
 is below real arch slice sizes (3–4k+ tokens), so enforcement trims architecture context
 on every issue regardless of budget size. Flipping enforce would silently drop required
 ARCHITECTURE.md sections — violating the "Never drop safety-critical content" goal.
@@ -293,7 +295,7 @@ ARCHITECTURE.md sections — violating the "Never drop safety-critical content" 
 3. **Re-run calibration** with the new `architecture.max_tokens` and a candidate budget.
    Gates: `over_budget_rate ≤ 10%` + `section_at_risk_rate == 0%`.
 
-4. **Flip** refine, plan, implement using the Observe → Enforce Procedure above.
+4. **Flip** implement using the Observe → Enforce Procedure above.
 
 ---
 


### PR DESCRIPTION
Closes omniscient/dark-factory#175

## Summary
Automated implementation for issue omniscient/dark-factory#175.

## Preview
_No preview environment — this change does not affect the running app ('All three files fall into skip-safe categories: agent/workflow config (.claude/), tests (dark-factory/tests/), and documentation (docs/). No runtime app code touched. preview.enabled=true; kill-switch not active.')._

## Commands
```bash
# Iterate after feedback
docker compose --profile factory run --rm dark-factory "Continue issue omniscient/dark-factory#175"

# Tear down preview when done
docker compose --profile factory run --rm dark-factory "Close issue omniscient/dark-factory#175"
```

---
*Generated by MarketHawk Dark Factory*