### PR TITLE
Implement event-scoped data quality warnings

### DIFF
--- a/backend/app/services/alert_service.py
+++ b/backend/app/services/alert_service.py
@@ -420,6 +420,10 @@ def save_event(
         )
         regime = None
 
+    metadata_payload = dict(enrichment)
+    if gate_metadata is not None:
+        metadata_payload["quality_gate"] = gate_metadata
+
     event_dict = {
         "ticker": ticker,
         "event_date": event_date,
@@ -431,7 +435,7 @@ def save_event(
         "closing_price": closing_price,
         "indicators": indicators,
         "criteria_met": criteria_met,
-        "metadata": enrichment,
+        "metadata": metadata_payload,
         "signal_quality_score": score,
         "regime": regime,
     }
@@ -458,10 +462,7 @@ def save_event(
         event_dict["id"] = existing.id
     else:
         model_data = event_dict.copy()
-        enrichment_with_gate = dict(model_data.pop("metadata"))
-        if gate_metadata is not None:
-            enrichment_with_gate["quality_gate"] = gate_metadata
-        model_data["metadata_"] = enrichment_with_gate
+        model_data["metadata_"] = model_data.pop("metadata")
         new_event = ScannerEvent(**model_data)
         db.add(new_event)
         db.flush()

--- a/backend/app/services/data_quality.py
+++ b/backend/app/services/data_quality.py
@@ -22,6 +22,7 @@ Grade scale
 import logging
 from collections import defaultdict
 from datetime import datetime, timezone
+from decimal import Decimal
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session
@@ -343,6 +344,40 @@ def _analyze_ticker_timespan(
 
 
 class DataQualityService:
+    @staticmethod
+    def summarize_event_bars(rows: List[Any], timespan: str, multiplier: int) -> Dict:
+        """Return event-scoped integrity/continuity counts for aggregate rows."""
+        bad_bar_count = 0
+        timestamps = []
+        for row in rows:
+            timestamps.append(row.timestamp)
+            high = Decimal(row.high)
+            low = Decimal(row.low)
+            open_ = Decimal(row.open)
+            close = Decimal(row.close)
+            volume = int(row.volume)
+            if (
+                high < low
+                or high < open_
+                or high < close
+                or low > open_
+                or low > close
+                or open_ <= 0
+                or close <= 0
+                or high <= 0
+                or low <= 0
+                or volume < 0
+            ):
+                bad_bar_count += 1
+
+        duplicate_count = len(timestamps) - len(set(timestamps))
+        gaps = _detect_gaps(timestamps, timespan, multiplier)
+        return {
+            "bad_bar_count": bad_bar_count,
+            "duplicate_count": duplicate_count,
+            "gap_count": len(gaps),
+        }
+
     @staticmethod
     def analyze_universe(db: Session, universe_id: int) -> Dict:
         """

--- a/backend/app/services/data_readiness.py
+++ b/backend/app/services/data_readiness.py
@@ -3,14 +3,42 @@ DataReadinessService — checks whether required aggregate data exists for outco
 """
 
 from dataclasses import dataclass, field
-from datetime import date, timedelta
-from typing import List, Optional
+from datetime import date, datetime, time, timedelta
+from typing import Any, List, Optional
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.models.scanner_config import ScannerConfig
 from app.models.stock_aggregate import StockAggregate
+from app.services.data_quality import DataQualityService
+
+EVENT_WARNING_CODES = {
+    "missing_required_timespan",
+    "low_coverage",
+    "integrity_violation",
+    "continuity_gap",
+    "stale_data",
+    "insufficient_lookback",
+}
+
+_BARS_PER_TRADING_DAY: dict[str, int] = {
+    "minute": 390,
+    "hour": 7,
+    "day": 1,
+    "week": 1,
+    "month": 1,
+}
+
+_COVERAGE_WARNING_THRESHOLD = 0.85
+
+_AFFECTED_INPUTS_BY_TIMESPAN: dict[str, list[str]] = {
+    "minute": ["minute_aggregates", "price", "volume"],
+    "hour": ["hourly_aggregates", "price", "volume"],
+    "day": ["daily_aggregates", "close", "volume"],
+    "week": ["weekly_aggregates", "close", "volume"],
+    "month": ["monthly_aggregates", "close", "volume"],
+}
 
 
 @dataclass
@@ -34,6 +62,329 @@ class ReadinessReport:
 
 
 class DataReadinessService:
+    @staticmethod
+    def _normalize_timespan_requirements(data_requirements: dict | None) -> list[dict]:
+        if not data_requirements:
+            return []
+        timespans = data_requirements.get("timespans")
+        if isinstance(timespans, list):
+            return [dict(req) for req in timespans if isinstance(req, dict)]
+        if "timespan" in data_requirements or "min_bars" in data_requirements:
+            return [dict(data_requirements)]
+        return []
+
+    @staticmethod
+    def _scanner_type_candidates(scanner_type: str) -> list[str]:
+        candidates = [scanner_type]
+        if scanner_type in {"liquidity_hunt_pre", "liquidity_hunt_post"}:
+            candidates.append("liquidity_hunt")
+        return candidates
+
+    @staticmethod
+    def _affected_inputs(req: dict) -> list[str]:
+        configured = req.get("affected_inputs")
+        if isinstance(configured, list) and configured:
+            return [str(value) for value in configured]
+        timespan = str(req.get("timespan", "minute"))
+        return list(
+            _AFFECTED_INPUTS_BY_TIMESPAN.get(
+                timespan, [f"{timespan}_aggregates", "price", "volume"]
+            )
+        )
+
+    @staticmethod
+    def _expected_bars(req: dict) -> Optional[int]:
+        if req.get("expected_bars") is not None:
+            return int(req["expected_bars"])
+        lookback_days = req.get("lookback_days")
+        if not lookback_days:
+            return None
+        timespan = str(req.get("timespan", "minute"))
+        multiplier = max(1, int(req.get("multiplier", 1)))
+        bars_per_day = max(1, _BARS_PER_TRADING_DAY.get(timespan, 60) // multiplier)
+        return int(lookback_days) * bars_per_day
+
+    @staticmethod
+    def _warning(
+        code: str,
+        *,
+        ticker: str,
+        scanner_type: str,
+        event_date: date,
+        req: dict,
+        severity: str = "medium",
+        message: str,
+        detail: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        return {
+            "code": code,
+            "severity": severity,
+            "message": message,
+            "affected_inputs": DataReadinessService._affected_inputs(req),
+            "detail": {
+                "ticker": ticker,
+                "scanner_type": scanner_type,
+                "event_date": event_date.isoformat(),
+                "timespan": str(req.get("timespan", "minute")),
+                "multiplier": int(req.get("multiplier", 1)),
+                **(detail or {}),
+            },
+        }
+
+    @staticmethod
+    def _load_event_rows(
+        db: Session,
+        ticker: str,
+        event_date: date,
+        req: dict,
+    ) -> list[Any]:
+        timespan = str(req.get("timespan", "minute"))
+        multiplier = int(req.get("multiplier", 1))
+        query = db.query(
+            StockAggregate.timestamp,
+            StockAggregate.open,
+            StockAggregate.high,
+            StockAggregate.low,
+            StockAggregate.close,
+            StockAggregate.volume,
+        ).filter(
+            StockAggregate.ticker == ticker,
+            StockAggregate.timespan == timespan,
+            StockAggregate.multiplier == multiplier,
+            StockAggregate.timestamp
+            < datetime.combine(event_date + timedelta(days=1), time.min),
+        )
+        lookback_days = req.get("lookback_days")
+        if lookback_days:
+            query = query.filter(
+                StockAggregate.timestamp
+                >= datetime.combine(
+                    event_date - timedelta(days=int(lookback_days)), time.min
+                )
+            )
+        return query.order_by(StockAggregate.timestamp.asc()).all()
+
+    @staticmethod
+    def event_warnings(
+        db: Session,
+        ticker: str,
+        scanner_type: str,
+        event_date: date,
+        data_requirements: Optional[dict] = None,
+    ) -> list[dict[str, Any]]:
+        """Return scanner-explanation-ready warnings scoped to one event."""
+        if data_requirements is None:
+            for candidate in DataReadinessService._scanner_type_candidates(
+                scanner_type
+            ):
+                config = (
+                    db.query(ScannerConfig)
+                    .filter(ScannerConfig.scanner_type == candidate)
+                    .first()
+                )
+                config_requirements = getattr(config, "data_requirements", None)
+                if config_requirements:
+                    data_requirements = config_requirements
+                    break
+
+        reqs = DataReadinessService._normalize_timespan_requirements(
+            data_requirements
+        )
+        if not reqs:
+            return []
+
+        warnings: list[dict[str, Any]] = []
+        for req in reqs:
+            timespan = str(req.get("timespan", "minute"))
+            multiplier = int(req.get("multiplier", 1))
+            rows = DataReadinessService._load_event_rows(db, ticker, event_date, req)
+            affected = f"{timespan}x{multiplier}"
+
+            if not rows:
+                warnings.append(
+                    DataReadinessService._warning(
+                        "missing_required_timespan",
+                        ticker=ticker,
+                        scanner_type=scanner_type,
+                        event_date=event_date,
+                        req=req,
+                        severity="high",
+                        message=(
+                            f"{ticker} has no {affected} aggregate data available"
+                            f" for the {event_date.isoformat()} explanation window."
+                        ),
+                        detail={"observed_bars": 0},
+                    )
+                )
+                continue
+
+            observed_bars = len(rows)
+            expected_bars = DataReadinessService._expected_bars(req)
+            if (
+                expected_bars
+                and observed_bars < expected_bars * _COVERAGE_WARNING_THRESHOLD
+            ):
+                coverage_pct = round(observed_bars / expected_bars * 100, 1)
+                warnings.append(
+                    DataReadinessService._warning(
+                        "low_coverage",
+                        ticker=ticker,
+                        scanner_type=scanner_type,
+                        event_date=event_date,
+                        req=req,
+                        message=(
+                            f"{ticker} {affected} coverage is {coverage_pct:.1f}%"
+                            " of the expected event window."
+                        ),
+                        detail={
+                            "observed_bars": observed_bars,
+                            "expected_bars": expected_bars,
+                            "coverage_pct": coverage_pct,
+                        },
+                    )
+                )
+
+            min_bars = req.get("min_bars")
+            if min_bars is not None and observed_bars < int(min_bars):
+                warnings.append(
+                    DataReadinessService._warning(
+                        "insufficient_lookback",
+                        ticker=ticker,
+                        scanner_type=scanner_type,
+                        event_date=event_date,
+                        req=req,
+                        message=(
+                            f"{ticker} has {observed_bars} {affected} bars but"
+                            f" {int(min_bars)} are required for the scanner lookback."
+                        ),
+                        detail={
+                            "observed_bars": observed_bars,
+                            "required_bars": int(min_bars),
+                        },
+                    )
+                )
+
+            quality_summary = DataQualityService.summarize_event_bars(
+                rows, timespan, multiplier
+            )
+            bad_bar_count = quality_summary["bad_bar_count"]
+            if bad_bar_count:
+                warnings.append(
+                    DataReadinessService._warning(
+                        "integrity_violation",
+                        ticker=ticker,
+                        scanner_type=scanner_type,
+                        event_date=event_date,
+                        req=req,
+                        severity="high",
+                        message=(
+                            f"{ticker} has {bad_bar_count} invalid {affected}"
+                            " OHLCV bar(s) in the explanation window."
+                        ),
+                        detail={"bad_bar_count": bad_bar_count},
+                    )
+                )
+
+            timestamps = [row.timestamp for row in rows]
+            duplicate_count = quality_summary["duplicate_count"]
+            gap_count = quality_summary["gap_count"]
+            if duplicate_count or gap_count:
+                warnings.append(
+                    DataReadinessService._warning(
+                        "continuity_gap",
+                        ticker=ticker,
+                        scanner_type=scanner_type,
+                        event_date=event_date,
+                        req=req,
+                        message=(
+                            f"{ticker} {affected} data has {gap_count} gap(s)"
+                            f" and {duplicate_count} duplicate timestamp(s)."
+                        ),
+                        detail={
+                            "gap_count": gap_count,
+                            "duplicate_count": duplicate_count,
+                        },
+                    )
+                )
+
+            last_bar_date = max(timestamps).date()
+            stale_tolerance_days = int(
+                req.get("max_stale_days", 1 if timespan == "day" else 0)
+            )
+            stale_after = event_date - timedelta(days=stale_tolerance_days)
+            if last_bar_date < stale_after:
+                warnings.append(
+                    DataReadinessService._warning(
+                        "stale_data",
+                        ticker=ticker,
+                        scanner_type=scanner_type,
+                        event_date=event_date,
+                        req=req,
+                        message=(
+                            f"{ticker} latest {affected} bar is {last_bar_date},"
+                            f" stale for the {event_date.isoformat()} event."
+                        ),
+                        detail={
+                            "last_bar": last_bar_date.isoformat(),
+                            "max_stale_days": stale_tolerance_days,
+                        },
+                    )
+                )
+
+        return warnings
+
+    @staticmethod
+    def event_warning_metadata(
+        base_metadata: Optional[dict[str, Any]],
+        warnings: list[dict[str, Any]],
+    ) -> Optional[dict[str, Any]]:
+        """Merge event-scoped warnings into existing quality_gate metadata."""
+        if not warnings:
+            return base_metadata
+
+        merged = dict(base_metadata or {})
+        merged.setdefault("tier", "warning")
+        merged.setdefault("schema_version", "quality_gate.v1")
+        existing = list(merged.get("warnings") or [])
+        seen = {
+            (
+                warning.get("code"),
+                tuple(warning.get("affected_inputs") or []),
+                str(warning.get("message")),
+            )
+            for warning in existing
+        }
+        for warning in warnings:
+            key = (
+                warning.get("code"),
+                tuple(warning.get("affected_inputs") or []),
+                str(warning.get("message")),
+            )
+            if key in seen:
+                continue
+            existing.append(warning)
+            seen.add(key)
+        merged["warnings"] = existing
+        return merged
+
+    @staticmethod
+    def event_quality_gate_metadata(
+        db: Session,
+        ticker: str,
+        scanner_type: str,
+        event_date: date,
+        base_metadata: Optional[dict[str, Any]],
+        data_requirements: Optional[dict] = None,
+    ) -> Optional[dict[str, Any]]:
+        warnings = DataReadinessService.event_warnings(
+            db,
+            ticker=ticker,
+            scanner_type=scanner_type,
+            event_date=event_date,
+            data_requirements=data_requirements,
+        )
+        return DataReadinessService.event_warning_metadata(base_metadata, warnings)
+
     @staticmethod
     def check(db: Session, ticker: str, scanner_type: str) -> ReadinessReport:
         config = (

--- a/backend/app/services/liquidity_hunt.py
+++ b/backend/app/services/liquidity_hunt.py
@@ -34,6 +34,7 @@ from app.models.stock_split import StockSplit
 from app.models.ticker_reference import TickerReference
 from app.services.alert_service import save_event as _save_event
 from app.services.catalyst_parser import CatalystParser
+from app.services.data_readiness import DataReadinessService
 from app.services.scanner_explanations import build_liquidity_hunt_explanation
 from app.utils.session import get_market_today
 from app.utils.time import to_utc_naive
@@ -542,6 +543,15 @@ async def run_liquidity_hunt_scan(
                             event_date,
                             session_metrics["pre_vol"],
                         )
+                        event_gate_metadata = (
+                            DataReadinessService.event_quality_gate_metadata(
+                                db=db,
+                                ticker=ticker,
+                                scanner_type="liquidity_hunt_pre",
+                                event_date=event_date,
+                                base_metadata=gate_metadata,
+                            )
+                        )
                         event_dict = _save_event(
                             db=db,
                             ticker=ticker,
@@ -553,12 +563,12 @@ async def run_liquidity_hunt_scan(
                             previous_close=prior_day_close,
                             opening_price=session_metrics["regular_open"],
                             closing_price=session_metrics["regular_close"],
-                            gate_metadata=gate_metadata,
+                            gate_metadata=event_gate_metadata,
                             explanation=build_liquidity_hunt_explanation(
                                 scanner_type="liquidity_hunt_pre",
                                 indicators=indicators_pre,
                                 criteria_met=criteria_pre,
-                                gate_metadata=gate_metadata,
+                                gate_metadata=event_gate_metadata,
                                 config=config,
                             ),
                         )
@@ -592,6 +602,15 @@ async def run_liquidity_hunt_scan(
                                 event_date,
                                 session_metrics["post_vol"],
                             )
+                            event_gate_metadata = (
+                                DataReadinessService.event_quality_gate_metadata(
+                                    db=db,
+                                    ticker=ticker,
+                                    scanner_type="liquidity_hunt_post",
+                                    event_date=event_date,
+                                    base_metadata=gate_metadata,
+                                )
+                            )
                             event_dict = _save_event(
                                 db=db,
                                 ticker=ticker,
@@ -603,12 +622,12 @@ async def run_liquidity_hunt_scan(
                                 previous_close=event_date_regular_close,
                                 opening_price=session_metrics["regular_open"],
                                 closing_price=session_metrics["regular_close"],
-                                gate_metadata=gate_metadata,
+                                gate_metadata=event_gate_metadata,
                                 explanation=build_liquidity_hunt_explanation(
                                     scanner_type="liquidity_hunt_post",
                                     indicators=indicators_post,
                                     criteria_met=criteria_post,
-                                    gate_metadata=gate_metadata,
+                                    gate_metadata=event_gate_metadata,
                                     config=config,
                                 ),
                             )

--- a/backend/app/services/oversold_bounce_scan.py
+++ b/backend/app/services/oversold_bounce_scan.py
@@ -16,6 +16,7 @@ from app.core.metrics import (
 )
 from app.exceptions import DataFetchError, ProviderError, ScanError
 from app.models.stock_aggregate import StockAggregate
+from app.services.data_readiness import DataReadinessService
 from app.services.scan_orchestrator import ScannerDescriptor, register
 from app.services.scanner_explanations import build_oversold_bounce_explanation
 from app.utils.session import get_market_today
@@ -181,6 +182,15 @@ async def run_oversold_bounce_scan(
                     }
 
                     enrichment = enrichment_batch.get(ticker.upper(), {})
+                    event_gate_metadata = (
+                        DataReadinessService.event_quality_gate_metadata(
+                            db=db,
+                            ticker=ticker,
+                            scanner_type="oversold_bounce",
+                            event_date=event_date,
+                            base_metadata=gate_metadata,
+                        )
+                    )
                     event_dict = ScannerService._save_event(
                         db=db,
                         ticker=ticker,
@@ -193,11 +203,11 @@ async def run_oversold_bounce_scan(
                         opening_price=float(today["Open"]),
                         closing_price=float(today["Close"]),
                         ranker_config=ranker_config,
-                        gate_metadata=gate_metadata,
+                        gate_metadata=event_gate_metadata,
                         explanation=build_oversold_bounce_explanation(
                             indicators=indicators,
                             criteria_met=criteria_met,
-                            gate_metadata=gate_metadata,
+                            gate_metadata=event_gate_metadata,
                         ),
                     )
                     results.append(event_dict)

--- a/backend/app/services/pocket_pivot.py
+++ b/backend/app/services/pocket_pivot.py
@@ -31,6 +31,7 @@ from app.models.stock_split import StockSplit
 from app.models.ticker_reference import TickerReference
 from app.services.alert_service import save_event as _save_event
 from app.services.catalyst_parser import CatalystParser
+from app.services.data_readiness import DataReadinessService
 from app.services.scanner_explanations import build_pocket_pivot_explanation
 from app.utils.session import get_market_today
 from app.utils.time import to_utc_naive
@@ -313,6 +314,15 @@ async def run_pocket_pivot_scan(
                         "volume_floor": True,
                     }
 
+                    event_gate_metadata = (
+                        DataReadinessService.event_quality_gate_metadata(
+                            db=db,
+                            ticker=ticker,
+                            scanner_type="pocket_pivot",
+                            event_date=event_date,
+                            base_metadata=gate_metadata,
+                        )
+                    )
                     event_dict = _save_event(
                         db=db,
                         ticker=ticker,
@@ -323,11 +333,11 @@ async def run_pocket_pivot_scan(
                         enrichment=enrichment,
                         previous_close=prior_close,
                         closing_price=today["close"],
-                        gate_metadata=gate_metadata,
+                        gate_metadata=event_gate_metadata,
                         explanation=build_pocket_pivot_explanation(
                             indicators=indicators,
                             criteria_met=criteria_met,
-                            gate_metadata=gate_metadata,
+                            gate_metadata=event_gate_metadata,
                         ),
                     )
                     results.append(event_dict)

--- a/backend/app/services/pre_market_scan.py
+++ b/backend/app/services/pre_market_scan.py
@@ -411,6 +411,7 @@ def _persist(
     scanner_run: Optional[Any],
     gate_metadata: Optional[Dict[str, Any]] = None,
 ) -> list[Dict[str, Any]]:
+    from app.services.data_readiness import DataReadinessService
     from app.services.scanner import ScannerService
     from app.services.scanner_explanations import build_pre_market_volume_explanation
     from app.services.signal_ranker import compute_signal_quality_score
@@ -426,10 +427,17 @@ def _persist(
             signal_quality_score = compute_signal_quality_score(
                 signal.indicators, ranker_config["weights"]
             )
+        event_gate_metadata = DataReadinessService.event_quality_gate_metadata(
+            db=db,
+            ticker=signal.raw.ticker,
+            scanner_type="pre_market_volume_spike",
+            event_date=event_date,
+            base_metadata=gate_metadata,
+        )
         explanation = build_pre_market_volume_explanation(
             signal,
             signal_quality_score=signal_quality_score,
-            gate_metadata=gate_metadata,
+            gate_metadata=event_gate_metadata,
         )
         event_dict = ScannerService._save_event(
             db=db,
@@ -443,7 +451,7 @@ def _persist(
             opening_price=signal.day_metrics.get("opening_price", 0.0),
             closing_price=signal.day_metrics.get("closing_price"),
             ranker_config=ranker_config,
-            gate_metadata=gate_metadata,
+            gate_metadata=event_gate_metadata,
             explanation=explanation,
         )
         results.append(event_dict)

--- a/backend/app/services/trend_pullback_scan.py
+++ b/backend/app/services/trend_pullback_scan.py
@@ -28,6 +28,7 @@ from app.core.metrics import (
 )
 from app.models.stock_aggregate import StockAggregate
 from app.services.alert_service import save_event as _save_event
+from app.services.data_readiness import DataReadinessService
 from app.services.scanner_explanations import build_trend_pullback_explanation
 from app.utils.session import get_market_today
 
@@ -328,6 +329,15 @@ async def run_trend_pullback_scan(
                     indicators = result["indicators"]
                     criteria_met = result["criteria_met"]
 
+                    event_gate_metadata = (
+                        DataReadinessService.event_quality_gate_metadata(
+                            db=db,
+                            ticker=ticker,
+                            scanner_type="trend_pullback",
+                            event_date=event_date,
+                            base_metadata=gate_metadata,
+                        )
+                    )
                     event_dict = _save_event(
                         db=db,
                         ticker=ticker,
@@ -338,11 +348,11 @@ async def run_trend_pullback_scan(
                         enrichment={},
                         previous_close=None,
                         closing_price=close_today,
-                        gate_metadata=gate_metadata,
+                        gate_metadata=event_gate_metadata,
                         explanation=build_trend_pullback_explanation(
                             indicators=indicators,
                             criteria_met=criteria_met,
-                            gate_metadata=gate_metadata,
+                            gate_metadata=event_gate_metadata,
                         ),
                     )
                     results.append(event_dict)

--- a/backend/tests/services/test_data_readiness.py
+++ b/backend/tests/services/test_data_readiness.py
@@ -1,0 +1,165 @@
+from datetime import date, datetime
+from types import SimpleNamespace
+
+from app.models.scanner_config import ScannerConfig
+from app.services.data_readiness import DataReadinessService
+
+
+class _QueryResult:
+    def __init__(self, *, first_value=None, rows=None):
+        self._first_value = first_value
+        self._rows = list(rows or [])
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def order_by(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._first_value
+
+    def all(self):
+        return list(self._rows)
+
+
+class _ReadinessDb:
+    def __init__(self, config, row_sets):
+        self._config = config
+        self._row_sets = list(row_sets)
+
+    def query(self, *entities):
+        if len(entities) == 1 and entities[0] is ScannerConfig:
+            return _QueryResult(first_value=self._config)
+        rows = self._row_sets.pop(0) if self._row_sets else []
+        return _QueryResult(rows=rows)
+
+
+def _config(data_requirements):
+    return SimpleNamespace(data_requirements=data_requirements)
+
+
+def _bar(
+    ts: datetime,
+    *,
+    open=10,
+    high=11,
+    low=9,
+    close=10,
+    volume=1000,
+):
+    return SimpleNamespace(
+        timestamp=ts,
+        open=open,
+        high=high,
+        low=low,
+        close=close,
+        volume=volume,
+    )
+
+
+def test_event_warnings_support_flat_requirements_and_affected_inputs():
+    db = _ReadinessDb(
+        _config({"timespan": "day", "multiplier": 1, "min_bars": 260}),
+        [[_bar(datetime(2026, 6, 1))]],
+    )
+
+    warnings = DataReadinessService.event_warnings(
+        db,
+        ticker="AAPL",
+        scanner_type="trend_pullback",
+        event_date=date(2026, 6, 2),
+    )
+
+    assert [w["code"] for w in warnings] == ["insufficient_lookback"]
+    assert warnings[0]["affected_inputs"] == ["daily_aggregates", "close", "volume"]
+    assert warnings[0]["detail"]["observed_bars"] == 1
+    assert warnings[0]["detail"]["required_bars"] == 260
+
+
+def test_event_warnings_emit_shared_codes_for_event_quality_failures():
+    db = _ReadinessDb(
+        _config(
+            {
+                "timespans": [
+                    {
+                        "timespan": "minute",
+                        "multiplier": 1,
+                        "lookback_days": 1,
+                        "min_bars": 10,
+                    }
+                ]
+            }
+        ),
+        [
+            [
+                _bar(datetime(2026, 6, 1, 9, 30)),
+                _bar(datetime(2026, 6, 1, 9, 30)),
+                _bar(datetime(2026, 6, 1, 10, 30), high=8),
+            ]
+        ],
+    )
+
+    warnings = DataReadinessService.event_warnings(
+        db,
+        ticker="AAPL",
+        scanner_type="pre_market_volume_spike",
+        event_date=date(2026, 6, 2),
+    )
+
+    codes = {w["code"] for w in warnings}
+    assert {
+        "low_coverage",
+        "integrity_violation",
+        "continuity_gap",
+        "stale_data",
+        "insufficient_lookback",
+    }.issubset(codes)
+    assert all("minute_aggregates" in w["affected_inputs"] for w in warnings)
+
+
+def test_missing_required_timespan_short_circuits_other_timespan_warnings():
+    db = _ReadinessDb(
+        _config({"timespans": [{"timespan": "minute", "lookback_days": 1}]}),
+        [[]],
+    )
+
+    warnings = DataReadinessService.event_warnings(
+        db,
+        ticker="AAPL",
+        scanner_type="pre_market_volume_spike",
+        event_date=date(2026, 6, 2),
+    )
+
+    assert [w["code"] for w in warnings] == ["missing_required_timespan"]
+
+
+def test_event_warning_metadata_merges_with_existing_quality_gate_metadata():
+    metadata = DataReadinessService.event_warning_metadata(
+        base_metadata={
+            "tier": "warning",
+            "schema_version": "quality_gate.v1",
+            "warnings": [
+                {
+                    "code": "provider_gap",
+                    "severity": "warning",
+                    "message": "Provider gaps were detected.",
+                }
+            ],
+        },
+        warnings=[
+            {
+                "code": "low_coverage",
+                "severity": "medium",
+                "message": "AAPL minute coverage is below target.",
+                "affected_inputs": ["minute_aggregates"],
+            }
+        ],
+    )
+
+    assert metadata["tier"] == "warning"
+    assert metadata["schema_version"] == "quality_gate.v1"
+    assert [w["code"] for w in metadata["warnings"]] == [
+        "provider_gap",
+        "low_coverage",
+    ]

--- a/backend/tests/services/test_scanner_explanations.py
+++ b/backend/tests/services/test_scanner_explanations.py
@@ -60,9 +60,10 @@ def test_build_pre_market_volume_explanation_splits_passed_and_failed_criteria()
             "tier": "warning",
             "warnings": [
                 {
-                    "code": "stale_bars",
+                    "code": "stale_data",
                     "severity": "warning",
                     "message": "Some bars are stale.",
+                    "affected_inputs": ["minute_aggregates", "price", "volume"],
                 }
             ],
         },
@@ -72,7 +73,13 @@ def test_build_pre_market_volume_explanation_splits_passed_and_failed_criteria()
     assert "premarket.volume_spike" in explanation["criteria_passed"]
     assert "premarket.liquidity" in explanation["criteria_failed"]
     assert explanation["confidence_inputs"]["signal_quality_score"] == 88.0
+    assert explanation["data_quality_warnings"][0]["code"] == "stale_data"
     assert explanation["data_quality_warnings"][0]["severity"] == "medium"
+    assert explanation["data_quality_warnings"][0]["affected_inputs"] == [
+        "minute_aggregates",
+        "price",
+        "volume",
+    ]
     assert explanation["evidence"]["reconstructed"] is False
 
 


### PR DESCRIPTION
## Summary
- add event-date-scoped data readiness warnings for scanner explanations
- add shared warning codes for missing timespan, low coverage, integrity, continuity, staleness, and insufficient lookback
- merge event warning metadata into historical scanner explanation builders and persisted event metadata
- preserve quality_gate metadata when existing scanner events are updated

Closes #454

## Verification
- ruff check .
- PYTEST_ADDOPTS='--no-cov' python -m pytest backend/tests/services/test_data_readiness.py backend/tests/services/test_quality_gate_evidence.py backend/tests/services/test_quality_gate_service.py backend/tests/services/test_scanner_explanations.py backend/tests/services/test_liquidity_hunt.py backend/tests/services/test_pre_market_scan_module.py backend/tests/services/test_oversold_bounce_scan_module.py backend/tests/services/test_pocket_pivot.py backend/tests/services/test_trend_pullback_scan.py backend/tests/services/test_alert_service.py backend/tests/tasks/test_scanning_tasks.py -q