### PR TITLE
Add scanner explanation feature extractor

### DIFF
--- a/backend/app/services/explanation_feature_extractor.py
+++ b/backend/app/services/explanation_feature_extractor.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.scanner_event import ScannerEvent
+from app.models.scanner_outcome_snapshot import ScannerOutcomeSnapshot
+from app.models.scanner_outcome_summary import ScannerOutcomeSummary
+
+_SAFE_KEY_RE = re.compile(r"[^a-zA-Z0-9_]+")
+
+
+class ExplanationFeatureExtractor:
+    """Flatten scanner explanations into rows suitable for outcome analysis."""
+
+    def extract_event(
+        self,
+        event: ScannerEvent,
+        outcome_summary: ScannerOutcomeSummary | None = None,
+        snapshots: Sequence[ScannerOutcomeSnapshot] | None = None,
+    ) -> list[dict[str, Any]]:
+        snapshot_rows = list(snapshots or [])
+        if not snapshot_rows:
+            snapshot_rows = [None]
+
+        base_row = self._event_base(event)
+        base_row.update(self._explanation_features(event.explanation))
+        base_row.update(self._summary_features(outcome_summary))
+
+        rows = []
+        for snapshot in snapshot_rows:
+            row = dict(base_row)
+            row.update(self._snapshot_features(snapshot))
+            rows.append(row)
+        return rows
+
+    def extract_rows_for_analysis(
+        self,
+        db: Session,
+        *,
+        scanner_type: str | None = None,
+        complete_only: bool = True,
+        captured_only: bool = True,
+    ) -> list[dict[str, Any]]:
+        query = (
+            db.query(ScannerEvent, ScannerOutcomeSummary, ScannerOutcomeSnapshot)
+            .join(
+                ScannerOutcomeSummary,
+                ScannerOutcomeSummary.scanner_event_id == ScannerEvent.id,
+            )
+            .join(
+                ScannerOutcomeSnapshot,
+                ScannerOutcomeSnapshot.scanner_event_id == ScannerEvent.id,
+            )
+        )
+        if scanner_type:
+            query = query.filter(ScannerEvent.scanner_type == scanner_type)
+        if complete_only:
+            query = query.filter(ScannerOutcomeSummary.is_complete.is_(True))
+        if captured_only:
+            query = query.filter(ScannerOutcomeSnapshot.status == "captured")
+
+        query = query.order_by(
+            ScannerEvent.event_date.asc(),
+            ScannerEvent.id.asc(),
+            ScannerOutcomeSnapshot.interval_key.asc(),
+        )
+
+        rows: list[dict[str, Any]] = []
+        for event, summary, snapshot in query.all():
+            rows.extend(self.extract_event(event, summary, [snapshot]))
+        return rows
+
+    def _event_base(self, event: ScannerEvent) -> dict[str, Any]:
+        return {
+            "event_id": event.id,
+            "scanner_event_id": event.id,
+            "scanner_event_uuid": str(event.uuid) if event.uuid else None,
+            "ticker": event.ticker,
+            "event_date": _serialize_value(event.event_date),
+            "scanner_type": event.scanner_type,
+            "severity": event.severity,
+            "signal_quality_score": _to_number(event.signal_quality_score),
+            "regime": event.regime,
+        }
+
+    def _explanation_features(self, explanation: dict[str, Any] | None) -> dict[str, Any]:
+        if not explanation:
+            return {
+                "has_explanation": 0.0,
+                "explanation_schema_version": None,
+                "explanation_reconstructed": 0.0,
+                "reconstruction_quality_category": None,
+                "criteria_passed_count": 0,
+                "criteria_failed_count": 0,
+                "criteria_passed_ids": [],
+                "criteria_failed_ids": [],
+                "data_quality_warning_count": 0,
+                "warning_severity_low_count": 0,
+                "warning_severity_medium_count": 0,
+                "warning_severity_high_count": 0,
+            }
+
+        criteria_passed = explanation.get("criteria_passed") or {}
+        criteria_failed = explanation.get("criteria_failed") or {}
+        evidence = explanation.get("evidence") or {}
+        warnings = explanation.get("data_quality_warnings") or []
+        reconstruction_quality = evidence.get("reconstruction_quality")
+
+        features: dict[str, Any] = {
+            "has_explanation": 1.0,
+            "explanation_schema_version": explanation.get("schema_version"),
+            "explanation_reconstructed": _to_number(evidence.get("reconstructed")) or 0.0,
+            "reconstruction_quality_category": reconstruction_quality,
+            "criteria_passed_count": len(criteria_passed),
+            "criteria_failed_count": len(criteria_failed),
+            "criteria_passed_ids": sorted(criteria_passed),
+            "criteria_failed_ids": sorted(criteria_failed),
+            "data_quality_warning_count": len(warnings),
+            "warning_severity_low_count": 0,
+            "warning_severity_medium_count": 0,
+            "warning_severity_high_count": 0,
+        }
+        if reconstruction_quality:
+            features[f"reconstruction_quality_{_safe_key(reconstruction_quality)}"] = 1.0
+
+        for criterion_id, criterion in criteria_passed.items():
+            features.update(
+                self._criterion_features(criterion_id, criterion, passed=True)
+            )
+        for criterion_id, criterion in criteria_failed.items():
+            features.update(
+                self._criterion_features(criterion_id, criterion, passed=False)
+            )
+        for name, value in (explanation.get("confidence_inputs") or {}).items():
+            self._assign_scalar_or_category(features, f"confidence_{_safe_key(name)}", value)
+        for warning in warnings:
+            code = _safe_key(warning.get("code") or "quality_gate_warning")
+            features[f"warning_{code}"] = 1.0
+            severity = warning.get("severity")
+            severity_key = f"warning_severity_{_safe_key(severity)}_count"
+            if severity_key in features:
+                features[severity_key] += 1
+        return features
+
+    def _criterion_features(
+        self,
+        criterion_id: str,
+        criterion: dict[str, Any],
+        *,
+        passed: bool,
+    ) -> dict[str, Any]:
+        prefix = f"criterion_{_safe_key(criterion_id)}"
+        features: dict[str, Any] = {
+            f"{prefix}_passed": 1.0 if passed else 0.0,
+            f"{prefix}_label": criterion.get("label"),
+            f"{prefix}_operator_category": criterion.get("operator"),
+            f"{prefix}_unit_category": criterion.get("unit"),
+            f"{prefix}_source_category": criterion.get("source"),
+            f"{prefix}_lookback_category": criterion.get("lookback"),
+        }
+        self._assign_scalar_or_category(
+            features,
+            f"{prefix}_observed",
+            criterion.get("observed"),
+        )
+        self._assign_scalar_or_category(
+            features,
+            f"{prefix}_threshold",
+            criterion.get("threshold"),
+        )
+        self._assign_scalar_or_category(
+            features,
+            f"{prefix}_importance",
+            criterion.get("importance"),
+        )
+        return features
+
+    def _summary_features(
+        self,
+        summary: ScannerOutcomeSummary | None,
+    ) -> dict[str, Any]:
+        if summary is None:
+            return {
+                "outcome_reference_price": None,
+                "outcome_mfe_pct": None,
+                "outcome_mfe_time_minutes": None,
+                "outcome_mae_pct": None,
+                "outcome_mae_time_minutes": None,
+                "outcome_mfe_mae_ratio": None,
+                "outcome_r_multiple": None,
+                "outcome_eod_pct_change": None,
+                "outcome_follow_through": None,
+                "outcome_gap_filled": None,
+                "outcome_is_complete": 0.0,
+            }
+        return {
+            "outcome_reference_price": _to_number(summary.reference_price),
+            "outcome_mfe_pct": _to_number(summary.mfe_pct),
+            "outcome_mfe_time_minutes": summary.mfe_time_minutes,
+            "outcome_mae_pct": _to_number(summary.mae_pct),
+            "outcome_mae_time_minutes": summary.mae_time_minutes,
+            "outcome_mfe_mae_ratio": _to_number(summary.mfe_mae_ratio),
+            "outcome_r_multiple": _to_number(summary.r_multiple),
+            "outcome_eod_pct_change": _to_number(summary.eod_pct_change),
+            "outcome_follow_through": _to_number(summary.follow_through),
+            "outcome_gap_filled": _to_number(summary.gap_filled),
+            "outcome_is_complete": _to_number(summary.is_complete) or 0.0,
+        }
+
+    def _snapshot_features(
+        self,
+        snapshot: ScannerOutcomeSnapshot | None,
+    ) -> dict[str, Any]:
+        if snapshot is None:
+            return {
+                "interval_key": None,
+                "pct_change": None,
+                "snapshot_reference_price": None,
+                "snapshot_price": None,
+                "snapshot_pct_change": None,
+                "snapshot_high_since_signal": None,
+                "snapshot_low_since_signal": None,
+                "snapshot_volume_since_signal": None,
+                "snapshot_status": None,
+                "snapshot_captured_at": None,
+            }
+        return {
+            "interval_key": snapshot.interval_key,
+            "pct_change": _to_number(snapshot.pct_change),
+            "snapshot_reference_price": _to_number(snapshot.reference_price),
+            "snapshot_price": _to_number(snapshot.snapshot_price),
+            "snapshot_pct_change": _to_number(snapshot.pct_change),
+            "snapshot_high_since_signal": _to_number(snapshot.high_since_signal),
+            "snapshot_low_since_signal": _to_number(snapshot.low_since_signal),
+            "snapshot_volume_since_signal": snapshot.volume_since_signal,
+            "snapshot_status": snapshot.status,
+            "snapshot_captured_at": _serialize_value(snapshot.captured_at),
+        }
+
+    def _assign_scalar_or_category(
+        self,
+        target: dict[str, Any],
+        key: str,
+        value: Any,
+    ) -> None:
+        number = _to_number(value)
+        if number is not None:
+            target[key] = number
+            return
+        if value is None:
+            target[key] = None
+            return
+        target[f"{key}_category"] = str(value)
+
+
+def _safe_key(value: Any) -> str:
+    raw = str(value or "unknown").strip().lower()
+    normalized = _SAFE_KEY_RE.sub("_", raw).strip("_")
+    return normalized or "unknown"
+
+
+def _to_number(value: Any) -> float | int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, (float, Decimal)):
+        return float(value)
+    return None
+
+
+def _serialize_value(value: Any) -> Any:
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    return value

--- a/backend/tests/services/test_explanation_feature_extractor.py
+++ b/backend/tests/services/test_explanation_feature_extractor.py
@@ -1,0 +1,200 @@
+from datetime import date
+from decimal import Decimal
+
+from app.models.scanner_event import ScannerEvent
+from app.models.scanner_outcome_snapshot import ScannerOutcomeSnapshot
+from app.models.scanner_outcome_summary import ScannerOutcomeSummary
+from app.services.explanation_feature_extractor import ExplanationFeatureExtractor
+
+
+def _explanation(
+    prefix: str,
+    *,
+    reconstructed: bool = False,
+    warnings: list[dict] | None = None,
+) -> dict:
+    return {
+        "schema_version": "scanner_explanation.v1",
+        "why": ["Deterministic explanation for feature tests."],
+        "criteria_passed": {
+            f"{prefix}.volume_spike": {
+                "label": "Volume spike",
+                "observed": 6.2,
+                "threshold": 4.0,
+                "operator": ">=",
+                "unit": "x",
+                "source": "minute_aggregates",
+                "importance": 1.0,
+            }
+        },
+        "criteria_failed": {
+            f"{prefix}.news_catalyst": {
+                "label": "News catalyst",
+                "observed": False,
+                "threshold": True,
+                "operator": "==",
+                "importance": 0.4,
+            }
+        },
+        "confidence_inputs": {
+            "signal_quality_score": 0.83,
+            "threshold_method": "static",
+            "has_news_catalyst": False,
+        },
+        "data_quality_warnings": warnings or [],
+        "evidence": {
+            "reconstructed": reconstructed,
+            "reconstruction_quality": "partial" if reconstructed else None,
+            "generator_version": "explanation_builder.v1",
+            "provider": "polygon",
+        },
+    }
+
+
+def _event(
+    *,
+    event_id: int,
+    scanner_type: str,
+    explanation: dict | None,
+) -> ScannerEvent:
+    return ScannerEvent(
+        id=event_id,
+        ticker=f"T{event_id}",
+        event_date=date(2026, 7, 3),
+        scanner_type=scanner_type,
+        summary="feature test signal",
+        severity="medium",
+        indicators={"legacy_indicator": 9.5},
+        criteria_met={},
+        metadata_={},
+        explanation=explanation,
+    )
+
+
+def _summary(event_id: int) -> ScannerOutcomeSummary:
+    return ScannerOutcomeSummary(
+        scanner_event_id=event_id,
+        reference_price=Decimal("10.00"),
+        mfe_pct=Decimal("4.25"),
+        mae_pct=Decimal("1.25"),
+        mfe_mae_ratio=Decimal("3.4000"),
+        r_multiple=Decimal("2.1000"),
+        eod_pct_change=Decimal("2.50"),
+        follow_through=True,
+        gap_filled=False,
+        is_complete=True,
+    )
+
+
+def _snapshot(event_id: int, interval_key: str = "15m") -> ScannerOutcomeSnapshot:
+    return ScannerOutcomeSnapshot(
+        scanner_event_id=event_id,
+        interval_key=interval_key,
+        reference_price=Decimal("10.00"),
+        snapshot_price=Decimal("10.25"),
+        pct_change=Decimal("2.50"),
+        high_since_signal=Decimal("10.50"),
+        low_since_signal=Decimal("9.90"),
+        volume_since_signal=120000,
+        status="captured",
+    )
+
+
+def test_extract_event_flattens_two_scanner_types_and_warnings():
+    extractor = ExplanationFeatureExtractor()
+    warning = {
+        "code": "missing_float",
+        "severity": "medium",
+        "message": "Float data was missing.",
+        "affected_inputs": ["float_shares"],
+    }
+    events = [
+        _event(
+            event_id=101,
+            scanner_type="pre_market_volume_spike",
+            explanation=_explanation("premarket", warnings=[warning]),
+        ),
+        _event(
+            event_id=102,
+            scanner_type="liquidity_hunt_pre",
+            explanation=_explanation("liquidity_hunt_pre"),
+        ),
+    ]
+
+    rows = [
+        extractor.extract_event(event, _summary(event.id), [_snapshot(event.id)])[0]
+        for event in events
+    ]
+
+    assert rows[0]["event_id"] == 101
+    assert rows[0]["scanner_event_id"] == 101
+    assert rows[0]["scanner_type"] == "pre_market_volume_spike"
+    assert rows[0]["criterion_premarket_volume_spike_passed"] == 1.0
+    assert rows[0]["criterion_premarket_volume_spike_observed"] == 6.2
+    assert rows[0]["criterion_premarket_news_catalyst_passed"] == 0.0
+    assert rows[0]["confidence_signal_quality_score"] == 0.83
+    assert rows[0]["confidence_threshold_method_category"] == "static"
+    assert rows[0]["data_quality_warning_count"] == 1
+    assert rows[0]["warning_missing_float"] == 1.0
+    assert rows[0]["warning_severity_medium_count"] == 1
+    assert rows[0]["criteria_passed_ids"] == ["premarket.volume_spike"]
+    assert rows[0]["criteria_failed_ids"] == ["premarket.news_catalyst"]
+
+    assert rows[1]["criterion_liquidity_hunt_pre_volume_spike_passed"] == 1.0
+    assert rows[1]["scanner_type"] == "liquidity_hunt_pre"
+
+
+def test_extract_event_handles_missing_and_reconstructed_explanations():
+    extractor = ExplanationFeatureExtractor()
+    missing = _event(event_id=201, scanner_type="pre_market_volume_spike", explanation=None)
+    reconstructed = _event(
+        event_id=202,
+        scanner_type="liquidity_hunt_post",
+        explanation=_explanation("liquidity_hunt_post", reconstructed=True),
+    )
+
+    missing_row = extractor.extract_event(missing, _summary(201), [_snapshot(201)])[0]
+    reconstructed_row = extractor.extract_event(
+        reconstructed, _summary(202), [_snapshot(202)]
+    )[0]
+
+    assert missing_row["has_explanation"] == 0.0
+    assert missing_row["criteria_passed_count"] == 0
+    assert missing_row["data_quality_warning_count"] == 0
+    assert missing_row["outcome_is_complete"] == 1.0
+
+    assert reconstructed_row["has_explanation"] == 1.0
+    assert reconstructed_row["explanation_reconstructed"] == 1.0
+    assert reconstructed_row["reconstruction_quality_category"] == "partial"
+    assert reconstructed_row["reconstruction_quality_partial"] == 1.0
+
+
+def test_extract_rows_for_analysis_joins_summary_and_captured_snapshots(db):
+    extractor = ExplanationFeatureExtractor()
+    event = _event(
+        event_id=301,
+        scanner_type="pre_market_volume_spike",
+        explanation=_explanation("premarket"),
+    )
+    db.add(event)
+    db.flush()
+    summary = _summary(event.id)
+    captured = _snapshot(event.id, "5m")
+    pending = _snapshot(event.id, "30m")
+    pending.status = "pending"
+    db.add(summary)
+    db.add(captured)
+    db.add(pending)
+    db.flush()
+
+    rows = extractor.extract_rows_for_analysis(db, scanner_type="pre_market_volume_spike")
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["event_id"] == event.id
+    assert row["interval_key"] == "5m"
+    assert row["pct_change"] == 2.5
+    assert row["outcome_mfe_pct"] == 4.25
+    assert row["outcome_mae_pct"] == 1.25
+    assert row["outcome_follow_through"] == 1.0
+    assert row["snapshot_volume_since_signal"] == 120000


### PR DESCRIPTION
## Summary
- Add a deterministic `ExplanationFeatureExtractor` service that flattens scanner explanations into analysis-ready event rows.
- Preserve event identity, scanner type, criterion IDs, confidence inputs, reconstruction metadata, warning flags, and joined ScannerOutcomeSummary/Snapshot fields.
- Add focused coverage for two scanner types, missing explanations, reconstructed explanations, warning-bearing payloads, and DB-backed outcome joins.

Fixes #463

## Verification
- `python -m ruff check backend`
- `PYTEST_ADDOPTS='--no-cov' python -m pytest backend/tests/services/test_explanation_feature_extractor.py backend/tests/services/test_statistical_discovery.py backend/tests/services/test_scanner_explanations.py backend/tests/schemas/test_scanner_explanation.py backend/tests/models/test_scanner_event_explanation.py -q`
- `PYTEST_ADDOPTS='--no-cov' python -m pytest backend/tests/api/test_outcomes.py backend/tests/services/test_explanation_feature_extractor.py -q`