### PR TITLE
Add deterministic AI signal brief endpoint

### DIFF
--- a/backend/app/routers/outcomes.py
+++ b/backend/app/routers/outcomes.py
@@ -32,6 +32,7 @@ from app.schemas.outcome import (
     SignalListResponse,
 )
 from app.schemas.regime import RegimeBreakdownResponse
+from app.services.ai_signal_brief import AISignalBriefService
 from app.services.data_readiness import DataReadinessService
 from app.services.outcome_service import OutcomeService
 from app.services.stats import StatsService
@@ -196,6 +197,15 @@ def get_event_outcome(
     )
 
     return EventOutcomeResponse(summary=summary, snapshots=snapshots)
+
+
+@router.get("/event/{event_id}/ai-signal-brief")
+def get_ai_signal_brief(
+    event_id: int,
+    db: Session = Depends(get_db),
+):
+    event = get_or_404(db, ScannerEvent, event_id, "ScannerEvent")
+    return AISignalBriefService().build(db, event)
 
 
 @router.get("/readiness/{ticker}", response_model=ReadinessResponse)

--- a/backend/app/services/ai_signal_brief.py
+++ b/backend/app/services/ai_signal_brief.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.scanner_event import ScannerEvent
+from app.models.scanner_outcome_snapshot import ScannerOutcomeSnapshot
+from app.models.scanner_outcome_summary import ScannerOutcomeSummary
+from app.models.signal_cluster import SignalCluster
+from app.services.historical_analog_service import HistoricalAnalogService
+
+
+class AISignalBriefService:
+    """Build deterministic, LLM-free signal brief payloads."""
+
+    schema_version = "ai_signal_brief.v1"
+
+    def __init__(self, analog_service: HistoricalAnalogService | None = None) -> None:
+        self._analog_service = analog_service or HistoricalAnalogService()
+
+    def build(self, db: Session, event: ScannerEvent) -> dict[str, Any]:
+        explanation = event.explanation or {}
+        summary = (
+            db.query(ScannerOutcomeSummary)
+            .filter(ScannerOutcomeSummary.scanner_event_id == event.id)
+            .first()
+        )
+        snapshots = (
+            db.query(ScannerOutcomeSnapshot)
+            .filter(ScannerOutcomeSnapshot.scanner_event_id == event.id)
+            .order_by(ScannerOutcomeSnapshot.interval_key)
+            .all()
+        )
+        analog_result = self._analog_service.find_similar_events(
+            db,
+            target_event_id=event.id,
+            limit=3,
+            min_sample_size=5,
+        )
+        archetype = self._archetype_payload(db, event)
+        warnings = list(explanation.get("data_quality_warnings") or [])
+        warnings.extend(analog_result.get("warnings") or [])
+
+        return {
+            "schema_version": self.schema_version,
+            "event_id": event.id,
+            "facts": self._facts(event),
+            "why": list(explanation.get("why") or []),
+            "risks": self._risks(event, explanation, summary, warnings),
+            "warnings": warnings,
+            "analogs": analog_result.get("analogs", []),
+            "outcome_context": {
+                "summary": self._summary_payload(summary),
+                "snapshots": [self._snapshot_payload(snapshot) for snapshot in snapshots],
+            },
+            "archetype": archetype,
+            "forbidden_claims": [
+                "Do not present this brief as investment advice.",
+                "Do not claim guaranteed future returns.",
+                "Do not claim an LLM inferred facts beyond this payload.",
+                "Do not recommend live trade execution from this brief alone.",
+            ],
+        }
+
+    def _facts(self, event: ScannerEvent) -> dict[str, Any]:
+        return {
+            "ticker": event.ticker,
+            "event_date": event.event_date.isoformat() if event.event_date else None,
+            "scanner_type": event.scanner_type,
+            "severity": event.severity,
+            "summary": event.summary,
+            "signal_quality_score": _serialize(event.signal_quality_score),
+            "regime": event.regime,
+        }
+
+    def _risks(
+        self,
+        event: ScannerEvent,
+        explanation: dict[str, Any],
+        summary: ScannerOutcomeSummary | None,
+        warnings: list[dict[str, Any]],
+    ) -> list[str]:
+        risks = []
+        if not explanation:
+            risks.append("Scanner explanation is missing.")
+        for criterion in (explanation.get("criteria_failed") or {}).values():
+            label = criterion.get("label") or "A scanner criterion"
+            risks.append(f"{label} did not pass.")
+        if explanation.get("data_quality_warnings"):
+            risks.append("Data quality warnings are present.")
+        if summary is None or not summary.is_complete:
+            risks.append("Outcome summary is incomplete or unavailable.")
+        if any(warning.get("code") == "no_historical_analogs" for warning in warnings):
+            risks.append("No historical analogs were available.")
+        if event.signal_cluster_id is None:
+            risks.append("No explanation-aware archetype is assigned yet.")
+        return risks
+
+    def _archetype_payload(
+        self,
+        db: Session,
+        event: ScannerEvent,
+    ) -> dict[str, Any] | None:
+        if event.signal_cluster_id is None:
+            return None
+        cluster = (
+            db.query(SignalCluster)
+            .filter(SignalCluster.id == event.signal_cluster_id)
+            .first()
+        )
+        if cluster is None:
+            return None
+        return {
+            "cluster_id": cluster.id,
+            "label": cluster.label,
+            "event_count": cluster.event_count,
+            "centroid": cluster.centroid or {},
+            "return_profile": cluster.return_profile or {},
+        }
+
+    def _summary_payload(
+        self,
+        summary: ScannerOutcomeSummary | None,
+    ) -> dict[str, Any] | None:
+        if summary is None:
+            return None
+        return {
+            "scanner_event_id": summary.scanner_event_id,
+            "reference_price": _serialize(summary.reference_price),
+            "mfe_pct": _serialize(summary.mfe_pct),
+            "mae_pct": _serialize(summary.mae_pct),
+            "mfe_mae_ratio": _serialize(summary.mfe_mae_ratio),
+            "r_multiple": _serialize(summary.r_multiple),
+            "eod_pct_change": _serialize(summary.eod_pct_change),
+            "follow_through": summary.follow_through,
+            "gap_filled": summary.gap_filled,
+            "is_complete": summary.is_complete,
+        }
+
+    def _snapshot_payload(self, snapshot: ScannerOutcomeSnapshot) -> dict[str, Any]:
+        return {
+            "interval_key": snapshot.interval_key,
+            "pct_change": _serialize(snapshot.pct_change),
+            "snapshot_price": _serialize(snapshot.snapshot_price),
+            "status": snapshot.status,
+            "captured_at": snapshot.captured_at.isoformat()
+            if snapshot.captured_at
+            else None,
+        }
+
+
+def _serialize(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return float(value)
+    return value

--- a/backend/tests/api/test_ai_signal_brief.py
+++ b/backend/tests/api/test_ai_signal_brief.py
@@ -1,0 +1,194 @@
+from datetime import date
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models.scanner_event import ScannerEvent
+from app.models.scanner_outcome_summary import ScannerOutcomeSummary
+from app.models.signal_analysis_run import SignalAnalysisRun
+from app.models.signal_cluster import SignalCluster
+
+client = TestClient(app)
+
+
+def _explanation(*, warnings: list[str] | None = None) -> dict:
+    return {
+        "schema_version": "scanner_explanation.v1",
+        "why": ["Volume and liquidity aligned with the scanner setup."],
+        "criteria_passed": {
+            "premarket.volume_spike": {
+                "label": "Volume Spike",
+                "observed": 6.0,
+                "threshold": 4.0,
+                "operator": ">=",
+                "importance": 1.0,
+            }
+        },
+        "criteria_failed": {
+            "premarket.news_catalyst": {
+                "label": "News Catalyst",
+                "observed": False,
+                "threshold": True,
+                "operator": "==",
+                "importance": 0.5,
+            }
+        },
+        "confidence_inputs": {"signal_quality_score": 0.86},
+        "data_quality_warnings": [
+            {
+                "code": code,
+                "severity": "medium",
+                "message": f"{code} warning.",
+                "affected_inputs": ["input"],
+            }
+            for code in warnings or []
+        ],
+        "evidence": {
+            "reconstructed": False,
+            "generator_version": "explanation_builder.v1",
+            "provider": "polygon",
+        },
+    }
+
+
+def _seed_event(
+    db,
+    *,
+    ticker: str,
+    event_date: date,
+    explanation: dict | None,
+    complete: bool = True,
+) -> ScannerEvent:
+    event = ScannerEvent(
+        ticker=ticker,
+        event_date=event_date,
+        scanner_type="pre_market_volume_spike",
+        summary=f"{ticker} signal",
+        severity="high",
+        indicators={"volume_spike_ratio": 6.0},
+        criteria_met={},
+        metadata_={},
+        explanation=explanation,
+    )
+    db.add(event)
+    db.flush()
+    if complete:
+        db.add(
+            ScannerOutcomeSummary(
+                scanner_event_id=event.id,
+                reference_price=Decimal("10.00"),
+                mfe_pct=Decimal("4.00"),
+                mae_pct=Decimal("1.00"),
+                mfe_mae_ratio=Decimal("4.0000"),
+                r_multiple=Decimal("2.0000"),
+                eod_pct_change=Decimal("2.00"),
+                follow_through=True,
+                gap_filled=False,
+                is_complete=True,
+            )
+        )
+    db.flush()
+    return event
+
+
+def _assign_archetype(db, event: ScannerEvent) -> SignalCluster:
+    run = SignalAnalysisRun(status="completed", scanner_type=event.scanner_type, event_count=1)
+    db.add(run)
+    db.flush()
+    cluster = SignalCluster(
+        analysis_run_id=run.id,
+        cluster_index=0,
+        label="Volume Spike / Positive Outcomes",
+        centroid={"traits": {"premarket.volume_spike": 1.0}},
+        return_profile={"win_rate_pct": 100.0, "sample_size": 1},
+        event_count=1,
+    )
+    db.add(cluster)
+    db.flush()
+    event.signal_cluster_id = cluster.id
+    db.flush()
+    return cluster
+
+
+def test_ai_signal_brief_complete_event_includes_contexts(db):
+    _seed_event(
+        db,
+        ticker="OLD",
+        event_date=date(2026, 7, 1),
+        explanation=_explanation(),
+    )
+    target = _seed_event(
+        db,
+        ticker="TGT",
+        event_date=date(2026, 7, 3),
+        explanation=_explanation(),
+    )
+    cluster = _assign_archetype(db, target)
+
+    response = client.get(f"/api/v1/outcomes/event/{target.id}/ai-signal-brief")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["schema_version"] == "ai_signal_brief.v1"
+    assert data["facts"]["ticker"] == "TGT"
+    assert data["why"] == ["Volume and liquidity aligned with the scanner setup."]
+    assert data["outcome_context"]["summary"]["eod_pct_change"] == 2.0
+    assert data["archetype"]["label"] == cluster.label
+    assert len(data["analogs"]) == 1
+    assert data["forbidden_claims"]
+
+
+def test_ai_signal_brief_partial_event_without_explanation_or_outcome(db):
+    target = _seed_event(
+        db,
+        ticker="NEW",
+        event_date=date(2026, 7, 3),
+        explanation=None,
+        complete=False,
+    )
+
+    response = client.get(f"/api/v1/outcomes/event/{target.id}/ai-signal-brief")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["why"] == []
+    assert data["outcome_context"]["summary"] is None
+    assert "Scanner explanation is missing." in data["risks"]
+
+
+def test_ai_signal_brief_warning_heavy_event_surfaces_warnings_and_risks(db):
+    target = _seed_event(
+        db,
+        ticker="WRN",
+        event_date=date(2026, 7, 3),
+        explanation=_explanation(warnings=["missing_float", "stale_quote"]),
+    )
+
+    response = client.get(f"/api/v1/outcomes/event/{target.id}/ai-signal-brief")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert [warning["code"] for warning in data["warnings"][:2]] == [
+        "missing_float",
+        "stale_quote",
+    ]
+    assert "Data quality warnings are present." in data["risks"]
+
+
+def test_ai_signal_brief_no_analog_event_reports_warning(db):
+    target = _seed_event(
+        db,
+        ticker="SOLO",
+        event_date=date(2026, 7, 3),
+        explanation=_explanation(),
+    )
+
+    response = client.get(f"/api/v1/outcomes/event/{target.id}/ai-signal-brief")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["analogs"] == []
+    assert any(
+        warning["code"] == "no_historical_analogs" for warning in data["warnings"]
+    )


### PR DESCRIPTION
## Summary
- Add deterministic `ai_signal_brief.v1` payload builder for scanner events with no LLM/provider dependency.
- Add `GET /api/v1/outcomes/event/{event_id}/ai-signal-brief`.
- Package facts, why bullets, risks, warnings, analogs, outcome context, archetype context, and forbidden claims.
- Cover complete, partial, warning-heavy, and no-analog events.

Fixes #467

## Verification
- `python -m ruff check backend`
- `PYTEST_ADDOPTS='--no-cov' python -m pytest backend/tests/api/test_ai_signal_brief.py backend/tests/api/test_outcomes.py backend/tests/services/test_historical_analog_service.py backend/tests/services/test_explanation_archetype_service.py backend/tests/services/test_explanation_trait_performance.py backend/tests/services/test_explanation_feature_extractor.py -q`