### PR TITLE
Upgrade Scorecard explanation intelligence

### DIFF
--- a/backend/app/routers/outcomes.py
+++ b/backend/app/routers/outcomes.py
@@ -34,6 +34,10 @@ from app.schemas.outcome import (
 from app.schemas.regime import RegimeBreakdownResponse
 from app.services.ai_signal_brief import AISignalBriefService
 from app.services.data_readiness import DataReadinessService
+from app.services.explanation_archetype_service import ExplanationArchetypeService
+from app.services.explanation_trait_performance import (
+    ExplanationTraitPerformanceService,
+)
 from app.services.outcome_service import OutcomeService
 from app.services.stats import StatsService
 from app.utils.db import get_or_404
@@ -108,6 +112,42 @@ def get_scorecard_by_type(
         include_warnings=include_warnings,
         include_all=include_all,
         review_window_days=review_window_days,
+    )
+
+
+@router.get("/traits/{scanner_type}")
+def get_explanation_trait_performance(
+    scanner_type: str,
+    date_range: OutcomeDateRange = Depends(get_outcome_date_range),
+    severity: Optional[str] = None,
+    min_sample_size: int = Query(default=5, ge=1, le=500),
+    db: Session = Depends(get_db),
+):
+    return ExplanationTraitPerformanceService().aggregate(
+        db,
+        scanner_type=scanner_type,
+        start_date=date_range.start_date,
+        end_date=date_range.end_date,
+        severity=severity,
+        min_sample_size=min_sample_size,
+    )
+
+
+@router.get("/archetypes/{scanner_type}")
+def get_explanation_archetypes(
+    scanner_type: str,
+    date_range: OutcomeDateRange = Depends(get_outcome_date_range),
+    severity: Optional[str] = None,
+    min_sample_size: int = Query(default=5, ge=1, le=500),
+    db: Session = Depends(get_db),
+):
+    return ExplanationArchetypeService().latest_performance(
+        db,
+        scanner_type=scanner_type,
+        start_date=date_range.start_date,
+        end_date=date_range.end_date,
+        severity=severity,
+        min_sample_size=min_sample_size,
     )
 
 

--- a/backend/app/services/explanation_archetype_service.py
+++ b/backend/app/services/explanation_archetype_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import date
 from decimal import Decimal
 from statistics import mean
 from typing import Any
@@ -16,6 +17,74 @@ from app.utils.time import utc_now
 
 class ExplanationArchetypeService:
     """Generate deterministic explanation-aware signal archetypes."""
+
+    def latest_performance(
+        self,
+        db: Session,
+        *,
+        scanner_type: str,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        severity: str | None = None,
+        min_sample_size: int = 5,
+    ) -> dict[str, Any]:
+        run = (
+            db.query(SignalAnalysisRun)
+            .filter(
+                SignalAnalysisRun.status == "completed",
+                SignalAnalysisRun.scanner_type == scanner_type,
+            )
+            .order_by(SignalAnalysisRun.completed_at.desc(), SignalAnalysisRun.id.desc())
+            .first()
+        )
+        filters = {
+            "scanner_type": scanner_type,
+            "start_date": start_date.isoformat() if start_date else None,
+            "end_date": end_date.isoformat() if end_date else None,
+            "severity": severity,
+            "min_sample_size": min_sample_size,
+        }
+        if not run:
+            return {
+                "analysis_run_id": None,
+                "scanner_type": scanner_type,
+                "event_count": 0,
+                "filters": filters,
+                "warnings": [
+                    {
+                        "code": "no_explanation_archetypes",
+                        "message": "No completed explanation archetype run is available.",
+                    }
+                ],
+                "archetypes": [],
+            }
+
+        clusters = (
+            db.query(SignalCluster)
+            .filter(SignalCluster.analysis_run_id == run.id)
+            .order_by(SignalCluster.cluster_index)
+            .all()
+        )
+        archetypes = [
+            self._cluster_payload(
+                db,
+                cluster,
+                scanner_type=scanner_type,
+                start_date=start_date,
+                end_date=end_date,
+                severity=severity,
+                min_sample_size=min_sample_size,
+            )
+            for cluster in clusters
+        ]
+        return {
+            "analysis_run_id": run.id,
+            "scanner_type": scanner_type,
+            "event_count": sum(item["sample_size"] for item in archetypes),
+            "filters": filters,
+            "warnings": [],
+            "archetypes": archetypes,
+        }
 
     def generate(
         self,
@@ -101,6 +170,68 @@ class ExplanationArchetypeService:
         )
         if scanner_type:
             query = query.filter(ScannerEvent.scanner_type == scanner_type)
+        return query.order_by(ScannerEvent.event_date.asc(), ScannerEvent.id.asc()).all()
+
+    def _cluster_payload(
+        self,
+        db: Session,
+        cluster: SignalCluster,
+        *,
+        scanner_type: str,
+        start_date: date | None,
+        end_date: date | None,
+        severity: str | None,
+        min_sample_size: int,
+    ) -> dict[str, Any]:
+        rows = self._cluster_rows(
+            db,
+            cluster.id,
+            scanner_type=scanner_type,
+            start_date=start_date,
+            end_date=end_date,
+            severity=severity,
+        )
+        return_profile = _return_profile([summary for _, summary in rows])
+        sample_size = len(rows)
+        return {
+            "cluster_id": cluster.id,
+            "cluster_index": cluster.cluster_index,
+            "label": cluster.label,
+            "sample_size": sample_size,
+            "event_ids": sorted(event.id for event, _ in rows),
+            "centroid": cluster.centroid or {},
+            "return_profile": return_profile,
+            "warnings": _sample_warnings(sample_size, min_sample_size),
+        }
+
+    def _cluster_rows(
+        self,
+        db: Session,
+        cluster_id: int,
+        *,
+        scanner_type: str,
+        start_date: date | None,
+        end_date: date | None,
+        severity: str | None,
+    ) -> list[tuple[ScannerEvent, ScannerOutcomeSummary]]:
+        query = (
+            db.query(ScannerEvent, ScannerOutcomeSummary)
+            .join(
+                ScannerOutcomeSummary,
+                ScannerOutcomeSummary.scanner_event_id == ScannerEvent.id,
+            )
+            .filter(
+                ScannerEvent.signal_cluster_id == cluster_id,
+                ScannerEvent.scanner_type == scanner_type,
+                ScannerOutcomeSummary.is_complete.is_(True),
+            )
+        )
+        if start_date:
+            query = query.filter(ScannerEvent.event_date >= start_date)
+        if end_date:
+            query = query.filter(ScannerEvent.event_date <= end_date)
+        if severity:
+            query = query.filter(ScannerEvent.severity == severity)
         return query.order_by(ScannerEvent.event_date.asc(), ScannerEvent.id.asc()).all()
 
     def _group_rows(
@@ -277,6 +408,41 @@ def _title_from_key(value: str) -> str:
 
 def _float_values(values) -> list[float]:
     return [converted for value in values if (converted := _to_float(value)) is not None]
+
+
+def _return_profile(summaries: list[ScannerOutcomeSummary]) -> dict[str, Any]:
+    eod_values = _float_values(summary.eod_pct_change for summary in summaries)
+    follow_values = [
+        bool(summary.follow_through)
+        for summary in summaries
+        if summary.follow_through is not None
+    ]
+    wins = sum(1 for value in eod_values if value > 0)
+    return {
+        "sample_size": len(summaries),
+        "win_rate_pct": _pct(wins, len(eod_values)),
+        "follow_through_rate_pct": _pct(
+            sum(1 for value in follow_values if value),
+            len(follow_values),
+        ),
+        "avg_mfe_pct": _mean(_float_values(summary.mfe_pct for summary in summaries)),
+        "avg_mae_pct": _mean(_float_values(summary.mae_pct for summary in summaries)),
+        "avg_eod_pct_change": _mean(eod_values),
+    }
+
+
+def _sample_warnings(sample_size: int, min_sample_size: int) -> list[dict[str, str]]:
+    if sample_size >= min_sample_size:
+        return []
+    return [
+        {
+            "code": "weak_archetype_sample",
+            "message": (
+                f"Only {sample_size} events matched this archetype; "
+                f"minimum recommended sample is {min_sample_size}."
+            ),
+        }
+    ]
 
 
 def _mean(values: list[float]) -> float | None:

--- a/backend/app/services/explanation_trait_performance.py
+++ b/backend/app/services/explanation_trait_performance.py
@@ -23,6 +23,7 @@ class ExplanationTraitPerformanceService:
         scanner_type: str | None = None,
         start_date: date | None = None,
         end_date: date | None = None,
+        severity: str | None = None,
         min_sample_size: int = 5,
     ) -> dict[str, Any]:
         rows = self._query_rows(
@@ -30,6 +31,7 @@ class ExplanationTraitPerformanceService:
             scanner_type=scanner_type,
             start_date=start_date,
             end_date=end_date,
+            severity=severity,
         )
         buckets: dict[tuple[str, str], _TraitBucket] = {}
 
@@ -64,6 +66,7 @@ class ExplanationTraitPerformanceService:
                 "scanner_type": scanner_type,
                 "start_date": start_date.isoformat() if start_date else None,
                 "end_date": end_date.isoformat() if end_date else None,
+                "severity": severity,
                 "min_sample_size": min_sample_size,
             },
             "traits": traits,
@@ -76,6 +79,7 @@ class ExplanationTraitPerformanceService:
         scanner_type: str | None,
         start_date: date | None,
         end_date: date | None,
+        severity: str | None,
     ) -> list[tuple[ScannerEvent, ScannerOutcomeSummary]]:
         query = (
             db.query(ScannerEvent, ScannerOutcomeSummary)
@@ -91,6 +95,8 @@ class ExplanationTraitPerformanceService:
             query = query.filter(ScannerEvent.event_date >= start_date)
         if end_date:
             query = query.filter(ScannerEvent.event_date <= end_date)
+        if severity:
+            query = query.filter(ScannerEvent.severity == severity)
         return query.order_by(ScannerEvent.event_date.asc(), ScannerEvent.id.asc()).all()
 
 

--- a/backend/tests/api/test_outcomes.py
+++ b/backend/tests/api/test_outcomes.py
@@ -3,11 +3,19 @@ Integration tests for outcomes API endpoints.
 Runs against a real Postgres DB (via testcontainers).
 """
 
+from datetime import date
+from decimal import Decimal
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.main import app
+from app.models.scanner_event import ScannerEvent
+from app.models.scanner_outcome_summary import ScannerOutcomeSummary
+from app.models.signal_analysis_run import SignalAnalysisRun
+from app.models.signal_cluster import SignalCluster
+from app.utils.time import utc_now
 from tests.fixtures.outcomes import (
     seed_outcomes,
     seed_outcomes_with_gate_tiers,
@@ -15,6 +23,65 @@ from tests.fixtures.outcomes import (
 )
 
 client = TestClient(app)
+
+
+def _trait_explanation(label: str = "Volume Spike") -> dict:
+    return {
+        "schema_version": "scanner_explanation.v1",
+        "why": ["Synthetic API explanation."],
+        "criteria_passed": {
+            "premarket.volume_spike": {
+                "label": label,
+                "observed": True,
+                "threshold": True,
+                "operator": "==",
+                "importance": 0.8,
+            }
+        },
+        "criteria_failed": {},
+        "confidence_inputs": {"signal_quality_score": 0.91},
+        "data_quality_warnings": [],
+        "evidence": {"reconstructed": False},
+    }
+
+
+def _seed_explained_outcome(
+    db: Session,
+    *,
+    ticker: str,
+    scanner_type: str = "pre_market_volume_spike",
+    severity: str = "medium",
+    eod_pct_change: str = "2.00",
+) -> ScannerEvent:
+    event = ScannerEvent(
+        ticker=ticker,
+        event_date=date(2026, 7, 3),
+        scanner_type=scanner_type,
+        summary=f"{ticker} signal",
+        severity=severity,
+        indicators={},
+        criteria_met={},
+        metadata_={},
+        explanation=_trait_explanation(),
+    )
+    db.add(event)
+    db.flush()
+    db.add(
+        ScannerOutcomeSummary(
+            scanner_event_id=event.id,
+            reference_price=Decimal("10.00"),
+            mfe_pct=Decimal("4.00"),
+            mae_pct=Decimal("1.00"),
+            mfe_mae_ratio=Decimal("4.0000"),
+            r_multiple=Decimal("2.0000"),
+            eod_pct_change=Decimal(eod_pct_change),
+            follow_through=True,
+            gap_filled=False,
+            is_complete=True,
+        )
+    )
+    db.flush()
+    return event
 
 
 # ---------------------------------------------------------------------------
@@ -89,6 +156,88 @@ def test_scorecard_follow_through_rate(db: Session):
 
     data = response.json()
     assert data["follow_through_rate_pct"] == pytest.approx(66.67, abs=0.1)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/outcomes/traits/{scanner_type}
+# ---------------------------------------------------------------------------
+
+
+def test_explanation_traits_endpoint_filters_by_severity(db: Session):
+    expected = _seed_explained_outcome(db, ticker="HIGH", severity="high")
+    _seed_explained_outcome(db, ticker="MEDM", severity="medium")
+
+    response = client.get(
+        "/api/v1/outcomes/traits/pre_market_volume_spike"
+        "?severity=high&min_sample_size=1"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["event_count"] == 1
+    assert data["filters"]["severity"] == "high"
+    trait = next(
+        item
+        for item in data["traits"]
+        if item["trait_key"] == "premarket.volume_spike"
+    )
+    assert trait["trait_key"] == "premarket.volume_spike"
+    assert trait["trait_label"] == "Volume Spike"
+    assert trait["event_ids"] == [expected.id]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/outcomes/archetypes/{scanner_type}
+# ---------------------------------------------------------------------------
+
+
+def test_explanation_archetypes_endpoint_returns_latest_completed_run(db: Session):
+    old_run = SignalAnalysisRun(
+        scanner_type="pre_market_volume_spike",
+        status="completed",
+        event_count=1,
+        completed_at=utc_now(),
+    )
+    db.add(old_run)
+    db.flush()
+    latest_run = SignalAnalysisRun(
+        scanner_type="pre_market_volume_spike",
+        status="completed",
+        event_count=8,
+        completed_at=utc_now(),
+    )
+    db.add(latest_run)
+    db.flush()
+    cluster = SignalCluster(
+        analysis_run_id=latest_run.id,
+        cluster_index=0,
+        label="Volume Spike / Positive Outcomes",
+        centroid={"premarket.volume_spike": 1.0},
+        return_profile={"win_rate_pct": 75.0, "avg_mfe_pct": 5.5},
+        event_count=8,
+    )
+    db.add(cluster)
+    db.flush()
+    matched = _seed_explained_outcome(db, ticker="ARCH", severity="high")
+    filtered_out = _seed_explained_outcome(db, ticker="ARCM", severity="medium")
+    matched.signal_cluster_id = cluster.id
+    filtered_out.signal_cluster_id = cluster.id
+    db.flush()
+
+    response = client.get(
+        "/api/v1/outcomes/archetypes/pre_market_volume_spike"
+        "?severity=high&min_sample_size=1"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["analysis_run_id"] == latest_run.id
+    assert data["event_count"] == 1
+    assert data["filters"]["severity"] == "high"
+    assert data["warnings"] == []
+    assert data["archetypes"][0]["label"] == "Volume Spike / Positive Outcomes"
+    assert data["archetypes"][0]["sample_size"] == 1
+    assert data["archetypes"][0]["event_ids"] == [matched.id]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_explanation_trait_performance.py
+++ b/backend/tests/services/test_explanation_trait_performance.py
@@ -225,6 +225,7 @@ def test_aggregate_trait_performance_filters_by_scanner_type_and_date_range(db):
         "scanner_type": "pre_market_volume_spike",
         "start_date": "2026-07-01",
         "end_date": "2026-07-03",
+        "severity": None,
         "min_sample_size": 5,
     }
     assert passed["sample_size"] == 1

--- a/frontend/src/api/outcomes.ts
+++ b/frontend/src/api/outcomes.ts
@@ -145,6 +145,70 @@ export interface SignalListResponse {
   offset: number;
 }
 
+export interface ExplanationWarning {
+  code: string;
+  message: string;
+}
+
+export interface ExplanationTrait {
+  trait_type: string;
+  trait_key: string;
+  trait_label: string;
+  sample_size: number;
+  event_ids: number[];
+  win_rate_pct: number | null;
+  follow_through_rate_pct: number | null;
+  avg_mfe_pct: number | null;
+  avg_mae_pct: number | null;
+  win_rate_ci_95_pct: { lower: number | null; upper: number | null };
+  warnings: ExplanationWarning[];
+}
+
+export interface ExplanationTraitPerformance {
+  event_count: number;
+  filters: {
+    scanner_type: string | null;
+    start_date: string | null;
+    end_date: string | null;
+    severity: string | null;
+    min_sample_size: number;
+  };
+  traits: ExplanationTrait[];
+}
+
+export interface ExplanationArchetype {
+  cluster_id: number;
+  cluster_index: number;
+  label: string;
+  sample_size: number;
+  event_ids: number[];
+  centroid: Record<string, unknown>;
+  return_profile: {
+    sample_size?: number;
+    win_rate_pct?: number | null;
+    follow_through_rate_pct?: number | null;
+    avg_mfe_pct?: number | null;
+    avg_mae_pct?: number | null;
+    avg_eod_pct_change?: number | null;
+  };
+  warnings: ExplanationWarning[];
+}
+
+export interface ExplanationArchetypeResponse {
+  analysis_run_id: number | null;
+  scanner_type: string;
+  event_count: number;
+  filters: {
+    scanner_type: string;
+    start_date: string | null;
+    end_date: string | null;
+    severity: string | null;
+    min_sample_size: number;
+  };
+  warnings: ExplanationWarning[];
+  archetypes: ExplanationArchetype[];
+}
+
 // ---- API Functions -------------------------------------------------------- //
 
 export const fetchScorecard = async (params: {
@@ -218,6 +282,38 @@ export const fetchSignals = async (params: {
 }): Promise<SignalListResponse> => {
   const { scanner_type, ...rest } = params;
   const response = await apiClient.get(`/outcomes/signals/${scanner_type}`, { params: rest });
+  return response.data;
+};
+
+export const fetchExplanationTraits = async (params: {
+  scanner_type: string;
+  start_date?: string;
+  end_date?: string;
+  severity?: string;
+}): Promise<ExplanationTraitPerformance> => {
+  const response = await apiClient.get(`/outcomes/traits/${params.scanner_type}`, {
+    params: {
+      start_date: params.start_date,
+      end_date: params.end_date,
+      severity: params.severity,
+    },
+  });
+  return response.data;
+};
+
+export const fetchExplanationArchetypes = async (params: {
+  scanner_type: string;
+  start_date?: string;
+  end_date?: string;
+  severity?: string;
+}): Promise<ExplanationArchetypeResponse> => {
+  const response = await apiClient.get(`/outcomes/archetypes/${params.scanner_type}`, {
+    params: {
+      start_date: params.start_date,
+      end_date: params.end_date,
+      severity: params.severity,
+    },
+  });
   return response.data;
 };
 

--- a/frontend/src/hooks/useScorecard.ts
+++ b/frontend/src/hooks/useScorecard.ts
@@ -6,12 +6,16 @@ import {
   fetchIntervals,
   fetchDistribution,
   fetchSignals,
+  fetchExplanationTraits,
+  fetchExplanationArchetypes,
   triggerBackfill,
   Scorecard,
   EdgeDecayPoint,
   IntervalBreakdown,
   DistributionPoint,
   SignalListResponse,
+  ExplanationTraitPerformance,
+  ExplanationArchetypeResponse,
   BackfillRequest,
   BackfillResponse,
 } from '../api/outcomes';
@@ -79,6 +83,28 @@ export const useSignals = (
   return useQuery<SignalListResponse>({
     queryKey: ['signals', scannerType, params],
     queryFn: () => fetchSignals({ scanner_type: scannerType!, ...params }),
+    enabled: !!scannerType,
+  });
+};
+
+export const useExplanationTraits = (
+  scannerType: string | undefined,
+  params?: { start_date?: string; end_date?: string; severity?: string },
+) => {
+  return useQuery<ExplanationTraitPerformance>({
+    queryKey: ['explanationTraits', scannerType, params],
+    queryFn: () => fetchExplanationTraits({ scanner_type: scannerType!, ...params }),
+    enabled: !!scannerType,
+  });
+};
+
+export const useExplanationArchetypes = (
+  scannerType: string | undefined,
+  params?: { start_date?: string; end_date?: string; severity?: string },
+) => {
+  return useQuery<ExplanationArchetypeResponse>({
+    queryKey: ['explanationArchetypes', scannerType, params],
+    queryFn: () => fetchExplanationArchetypes({ scanner_type: scannerType!, ...params }),
     enabled: !!scannerType,
   });
 };

--- a/frontend/src/pages/ScorecardDetail.test.tsx
+++ b/frontend/src/pages/ScorecardDetail.test.tsx
@@ -10,6 +10,8 @@ const mockUseIntervals = vi.fn();
 const mockUseDistribution = vi.fn();
 const mockUseBackfillMutation = vi.fn();
 const mockUseSignals = vi.fn();
+const mockUseExplanationTraits = vi.fn();
+const mockUseExplanationArchetypes = vi.fn();
 
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router-dom')>();
@@ -24,6 +26,8 @@ vi.mock('../hooks/useScorecard', () => ({
   useEdgeDecay: (...args: unknown[]) => mockUseEdgeDecay(...args),
   useIntervals: (...args: unknown[]) => mockUseIntervals(...args),
   useDistribution: (...args: unknown[]) => mockUseDistribution(...args),
+  useExplanationTraits: (...args: unknown[]) => mockUseExplanationTraits(...args),
+  useExplanationArchetypes: (...args: unknown[]) => mockUseExplanationArchetypes(...args),
   useBackfillMutation: () => mockUseBackfillMutation(),
   useSignals: (...args: unknown[]) => mockUseSignals(...args),
 }));
@@ -49,11 +53,31 @@ const makeScorecard = (overrides: Partial<Scorecard> = {}): Scorecard => ({
   ...overrides,
 });
 
+const explanationFilters = {
+  scanner_type: 'pre_market_volume_spike',
+  start_date: null,
+  end_date: null,
+  severity: null,
+  min_sample_size: 5,
+};
+
 const noDataDefaults = () => {
   mockUseScorecard.mockReturnValue({ data: null, isLoading: false, isError: false });
   mockUseEdgeDecay.mockReturnValue({ data: [], isLoading: false });
   mockUseIntervals.mockReturnValue({ data: {}, isLoading: false });
   mockUseDistribution.mockReturnValue({ data: [], isLoading: false });
+  mockUseExplanationTraits.mockReturnValue({ data: { event_count: 0, traits: [] }, isLoading: false });
+  mockUseExplanationArchetypes.mockReturnValue({
+    data: {
+      analysis_run_id: null,
+      scanner_type: 'pre_market_volume_spike',
+      event_count: 0,
+      filters: explanationFilters,
+      archetypes: [],
+      warnings: [],
+    },
+    isLoading: false,
+  });
   mockUseBackfillMutation.mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
@@ -141,5 +165,117 @@ describe('ScorecardDetail — derived values', () => {
   it('renders scanner type as uppercased heading', () => {
     renderWithQuery(<ScorecardDetail />);
     expect(screen.getByRole('heading', { name: 'PRE MARKET VOLUME SPIKE' })).toBeInTheDocument();
+  });
+});
+
+describe('ScorecardDetail — explanation intelligence', () => {
+  beforeEach(noDataDefaults);
+
+  it('shows explanation panel loading states', () => {
+    mockUseExplanationTraits.mockReturnValue({ data: null, isLoading: true });
+    mockUseExplanationArchetypes.mockReturnValue({ data: null, isLoading: true });
+    renderWithQuery(<ScorecardDetail />);
+    expect(screen.getByText(/Explanation Traits/i)).toBeInTheDocument();
+    expect(screen.getByText(/Archetypes/i)).toBeInTheDocument();
+  });
+
+  it('shows empty states when explanation intelligence has no rows', () => {
+    renderWithQuery(<ScorecardDetail />);
+    expect(screen.getByText(/No explanation trait performance yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/No explanation archetypes yet/i)).toBeInTheDocument();
+  });
+
+  it('shows low-sample warnings from trait performance', () => {
+    mockUseExplanationTraits.mockReturnValue({
+      isLoading: false,
+      data: {
+        event_count: 1,
+        traits: [
+          {
+            trait_type: 'criterion_passed',
+            trait_key: 'premarket.volume_spike',
+            trait_label: 'Volume Spike',
+            sample_size: 1,
+            event_ids: [1],
+            win_rate_pct: 100,
+            follow_through_rate_pct: 100,
+            avg_mfe_pct: 4,
+            avg_mae_pct: 1,
+            win_rate_ci_95_pct: { lower: 20, upper: 100 },
+            warnings: [{ code: 'weak_sample_size', message: 'Only 1 events matched this trait.' }],
+          },
+        ],
+      },
+    });
+    renderWithQuery(<ScorecardDetail />);
+    expect(screen.getByText(/Low sample/i)).toBeInTheDocument();
+    expect(screen.getByText(/Only 1 events matched this trait/i)).toBeInTheDocument();
+  });
+
+  it('renders populated trait and archetype performance', () => {
+    mockUseExplanationTraits.mockReturnValue({
+      isLoading: false,
+      data: {
+        event_count: 12,
+        traits: [
+          {
+            trait_type: 'criterion_passed',
+            trait_key: 'premarket.volume_spike',
+            trait_label: 'Volume Spike',
+            sample_size: 8,
+            event_ids: [1, 2],
+            win_rate_pct: 75,
+            follow_through_rate_pct: 70,
+            avg_mfe_pct: 5.5,
+            avg_mae_pct: 1.1,
+            win_rate_ci_95_pct: { lower: 40, upper: 90 },
+            warnings: [],
+          },
+          {
+            trait_type: 'warning',
+            trait_key: 'missing_float',
+            trait_label: 'Missing Float',
+            sample_size: 4,
+            event_ids: [3, 4],
+            win_rate_pct: 25,
+            follow_through_rate_pct: 25,
+            avg_mfe_pct: 1.5,
+            avg_mae_pct: 3.2,
+            win_rate_ci_95_pct: { lower: 5, upper: 55 },
+            warnings: [],
+          },
+        ],
+      },
+    });
+    mockUseExplanationArchetypes.mockReturnValue({
+      isLoading: false,
+      data: {
+        analysis_run_id: 1,
+        scanner_type: 'pre_market_volume_spike',
+        event_count: 12,
+        filters: explanationFilters,
+        warnings: [],
+        archetypes: [
+          {
+            cluster_id: 10,
+            cluster_index: 0,
+            label: 'Volume Spike / Positive Outcomes',
+            sample_size: 8,
+            event_ids: [1, 2],
+            centroid: {},
+            return_profile: { win_rate_pct: 75, avg_mfe_pct: 5.5 },
+            warnings: [],
+          },
+        ],
+      },
+    });
+
+    renderWithQuery(<ScorecardDetail />);
+
+    expect(screen.getByText(/Top Positive Traits/i)).toBeInTheDocument();
+    expect(screen.getByText(/Top Negative Traits/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/^Volume Spike$/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/^Missing Float$/i)).toBeInTheDocument();
+    expect(screen.getByText(/Volume Spike \/ Positive Outcomes/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ScorecardDetail.tsx
+++ b/frontend/src/pages/ScorecardDetail.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { ArrowLeft } from 'lucide-react';
-import { useScorecard, useEdgeDecay, useIntervals, useDistribution } from '../hooks/useScorecard';
+import { ArrowLeft, AlertTriangle } from 'lucide-react';
+import { useScorecard, useEdgeDecay, useIntervals, useDistribution, useExplanationTraits, useExplanationArchetypes } from '../hooks/useScorecard';
+import type { ExplanationArchetype, ExplanationTrait } from '../api/outcomes';
 import HeroMetrics from '../components/scorecard/HeroMetrics';
 import EdgeDecayChart from '../components/scorecard/EdgeDecayChart';
 import DistributionChart from '../components/scorecard/DistributionChart';
@@ -32,6 +33,16 @@ const PERIODS: { label: string; value: Period }[] = [
 
 const SEVERITIES = ['All Severities', 'high', 'medium', 'low'] as const;
 
+const fmtPct = (value: number | null | undefined): string => (
+  value === null || value === undefined ? '—' : `${value.toFixed(1)}%`
+);
+
+const traitOutcomeScore = (trait: ExplanationTrait): number => (
+  (trait.win_rate_pct ?? 0) + (trait.avg_mfe_pct ?? 0) - Math.abs(trait.avg_mae_pct ?? 0)
+);
+
+const compactTraitType = (type: string): string => type.replace(/_/g, ' ');
+
 const ScorecardDetail: React.FC = () => {
   const { scannerType } = useParams<{ scannerType: string }>();
   const [period, setPeriod] = useState<Period>('30d');
@@ -47,8 +58,21 @@ const ScorecardDetail: React.FC = () => {
   const { data: edgeDecay, isLoading: loadingEdge } = useEdgeDecay(scannerType, dates);
   const { data: intervals, isLoading: loadingIntervals } = useIntervals(scannerType);
   const { data: distribution, isLoading: loadingDist } = useDistribution(scannerType);
+  const { data: traits, isLoading: loadingTraits } = useExplanationTraits(scannerType, scorecardParams);
+  const { data: archetypes, isLoading: loadingArchetypes } = useExplanationArchetypes(scannerType, scorecardParams);
 
   const displayName = scannerType?.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()) ?? '';
+  const rankedTraits = traits?.traits ?? [];
+  const positiveTraits = rankedTraits
+    .filter((trait) => (trait.win_rate_pct ?? 0) >= 50)
+    .sort((a, b) => traitOutcomeScore(b) - traitOutcomeScore(a))
+    .slice(0, 4);
+  const negativeTraits = rankedTraits
+    .filter((trait) => (trait.win_rate_pct ?? 0) < 50)
+    .sort((a, b) => traitOutcomeScore(a) - traitOutcomeScore(b))
+    .slice(0, 4);
+  const hasTraitData = rankedTraits.length > 0;
+  const archetypeRows = archetypes?.archetypes ?? [];
 
   return (
     <div className="space-y-6 animate-fade-in">
@@ -120,6 +144,68 @@ const ScorecardDetail: React.FC = () => {
       {/* Hero Metrics */}
       {scorecard && <HeroMetrics scorecard={scorecard} />}
 
+      {/* Explanation Intelligence */}
+      <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        <section className="xl:col-span-2 bg-financial-gray rounded-lg border border-gray-700 p-5">
+          <div className="flex items-center justify-between gap-3 mb-4">
+            <div>
+              <h2 className="text-sm font-bold text-financial-light uppercase tracking-wider">Explanation Traits</h2>
+              <p className="text-xs text-gray-500 mt-1">{traits?.event_count ?? 0} complete signals in scope</p>
+            </div>
+            {rankedTraits.some((trait) => trait.warnings.length > 0) && (
+              <div className="flex items-center gap-1 text-amber-300 text-xs font-semibold">
+                <AlertTriangle className="h-4 w-4" />
+                Low sample
+              </div>
+            )}
+          </div>
+
+          {loadingTraits && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {[1, 2, 3, 4].map((i) => (
+                <div key={i} className="h-16 bg-gray-800 rounded animate-pulse" />
+              ))}
+            </div>
+          )}
+
+          {!loadingTraits && !hasTraitData && (
+            <div className="border border-dashed border-gray-700 rounded-lg p-5 text-sm text-gray-400">
+              No explanation trait performance yet.
+            </div>
+          )}
+
+          {!loadingTraits && hasTraitData && (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+              <TraitList title="Top Positive Traits" traits={positiveTraits} />
+              <TraitList title="Top Negative Traits" traits={negativeTraits} />
+            </div>
+          )}
+        </section>
+
+        <section className="bg-financial-gray rounded-lg border border-gray-700 p-5">
+          <div className="mb-4">
+            <h2 className="text-sm font-bold text-financial-light uppercase tracking-wider">Archetypes</h2>
+            <p className="text-xs text-gray-500 mt-1">{archetypes?.event_count ?? 0} assigned signals</p>
+          </div>
+
+          {loadingArchetypes && <div className="h-24 bg-gray-800 rounded animate-pulse" />}
+
+          {!loadingArchetypes && archetypeRows.length === 0 && (
+            <div className="border border-dashed border-gray-700 rounded-lg p-5 text-sm text-gray-400">
+              No explanation archetypes yet.
+            </div>
+          )}
+
+          {!loadingArchetypes && archetypeRows.length > 0 && (
+            <div className="space-y-3">
+              {archetypeRows.slice(0, 4).map((archetype) => (
+                <ArchetypeRow key={archetype.cluster_id} archetype={archetype} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+
       {/* No data state */}
       {!loadingScorecard && !scorecardError && !scorecard && (
         <div className="flex flex-col items-center justify-center h-48 bg-gray-900/50 rounded-2xl border-2 border-dashed border-gray-800">
@@ -152,5 +238,58 @@ const ScorecardDetail: React.FC = () => {
     </div>
   );
 };
+
+const TraitList: React.FC<{ title: string; traits: ExplanationTrait[] }> = ({ title, traits }) => (
+  <div>
+    <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-3">{title}</h3>
+    <div className="space-y-2">
+      {traits.length === 0 && (
+        <div className="border border-dashed border-gray-800 rounded-lg p-3 text-sm text-gray-500">
+          No traits in this group.
+        </div>
+      )}
+      {traits.map((trait) => (
+        <div key={`${title}-${trait.trait_type}-${trait.trait_key}`} className="border border-gray-800 rounded-lg p-3">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <div className="text-sm font-semibold text-financial-light">{trait.trait_label}</div>
+              <div className="text-xs text-gray-500 capitalize">{compactTraitType(trait.trait_type)} • n={trait.sample_size}</div>
+            </div>
+            <div className="text-right">
+              <div className="text-sm font-bold text-financial-light">{fmtPct(trait.win_rate_pct)}</div>
+              <div className="text-xs text-gray-500">MFE {fmtPct(trait.avg_mfe_pct)}</div>
+            </div>
+          </div>
+          {trait.warnings.length > 0 && (
+            <div className="mt-2 text-xs text-amber-300">{trait.warnings[0].message}</div>
+          )}
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+const ArchetypeRow: React.FC<{ archetype: ExplanationArchetype }> = ({ archetype }) => (
+  <div className="border border-gray-800 rounded-lg p-3">
+    <div className="text-sm font-semibold text-financial-light">{archetype.label}</div>
+    <div className="mt-2 grid grid-cols-3 gap-2 text-xs">
+      <div>
+        <div className="text-gray-500">Sample</div>
+        <div className="text-financial-light font-semibold">{archetype.sample_size}</div>
+      </div>
+      <div>
+        <div className="text-gray-500">Win</div>
+        <div className="text-financial-light font-semibold">{fmtPct(archetype.return_profile.win_rate_pct)}</div>
+      </div>
+      <div>
+        <div className="text-gray-500">MFE</div>
+        <div className="text-financial-light font-semibold">{fmtPct(archetype.return_profile.avg_mfe_pct)}</div>
+      </div>
+    </div>
+    {archetype.warnings.length > 0 && (
+      <div className="mt-2 text-xs text-amber-300">{archetype.warnings[0].message}</div>
+    )}
+  </div>
+);
 
 export default ScorecardDetail;


### PR DESCRIPTION
## Summary
- add filtered explanation trait and archetype performance endpoints for Scorecard
- wire Scorecard detail to show top positive/negative traits, archetype sample sizes, and low-sample warnings
- add backend API/service coverage and frontend loading/empty/low-sample/populated tests

Fixes #468

## Verification
- python -m ruff check backend
- $env:PYTEST_ADDOPTS='--no-cov'; python -m pytest backend/tests/api/test_outcomes.py backend/tests/services/test_explanation_trait_performance.py backend/tests/services/test_explanation_archetype_service.py -q
- npm test -- ScorecardDetail.test.tsx
- npx tsc --noEmit
- npm run build
- npx eslint . --report-unused-disable-directives-severity error
- npm audit --audit-level=high

Note: full frontend npm test still has unrelated existing failures in Dashboard matchMedia setup and AlertBadge partial label queries; CI does not run that target.