### PR TITLE
Add EdgeExplorer explanation analysis

### DIFF
--- a/frontend/src/pages/EdgeExplorer.test.tsx
+++ b/frontend/src/pages/EdgeExplorer.test.tsx
@@ -1,0 +1,220 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithQuery } from '../test-utils/renderWithQuery';
+import EdgeExplorer from './EdgeExplorer';
+
+const mocks = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+  fetchScannerConfigs: vi.fn(),
+  getSignalQualityDistribution: vi.fn(),
+  fetchCorrelations: vi.fn(),
+  triggerAnalysis: vi.fn(),
+  fetchExplanationTraits: vi.fn(),
+  fetchExplanationArchetypes: vi.fn(),
+  fetchEdgeDecay: vi.fn(),
+}));
+
+vi.mock('../api/client', () => ({
+  apiClient: { get: mocks.apiGet },
+}));
+
+vi.mock('../api/scanner', () => ({
+  fetchScannerConfigs: (...args: unknown[]) => mocks.fetchScannerConfigs(...args),
+  getSignalQualityDistribution: (...args: unknown[]) => mocks.getSignalQualityDistribution(...args),
+}));
+
+vi.mock('../api/analysis', () => ({
+  fetchCorrelations: (...args: unknown[]) => mocks.fetchCorrelations(...args),
+  triggerAnalysis: (...args: unknown[]) => mocks.triggerAnalysis(...args),
+}));
+
+vi.mock('../api/outcomes', () => ({
+  fetchExplanationTraits: (...args: unknown[]) => mocks.fetchExplanationTraits(...args),
+  fetchExplanationArchetypes: (...args: unknown[]) => mocks.fetchExplanationArchetypes(...args),
+  fetchEdgeDecay: (...args: unknown[]) => mocks.fetchEdgeDecay(...args),
+}));
+
+vi.mock('recharts', () => {
+  const passthrough = ({ children }: { children?: React.ReactNode }) => <div>{children}</div>;
+  const noop = () => null;
+  return {
+    ResponsiveContainer: passthrough,
+    ScatterChart: passthrough,
+    Scatter: passthrough,
+    AreaChart: passthrough,
+    Area: noop,
+    ComposedChart: passthrough,
+    Bar: noop,
+    Line: noop,
+    XAxis: noop,
+    YAxis: noop,
+    CartesianGrid: noop,
+    Tooltip: noop,
+    ZAxis: noop,
+    Cell: noop,
+    Legend: noop,
+  };
+});
+
+const scannerConfig = {
+  scanner_type: 'pre_market_volume_spike',
+  name: 'Pre Market Volume Spike',
+};
+
+const traitResponse = {
+  event_count: 12,
+  filters: {
+    scanner_type: 'pre_market_volume_spike',
+    start_date: null,
+    end_date: null,
+    severity: null,
+    min_sample_size: 5,
+  },
+  traits: [
+    {
+      trait_type: 'criterion_passed',
+      trait_key: 'premarket.volume_spike',
+      trait_label: 'Volume Spike',
+      sample_size: 8,
+      event_ids: [1, 2],
+      win_rate_pct: 75,
+      follow_through_rate_pct: 70,
+      avg_mfe_pct: 5.5,
+      avg_mae_pct: 1.1,
+      win_rate_ci_95_pct: { lower: 40, upper: 90 },
+      warnings: [],
+    },
+    {
+      trait_type: 'warning',
+      trait_key: 'missing_float',
+      trait_label: 'Missing Float',
+      sample_size: 1,
+      event_ids: [3],
+      win_rate_pct: 0,
+      follow_through_rate_pct: 0,
+      avg_mfe_pct: 0.7,
+      avg_mae_pct: 3.2,
+      win_rate_ci_95_pct: { lower: 0, upper: 80 },
+      warnings: [{ code: 'weak_sample_size', message: 'Only 1 events matched this trait.' }],
+    },
+    {
+      trait_type: 'confidence_input',
+      trait_key: 'signal_quality_score:high',
+      trait_label: 'signal_quality_score = high',
+      sample_size: 6,
+      event_ids: [4, 5],
+      win_rate_pct: 66.67,
+      follow_through_rate_pct: 60,
+      avg_mfe_pct: 4.2,
+      avg_mae_pct: 1.5,
+      win_rate_ci_95_pct: { lower: 25, upper: 90 },
+      warnings: [],
+    },
+  ],
+};
+
+const archetypeResponse = {
+  analysis_run_id: 10,
+  scanner_type: 'pre_market_volume_spike',
+  event_count: 12,
+  filters: traitResponse.filters,
+  warnings: [],
+  archetypes: [
+    {
+      cluster_id: 100,
+      cluster_index: 0,
+      label: 'Volume Spike / Positive Outcomes',
+      sample_size: 8,
+      event_ids: [1, 2],
+      centroid: {},
+      return_profile: { sample_size: 8, win_rate_pct: 75, avg_mfe_pct: 5.5 },
+      warnings: [],
+    },
+    {
+      cluster_id: 101,
+      cluster_index: 1,
+      label: 'Missing Float / Weak Outcomes',
+      sample_size: 1,
+      event_ids: [3],
+      centroid: {},
+      return_profile: { sample_size: 1, win_rate_pct: 0, avg_mfe_pct: 0.7 },
+      warnings: [{ code: 'weak_archetype_sample', message: 'Only 1 events matched this archetype.' }],
+    },
+  ],
+};
+
+const edgeDecay = [
+  { period: '2026-W27', win_rate: 75, avg_mfe: 5.5, avg_mae: 1.1, sample_size: 8 },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.fetchScannerConfigs.mockResolvedValue([scannerConfig]);
+  mocks.getSignalQualityDistribution.mockResolvedValue({ deciles: [], signal_ranker_version: 'test' });
+  mocks.fetchCorrelations.mockResolvedValue(null);
+  mocks.triggerAnalysis.mockResolvedValue({ task_id: 'task-1' });
+  mocks.fetchExplanationTraits.mockResolvedValue(traitResponse);
+  mocks.fetchExplanationArchetypes.mockResolvedValue(archetypeResponse);
+  mocks.fetchEdgeDecay.mockResolvedValue(edgeDecay);
+  mocks.apiGet.mockImplementation((url: string) => {
+    if (url.startsWith('/scanner/edge-stats')) {
+      return Promise.resolve({
+        data: [{ label: 'Jul 2026', event_count: 2, avg_gap_pct: 4, avg_fade_pct: -1, avg_day_range_pct: 6, avg_rel_vol: 3 }],
+      });
+    }
+    if (url.startsWith('/scanner/edge-distribution')) {
+      return Promise.resolve({ data: { events: [] } });
+    }
+    return Promise.resolve({ data: [] });
+  });
+});
+
+describe('EdgeExplorer explanation intelligence', () => {
+  it('prompts for a strategy before loading explanation filters', async () => {
+    renderWithQuery(<EdgeExplorer />);
+
+    expect(await screen.findByText(/Select a strategy to research edge/i)).toBeInTheDocument();
+    expect(mocks.fetchExplanationTraits).not.toHaveBeenCalled();
+    expect(mocks.fetchExplanationArchetypes).not.toHaveBeenCalled();
+  });
+
+  it('renders trait, warning, confidence, archetype, and edge decay analysis', async () => {
+    renderWithQuery(<EdgeExplorer />);
+
+    await screen.findByRole('option', { name: /Pre Market Volume Spike/i });
+    fireEvent.change(screen.getByLabelText(/Strategy filter/i), {
+      target: { value: 'pre_market_volume_spike' },
+    });
+
+    expect(await screen.findByText(/^Volume Spike$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Missing Float$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^signal_quality_score = high$/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Volume Spike \/ Positive Outcomes/i).length).toBeGreaterThan(1);
+    expect(screen.getByText(/Only 1 events matched this trait/i)).toBeInTheDocument();
+    expect(screen.getByText(/Only 1 events matched this archetype/i)).toBeInTheDocument();
+    expect(screen.getByText(/Scanner Edge Decay/i)).toBeInTheDocument();
+    expect(mocks.fetchEdgeDecay).toHaveBeenCalledWith('pre_market_volume_spike', { period: 'monthly' });
+  });
+
+  it('filters visible performance rows by selected trait and archetype', async () => {
+    renderWithQuery(<EdgeExplorer />);
+
+    await screen.findByRole('option', { name: /Pre Market Volume Spike/i });
+    fireEvent.change(screen.getByLabelText(/Strategy filter/i), {
+      target: { value: 'pre_market_volume_spike' },
+    });
+    await screen.findByText(/^Volume Spike$/i);
+
+    fireEvent.change(screen.getByLabelText(/Explanation trait filter/i), {
+      target: { value: 'warning:missing_float' },
+    });
+    fireEvent.change(screen.getByLabelText(/Signal archetype filter/i), {
+      target: { value: '101' },
+    });
+
+    expect(screen.getByText(/^Missing Float$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Volume Spike$/i)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/Missing Float \/ Weak Outcomes/i).length).toBeGreaterThan(1);
+    expect(screen.getAllByText(/Volume Spike \/ Positive Outcomes/i)).toHaveLength(1);
+  });
+});

--- a/frontend/src/pages/EdgeExplorer.tsx
+++ b/frontend/src/pages/EdgeExplorer.tsx
@@ -6,7 +6,8 @@ import {
   Calendar,
   Layers,
   Search,
-  Target
+  Target,
+  AlertTriangle,
 } from 'lucide-react';
 
 // Per spec Req 7: library cast, does not count against @ts-expect-error budget.
@@ -41,11 +42,47 @@ import type { EdgeDistributionEvent, EdgeStatEntry } from '../api/scanner';
 import { apiClient } from '../api/client';
 import CorrelationHeatmap from '../components/CorrelationHeatmap';
 import { fetchCorrelations, triggerAnalysis } from '../api/analysis';
+import {
+  fetchEdgeDecay,
+  fetchExplanationArchetypes,
+  fetchExplanationTraits,
+} from '../api/outcomes';
+import type {
+  EdgeDecayPoint,
+  ExplanationArchetype,
+  ExplanationTrait,
+} from '../api/outcomes';
+
+const fmtPct = (value: number | null | undefined): string => (
+  value === null || value === undefined ? 'N/A' : `${value.toFixed(1)}%`
+);
+
+const traitValue = (trait: ExplanationTrait): string => `${trait.trait_type}:${trait.trait_key}`;
+
+const traitTypeLabel = (type: string): string => {
+  const labels: Record<string, string> = {
+    criterion_passed: 'Criterion',
+    criterion_failed: 'Failed Criterion',
+    warning: 'Warning',
+    confidence_input: 'Confidence',
+  };
+  return labels[type] ?? type.replace(/_/g, ' ');
+};
+
+const traitOptionLabel = (trait: ExplanationTrait): string => (
+  `${traitTypeLabel(trait.trait_type)}: ${trait.trait_label}`
+);
+
+const traitChartLabel = (trait: ExplanationTrait): string => (
+  trait.trait_label.length > 22 ? `${trait.trait_label.slice(0, 19)}...` : trait.trait_label
+);
 
 const EdgeExplorer: React.FC = () => {
   const [period, setPeriod] = useState<'weekly' | 'monthly' | 'quarterly'>('monthly');
   const [ticker, setTicker] = useState<string>('');
   const [scannerType, setScannerType] = useState<string>('');
+  const [traitFilter, setTraitFilter] = useState<string>('');
+  const [archetypeFilter, setArchetypeFilter] = useState<string>('');
 
   // Fetch scanner configurations for the dropdown
   const { data: configs } = useQuery({
@@ -85,6 +122,24 @@ const EdgeExplorer: React.FC = () => {
     retry: false,
   });
 
+  const { data: explanationTraits, isLoading: loadingTraits } = useQuery({
+    queryKey: ['edgeExplanationTraits', scannerType],
+    queryFn: () => fetchExplanationTraits({ scanner_type: scannerType }),
+    enabled: !!scannerType,
+  });
+
+  const { data: explanationArchetypes, isLoading: loadingArchetypes } = useQuery({
+    queryKey: ['edgeExplanationArchetypes', scannerType],
+    queryFn: () => fetchExplanationArchetypes({ scanner_type: scannerType }),
+    enabled: !!scannerType,
+  });
+
+  const { data: edgeDecay, isLoading: loadingEdgeDecay } = useQuery<EdgeDecayPoint[]>({
+    queryKey: ['edgeExplanationDecay', scannerType, period],
+    queryFn: () => fetchEdgeDecay(scannerType, { period }),
+    enabled: !!scannerType,
+  });
+
   const triggerMutation = useMutation({
     mutationFn: () => triggerAnalysis(scannerType || undefined),
     onSuccess: (data) => {
@@ -103,6 +158,29 @@ const EdgeExplorer: React.FC = () => {
   const isLoading = loadingStats || loadingDist;
 
   const events = distribution?.events || [];
+  const traitRows = explanationTraits?.traits ?? [];
+  const archetypeRows = explanationArchetypes?.archetypes ?? [];
+  const selectedTraits = traitFilter
+    ? traitRows.filter((trait) => traitValue(trait) === traitFilter)
+    : traitRows.slice(0, 8);
+  const selectedArchetypes = archetypeFilter
+    ? archetypeRows.filter((archetype) => String(archetype.cluster_id) === archetypeFilter)
+    : archetypeRows.slice(0, 6);
+  const traitChartData = selectedTraits.map((trait) => ({
+    name: traitChartLabel(trait),
+    label: trait.trait_label,
+    sample_size: trait.sample_size,
+    win_rate_pct: trait.win_rate_pct ?? 0,
+    avg_mfe_pct: trait.avg_mfe_pct ?? 0,
+    avg_mae_pct: trait.avg_mae_pct ?? 0,
+  }));
+  const archetypeChartData = selectedArchetypes.map((archetype) => ({
+    name: archetype.label.length > 26 ? `${archetype.label.slice(0, 23)}...` : archetype.label,
+    label: archetype.label,
+    sample_size: archetype.sample_size,
+    win_rate_pct: archetype.return_profile.win_rate_pct ?? 0,
+    avg_mfe_pct: archetype.return_profile.avg_mfe_pct ?? 0,
+  }));
   
   // Calculate aggregate metrics
   const avgGap = events.length > 0 ? events.reduce((acc, e) => acc + (e.gap_pct || 0), 0) / events.length : 0;
@@ -123,9 +201,14 @@ const EdgeExplorer: React.FC = () => {
           <div className="relative min-w-[200px]">
             <Target className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-financial-blue" />
             <select 
+              aria-label="Strategy filter"
               className="pl-9 pr-4 py-2 w-full bg-gray-900 border border-gray-700 rounded-lg text-xs font-bold focus:outline-none focus:ring-1 focus:ring-financial-blue text-white uppercase tracking-wider"
               value={scannerType}
-              onChange={(e) => setScannerType(e.target.value)}
+              onChange={(e) => {
+                setScannerType(e.target.value);
+                setTraitFilter('');
+                setArchetypeFilter('');
+              }}
             >
               <option value="">All Strategies</option>
               {configs?.map(c => (
@@ -197,6 +280,22 @@ const EdgeExplorer: React.FC = () => {
               color="purple"
             />
           </div>
+
+          <ExplanationResearchSection
+            scannerType={scannerType}
+            traitRows={traitRows}
+            archetypeRows={archetypeRows}
+            traitFilter={traitFilter}
+            archetypeFilter={archetypeFilter}
+            onTraitFilter={setTraitFilter}
+            onArchetypeFilter={setArchetypeFilter}
+            selectedTraits={selectedTraits}
+            selectedArchetypes={selectedArchetypes}
+            traitChartData={traitChartData}
+            archetypeChartData={archetypeChartData}
+            edgeDecay={edgeDecay ?? []}
+            isLoading={loadingTraits || loadingArchetypes || loadingEdgeDecay}
+          />
 
           {/* Distribution Charts */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -402,5 +501,249 @@ const EdgeExplorer: React.FC = () => {
     </div>
   );
 };
+
+interface ExplanationResearchSectionProps {
+  scannerType: string;
+  traitRows: ExplanationTrait[];
+  archetypeRows: ExplanationArchetype[];
+  traitFilter: string;
+  archetypeFilter: string;
+  onTraitFilter: (value: string) => void;
+  onArchetypeFilter: (value: string) => void;
+  selectedTraits: ExplanationTrait[];
+  selectedArchetypes: ExplanationArchetype[];
+  traitChartData: Array<{
+    name: string;
+    label: string;
+    sample_size: number;
+    win_rate_pct: number;
+    avg_mfe_pct: number;
+    avg_mae_pct: number;
+  }>;
+  archetypeChartData: Array<{
+    name: string;
+    label: string;
+    sample_size: number;
+    win_rate_pct: number;
+    avg_mfe_pct: number;
+  }>;
+  edgeDecay: EdgeDecayPoint[];
+  isLoading: boolean;
+}
+
+const ExplanationResearchSection: React.FC<ExplanationResearchSectionProps> = ({
+  scannerType,
+  traitRows,
+  archetypeRows,
+  traitFilter,
+  archetypeFilter,
+  onTraitFilter,
+  onArchetypeFilter,
+  selectedTraits,
+  selectedArchetypes,
+  traitChartData,
+  archetypeChartData,
+  edgeDecay,
+  isLoading,
+}) => (
+  <Card title="Explanation Edge Research" icon={Target}>
+    {!scannerType ? (
+      <div className="flex items-center justify-center h-28 border border-dashed border-gray-800 rounded-lg text-sm text-gray-500">
+        Select a strategy to research edge by explanation trait and archetype.
+      </div>
+    ) : isLoading ? (
+      <div className="flex items-center justify-center h-28 text-gray-500 text-xs uppercase tracking-widest">
+        Loading explanation analysis...
+      </div>
+    ) : (
+      <div className="space-y-5">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+          <label className="space-y-1">
+            <span className="text-[10px] font-black uppercase tracking-widest text-gray-500">
+              Explanation Trait
+            </span>
+            <select
+              aria-label="Explanation trait filter"
+              value={traitFilter}
+              onChange={(event) => onTraitFilter(event.target.value)}
+              className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-xs font-bold text-white focus:outline-none focus:ring-1 focus:ring-financial-blue"
+            >
+              <option value="">All explanation traits</option>
+              {traitRows.map((trait) => (
+                <option key={traitValue(trait)} value={traitValue(trait)}>
+                  {traitOptionLabel(trait)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="space-y-1">
+            <span className="text-[10px] font-black uppercase tracking-widest text-gray-500">
+              Signal Archetype
+            </span>
+            <select
+              aria-label="Signal archetype filter"
+              value={archetypeFilter}
+              onChange={(event) => onArchetypeFilter(event.target.value)}
+              className="w-full bg-gray-900 border border-gray-700 rounded-lg px-3 py-2 text-xs font-bold text-white focus:outline-none focus:ring-1 focus:ring-financial-blue"
+            >
+              <option value="">All signal archetypes</option>
+              {archetypeRows.map((archetype) => (
+                <option key={archetype.cluster_id} value={archetype.cluster_id}>
+                  {archetype.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-5">
+          <ExplanationPanel
+            title="Trait Performance"
+            isEmpty={selectedTraits.length === 0}
+            emptyText="No explanation trait performance exists for this strategy yet."
+          >
+            <ResponsiveContainer width="100%" height={240}>
+              <ComposedChart data={traitChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#374151" vertical={false} />
+                <XAxis dataKey="name" stroke="#6B7280" tick={{ fontSize: 10 }} />
+                <YAxis yAxisId="left" stroke="#6B7280" tick={{ fontSize: 10 }} />
+                <YAxis yAxisId="right" orientation="right" stroke="#6B7280" tick={{ fontSize: 10 }} />
+                <Tooltip contentStyle={{ backgroundColor: '#111827', border: '1px solid #374151' }} />
+                <Legend wrapperStyle={{ fontSize: '10px', textTransform: 'uppercase' }} />
+                <Bar yAxisId="left" dataKey="sample_size" name="Sample" fill="#3B82F6" radius={[2, 2, 0, 0]} />
+                <Bar yAxisId="right" dataKey="avg_mfe_pct" name="Avg MFE %" fill="#10B981" radius={[2, 2, 0, 0]} />
+                <Line yAxisId="right" type="monotone" dataKey="win_rate_pct" name="Win %" stroke="#F59E0B" />
+              </ComposedChart>
+            </ResponsiveContainer>
+            <div className="space-y-2">
+              {selectedTraits.map((trait) => (
+                <ExplanationSummaryRow
+                  key={traitValue(trait)}
+                  label={trait.trait_label}
+                  prefix={traitTypeLabel(trait.trait_type)}
+                  sampleSize={trait.sample_size}
+                  winRate={trait.win_rate_pct}
+                  avgMfe={trait.avg_mfe_pct}
+                  warnings={trait.warnings}
+                />
+              ))}
+            </div>
+          </ExplanationPanel>
+
+          <ExplanationPanel
+            title="Archetype Performance"
+            isEmpty={selectedArchetypes.length === 0}
+            emptyText="No explanation archetypes exist for this strategy yet."
+          >
+            <ResponsiveContainer width="100%" height={240}>
+              <ComposedChart data={archetypeChartData} margin={{ top: 10, right: 20, left: 0, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#374151" vertical={false} />
+                <XAxis dataKey="name" stroke="#6B7280" tick={{ fontSize: 10 }} />
+                <YAxis yAxisId="left" stroke="#6B7280" tick={{ fontSize: 10 }} />
+                <YAxis yAxisId="right" orientation="right" stroke="#6B7280" tick={{ fontSize: 10 }} />
+                <Tooltip contentStyle={{ backgroundColor: '#111827', border: '1px solid #374151' }} />
+                <Legend wrapperStyle={{ fontSize: '10px', textTransform: 'uppercase' }} />
+                <Bar yAxisId="left" dataKey="sample_size" name="Sample" fill="#8B5CF6" radius={[2, 2, 0, 0]} />
+                <Bar yAxisId="right" dataKey="avg_mfe_pct" name="Avg MFE %" fill="#10B981" radius={[2, 2, 0, 0]} />
+                <Line yAxisId="right" type="monotone" dataKey="win_rate_pct" name="Win %" stroke="#F59E0B" />
+              </ComposedChart>
+            </ResponsiveContainer>
+            <div className="space-y-2">
+              {selectedArchetypes.map((archetype) => (
+                <ExplanationSummaryRow
+                  key={archetype.cluster_id}
+                  label={archetype.label}
+                  prefix="Archetype"
+                  sampleSize={archetype.sample_size}
+                  winRate={archetype.return_profile.win_rate_pct}
+                  avgMfe={archetype.return_profile.avg_mfe_pct}
+                  warnings={archetype.warnings}
+                />
+              ))}
+            </div>
+          </ExplanationPanel>
+        </div>
+
+        <ExplanationPanel
+          title="Scanner Edge Decay"
+          isEmpty={edgeDecay.length === 0}
+          emptyText="No edge decay series exists for this strategy yet."
+        >
+          <ResponsiveContainer width="100%" height={240}>
+            <ComposedChart data={edgeDecay} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#374151" vertical={false} />
+              <XAxis dataKey="period" stroke="#6B7280" tick={{ fontSize: 10 }} />
+              <YAxis yAxisId="left" stroke="#6B7280" tick={{ fontSize: 10 }} />
+              <YAxis yAxisId="right" orientation="right" stroke="#6B7280" tick={{ fontSize: 10 }} />
+              <Tooltip contentStyle={{ backgroundColor: '#111827', border: '1px solid #374151' }} />
+              <Legend wrapperStyle={{ fontSize: '10px', textTransform: 'uppercase' }} />
+              <Bar yAxisId="left" dataKey="sample_size" name="Sample" fill="#3B82F6" radius={[2, 2, 0, 0]} />
+              <Line yAxisId="right" type="monotone" dataKey="win_rate" name="Win %" stroke="#F59E0B" />
+              <Line yAxisId="right" type="monotone" dataKey="avg_mfe" name="Avg MFE" stroke="#10B981" />
+              <Line yAxisId="right" type="monotone" dataKey="avg_mae" name="Avg MAE" stroke="#EF4444" />
+            </ComposedChart>
+          </ResponsiveContainer>
+        </ExplanationPanel>
+      </div>
+    )}
+  </Card>
+);
+
+const ExplanationPanel: React.FC<{
+  title: string;
+  isEmpty: boolean;
+  emptyText: string;
+  children: React.ReactNode;
+}> = ({ title, isEmpty, emptyText, children }) => (
+  <section className="border border-gray-800 rounded-lg p-4 bg-gray-900/30">
+    <h3 className="text-xs font-black uppercase tracking-widest text-financial-light mb-3">
+      {title}
+    </h3>
+    {isEmpty ? (
+      <div className="flex items-center justify-center h-32 border border-dashed border-gray-800 rounded-lg text-sm text-gray-500">
+        {emptyText}
+      </div>
+    ) : (
+      <div className="space-y-3">{children}</div>
+    )}
+  </section>
+);
+
+const ExplanationSummaryRow: React.FC<{
+  label: string;
+  prefix: string;
+  sampleSize: number;
+  winRate: number | null | undefined;
+  avgMfe: number | null | undefined;
+  warnings: Array<{ code: string; message: string }>;
+}> = ({ label, prefix, sampleSize, winRate, avgMfe, warnings }) => (
+  <div className="border border-gray-800 rounded-lg p-3 bg-gray-950/30">
+    <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-2">
+      <div>
+        <div className="text-sm font-bold text-financial-light">{label}</div>
+        <div className="text-[10px] font-black uppercase tracking-widest text-gray-500">
+          {prefix} / n={sampleSize}
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-3 text-right text-xs">
+        <div>
+          <div className="text-gray-500">Win</div>
+          <div className="font-bold text-financial-light">{fmtPct(winRate)}</div>
+        </div>
+        <div>
+          <div className="text-gray-500">MFE</div>
+          <div className="font-bold text-positive">{fmtPct(avgMfe)}</div>
+        </div>
+      </div>
+    </div>
+    {warnings.length > 0 && (
+      <div className="mt-2 flex items-start gap-2 text-xs text-amber-300">
+        <AlertTriangle className="h-4 w-4 shrink-0" />
+        <span>{warnings[0].message}</span>
+      </div>
+    )}
+  </div>
+);
 
 export default EdgeExplorer;


### PR DESCRIPTION
## Summary
- add EdgeExplorer explanation trait and archetype filters
- add trait, archetype, and scanner edge-decay analysis panels with low-sample/no-data states
- add frontend coverage for strategy gating, populated analysis, and selected trait/archetype filters

Fixes #469

## Verification
- npm test -- EdgeExplorer.test.tsx
- npx tsc --noEmit
- npm run build
- npx eslint . --report-unused-disable-directives-severity error
- npm audit --audit-level=high