### PR TITLE
Add EdgeExplorer historical analog drilldown

### DIFF
--- a/backend/app/routers/outcomes.py
+++ b/backend/app/routers/outcomes.py
@@ -3,7 +3,7 @@ Outcomes router — scanner signal quality and outcome tracking endpoints.
 """
 
 from datetime import date
-from typing import Optional
+from typing import Any, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import ValidationError
@@ -38,6 +38,7 @@ from app.services.explanation_archetype_service import ExplanationArchetypeServi
 from app.services.explanation_trait_performance import (
     ExplanationTraitPerformanceService,
 )
+from app.services.historical_analog_service import HistoricalAnalogService
 from app.services.outcome_service import OutcomeService
 from app.services.stats import StatsService
 from app.utils.db import get_or_404
@@ -63,6 +64,44 @@ def get_outcome_date_range(
             status_code=422,
             detail="; ".join(e["msg"] for e in exc.errors()),
         ) from exc
+
+
+def _analog_event_payload(event: ScannerEvent) -> dict[str, Any]:
+    explanation = event.explanation or {}
+    return {
+        "id": event.id,
+        "ticker": event.ticker,
+        "event_date": event.event_date.isoformat() if event.event_date else None,
+        "scanner_type": event.scanner_type,
+        "summary": event.summary,
+        "severity": event.severity,
+        "why": list(explanation.get("why") or []),
+        "criteria_passed": _criteria_payload(explanation.get("criteria_passed") or {}),
+        "criteria_failed": _criteria_payload(explanation.get("criteria_failed") or {}),
+        "warnings": [
+            {
+                "code": str(warning.get("code") or "quality_warning"),
+                "severity": warning.get("severity"),
+                "message": warning.get("message") or warning.get("code"),
+                "affected_inputs": warning.get("affected_inputs") or [],
+            }
+            for warning in explanation.get("data_quality_warnings") or []
+        ],
+    }
+
+
+def _criteria_payload(criteria: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {
+            "key": key,
+            "label": criterion.get("label") or key,
+            "observed": criterion.get("observed"),
+            "threshold": criterion.get("threshold"),
+            "operator": criterion.get("operator"),
+            "importance": criterion.get("importance"),
+        }
+        for key, criterion in sorted(criteria.items())
+    ]
 
 
 @router.get("/scorecard")
@@ -246,6 +285,41 @@ def get_ai_signal_brief(
 ):
     event = get_or_404(db, ScannerEvent, event_id, "ScannerEvent")
     return AISignalBriefService().build(db, event)
+
+
+@router.get("/event/{event_id}/historical-analogs")
+def get_historical_analogs(
+    event_id: int,
+    limit: int = Query(default=5, ge=1, le=25),
+    min_sample_size: int = Query(default=5, ge=1, le=100),
+    same_scanner_only: bool = True,
+    db: Session = Depends(get_db),
+):
+    target = get_or_404(db, ScannerEvent, event_id, "ScannerEvent")
+    result = HistoricalAnalogService().find_similar_events(
+        db,
+        target_event_id=target.id,
+        limit=limit,
+        min_sample_size=min_sample_size,
+        same_scanner_only=same_scanner_only,
+    )
+    analog_ids = [analog["event_id"] for analog in result["analogs"]]
+    events_by_id = {
+        event.id: event
+        for event in db.query(ScannerEvent).filter(ScannerEvent.id.in_(analog_ids)).all()
+    }
+    return {
+        **result,
+        "target_event": _analog_event_payload(target),
+        "analogs": [
+            {
+                **analog,
+                "event": _analog_event_payload(events_by_id[analog["event_id"]]),
+            }
+            for analog in result["analogs"]
+            if analog["event_id"] in events_by_id
+        ],
+    }
 
 
 @router.get("/readiness/{ticker}", response_model=ReadinessResponse)

--- a/backend/tests/api/test_ai_signal_brief.py
+++ b/backend/tests/api/test_ai_signal_brief.py
@@ -192,3 +192,35 @@ def test_ai_signal_brief_no_analog_event_reports_warning(db):
     assert any(
         warning["code"] == "no_historical_analogs" for warning in data["warnings"]
     )
+
+
+def test_historical_analogs_endpoint_enriches_events_explanations_and_outcomes(db):
+    _seed_event(
+        db,
+        ticker="OLD",
+        event_date=date(2026, 7, 1),
+        explanation=_explanation(warnings=["missing_float"]),
+    )
+    target = _seed_event(
+        db,
+        ticker="TGT",
+        event_date=date(2026, 7, 3),
+        explanation=_explanation(),
+        complete=False,
+    )
+
+    response = client.get(
+        f"/api/v1/outcomes/event/{target.id}/historical-analogs?min_sample_size=1"
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["target_event"]["ticker"] == "TGT"
+    assert data["target_event"]["why"] == [
+        "Volume and liquidity aligned with the scanner setup."
+    ]
+    assert data["analogs"][0]["ticker"] == "OLD"
+    assert data["analogs"][0]["event"]["criteria_passed"][0]["label"] == "Volume Spike"
+    assert data["analogs"][0]["event"]["criteria_failed"][0]["label"] == "News Catalyst"
+    assert data["analogs"][0]["event"]["warnings"][0]["code"] == "missing_float"
+    assert data["analogs"][0]["outcome_summary"]["eod_pct_change"] == 2.0

--- a/frontend/src/api/outcomes.ts
+++ b/frontend/src/api/outcomes.ts
@@ -150,6 +150,57 @@ export interface ExplanationWarning {
   message: string;
 }
 
+export interface AnalogCriterion {
+  key: string;
+  label: string;
+  observed: unknown;
+  threshold: unknown;
+  operator: string | null;
+  importance: number | null;
+}
+
+export interface AnalogEvent {
+  id: number;
+  ticker: string;
+  event_date: string | null;
+  scanner_type: string;
+  summary: string | null;
+  severity: string | null;
+  why: string[];
+  criteria_passed: AnalogCriterion[];
+  criteria_failed: AnalogCriterion[];
+  warnings: Array<ExplanationWarning & { severity?: string | null; affected_inputs?: string[] }>;
+}
+
+export interface HistoricalAnalog {
+  event_id: number;
+  ticker: string;
+  event_date: string | null;
+  scanner_type: string;
+  similarity_score: number;
+  score_components: Record<string, number>;
+  matched_criteria: string[];
+  outcome_summary: Partial<OutcomeSummary> | null;
+  captured_snapshot_count: number;
+  warning_count: number;
+  event: AnalogEvent;
+}
+
+export interface HistoricalAnalogResponse {
+  target_event_id: number;
+  target_scanner_type: string;
+  target_event: AnalogEvent;
+  sample_size: number;
+  filters: {
+    scanner_type: string | null;
+    same_scanner_only: boolean;
+    prior_only: boolean;
+    complete_only: boolean;
+  };
+  warnings: ExplanationWarning[];
+  analogs: HistoricalAnalog[];
+}
+
 export interface ExplanationTrait {
   trait_type: string;
   trait_key: string;
@@ -257,6 +308,13 @@ export const fetchEdgeDecay = async (
 
 export const fetchEventOutcome = async (eventId: number): Promise<EventOutcome> => {
   const response = await apiClient.get(`/outcomes/event/${eventId}`);
+  return response.data;
+};
+
+export const fetchHistoricalAnalogs = async (
+  eventId: number,
+): Promise<HistoricalAnalogResponse> => {
+  const response = await apiClient.get(`/outcomes/event/${eventId}/historical-analogs`);
   return response.data;
 };
 

--- a/frontend/src/pages/EdgeExplorer.test.tsx
+++ b/frontend/src/pages/EdgeExplorer.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   fetchExplanationTraits: vi.fn(),
   fetchExplanationArchetypes: vi.fn(),
   fetchEdgeDecay: vi.fn(),
+  fetchHistoricalAnalogs: vi.fn(),
 }));
 
 vi.mock('../api/client', () => ({
@@ -32,6 +33,7 @@ vi.mock('../api/outcomes', () => ({
   fetchExplanationTraits: (...args: unknown[]) => mocks.fetchExplanationTraits(...args),
   fetchExplanationArchetypes: (...args: unknown[]) => mocks.fetchExplanationArchetypes(...args),
   fetchEdgeDecay: (...args: unknown[]) => mocks.fetchEdgeDecay(...args),
+  fetchHistoricalAnalogs: (...args: unknown[]) => mocks.fetchHistoricalAnalogs(...args),
 }));
 
 vi.mock('recharts', () => {
@@ -147,6 +149,57 @@ const edgeDecay = [
   { period: '2026-W27', win_rate: 75, avg_mfe: 5.5, avg_mae: 1.1, sample_size: 8 },
 ];
 
+const analogResponse = {
+  target_event_id: 1,
+  target_scanner_type: 'pre_market_volume_spike',
+  target_event: {
+    id: 1,
+    ticker: 'TGT',
+    event_date: '2026-07-03',
+    scanner_type: 'pre_market_volume_spike',
+    summary: 'TGT signal',
+    severity: 'high',
+    why: ['Volume and liquidity aligned.'],
+    criteria_passed: [{ key: 'premarket.volume_spike', label: 'Volume Spike', observed: 6, threshold: 4, operator: '>=', importance: 1 }],
+    criteria_failed: [],
+    warnings: [],
+  },
+  sample_size: 1,
+  filters: {
+    scanner_type: 'pre_market_volume_spike',
+    same_scanner_only: true,
+    prior_only: true,
+    complete_only: true,
+  },
+  warnings: [],
+  analogs: [
+    {
+      event_id: 2,
+      ticker: 'OLD',
+      event_date: '2026-07-01',
+      scanner_type: 'pre_market_volume_spike',
+      similarity_score: 0.82,
+      score_components: { criterion_overlap: 1 },
+      matched_criteria: ['premarket.volume_spike'],
+      outcome_summary: { eod_pct_change: 2, mfe_pct: 4, mae_pct: 1 },
+      captured_snapshot_count: 2,
+      warning_count: 0,
+      event: {
+        id: 2,
+        ticker: 'OLD',
+        event_date: '2026-07-01',
+        scanner_type: 'pre_market_volume_spike',
+        summary: 'OLD signal',
+        severity: 'medium',
+        why: ['Historical setup matched the current event.'],
+        criteria_passed: [{ key: 'premarket.volume_spike', label: 'Volume Spike', observed: 5.8, threshold: 4, operator: '>=', importance: 1 }],
+        criteria_failed: [{ key: 'premarket.news_catalyst', label: 'News Catalyst', observed: false, threshold: true, operator: '==', importance: 0.5 }],
+        warnings: [],
+      },
+    },
+  ],
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.fetchScannerConfigs.mockResolvedValue([scannerConfig]);
@@ -156,6 +209,7 @@ beforeEach(() => {
   mocks.fetchExplanationTraits.mockResolvedValue(traitResponse);
   mocks.fetchExplanationArchetypes.mockResolvedValue(archetypeResponse);
   mocks.fetchEdgeDecay.mockResolvedValue(edgeDecay);
+  mocks.fetchHistoricalAnalogs.mockResolvedValue(analogResponse);
   mocks.apiGet.mockImplementation((url: string) => {
     if (url.startsWith('/scanner/edge-stats')) {
       return Promise.resolve({
@@ -216,5 +270,69 @@ describe('EdgeExplorer explanation intelligence', () => {
     expect(screen.queryByText(/^Volume Spike$/i)).not.toBeInTheDocument();
     expect(screen.getAllByText(/Missing Float \/ Weak Outcomes/i).length).toBeGreaterThan(1);
     expect(screen.getAllByText(/Volume Spike \/ Positive Outcomes/i)).toHaveLength(1);
+  });
+
+  it('drills into populated analog events from an archetype', async () => {
+    renderWithQuery(<EdgeExplorer />);
+
+    await screen.findByRole('option', { name: /Pre Market Volume Spike/i });
+    fireEvent.change(screen.getByLabelText(/Strategy filter/i), {
+      target: { value: 'pre_market_volume_spike' },
+    });
+    fireEvent.click(await screen.findAllByRole('button', { name: /Inspect analogs/i }).then((buttons) => buttons[0]));
+
+    expect(await screen.findByText(/Historical Analog Drill-Down/i)).toBeInTheDocument();
+    expect(await screen.findByText(/TGT \/ 2026-07-03/i)).toBeInTheDocument();
+    expect(screen.getByText(/OLD \/ 2026-07-01/i)).toBeInTheDocument();
+    expect(screen.getByText(/Historical setup matched the current event/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/^Volume Spike$/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/^News Catalyst$/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Stock/i })).toHaveAttribute('href', '/stock/OLD');
+    expect(mocks.fetchHistoricalAnalogs).toHaveBeenCalledWith(1);
+  });
+
+  it('shows a no-analog drill-down state', async () => {
+    mocks.fetchHistoricalAnalogs.mockResolvedValueOnce({
+      ...analogResponse,
+      sample_size: 0,
+      warnings: [{ code: 'no_historical_analogs', message: 'No complete prior analogs were available for this target event.' }],
+      analogs: [],
+    });
+    renderWithQuery(<EdgeExplorer />);
+
+    await screen.findByRole('option', { name: /Pre Market Volume Spike/i });
+    fireEvent.change(screen.getByLabelText(/Strategy filter/i), {
+      target: { value: 'pre_market_volume_spike' },
+    });
+    fireEvent.click(await screen.findAllByRole('button', { name: /Inspect analogs/i }).then((buttons) => buttons[0]));
+
+    expect(await screen.findByText(/No complete prior analogs were available/i)).toBeInTheDocument();
+    expect(screen.getByText(/No historical analogs matched this event/i)).toBeInTheDocument();
+  });
+
+  it('surfaces warning-heavy analog groups', async () => {
+    mocks.fetchHistoricalAnalogs.mockResolvedValueOnce({
+      ...analogResponse,
+      warnings: [{ code: 'weak_sample_size', message: 'Only 1 analog candidates were available.' }],
+      analogs: [
+        {
+          ...analogResponse.analogs[0],
+          event: {
+            ...analogResponse.analogs[0].event,
+            warnings: [{ code: 'missing_float', message: 'Float data was missing.' }],
+          },
+        },
+      ],
+    });
+    renderWithQuery(<EdgeExplorer />);
+
+    await screen.findByRole('option', { name: /Pre Market Volume Spike/i });
+    fireEvent.change(screen.getByLabelText(/Strategy filter/i), {
+      target: { value: 'pre_market_volume_spike' },
+    });
+    fireEvent.click(await screen.findAllByRole('button', { name: /Inspect analogs/i }).then((buttons) => buttons[0]));
+
+    expect(await screen.findByText(/Only 1 analog candidates were available/i)).toBeInTheDocument();
+    expect(screen.getByText(/Float data was missing/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/EdgeExplorer.tsx
+++ b/frontend/src/pages/EdgeExplorer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
 import {
   BarChart2,
   TrendingUp,
@@ -46,11 +47,13 @@ import {
   fetchEdgeDecay,
   fetchExplanationArchetypes,
   fetchExplanationTraits,
+  fetchHistoricalAnalogs,
 } from '../api/outcomes';
 import type {
   EdgeDecayPoint,
   ExplanationArchetype,
   ExplanationTrait,
+  HistoricalAnalogResponse,
 } from '../api/outcomes';
 
 const fmtPct = (value: number | null | undefined): string => (
@@ -83,6 +86,7 @@ const EdgeExplorer: React.FC = () => {
   const [scannerType, setScannerType] = useState<string>('');
   const [traitFilter, setTraitFilter] = useState<string>('');
   const [archetypeFilter, setArchetypeFilter] = useState<string>('');
+  const [analogTargetEventId, setAnalogTargetEventId] = useState<number | null>(null);
 
   // Fetch scanner configurations for the dropdown
   const { data: configs } = useQuery({
@@ -138,6 +142,12 @@ const EdgeExplorer: React.FC = () => {
     queryKey: ['edgeExplanationDecay', scannerType, period],
     queryFn: () => fetchEdgeDecay(scannerType, { period }),
     enabled: !!scannerType,
+  });
+
+  const { data: analogDrilldown, isLoading: loadingAnalogs } = useQuery<HistoricalAnalogResponse>({
+    queryKey: ['edgeHistoricalAnalogs', analogTargetEventId],
+    queryFn: () => fetchHistoricalAnalogs(analogTargetEventId!),
+    enabled: analogTargetEventId !== null,
   });
 
   const triggerMutation = useMutation({
@@ -208,6 +218,7 @@ const EdgeExplorer: React.FC = () => {
                 setScannerType(e.target.value);
                 setTraitFilter('');
                 setArchetypeFilter('');
+                setAnalogTargetEventId(null);
               }}
             >
               <option value="">All Strategies</option>
@@ -295,6 +306,10 @@ const EdgeExplorer: React.FC = () => {
             archetypeChartData={archetypeChartData}
             edgeDecay={edgeDecay ?? []}
             isLoading={loadingTraits || loadingArchetypes || loadingEdgeDecay}
+            analogTargetEventId={analogTargetEventId}
+            onAnalogTarget={setAnalogTargetEventId}
+            analogDrilldown={analogDrilldown}
+            loadingAnalogs={loadingAnalogs}
           />
 
           {/* Distribution Charts */}
@@ -529,6 +544,10 @@ interface ExplanationResearchSectionProps {
   }>;
   edgeDecay: EdgeDecayPoint[];
   isLoading: boolean;
+  analogTargetEventId: number | null;
+  onAnalogTarget: (eventId: number) => void;
+  analogDrilldown: HistoricalAnalogResponse | undefined;
+  loadingAnalogs: boolean;
 }
 
 const ExplanationResearchSection: React.FC<ExplanationResearchSectionProps> = ({
@@ -545,6 +564,10 @@ const ExplanationResearchSection: React.FC<ExplanationResearchSectionProps> = ({
   archetypeChartData,
   edgeDecay,
   isLoading,
+  analogTargetEventId,
+  onAnalogTarget,
+  analogDrilldown,
+  loadingAnalogs,
 }) => (
   <Card title="Explanation Edge Research" icon={Target}>
     {!scannerType ? (
@@ -659,6 +682,15 @@ const ExplanationResearchSection: React.FC<ExplanationResearchSectionProps> = ({
                   winRate={archetype.return_profile.win_rate_pct}
                   avgMfe={archetype.return_profile.avg_mfe_pct}
                   warnings={archetype.warnings}
+                  action={archetype.event_ids[0] ? (
+                    <button
+                      type="button"
+                      onClick={() => onAnalogTarget(archetype.event_ids[0])}
+                      className="px-3 py-1.5 rounded-md bg-financial-blue/20 text-financial-blue hover:bg-financial-blue hover:text-white text-[10px] font-black uppercase tracking-widest transition-colors"
+                    >
+                      Inspect analogs
+                    </button>
+                  ) : undefined}
                 />
               ))}
             </div>
@@ -685,6 +717,13 @@ const ExplanationResearchSection: React.FC<ExplanationResearchSectionProps> = ({
             </ComposedChart>
           </ResponsiveContainer>
         </ExplanationPanel>
+
+        <AnalogDrilldownPanel
+          analogTargetEventId={analogTargetEventId}
+          data={analogDrilldown}
+          isLoading={loadingAnalogs}
+          scannerType={scannerType}
+        />
       </div>
     )}
   </Card>
@@ -717,7 +756,8 @@ const ExplanationSummaryRow: React.FC<{
   winRate: number | null | undefined;
   avgMfe: number | null | undefined;
   warnings: Array<{ code: string; message: string }>;
-}> = ({ label, prefix, sampleSize, winRate, avgMfe, warnings }) => (
+  action?: React.ReactNode;
+}> = ({ label, prefix, sampleSize, winRate, avgMfe, warnings, action }) => (
   <div className="border border-gray-800 rounded-lg p-3 bg-gray-950/30">
     <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-2">
       <div>
@@ -736,6 +776,7 @@ const ExplanationSummaryRow: React.FC<{
           <div className="font-bold text-positive">{fmtPct(avgMfe)}</div>
         </div>
       </div>
+      {action}
     </div>
     {warnings.length > 0 && (
       <div className="mt-2 flex items-start gap-2 text-xs text-amber-300">
@@ -745,5 +786,159 @@ const ExplanationSummaryRow: React.FC<{
     )}
   </div>
 );
+
+const AnalogDrilldownPanel: React.FC<{
+  analogTargetEventId: number | null;
+  data: HistoricalAnalogResponse | undefined;
+  isLoading: boolean;
+  scannerType: string;
+}> = ({ analogTargetEventId, data, isLoading, scannerType }) => (
+  <section className="border border-gray-800 rounded-lg p-4 bg-gray-900/30">
+    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-3">
+      <div>
+        <h3 className="text-xs font-black uppercase tracking-widest text-financial-light">
+          Historical Analog Drill-Down
+        </h3>
+        <p className="text-xs text-gray-500 mt-1">
+          Inspect matching historical events behind the selected archetype.
+        </p>
+      </div>
+      {analogTargetEventId && (
+        <Link
+          to={`/scorecard/${scannerType}`}
+          className="text-[10px] font-black uppercase tracking-widest text-financial-blue hover:text-white"
+        >
+          Open scorecard detail
+        </Link>
+      )}
+    </div>
+
+    {analogTargetEventId === null ? (
+      <div className="flex items-center justify-center h-28 border border-dashed border-gray-800 rounded-lg text-sm text-gray-500">
+        Choose Inspect analogs on an archetype to review its matching event set.
+      </div>
+    ) : isLoading ? (
+      <div className="flex items-center justify-center h-28 text-gray-500 text-xs uppercase tracking-widest">
+        Loading historical analogs...
+      </div>
+    ) : !data ? (
+      <div className="flex items-center justify-center h-28 border border-dashed border-gray-800 rounded-lg text-sm text-gray-500">
+        Analog data is unavailable for this event.
+      </div>
+    ) : (
+      <div className="space-y-4">
+        {data.warnings.length > 0 && (
+          <div className="border border-amber-500/30 bg-amber-500/10 rounded-lg p-3 text-xs text-amber-300 space-y-1">
+            {data.warnings.map((warning) => (
+              <div key={warning.code}>{warning.message}</div>
+            ))}
+          </div>
+        )}
+
+        <div className="border border-gray-800 rounded-lg p-3 bg-gray-950/30">
+          <div className="text-[10px] font-black uppercase tracking-widest text-gray-500">
+            Target Event
+          </div>
+          <div className="mt-1 text-sm font-bold text-financial-light">
+            {data.target_event.ticker} / {data.target_event.event_date ?? 'No date'}
+          </div>
+          <ExplanationDetail event={data.target_event} />
+        </div>
+
+        {data.analogs.length === 0 ? (
+          <div className="flex items-center justify-center h-28 border border-dashed border-gray-800 rounded-lg text-sm text-gray-500">
+            No historical analogs matched this event.
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
+            {data.analogs.map((analog) => (
+              <div key={analog.event_id} className="border border-gray-800 rounded-lg p-3 bg-gray-950/30">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-sm font-bold text-financial-light">
+                      {analog.ticker} / {analog.event_date ?? 'No date'}
+                    </div>
+                    <div className="text-[10px] font-black uppercase tracking-widest text-gray-500">
+                      Similarity {(analog.similarity_score * 100).toFixed(1)}% / snapshots {analog.captured_snapshot_count}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3 text-[10px] font-black uppercase tracking-widest">
+                    <Link to={`/stock/${analog.ticker}`} className="text-financial-blue hover:text-white">
+                      Stock
+                    </Link>
+                    <Link to={`/scorecard/${analog.scanner_type}`} className="text-financial-blue hover:text-white">
+                      Scorecard
+                    </Link>
+                  </div>
+                </div>
+                <div className="mt-3 grid grid-cols-3 gap-2 text-xs">
+                  <Metric label="EOD" value={fmtPct(analog.outcome_summary?.eod_pct_change)} />
+                  <Metric label="MFE" value={fmtPct(analog.outcome_summary?.mfe_pct)} />
+                  <Metric label="MAE" value={fmtPct(analog.outcome_summary?.mae_pct)} />
+                </div>
+                <ExplanationDetail event={analog.event} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    )}
+  </section>
+);
+
+const Metric: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div>
+    <div className="text-gray-500">{label}</div>
+    <div className="font-bold text-financial-light">{value}</div>
+  </div>
+);
+
+const ExplanationDetail: React.FC<{ event: HistoricalAnalogResponse['target_event'] }> = ({ event }) => (
+  <div className="mt-3 space-y-3">
+    {event.why.length > 0 && (
+      <div>
+        <div className="text-[10px] font-black uppercase tracking-widest text-gray-500 mb-1">Why</div>
+        <ul className="space-y-1 text-xs text-gray-300">
+          {event.why.map((reason) => (
+            <li key={reason}>{reason}</li>
+          ))}
+        </ul>
+      </div>
+    )}
+    <CriteriaList title="Key Criteria" rows={event.criteria_passed} />
+    <CriteriaList title="Failed Criteria" rows={event.criteria_failed} />
+    {event.warnings.length > 0 && (
+      <div>
+        <div className="text-[10px] font-black uppercase tracking-widest text-gray-500 mb-1">Warnings</div>
+        <div className="space-y-1">
+          {event.warnings.map((warning) => (
+            <div key={warning.code} className="text-xs text-amber-300">
+              {warning.message}
+            </div>
+          ))}
+        </div>
+      </div>
+    )}
+  </div>
+);
+
+const CriteriaList: React.FC<{
+  title: string;
+  rows: HistoricalAnalogResponse['target_event']['criteria_passed'];
+}> = ({ title, rows }) => {
+  if (rows.length === 0) return null;
+  return (
+    <div>
+      <div className="text-[10px] font-black uppercase tracking-widest text-gray-500 mb-1">{title}</div>
+      <div className="flex flex-wrap gap-2">
+        {rows.map((criterion) => (
+          <span key={criterion.key} className="px-2 py-1 rounded-md bg-gray-800 text-xs text-gray-300">
+            {criterion.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+};
 
 export default EdgeExplorer;


### PR DESCRIPTION
## Summary
- add an outcomes endpoint for enriched historical analog drill-downs
- expose analog response types and fetcher in the frontend outcomes API
- add EdgeExplorer drill-down from archetypes into target/analog explanations, criteria, warnings, outcomes, and navigation links
- extend tests for populated, no-analog, and warning-heavy analog groups

Fixes #470

## Verification
- $env:PYTEST_ADDOPTS='--no-cov'; python -m pytest backend/tests/api/test_ai_signal_brief.py backend/tests/services/test_historical_analog_service.py -q
- npm test -- EdgeExplorer.test.tsx
- python -m ruff check backend
- npx tsc --noEmit
- npm run build
- npx eslint . --report-unused-disable-directives-severity error
- npm audit --audit-level=high