### PR TITLE
Upgrade event-level intelligence UI

### DIFF
--- a/frontend/src/api/outcomes.ts
+++ b/frontend/src/api/outcomes.ts
@@ -201,6 +201,42 @@ export interface HistoricalAnalogResponse {
   analogs: HistoricalAnalog[];
 }
 
+export interface AISignalBrief {
+  schema_version: string;
+  event_id: number;
+  facts: {
+    ticker: string;
+    event_date: string | null;
+    scanner_type: string;
+    severity: string | null;
+    summary: string | null;
+    signal_quality_score: number | null;
+    regime: string | null;
+  };
+  why: string[];
+  risks: string[];
+  warnings: Array<ExplanationWarning & { severity?: string | null }>;
+  analogs: HistoricalAnalog[];
+  outcome_context: {
+    summary: Partial<OutcomeSummary> | null;
+    snapshots: Array<{
+      interval_key: string;
+      pct_change: number | null;
+      snapshot_price: number | null;
+      status: string;
+      captured_at: string | null;
+    }>;
+  };
+  archetype: {
+    cluster_id: number;
+    label: string;
+    event_count: number;
+    centroid: Record<string, unknown>;
+    return_profile: Record<string, unknown>;
+  } | null;
+  forbidden_claims: string[];
+}
+
 export interface ExplanationTrait {
   trait_type: string;
   trait_key: string;
@@ -315,6 +351,11 @@ export const fetchHistoricalAnalogs = async (
   eventId: number,
 ): Promise<HistoricalAnalogResponse> => {
   const response = await apiClient.get(`/outcomes/event/${eventId}/historical-analogs`);
+  return response.data;
+};
+
+export const fetchAISignalBrief = async (eventId: number): Promise<AISignalBrief> => {
+  const response = await apiClient.get(`/outcomes/event/${eventId}/ai-signal-brief`);
   return response.data;
 };
 

--- a/frontend/src/components/scorecard/SignalTable.test.tsx
+++ b/frontend/src/components/scorecard/SignalTable.test.tsx
@@ -1,13 +1,20 @@
-import { vi, describe, it, expect } from 'vitest';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { screen, fireEvent } from '@testing-library/react';
 import { renderWithQuery } from '../../test-utils/renderWithQuery';
 import SignalTable from './SignalTable';
-import type { SignalListItem } from '../../api/outcomes';
+import type { AISignalBrief, SignalListItem } from '../../api/outcomes';
 
-const mockUseSignals = vi.fn();
+const mocks = vi.hoisted(() => ({
+  useSignals: vi.fn(),
+  fetchAISignalBrief: vi.fn(),
+}));
 
 vi.mock('../../hooks/useScorecard', () => ({
-  useSignals: (...args: unknown[]) => mockUseSignals(...args),
+  useSignals: (...args: unknown[]) => mocks.useSignals(...args),
+}));
+
+vi.mock('../../api/outcomes', () => ({
+  fetchAISignalBrief: (...args: unknown[]) => mocks.fetchAISignalBrief(...args),
 }));
 
 const makeSignal = (overrides: Partial<SignalListItem> = {}): SignalListItem => ({
@@ -29,9 +36,179 @@ const makeSignal = (overrides: Partial<SignalListItem> = {}): SignalListItem => 
   ...overrides,
 });
 
+describe('SignalTable - event intelligence brief', () => {
+  beforeEach(() => {
+    mocks.useSignals.mockReturnValue({
+      data: {
+        signals: [makeSignal({ ticker: 'TSLA', id: 1 })],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      },
+      isLoading: false,
+    });
+    mocks.fetchAISignalBrief.mockResolvedValue(makeBrief());
+  });
+
+  it('shows deterministic explanation, analogs, expected behavior, archetype, and outcome context for a complete event', async () => {
+    renderWithQuery(<SignalTable scannerType="pre_market_volume_spike" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Brief/i }));
+
+    expect(await screen.findByText('Deterministic Signal Brief')).toBeInTheDocument();
+    expect(screen.getByText(/Facts only/i)).toBeInTheDocument();
+    expect(screen.getByText('Relative volume exceeded the configured threshold.')).toBeInTheDocument();
+    expect(screen.getByText(/NVDA/)).toBeInTheDocument();
+    expect(screen.getByText(/expected behavior/i)).toBeInTheDocument();
+    expect(screen.getByText(/Gap continuation/)).toBeInTheDocument();
+    expect(screen.getByText(/EOD \+1.50%/)).toBeInTheDocument();
+    expect(screen.getByText(/MFE \+3.20%/)).toBeInTheDocument();
+    expect(screen.getByText(/MAE -1.10%/)).toBeInTheDocument();
+  });
+
+  it('shows partial-state copy when explanation, analogs, archetype, and complete outcome are unavailable', async () => {
+    mocks.fetchAISignalBrief.mockResolvedValueOnce(makeBrief({
+      why: [],
+      analogs: [],
+      archetype: null,
+      outcome_context: { summary: null, snapshots: [] },
+      risks: [
+        'Scanner explanation is missing.',
+        'Outcome summary is incomplete or unavailable.',
+        'No explanation-aware archetype is assigned yet.',
+      ],
+    }));
+
+    renderWithQuery(<SignalTable scannerType="pre_market_volume_spike" />);
+    fireEvent.click(screen.getByRole('button', { name: /Brief/i }));
+
+    expect(await screen.findByText('No explanation bullets are stored.')).toBeInTheDocument();
+    expect(screen.getByText('No historical analogs were available.')).toBeInTheDocument();
+    expect(screen.getByText(/Unassigned/)).toBeInTheDocument();
+    expect(screen.getByText('Scanner explanation is missing.')).toBeInTheDocument();
+    expect(screen.getByText('Outcome summary is incomplete or unavailable.')).toBeInTheDocument();
+  });
+
+  it('keeps no-outcome events factual and labels the missing outcome context', async () => {
+    mocks.useSignals.mockReturnValue({
+      data: {
+        signals: [
+          makeSignal({
+            id: 9,
+            ticker: 'MSFT',
+            eod_pct_change: null,
+            mfe_pct: null,
+            mae_pct: null,
+            mfe_mae_ratio: null,
+            follow_through: null,
+            is_complete: false,
+          }),
+        ],
+        total: 1,
+        limit: 20,
+        offset: 0,
+      },
+      isLoading: false,
+    });
+    mocks.fetchAISignalBrief.mockResolvedValueOnce(makeBrief({
+      event_id: 9,
+      facts: {
+        ticker: 'MSFT',
+        event_date: '2026-01-15',
+        scanner_type: 'pre_market_volume_spike',
+        severity: 'high',
+        summary: null,
+        signal_quality_score: null,
+        regime: null,
+      },
+      outcome_context: { summary: null, snapshots: [] },
+      risks: ['Outcome summary is incomplete or unavailable.'],
+    }));
+
+    renderWithQuery(<SignalTable scannerType="pre_market_volume_spike" />);
+    fireEvent.click(screen.getByRole('button', { name: /Brief/i }));
+
+    expect(await screen.findByText('Deterministic Signal Brief')).toBeInTheDocument();
+    expect(screen.getAllByText(/MSFT/).length).toBeGreaterThan(1);
+    expect(screen.getByText('Outcome summary is incomplete or unavailable.')).toBeInTheDocument();
+    expect(screen.getByText(/Generated narrative can be added later/i)).toBeInTheDocument();
+  });
+});
+
+const makeBrief = (overrides: Partial<AISignalBrief> = {}): AISignalBrief => ({
+  schema_version: 'ai_signal_brief.v1',
+  event_id: 1,
+  facts: {
+    ticker: 'TSLA',
+    event_date: '2026-01-15',
+    scanner_type: 'pre_market_volume_spike',
+    severity: 'high',
+    summary: 'Premarket volume expansion with elevated gap.',
+    signal_quality_score: 82,
+    regime: 'risk_on',
+  },
+  why: ['Relative volume exceeded the configured threshold.'],
+  risks: [],
+  warnings: [],
+  analogs: [
+    {
+      event_id: 22,
+      ticker: 'NVDA',
+      event_date: '2025-11-03',
+      scanner_type: 'pre_market_volume_spike',
+      similarity_score: 0.87,
+      score_components: {},
+      matched_criteria: ['premarket.volume_spike'],
+      outcome_summary: {
+        eod_pct_change: 2.4,
+        mfe_pct: 4.1,
+        mae_pct: -0.8,
+      },
+      captured_snapshot_count: 4,
+      warning_count: 0,
+      event: {
+        id: 22,
+        ticker: 'NVDA',
+        event_date: '2025-11-03',
+        scanner_type: 'pre_market_volume_spike',
+        summary: null,
+        severity: 'medium',
+        why: [],
+        criteria_passed: [],
+        criteria_failed: [],
+        warnings: [],
+      },
+    },
+  ],
+  outcome_context: {
+    summary: {
+      eod_pct_change: 1.5,
+      mfe_pct: 3.2,
+      mae_pct: -1.1,
+      follow_through: true,
+      is_complete: true,
+    },
+    snapshots: [],
+  },
+  archetype: {
+    cluster_id: 7,
+    label: 'Gap continuation',
+    event_count: 18,
+    centroid: {},
+    return_profile: {},
+  },
+  forbidden_claims: ['Do not claim guaranteed future returns.'],
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.fetchAISignalBrief.mockResolvedValue(makeBrief());
+});
+
 describe('SignalTable — loading state', () => {
   it('shows loading skeleton when isLoading', () => {
-    mockUseSignals.mockReturnValue({ data: undefined, isLoading: true });
+    mocks.useSignals.mockReturnValue({ data: undefined, isLoading: true });
     const { container } = renderWithQuery(
       <SignalTable scannerType="pre_market_volume_spike" />,
     );
@@ -39,7 +216,7 @@ describe('SignalTable — loading state', () => {
   });
 
   it('shows "Signals" heading in loading state', () => {
-    mockUseSignals.mockReturnValue({ data: undefined, isLoading: true });
+    mocks.useSignals.mockReturnValue({ data: undefined, isLoading: true });
     renderWithQuery(<SignalTable scannerType="pre_market_volume_spike" />);
     expect(screen.getByText(/^Signals$/)).toBeInTheDocument();
   });
@@ -47,7 +224,7 @@ describe('SignalTable — loading state', () => {
 
 describe('SignalTable — empty state', () => {
   it('shows "No signals found" when data total is 0', () => {
-    mockUseSignals.mockReturnValue({
+    mocks.useSignals.mockReturnValue({
       data: { signals: [], total: 0, limit: 20, offset: 0 },
       isLoading: false,
     });
@@ -56,7 +233,7 @@ describe('SignalTable — empty state', () => {
   });
 
   it('shows "No signals found" when data is undefined', () => {
-    mockUseSignals.mockReturnValue({ data: undefined, isLoading: false });
+    mocks.useSignals.mockReturnValue({ data: undefined, isLoading: false });
     renderWithQuery(<SignalTable scannerType="pre_market_volume_spike" />);
     expect(screen.getByText(/No signals found/i)).toBeInTheDocument();
   });
@@ -64,7 +241,7 @@ describe('SignalTable — empty state', () => {
 
 describe('SignalTable — data state', () => {
   beforeEach(() => {
-    mockUseSignals.mockReturnValue({
+    mocks.useSignals.mockReturnValue({
       data: {
         signals: [makeSignal({ ticker: 'TSLA', id: 1 })],
         total: 1,
@@ -109,7 +286,7 @@ describe('SignalTable — data state', () => {
 
 describe('SignalTable — sorting', () => {
   beforeEach(() => {
-    mockUseSignals.mockReturnValue({
+    mocks.useSignals.mockReturnValue({
       data: { signals: [makeSignal()], total: 1, limit: 20, offset: 0 },
       isLoading: false,
     });
@@ -118,7 +295,7 @@ describe('SignalTable — sorting', () => {
   it('clicking Date header calls useSignals with changed sort params', () => {
     renderWithQuery(<SignalTable scannerType="pre_market_volume_spike" />);
     fireEvent.click(screen.getByText(/^Date/i));
-    expect(mockUseSignals).toHaveBeenCalled();
+    expect(mocks.useSignals).toHaveBeenCalled();
   });
 
   it('clicking Ticker header triggers a re-render', () => {
@@ -130,7 +307,7 @@ describe('SignalTable — sorting', () => {
 
 describe('SignalTable — pagination', () => {
   it('shows pagination controls when total > PAGE_SIZE', () => {
-    mockUseSignals.mockReturnValue({
+    mocks.useSignals.mockReturnValue({
       data: {
         signals: Array.from({ length: 20 }, (_, i) => makeSignal({ id: i + 1, ticker: `SYM${i}` })),
         total: 45,

--- a/frontend/src/components/scorecard/SignalTable.tsx
+++ b/frontend/src/components/scorecard/SignalTable.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
-import { ChevronUp, ChevronDown, ChevronLeft, ChevronRight, Check, X } from 'lucide-react';
+import { ChevronUp, ChevronDown, ChevronLeft, ChevronRight, Check, X, Sparkles } from 'lucide-react';
+import { fetchAISignalBrief } from '../../api/outcomes';
+import type { AISignalBrief } from '../../api/outcomes';
 import { useSignals } from '../../hooks/useScorecard';
 
 interface SignalTableProps {
@@ -60,6 +63,7 @@ const SignalTable: React.FC<SignalTableProps> = ({ scannerType, startDate, endDa
   const [sortBy, setSortBy] = useState<SortField>('event_date');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
   const [page, setPage] = useState(0);
+  const [expandedEventId, setExpandedEventId] = useState<number | null>(null);
 
   const { data, isLoading } = useSignals(scannerType, {
     start_date: startDate,
@@ -176,14 +180,13 @@ const SignalTable: React.FC<SignalTableProps> = ({ scannerType, startDate, endDa
               <th className="px-3 py-3 text-right">MFE:MAE</th>
               <th className="px-3 py-3 text-center">FT</th>
               <th className="px-3 py-3 text-center">Status</th>
+              <th className="px-3 py-3 text-center">Intel</th>
             </tr>
           </thead>
           <tbody>
             {data.signals.map((signal) => (
-              <tr
-                key={signal.id}
-                className="border-b border-gray-800 hover:bg-gray-800/30 transition-colors"
-              >
+              <React.Fragment key={signal.id}>
+              <tr className="border-b border-gray-800 hover:bg-gray-800/30 transition-colors">
                 <td className="px-3 py-2.5 text-sm font-mono text-gray-300">{signal.event_date}</td>
                 <td className="px-3 py-2.5">
                   <Link
@@ -227,7 +230,26 @@ const SignalTable: React.FC<SignalTableProps> = ({ scannerType, startDate, endDa
                     <span className="text-[10px] font-bold text-yellow-500/70 uppercase">pending</span>
                   )}
                 </td>
+                <td className="px-3 py-2.5 text-center">
+                  <button
+                    type="button"
+                    onClick={() => setExpandedEventId(expandedEventId === signal.id ? null : signal.id)}
+                    aria-expanded={expandedEventId === signal.id}
+                    className="inline-flex items-center gap-1 rounded border border-gray-700 px-2 py-1 text-[11px] font-semibold text-gray-300 hover:border-financial-blue hover:text-financial-blue"
+                  >
+                    <Sparkles className="h-3 w-3" />
+                    Brief
+                  </button>
+                </td>
               </tr>
+              {expandedEventId === signal.id && (
+                <tr className="border-b border-gray-800 bg-gray-950/30">
+                  <td colSpan={11} className="px-3 py-3">
+                    <SignalIntelligencePanel eventId={signal.id} />
+                  </td>
+                </tr>
+              )}
+              </React.Fragment>
             ))}
           </tbody>
         </table>
@@ -235,5 +257,126 @@ const SignalTable: React.FC<SignalTableProps> = ({ scannerType, startDate, endDa
     </div>
   );
 };
+
+const SignalIntelligencePanel: React.FC<{ eventId: number }> = ({ eventId }) => {
+  const { data, isLoading, isError } = useQuery<AISignalBrief>({
+    queryKey: ['aiSignalBrief', eventId],
+    queryFn: () => fetchAISignalBrief(eventId),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="rounded border border-gray-800 bg-gray-950/50 p-4 text-sm text-gray-400">
+        Loading deterministic brief...
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="rounded border border-red-900/60 bg-red-950/20 p-4 text-sm text-red-300">
+        Deterministic brief is unavailable.
+      </div>
+    );
+  }
+
+  const summary = data.outcome_context.summary;
+  const analogs = data.analogs.slice(0, 3);
+
+  return (
+    <div className="rounded border border-gray-800 bg-gray-950/60 p-4">
+      <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="text-sm font-semibold text-financial-light">
+            Deterministic Signal Brief
+          </div>
+          <div className="mt-1 text-xs text-gray-400">
+            Facts only. Generated narrative can be added later, but this panel does not infer beyond stored data.
+          </div>
+        </div>
+        <div className="text-xs font-mono text-gray-400">
+          {data.facts.ticker} - {data.facts.event_date ?? 'no date'}
+        </div>
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-3">
+        <BriefBlock title="Explanation">
+          {data.why.length > 0 ? (
+            <ul className="space-y-1">
+              {data.why.map((why) => (
+                <li key={why}>{why}</li>
+              ))}
+            </ul>
+          ) : (
+            <span>No explanation bullets are stored.</span>
+          )}
+        </BriefBlock>
+
+        <BriefBlock title="Expected behavior">
+          {analogs.length > 0 ? (
+            <ul className="space-y-2">
+              {analogs.map((analog) => (
+                <li key={analog.event_id} className="flex items-center justify-between gap-3">
+                  <span>
+                    <span className="font-semibold text-financial-light">{analog.ticker}</span>
+                    <span className="text-gray-500"> - {Math.round(analog.similarity_score * 100)}% similar</span>
+                  </span>
+                  <span className={colorForPct(analog.outcome_summary?.eod_pct_change ?? null)}>
+                    EOD {fmtPct(analog.outcome_summary?.eod_pct_change ?? null)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <span>No historical analogs were available.</span>
+          )}
+        </BriefBlock>
+
+        <BriefBlock title="Archetype / Outcome">
+          <div className="space-y-2">
+            <div>
+              <span className="text-gray-500">Archetype </span>
+              <span className="font-semibold text-financial-light">
+                {data.archetype ? `${data.archetype.label} (${data.archetype.event_count})` : 'Unassigned'}
+              </span>
+            </div>
+            <div className="grid grid-cols-3 gap-2 font-mono">
+              <Metric label="EOD" value={summary?.eod_pct_change ?? null} />
+              <Metric label="MFE" value={summary?.mfe_pct ?? null} />
+              <Metric label="MAE" value={summary?.mae_pct ?? null} />
+            </div>
+          </div>
+        </BriefBlock>
+      </div>
+
+      {data.risks.length > 0 && (
+        <div className="mt-3 rounded border border-yellow-700/40 bg-yellow-950/20 p-3">
+          <div className="mb-1 text-[11px] font-bold uppercase text-yellow-300">Risk flags</div>
+          <ul className="space-y-1 text-xs text-yellow-100">
+            {data.risks.map((risk) => (
+              <li key={risk}>{risk}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const BriefBlock: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
+  <div className="rounded border border-gray-800 bg-gray-900/40 p-3 text-xs text-gray-300">
+    <div className="mb-2 text-[11px] font-bold uppercase text-gray-500">{title}</div>
+    {children}
+  </div>
+);
+
+const Metric: React.FC<{ label: string; value: number | null }> = ({ label, value }) => (
+  <div>
+    <div className="text-[10px] uppercase text-gray-500">{label}</div>
+    <div className={colorForPct(value)}>
+      {label} {fmtPct(value)}
+    </div>
+  </div>
+);
 
 export default SignalTable;


### PR DESCRIPTION
## Summary
- adds a deterministic Signal Brief expansion to Scorecard signal rows
- surfaces stored explanation bullets, historical analog expected behavior, archetype assignment, and outcome context without generated prose
- covers complete, partial, and no-outcome event states in SignalTable tests

## Verification
- npm test -- SignalTable.test.tsx
- npx tsc --noEmit
- npm run build
- npx eslint . --report-unused-disable-directives-severity error (0 errors; existing Fast Refresh warnings only)
- npm audit --audit-level=high

Fixes #471