### PR TITLE
Add regime performance panel to Scorecard

### DIFF
--- a/frontend/src/api/outcomes.test.ts
+++ b/frontend/src/api/outcomes.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fetchRegimeBreakdown } from './outcomes';
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+vi.mock('./client', () => ({
+  apiClient: {
+    get: (...args: unknown[]) => mocks.get(...args),
+  },
+}));
+
+describe('outcomes API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches regime breakdown for a scanner with date filters', async () => {
+    mocks.get.mockResolvedValueOnce({
+      data: {
+        scanner_type: 'pre_market_volume_spike',
+        total_events: 2,
+        breakdown: {
+          risk_on: {
+            sample_size: 2,
+            win_rate_pct: 50,
+            avg_mfe_pct: 3.5,
+            avg_mae_pct: -1.2,
+          },
+        },
+      },
+    });
+
+    const result = await fetchRegimeBreakdown('pre_market_volume_spike', {
+      start_date: '2026-01-01',
+      end_date: '2026-01-31',
+    });
+
+    expect(mocks.get).toHaveBeenCalledWith('/outcomes/regime-breakdown/pre_market_volume_spike', {
+      params: {
+        start_date: '2026-01-01',
+        end_date: '2026-01-31',
+      },
+    });
+    expect(result.breakdown.risk_on.sample_size).toBe(2);
+  });
+});

--- a/frontend/src/api/outcomes.ts
+++ b/frontend/src/api/outcomes.ts
@@ -237,6 +237,19 @@ export interface AISignalBrief {
   forbidden_claims: string[];
 }
 
+export interface RegimeSlice {
+  sample_size: number;
+  win_rate_pct: number | null;
+  avg_mfe_pct: number | null;
+  avg_mae_pct: number | null;
+}
+
+export interface RegimeBreakdownResponse {
+  scanner_type: string;
+  total_events: number;
+  breakdown: Record<string, RegimeSlice>;
+}
+
 export interface ExplanationTrait {
   trait_type: string;
   trait_key: string;
@@ -356,6 +369,19 @@ export const fetchHistoricalAnalogs = async (
 
 export const fetchAISignalBrief = async (eventId: number): Promise<AISignalBrief> => {
   const response = await apiClient.get(`/outcomes/event/${eventId}/ai-signal-brief`);
+  return response.data;
+};
+
+export const fetchRegimeBreakdown = async (
+  scannerType: string,
+  params?: { start_date?: string; end_date?: string },
+): Promise<RegimeBreakdownResponse> => {
+  const response = await apiClient.get(`/outcomes/regime-breakdown/${scannerType}`, {
+    params: {
+      start_date: params?.start_date,
+      end_date: params?.end_date,
+    },
+  });
   return response.data;
 };
 

--- a/frontend/src/components/scorecard/RegimePerformancePanel.tsx
+++ b/frontend/src/components/scorecard/RegimePerformancePanel.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { AlertTriangle, ShieldCheck, TrendingDown, TrendingUp } from 'lucide-react';
+import type { RegimeBreakdownResponse, RegimeSlice } from '../../api/outcomes';
+
+type RegimeInterpretation =
+  | 'insufficient'
+  | 'favorable'
+  | 'hostile'
+  | 'neutral';
+
+interface RegimeRow {
+  key: string;
+  label: string;
+  sampleSize: number;
+  winRatePct: number | null;
+  avgMfePct: number | null;
+  avgMaePct: number | null;
+  interpretation: RegimeInterpretation;
+}
+
+interface RegimePerformancePanelProps {
+  data: RegimeBreakdownResponse | null | undefined;
+  isLoading: boolean;
+}
+
+const MIN_SAMPLE_SIZE = 5;
+
+const formatRegimeLabel = (regime: string): string => (
+  regime
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+);
+
+const interpretRegime = (slice: RegimeSlice): RegimeInterpretation => {
+  if (slice.sample_size < MIN_SAMPLE_SIZE) return 'insufficient';
+
+  const winRate = slice.win_rate_pct ?? 0;
+  const avgMfe = slice.avg_mfe_pct ?? 0;
+  const avgMae = slice.avg_mae_pct ?? 0;
+  const adverseMove = Math.abs(avgMae);
+
+  if (winRate >= 60 && avgMfe > adverseMove) return 'favorable';
+  if (winRate <= 40 || avgMae <= -3) return 'hostile';
+  return 'neutral';
+};
+
+const regimeRows = (data: RegimeBreakdownResponse | null | undefined): RegimeRow[] => (
+  Object.entries(data?.breakdown ?? {})
+    .map(([key, slice]) => ({
+      key,
+      label: formatRegimeLabel(key),
+      sampleSize: slice.sample_size,
+      winRatePct: slice.win_rate_pct,
+      avgMfePct: slice.avg_mfe_pct,
+      avgMaePct: slice.avg_mae_pct,
+      interpretation: interpretRegime(slice),
+    }))
+    .sort((a, b) => b.sampleSize - a.sampleSize)
+);
+
+const fmtPct = (value: number | null | undefined): string => (
+  value === null || value === undefined ? 'N/A' : `${value.toFixed(1)}%`
+);
+
+const interpretationCopy: Record<RegimeInterpretation, { label: string; className: string; icon: React.ReactNode }> = {
+  insufficient: {
+    label: 'Insufficient evidence',
+    className: 'text-amber-300 border-amber-700/50 bg-amber-950/20',
+    icon: <AlertTriangle className="h-4 w-4" />,
+  },
+  favorable: {
+    label: 'Candidate favorable regime',
+    className: 'text-green-300 border-green-700/50 bg-green-950/20',
+    icon: <TrendingUp className="h-4 w-4" />,
+  },
+  hostile: {
+    label: 'Candidate hostile regime',
+    className: 'text-red-300 border-red-700/50 bg-red-950/20',
+    icon: <TrendingDown className="h-4 w-4" />,
+  },
+  neutral: {
+    label: 'Neutral / mixed evidence',
+    className: 'text-blue-300 border-blue-700/50 bg-blue-950/20',
+    icon: <ShieldCheck className="h-4 w-4" />,
+  },
+};
+
+const RegimePerformancePanel: React.FC<RegimePerformancePanelProps> = ({ data, isLoading }) => {
+  const rows = regimeRows(data);
+
+  return (
+    <section className="bg-financial-gray rounded-lg border border-gray-700 p-5">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-sm font-bold text-financial-light uppercase tracking-wider">
+            Regime Performance
+          </h2>
+          <p className="text-xs text-gray-500 mt-1">
+            Per-regime scanner evidence. This is advisory evidence, not a trading rule.
+          </p>
+        </div>
+        <div className="text-xs text-gray-500">
+          {data?.total_events ?? 0} tagged events
+        </div>
+      </div>
+
+      {isLoading && (
+        <div className="mt-4 h-20 rounded border border-gray-800 bg-gray-900/50 p-4 text-sm text-gray-400">
+          Loading regime evidence...
+        </div>
+      )}
+
+      {!isLoading && rows.length === 0 && (
+        <div className="mt-4 rounded border border-dashed border-gray-700 p-5 text-sm text-gray-400">
+          No regime outcome evidence yet.
+        </div>
+      )}
+
+      {!isLoading && rows.length > 0 && (
+        <div className="mt-4 grid grid-cols-1 lg:grid-cols-3 gap-3">
+          {rows.map((row) => (
+            <RegimeCard key={row.key} row={row} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+};
+
+const RegimeCard: React.FC<{ row: RegimeRow }> = ({ row }) => {
+  const interpretation = interpretationCopy[row.interpretation];
+  return (
+    <div className="rounded border border-gray-800 bg-gray-900/40 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-semibold text-financial-light">{row.label}</div>
+          <div className="text-xs text-gray-500">n={row.sampleSize}</div>
+        </div>
+        <div className={`inline-flex items-center gap-1 rounded border px-2 py-1 text-[11px] font-semibold ${interpretation.className}`}>
+          {interpretation.icon}
+          {interpretation.label}
+        </div>
+      </div>
+
+      <div className="mt-4 grid grid-cols-3 gap-3 text-xs">
+        <Metric label="Win" value={fmtPct(row.winRatePct)} />
+        <Metric label="Avg MFE" value={fmtPct(row.avgMfePct)} />
+        <Metric label="Avg MAE" value={fmtPct(row.avgMaePct)} />
+      </div>
+    </div>
+  );
+};
+
+const Metric: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div>
+    <div className="text-gray-500">{label}</div>
+    <div className="mt-1 font-mono font-semibold text-financial-light">{value}</div>
+  </div>
+);
+
+export default RegimePerformancePanel;

--- a/frontend/src/hooks/useScorecard.ts
+++ b/frontend/src/hooks/useScorecard.ts
@@ -6,6 +6,7 @@ import {
   fetchIntervals,
   fetchDistribution,
   fetchSignals,
+  fetchRegimeBreakdown,
   fetchExplanationTraits,
   fetchExplanationArchetypes,
   triggerBackfill,
@@ -14,6 +15,7 @@ import {
   IntervalBreakdown,
   DistributionPoint,
   SignalListResponse,
+  RegimeBreakdownResponse,
   ExplanationTraitPerformance,
   ExplanationArchetypeResponse,
   BackfillRequest,
@@ -87,6 +89,17 @@ export const useSignals = (
   });
 };
 
+export const useRegimeBreakdown = (
+  scannerType: string | undefined,
+  params?: { start_date?: string; end_date?: string },
+) => {
+  return useQuery<RegimeBreakdownResponse>({
+    queryKey: ['regimeBreakdown', scannerType, params],
+    queryFn: () => fetchRegimeBreakdown(scannerType!, params),
+    enabled: !!scannerType,
+  });
+};
+
 export const useExplanationTraits = (
   scannerType: string | undefined,
   params?: { start_date?: string; end_date?: string; severity?: string },
@@ -118,6 +131,7 @@ export const useBackfillMutation = () => {
       queryClient.invalidateQueries({ queryKey: ['edgeDecay'] });
       queryClient.invalidateQueries({ queryKey: ['intervals'] });
       queryClient.invalidateQueries({ queryKey: ['distribution'] });
+      queryClient.invalidateQueries({ queryKey: ['regimeBreakdown'] });
     },
   });
 };

--- a/frontend/src/pages/ScorecardDetail.test.tsx
+++ b/frontend/src/pages/ScorecardDetail.test.tsx
@@ -12,6 +12,7 @@ const mockUseBackfillMutation = vi.fn();
 const mockUseSignals = vi.fn();
 const mockUseExplanationTraits = vi.fn();
 const mockUseExplanationArchetypes = vi.fn();
+const mockUseRegimeBreakdown = vi.fn();
 
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-router-dom')>();
@@ -28,6 +29,7 @@ vi.mock('../hooks/useScorecard', () => ({
   useDistribution: (...args: unknown[]) => mockUseDistribution(...args),
   useExplanationTraits: (...args: unknown[]) => mockUseExplanationTraits(...args),
   useExplanationArchetypes: (...args: unknown[]) => mockUseExplanationArchetypes(...args),
+  useRegimeBreakdown: (...args: unknown[]) => mockUseRegimeBreakdown(...args),
   useBackfillMutation: () => mockUseBackfillMutation(),
   useSignals: (...args: unknown[]) => mockUseSignals(...args),
 }));
@@ -78,6 +80,14 @@ const noDataDefaults = () => {
     },
     isLoading: false,
   });
+  mockUseRegimeBreakdown.mockReturnValue({
+    data: {
+      scanner_type: 'pre_market_volume_spike',
+      total_events: 0,
+      breakdown: {},
+    },
+    isLoading: false,
+  });
   mockUseBackfillMutation.mockReturnValue({
     mutate: vi.fn(),
     isPending: false,
@@ -117,6 +127,64 @@ describe('ScorecardDetail — shell', () => {
   it('shows back arrow link', () => {
     renderWithQuery(<ScorecardDetail />);
     expect(screen.getByRole('link')).toBeInTheDocument();
+  });
+});
+
+describe('ScorecardDetail — regime performance', () => {
+  beforeEach(noDataDefaults);
+
+  it('shows empty advisory state when no regime outcome evidence exists', () => {
+    renderWithQuery(<ScorecardDetail />);
+    expect(screen.getByText(/Regime Performance/i)).toBeInTheDocument();
+    expect(screen.getByText(/No regime outcome evidence yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/advisory evidence, not a trading rule/i)).toBeInTheDocument();
+  });
+
+  it('shows loading state while regime breakdown loads', () => {
+    mockUseRegimeBreakdown.mockReturnValue({ data: null, isLoading: true });
+    renderWithQuery(<ScorecardDetail />);
+    expect(screen.getByText(/Regime Performance/i)).toBeInTheDocument();
+    expect(screen.getByText(/Loading regime evidence/i)).toBeInTheDocument();
+  });
+
+  it('renders conservative interpretations for populated and low-sample regimes', () => {
+    mockUseRegimeBreakdown.mockReturnValue({
+      isLoading: false,
+      data: {
+        scanner_type: 'pre_market_volume_spike',
+        total_events: 26,
+        breakdown: {
+          risk_on: {
+            sample_size: 18,
+            win_rate_pct: 68,
+            avg_mfe_pct: 4.2,
+            avg_mae_pct: -1.0,
+          },
+          high_volatility: {
+            sample_size: 3,
+            win_rate_pct: 80,
+            avg_mfe_pct: 6.5,
+            avg_mae_pct: -3.2,
+          },
+          risk_off: {
+            sample_size: 5,
+            win_rate_pct: 35,
+            avg_mfe_pct: 1.4,
+            avg_mae_pct: -4.1,
+          },
+        },
+      },
+    });
+
+    renderWithQuery(<ScorecardDetail />);
+
+    expect(screen.getByText(/Risk On/i)).toBeInTheDocument();
+    expect(screen.getByText(/Candidate favorable regime/i)).toBeInTheDocument();
+    expect(screen.getByText(/High Volatility/i)).toBeInTheDocument();
+    expect(screen.getByText(/Insufficient evidence/i)).toBeInTheDocument();
+    expect(screen.getByText(/Risk Off/i)).toBeInTheDocument();
+    expect(screen.getByText(/Candidate hostile regime/i)).toBeInTheDocument();
+    expect(screen.getByText(/n=18/i)).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/pages/ScorecardDetail.tsx
+++ b/frontend/src/pages/ScorecardDetail.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, AlertTriangle } from 'lucide-react';
-import { useScorecard, useEdgeDecay, useIntervals, useDistribution, useExplanationTraits, useExplanationArchetypes } from '../hooks/useScorecard';
+import { useScorecard, useEdgeDecay, useIntervals, useDistribution, useRegimeBreakdown, useExplanationTraits, useExplanationArchetypes } from '../hooks/useScorecard';
 import type { ExplanationArchetype, ExplanationTrait } from '../api/outcomes';
 import HeroMetrics from '../components/scorecard/HeroMetrics';
 import EdgeDecayChart from '../components/scorecard/EdgeDecayChart';
@@ -9,6 +9,7 @@ import DistributionChart from '../components/scorecard/DistributionChart';
 import IntervalTable from '../components/scorecard/IntervalTable';
 import BackfillPanel from '../components/scorecard/BackfillPanel';
 import SignalTable from '../components/scorecard/SignalTable';
+import RegimePerformancePanel from '../components/scorecard/RegimePerformancePanel';
 
 type Period = '7d' | '30d' | '90d' | 'all';
 
@@ -58,6 +59,7 @@ const ScorecardDetail: React.FC = () => {
   const { data: edgeDecay, isLoading: loadingEdge } = useEdgeDecay(scannerType, dates);
   const { data: intervals, isLoading: loadingIntervals } = useIntervals(scannerType);
   const { data: distribution, isLoading: loadingDist } = useDistribution(scannerType);
+  const { data: regimeBreakdown, isLoading: loadingRegimes } = useRegimeBreakdown(scannerType, dates);
   const { data: traits, isLoading: loadingTraits } = useExplanationTraits(scannerType, scorecardParams);
   const { data: archetypes, isLoading: loadingArchetypes } = useExplanationArchetypes(scannerType, scorecardParams);
 
@@ -143,6 +145,8 @@ const ScorecardDetail: React.FC = () => {
 
       {/* Hero Metrics */}
       {scorecard && <HeroMetrics scorecard={scorecard} />}
+
+      <RegimePerformancePanel data={regimeBreakdown} isLoading={loadingRegimes} />
 
       {/* Explanation Intelligence */}
       <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">


### PR DESCRIPTION
## Summary
- adds a Scorecard regime performance panel backed by the existing regime-breakdown endpoint
- shows per-regime sample size, win rate, avg MFE, avg MAE, and advisory interpretation
- treats regimes with fewer than 5 samples as insufficient evidence and keeps the copy explicitly advisory
- adds API-client and Scorecard rendering tests for empty, loading, populated, and low-sample states

## Verification
- npm test -- ScorecardDetail.test.tsx outcomes.test.ts
- npm test -- useScorecard.test.ts
- npm test -- ScorecardDetail.test.tsx outcomes.test.ts useScorecard.test.ts
- npx tsc --noEmit
- npm run build
- npx eslint . --report-unused-disable-directives-severity error (0 errors; existing Fast Refresh warnings only)
- npm audit --audit-level=high

Fixes #526