### PR TITLE
Add LLM feature flags and guardrails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,6 +114,23 @@ FLOWER_BASIC_AUTH=admin:change_me_flower_password
 RATE_LIMITING_ENABLED=true
 
 # =============================================================================
+# OPTIONAL: LLM Features
+# =============================================================================
+# Disabled by default. Provider/model values are inert unless LLM_FEATURES_ENABLED=true
+# and the feature area is included in LLM_ALLOWED_FEATURES.
+# Supported providers: disabled, openai, anthropic, local
+# Allowed features: scanner_narrative, alert_copy, post_mortem, semantic_search,
+# analyst_qa, embeddings
+# LLM_FEATURES_ENABLED=false
+# LLM_PROVIDER=disabled
+# LLM_MODEL=
+# LLM_MAX_TOKENS=800
+# LLM_TIMEOUT_SECONDS=10.0
+# LLM_MAX_RETRIES=1
+# LLM_RETRY_BACKOFF_SECONDS=0.5
+# LLM_ALLOWED_FEATURES=
+
+# =============================================================================
 # OPTIONAL: Logging
 # =============================================================================
 # Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -53,6 +53,25 @@ These must be set before starting the stack. The application will start without 
 
 ---
 
+## Optional LLM Features
+
+LLM-powered narratives and semantic intelligence are disabled by default. Setting provider/model values alone does not affect deterministic scanner explainability; callers must explicitly enable LLM features and opt feature areas into the allowlist.
+
+Allowed feature areas: `scanner_narrative`, `alert_copy`, `post_mortem`, `semantic_search`, `analyst_qa`, `embeddings`.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `LLM_FEATURES_ENABLED` | `false` | Master flag for optional LLM feature paths. When `false`, LLM guardrails deny every feature area. |
+| `LLM_PROVIDER` | `disabled` | Provider selector. Supported values: `disabled`, `openai`, `anthropic`, `local`. Must be non-`disabled` when `LLM_FEATURES_ENABLED=true`. |
+| `LLM_MODEL` | `` (empty) | Model identifier for the selected provider. Required when `LLM_FEATURES_ENABLED=true`. |
+| `LLM_MAX_TOKENS` | `800` | Maximum output tokens allowed for one LLM call. Must be greater than zero. |
+| `LLM_TIMEOUT_SECONDS` | `10.0` | Per-call timeout in seconds. Must be greater than zero. |
+| `LLM_MAX_RETRIES` | `1` | Maximum retry attempts after an LLM call failure. Must be zero or greater. |
+| `LLM_RETRY_BACKOFF_SECONDS` | `0.5` | Backoff delay between retry attempts in seconds. Must be greater than zero. |
+| `LLM_ALLOWED_FEATURES` | `` (empty) | Comma-separated allowlist of feature areas permitted to use LLMs, e.g. `scanner_narrative,semantic_search`. Unknown areas fail startup validation. |
+
+---
+
 ## System Notifications
 
 Generic (non-scanner) email + browser-push notifications via `notify_system()` and `POST /api/v1/alerts/system`. Used by server-to-server callers such as the dark-factory scheduler.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -8,6 +8,18 @@ from urllib.parse import quote
 from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+LLM_ALLOWED_FEATURE_AREAS = frozenset(
+    {
+        "scanner_narrative",
+        "alert_copy",
+        "post_mortem",
+        "semantic_search",
+        "analyst_qa",
+        "embeddings",
+    }
+)
+LLM_SUPPORTED_PROVIDERS = frozenset({"disabled", "openai", "anthropic", "local"})
+
 
 class Settings(BaseSettings):
     """Application settings loaded from environment variables."""
@@ -140,6 +152,18 @@ class Settings(BaseSettings):
     SCAN_DURATION_SLO_SECONDS: int = 120
     SCAN_STALENESS_SLO_SECONDS: int = 900
 
+    # Optional LLM features. These remain disabled by default and are only
+    # consulted by explicit LLM feature paths; deterministic explainability is
+    # intentionally independent of these provider settings.
+    LLM_FEATURES_ENABLED: bool = False
+    LLM_PROVIDER: str = "disabled"
+    LLM_MODEL: str = ""
+    LLM_MAX_TOKENS: int = Field(default=800, gt=0)
+    LLM_TIMEOUT_SECONDS: float = Field(default=10.0, gt=0)
+    LLM_MAX_RETRIES: int = Field(default=1, ge=0)
+    LLM_RETRY_BACKOFF_SECONDS: float = Field(default=0.5, gt=0)
+    LLM_ALLOWED_FEATURES: str = ""
+
     # ── WebSocket resource limits ──────────────────────────────────────────
     # Single-process in-memory counters (see app/core/ws_limits.py).
     # For multi-replica deployments, migrate counters to Redis.
@@ -175,6 +199,15 @@ class Settings(BaseSettings):
     @classmethod
     def normalize_environment(cls, v: str) -> str:
         return v.lower()
+
+    @field_validator("LLM_PROVIDER")
+    @classmethod
+    def normalize_llm_provider(cls, v: str) -> str:
+        provider = v.strip().lower()
+        if provider not in LLM_SUPPORTED_PROVIDERS:
+            supported = ", ".join(sorted(LLM_SUPPORTED_PROVIDERS))
+            raise ValueError(f"LLM_PROVIDER must be one of: {supported}")
+        return provider
 
     @field_validator("LIVE_TRADING_ARMED")
     @classmethod
@@ -224,6 +257,31 @@ class Settings(BaseSettings):
                 "Generate one with: python -c 'import secrets; print(secrets.token_urlsafe(48))'"
             )
         return v
+
+    @model_validator(mode="after")
+    def validate_llm_guardrails(self) -> "Settings":
+        unknown_features = self.llm_allowed_feature_set - LLM_ALLOWED_FEATURE_AREAS
+        if unknown_features:
+            unknown = ", ".join(sorted(unknown_features))
+            supported = ", ".join(sorted(LLM_ALLOWED_FEATURE_AREAS))
+            raise ValueError(
+                f"LLM_ALLOWED_FEATURES contains unsupported feature area(s): {unknown}. "
+                f"Supported areas: {supported}"
+            )
+        if self.LLM_FEATURES_ENABLED:
+            if self.LLM_PROVIDER == "disabled":
+                raise ValueError("LLM_PROVIDER must be configured when LLM features are enabled")
+            if not self.LLM_MODEL.strip():
+                raise ValueError("LLM_MODEL must be configured when LLM features are enabled")
+        return self
+
+    @property
+    def llm_allowed_feature_set(self) -> frozenset[str]:
+        return frozenset(
+            feature.strip()
+            for feature in self.LLM_ALLOWED_FEATURES.split(",")
+            if feature.strip()
+        )
 
 
 @lru_cache()

--- a/backend/app/core/llm_guardrails.py
+++ b/backend/app/core/llm_guardrails.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.core.config import Settings
+
+
+@dataclass(frozen=True)
+class LLMUsageGuardrails:
+    enabled: bool
+    provider: str
+    model: str
+    max_tokens: int
+    timeout_seconds: float
+    max_retries: int
+    retry_backoff_seconds: float
+    allowed_features: frozenset[str]
+
+    def allows(self, feature_area: str) -> bool:
+        return self.enabled and feature_area in self.allowed_features
+
+
+def build_llm_usage_guardrails(settings: Settings) -> LLMUsageGuardrails:
+    return LLMUsageGuardrails(
+        enabled=settings.LLM_FEATURES_ENABLED,
+        provider=settings.LLM_PROVIDER,
+        model=settings.LLM_MODEL,
+        max_tokens=settings.LLM_MAX_TOKENS,
+        timeout_seconds=settings.LLM_TIMEOUT_SECONDS,
+        max_retries=settings.LLM_MAX_RETRIES,
+        retry_backoff_seconds=settings.LLM_RETRY_BACKOFF_SECONDS,
+        allowed_features=settings.llm_allowed_feature_set,
+    )

--- a/backend/tests/core/test_llm_guardrails.py
+++ b/backend/tests/core/test_llm_guardrails.py
@@ -1,0 +1,113 @@
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import Settings
+from app.core.llm_guardrails import build_llm_usage_guardrails
+
+BASE_SETTINGS = {
+    "DATABASE_URL": "postgresql://test:test@localhost/test",
+    "POLYGON_API_KEY": "test-key",
+    "JWT_SECRET_KEY": "a" * 32,
+    "REDIS_PASSWORD": "r" * 16,
+}
+
+
+def make_settings(**overrides) -> Settings:
+    return Settings(_env_file=None, **{**BASE_SETTINGS, **overrides})
+
+
+def test_llm_features_are_disabled_by_default():
+    settings = make_settings()
+
+    guardrails = build_llm_usage_guardrails(settings)
+
+    assert settings.LLM_FEATURES_ENABLED is False
+    assert settings.llm_allowed_feature_set == frozenset()
+    assert guardrails.enabled is False
+    assert guardrails.allows("scanner_narrative") is False
+
+
+def test_llm_config_parses_provider_model_and_guardrails():
+    settings = make_settings(
+        LLM_FEATURES_ENABLED=True,
+        LLM_PROVIDER="OpenAI",
+        LLM_MODEL="market-narrative-test",
+        LLM_ALLOWED_FEATURES="scanner_narrative, semantic_search",
+        LLM_MAX_TOKENS=1200,
+        LLM_TIMEOUT_SECONDS=12.5,
+        LLM_MAX_RETRIES=2,
+        LLM_RETRY_BACKOFF_SECONDS=0.25,
+    )
+
+    guardrails = build_llm_usage_guardrails(settings)
+
+    assert settings.LLM_PROVIDER == "openai"
+    assert settings.llm_allowed_feature_set == frozenset(
+        {"scanner_narrative", "semantic_search"}
+    )
+    assert guardrails.provider == "openai"
+    assert guardrails.model == "market-narrative-test"
+    assert guardrails.max_tokens == 1200
+    assert guardrails.timeout_seconds == 12.5
+    assert guardrails.max_retries == 2
+    assert guardrails.retry_backoff_seconds == 0.25
+    assert guardrails.allows("scanner_narrative") is True
+    assert guardrails.allows("analyst_qa") is False
+
+
+def test_llm_config_parses_from_environment(monkeypatch):
+    for key, value in BASE_SETTINGS.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setenv("LLM_FEATURES_ENABLED", "true")
+    monkeypatch.setenv("LLM_PROVIDER", "local")
+    monkeypatch.setenv("LLM_MODEL", "local-narrative")
+    monkeypatch.setenv("LLM_ALLOWED_FEATURES", "post_mortem,analyst_qa")
+    monkeypatch.setenv("LLM_MAX_TOKENS", "640")
+    monkeypatch.setenv("LLM_TIMEOUT_SECONDS", "4.5")
+    monkeypatch.setenv("LLM_MAX_RETRIES", "0")
+    monkeypatch.setenv("LLM_RETRY_BACKOFF_SECONDS", "0.75")
+
+    settings = Settings(_env_file=None)
+
+    assert settings.LLM_FEATURES_ENABLED is True
+    assert settings.LLM_PROVIDER == "local"
+    assert settings.llm_allowed_feature_set == frozenset({"post_mortem", "analyst_qa"})
+    assert settings.LLM_MAX_TOKENS == 640
+    assert settings.LLM_TIMEOUT_SECONDS == 4.5
+    assert settings.LLM_MAX_RETRIES == 0
+    assert settings.LLM_RETRY_BACKOFF_SECONDS == 0.75
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("LLM_MAX_TOKENS", 0),
+        ("LLM_TIMEOUT_SECONDS", 0),
+        ("LLM_MAX_RETRIES", -1),
+        ("LLM_RETRY_BACKOFF_SECONDS", 0),
+    ],
+)
+def test_llm_numeric_guardrails_must_be_positive(field, value):
+    with pytest.raises(ValidationError):
+        make_settings(**{field: value})
+
+
+def test_enabled_llm_requires_real_provider_and_model():
+    with pytest.raises(ValidationError, match="LLM_PROVIDER"):
+        make_settings(LLM_FEATURES_ENABLED=True)
+
+    with pytest.raises(ValidationError, match="LLM_MODEL"):
+        make_settings(
+            LLM_FEATURES_ENABLED=True,
+            LLM_PROVIDER="openai",
+        )
+
+
+def test_llm_allowed_features_reject_unknown_feature_area():
+    with pytest.raises(ValidationError, match="unknown_llm_feature"):
+        make_settings(
+            LLM_FEATURES_ENABLED=True,
+            LLM_PROVIDER="openai",
+            LLM_MODEL="market-narrative-test",
+            LLM_ALLOWED_FEATURES="scanner_narrative,unknown_llm_feature",
+        )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,6 +158,15 @@ services:
       SEQ_URL: http://seq:5341
       WATCHFILES_FORCE_POLLING: "true"
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      # Optional LLM features are disabled by default and require an allowlist.
+      LLM_FEATURES_ENABLED: ${LLM_FEATURES_ENABLED:-false}
+      LLM_PROVIDER: ${LLM_PROVIDER:-disabled}
+      LLM_MODEL: ${LLM_MODEL:-}
+      LLM_MAX_TOKENS: ${LLM_MAX_TOKENS:-800}
+      LLM_TIMEOUT_SECONDS: ${LLM_TIMEOUT_SECONDS:-10.0}
+      LLM_MAX_RETRIES: ${LLM_MAX_RETRIES:-1}
+      LLM_RETRY_BACKOFF_SECONDS: ${LLM_RETRY_BACKOFF_SECONDS:-0.5}
+      LLM_ALLOWED_FEATURES: ${LLM_ALLOWED_FEATURES:-}
       IBKR_HOST: ib-gateway
       IBKR_PORT: 4004
       IBKR_CLIENT_ID: ${IBKR_CLIENT_ID:-10}
@@ -246,6 +255,15 @@ services:
       SEQ_URL: http://seq:5341
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       WATCHFILES_FORCE_POLLING: "true"
+      # Optional LLM features are disabled by default and require an allowlist.
+      LLM_FEATURES_ENABLED: ${LLM_FEATURES_ENABLED:-false}
+      LLM_PROVIDER: ${LLM_PROVIDER:-disabled}
+      LLM_MODEL: ${LLM_MODEL:-}
+      LLM_MAX_TOKENS: ${LLM_MAX_TOKENS:-800}
+      LLM_TIMEOUT_SECONDS: ${LLM_TIMEOUT_SECONDS:-10.0}
+      LLM_MAX_RETRIES: ${LLM_MAX_RETRIES:-1}
+      LLM_RETRY_BACKOFF_SECONDS: ${LLM_RETRY_BACKOFF_SECONDS:-0.5}
+      LLM_ALLOWED_FEATURES: ${LLM_ALLOWED_FEATURES:-}
       IBKR_HOST: ib-gateway
       IBKR_PORT: 4004
       IBKR_CLIENT_ID: ${IBKR_CLIENT_ID:-10}
@@ -337,6 +355,15 @@ services:
       SEQ_URL: http://seq:5341
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
       PYTHONDONTWRITEBYTECODE: "1"
+      # Optional LLM features are disabled by default and require an allowlist.
+      LLM_FEATURES_ENABLED: ${LLM_FEATURES_ENABLED:-false}
+      LLM_PROVIDER: ${LLM_PROVIDER:-disabled}
+      LLM_MODEL: ${LLM_MODEL:-}
+      LLM_MAX_TOKENS: ${LLM_MAX_TOKENS:-800}
+      LLM_TIMEOUT_SECONDS: ${LLM_TIMEOUT_SECONDS:-10.0}
+      LLM_MAX_RETRIES: ${LLM_MAX_RETRIES:-1}
+      LLM_RETRY_BACKOFF_SECONDS: ${LLM_RETRY_BACKOFF_SECONDS:-0.5}
+      LLM_ALLOWED_FEATURES: ${LLM_ALLOWED_FEATURES:-}
       OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
       OTEL_SERVICE_NAME: markethawk-beat
       # JWT auth secret — required by Settings validator (>=32 chars), sourced from .env
@@ -861,5 +888,4 @@ networks:
     driver: bridge
   factory-network:
     driver: bridge
-
 


### PR DESCRIPTION
## Summary
- add disabled-by-default LLM feature settings with provider/model validation and usage limits
- add a reusable guardrail object for future optional LLM feature paths
- document LLM env vars and pass them into backend/Celery services

## Tests
- python -m pytest backend/tests/core/test_config.py backend/tests/test_settings.py backend/tests/core/test_llm_guardrails.py --no-cov
- python -m ruff check backend/app/core/config.py backend/app/core/llm_guardrails.py backend/tests/core/test_llm_guardrails.py
- docker compose --env-file .env.example config --quiet

Closes #472