### PR TITLE
feat(factory-adapter): smoke-gate (check-only) + validate hooks (#738)

### DIFF
--- a/.factory/hooks/smoke-gate
+++ b/.factory/hooks/smoke-gate
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# MarketHawk smoke-gate hook — CHECK ONLY.
+# Exit 0 = origin/main is green; non-zero = red.
+# Red/green STATE handling (sentinel file, regression ticket, clean-halt exit 0)
+# stays factory-side: dark-factory scripts/hooks.sh wraps this check with
+# _smoke_on_red/_smoke_on_green. Do not add state handling here.
+# Ported from dark-factory smoke_gate.sh _smoke_check_main.
+set -uo pipefail
+
+echo "[smoke-gate hook] Checking frontend TypeScript (tsc)..."
+if ! (cd "${CLONE_DIR}/frontend" \
+      && rm -f tsconfig.app.tsbuildinfo \
+      && npx tsc -p tsconfig.app.json --noEmit 2>&1); then
+  echo "[smoke-gate hook] tsc FAILED — main is red"
+  exit 1
+fi
+
+echo "[smoke-gate hook] Checking backend Python import graph..."
+# Throwaway values: the gate verifies the import graph compiles, NOT that config
+# is real. Settings() instantiates at import time and requires DATABASE_URL /
+# POLYGON_API_KEY / JWT_SECRET_KEY (>=32 chars) / REDIS_PASSWORD (>=16 chars).
+if ! (cd "${CLONE_DIR}/backend" \
+      && DATABASE_URL="postgresql://smoke:smoke@localhost:5432/smoke" \
+         POLYGON_API_KEY="smoke-gate-only-not-a-real-key" \
+         JWT_SECRET_KEY="smoke-gate-only-not-secret-0123456789abcdef" \
+         REDIS_PASSWORD="smoke-gate-only-not-a-real-redis-password" \
+         python -c "import app.main" 2>&1); then
+  echo "[smoke-gate hook] python import FAILED — main is red"
+  exit 1
+fi
+
+echo "[smoke-gate hook] main is green"
+exit 0

--- a/.factory/hooks/validate
+++ b/.factory/hooks/validate
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# MarketHawk validate hook — lightweight post-merge validation (no running DB).
+# Called as a gate by the factory's deconflict flow; non-zero exit escalates
+# the ticket to Blocked. Ported from entrypoint.sh's inline deconflict tsc check.
+set -uo pipefail
+
+echo "[validate hook] TypeScript type check..."
+cd "${CLONE_DIR}/frontend" && npx tsc --noEmit


### PR DESCRIPTION
﻿## Summary

- Adds `.factory/hooks/smoke-gate`: check-only port of `_smoke_check_main` from dark-factory `smoke_gate.sh`. Runs frontend tsc + backend Python import graph with throwaway env. Exits 0 (green) or non-zero (red); state handling (sentinel file, regression ticket, clean-halt) remains factory-side in `scripts/hooks.sh`.
- Adds `.factory/hooks/validate`: lightweight post-merge TypeScript type-check gate, ported from entrypoint.sh's inline deconflict tsc check. Called by the factory's deconflict flow; non-zero escalates to Blocked.
- Both files are pure additions (new executable files only; nothing existing rewired in MarketHawk).
- Executable bit verified: `git ls-files -s .factory/hooks/` shows `100755` on both.

Closes omniscient/dark-factory#177

## Test plan

- [x] `bash -n` syntax check passes on both hooks
- [x] `docker run ... bash /clone/.factory/hooks/smoke-gate && bash /clone/.factory/hooks/validate` inside `ghcr.io/omniscient/dark-factory:latest` against the worktree — both exit 0, smoke-gate prints `[smoke-gate hook] main is green`
- [x] `git ls-files -s .factory/hooks/` shows mode `100755` on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyNzjNGmqJ8fSZNTb55n9c