### PR TITLE
Add cached scanner event narrative generation

### DIFF
--- a/backend/app/alembic/versions/b6c7d8e9f0a1_add_scanner_event_narratives.py
+++ b/backend/app/alembic/versions/b6c7d8e9f0a1_add_scanner_event_narratives.py
@@ -1,0 +1,93 @@
+"""add_scanner_event_narratives
+
+Revision ID: b6c7d8e9f0a1
+Revises: a2b3c4d5e6f7
+Create Date: 2026-07-04 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "b6c7d8e9f0a1"
+down_revision: Union[str, None] = "a2b3c4d5e6f7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "scanner_event_narratives",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("scanner_event_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "feature_area",
+            sa.String(length=50),
+            nullable=False,
+            server_default="scanner_narrative",
+        ),
+        sa.Column("narrative_text", sa.Text(), nullable=False),
+        sa.Column("provider", sa.String(length=50), nullable=False),
+        sa.Column("model", sa.String(length=100), nullable=False),
+        sa.Column("prompt_version", sa.String(length=50), nullable=False),
+        sa.Column("brief_schema_version", sa.String(length=50), nullable=False),
+        sa.Column("brief_fingerprint", sa.String(length=64), nullable=False),
+        sa.Column(
+            "input_payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="{}",
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["scanner_event_id"], ["scanner_events.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "scanner_event_id",
+            "feature_area",
+            "provider",
+            "model",
+            "prompt_version",
+            name="uq_scanner_event_narrative_cache",
+        ),
+    )
+    op.create_index(
+        op.f("ix_scanner_event_narratives_id"),
+        "scanner_event_narratives",
+        ["id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_scanner_event_narratives_scanner_event_id"),
+        "scanner_event_narratives",
+        ["scanner_event_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_scanner_event_narratives_brief_fingerprint"),
+        "scanner_event_narratives",
+        ["brief_fingerprint"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_scanner_event_narratives_brief_fingerprint"),
+        table_name="scanner_event_narratives",
+    )
+    op.drop_index(
+        op.f("ix_scanner_event_narratives_scanner_event_id"),
+        table_name="scanner_event_narratives",
+    )
+    op.drop_index(
+        op.f("ix_scanner_event_narratives_id"),
+        table_name="scanner_event_narratives",
+    )
+    op.drop_table("scanner_event_narratives")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -22,6 +22,7 @@ from app.models.replay_run import ReplayRun
 from app.models.replay_trade import ReplayTrade
 from app.models.scanner_config import ScannerConfig
 from app.models.scanner_event import ScannerEvent
+from app.models.scanner_event_narrative import ScannerEventNarrative
 from app.models.scanner_outcome_snapshot import ScannerOutcomeSnapshot
 from app.models.scanner_outcome_summary import ScannerOutcomeSummary
 from app.models.scanner_replay_diff import ScannerReplayDiff
@@ -48,6 +49,7 @@ __all__ = [
     "StockUniverse",
     "MonitoredStock",
     "ScannerEvent",
+    "ScannerEventNarrative",
     "ScannerConfig",
     "ScannerRun",
     "TickerReference",

--- a/backend/app/models/scanner_event_narrative.py
+++ b/backend/app/models/scanner_event_narrative.py
@@ -1,0 +1,52 @@
+"""
+Cached scanner event narrative model.
+"""
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+
+from app.core.database import Base
+from app.utils.time import utc_now
+
+
+class ScannerEventNarrative(Base):
+    """Cached generated narrative for one scanner event and LLM config."""
+
+    __tablename__ = "scanner_event_narratives"
+
+    id = Column(Integer, primary_key=True, index=True)
+    scanner_event_id = Column(
+        Integer,
+        ForeignKey("scanner_events.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    feature_area = Column(String(50), nullable=False, default="scanner_narrative")
+    narrative_text = Column(Text, nullable=False)
+    provider = Column(String(50), nullable=False)
+    model = Column(String(100), nullable=False)
+    prompt_version = Column(String(50), nullable=False)
+    brief_schema_version = Column(String(50), nullable=False)
+    brief_fingerprint = Column(String(64), nullable=False, index=True)
+    input_payload = Column(JSONB, nullable=False, default=dict)
+    created_at = Column(DateTime, default=utc_now)
+    updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "scanner_event_id",
+            "feature_area",
+            "provider",
+            "model",
+            "prompt_version",
+            name="uq_scanner_event_narrative_cache",
+        ),
+    )

--- a/backend/app/routers/outcomes.py
+++ b/backend/app/routers/outcomes.py
@@ -40,6 +40,7 @@ from app.services.explanation_trait_performance import (
 )
 from app.services.historical_analog_service import HistoricalAnalogService
 from app.services.outcome_service import OutcomeService
+from app.services.scanner_event_narrative import ScannerEventNarrativeService
 from app.services.stats import StatsService
 from app.utils.db import get_or_404
 
@@ -285,6 +286,15 @@ def get_ai_signal_brief(
 ):
     event = get_or_404(db, ScannerEvent, event_id, "ScannerEvent")
     return AISignalBriefService().build(db, event)
+
+
+@router.get("/event/{event_id}/ai-signal-narrative")
+def get_ai_signal_narrative(
+    event_id: int,
+    db: Session = Depends(get_db),
+):
+    event = get_or_404(db, ScannerEvent, event_id, "ScannerEvent")
+    return ScannerEventNarrativeService().build(db, event)
 
 
 @router.get("/event/{event_id}/historical-analogs")

--- a/backend/app/services/scanner_event_narrative.py
+++ b/backend/app/services/scanner_event_narrative.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Protocol
+
+from sqlalchemy.orm import Session
+
+from app.core.config import Settings, settings
+from app.core.llm_guardrails import LLMUsageGuardrails, build_llm_usage_guardrails
+from app.models.scanner_event import ScannerEvent
+from app.models.scanner_event_narrative import ScannerEventNarrative
+from app.services.ai_signal_brief import AISignalBriefService
+
+SCANNER_NARRATIVE_FEATURE = "scanner_narrative"
+SCANNER_NARRATIVE_PROMPT_VERSION = "scanner_narrative.v1"
+
+
+class ScannerNarrativeGenerator(Protocol):
+    provider_name: str
+    model_name: str
+
+    def generate(
+        self,
+        brief: dict[str, Any],
+        guardrails: LLMUsageGuardrails,
+    ) -> str: ...
+
+
+class LocalBriefNarrativeGenerator:
+    """Grounded local renderer for scanner narratives.
+
+    This intentionally reads only the deterministic brief facts and risks. External
+    provider integration can replace this generator without changing cache policy.
+    """
+
+    provider_name = "local"
+    model_name = "grounded-template-v1"
+
+    def generate(
+        self,
+        brief: dict[str, Any],
+        guardrails: LLMUsageGuardrails,
+    ) -> str:
+        facts = brief.get("facts") or {}
+        risks = list(brief.get("risks") or [])
+        ticker = facts.get("ticker") or "Unknown ticker"
+        scanner_type = facts.get("scanner_type") or "unknown scanner"
+        event_date = facts.get("event_date") or "unknown date"
+        severity = facts.get("severity") or "unknown severity"
+        summary = facts.get("summary") or "No summary provided."
+        score = facts.get("signal_quality_score")
+
+        score_text = f" Signal quality score: {score}." if score is not None else ""
+        risk_text = " Key risks: " + "; ".join(risks) if risks else " Key risks: none listed."
+        return (
+            f"{ticker} produced a {severity} {scanner_type} signal on {event_date}. "
+            f"{summary}.{score_text}{risk_text}"
+        )
+
+
+class ScannerEventNarrativeService:
+    def __init__(
+        self,
+        *,
+        brief_service: AISignalBriefService | None = None,
+        generator: ScannerNarrativeGenerator | None = None,
+        settings: Settings = settings,
+    ) -> None:
+        self._brief_service = brief_service or AISignalBriefService()
+        self._settings = settings
+        self._generator = generator or LocalBriefNarrativeGenerator()
+
+    def build(self, db: Session, event: ScannerEvent) -> dict[str, Any]:
+        brief = self._brief_service.build(db, event)
+        guardrails = build_llm_usage_guardrails(self._settings)
+
+        if not guardrails.allows(SCANNER_NARRATIVE_FEATURE):
+            return {
+                "brief": brief,
+                "narrative": None,
+                "cache": {"status": "disabled"},
+                "guardrails": guardrails,
+            }
+
+        input_payload = _narrative_input_payload(brief)
+        fingerprint = _brief_fingerprint(brief)
+        cache = self._cache_query(db, event, guardrails).first()
+        if cache and cache.brief_fingerprint == fingerprint:
+            return {
+                "brief": brief,
+                "narrative": self._narrative_payload(cache),
+                "cache": {"status": "hit"},
+                "guardrails": guardrails,
+            }
+
+        narrative_text = self._generator.generate(brief, guardrails)
+        status = "stale_regenerated" if cache else "miss"
+        if cache is None:
+            cache = ScannerEventNarrative(
+                scanner_event_id=event.id,
+                feature_area=SCANNER_NARRATIVE_FEATURE,
+                provider=guardrails.provider,
+                model=guardrails.model,
+                prompt_version=SCANNER_NARRATIVE_PROMPT_VERSION,
+            )
+            db.add(cache)
+
+        cache.narrative_text = narrative_text
+        cache.brief_schema_version = str(brief.get("schema_version") or "")
+        cache.brief_fingerprint = fingerprint
+        cache.input_payload = input_payload
+        db.flush()
+
+        return {
+            "brief": brief,
+            "narrative": self._narrative_payload(cache),
+            "cache": {"status": status},
+            "guardrails": guardrails,
+        }
+
+    def _cache_query(
+        self,
+        db: Session,
+        event: ScannerEvent,
+        guardrails: LLMUsageGuardrails,
+    ):
+        return db.query(ScannerEventNarrative).filter(
+            ScannerEventNarrative.scanner_event_id == event.id,
+            ScannerEventNarrative.feature_area == SCANNER_NARRATIVE_FEATURE,
+            ScannerEventNarrative.provider == guardrails.provider,
+            ScannerEventNarrative.model == guardrails.model,
+            ScannerEventNarrative.prompt_version == SCANNER_NARRATIVE_PROMPT_VERSION,
+        )
+
+    def _narrative_payload(self, cache: ScannerEventNarrative) -> dict[str, Any]:
+        return {
+            "text": cache.narrative_text,
+            "provider": cache.provider,
+            "model": cache.model,
+            "prompt_version": cache.prompt_version,
+            "brief_schema_version": cache.brief_schema_version,
+            "brief_fingerprint": cache.brief_fingerprint,
+            "created_at": cache.created_at.isoformat() if cache.created_at else None,
+            "updated_at": cache.updated_at.isoformat() if cache.updated_at else None,
+        }
+
+
+def _narrative_input_payload(brief: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "facts": brief.get("facts") or {},
+        "risks": list(brief.get("risks") or []),
+    }
+
+
+def _brief_fingerprint(brief: dict[str, Any]) -> str:
+    payload = {
+        "schema_version": brief.get("schema_version"),
+        **_narrative_input_payload(brief),
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()

--- a/backend/tests/api/test_ai_signal_brief.py
+++ b/backend/tests/api/test_ai_signal_brief.py
@@ -194,6 +194,23 @@ def test_ai_signal_brief_no_analog_event_reports_warning(db):
     )
 
 
+def test_ai_signal_narrative_disabled_returns_brief_without_generated_text(db):
+    target = _seed_event(
+        db,
+        ticker="DIS",
+        event_date=date(2026, 7, 3),
+        explanation=_explanation(),
+    )
+
+    response = client.get(f"/api/v1/outcomes/event/{target.id}/ai-signal-narrative")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["brief"]["facts"]["ticker"] == "DIS"
+    assert data["narrative"] is None
+    assert data["cache"]["status"] == "disabled"
+
+
 def test_historical_analogs_endpoint_enriches_events_explanations_and_outcomes(db):
     _seed_event(
         db,

--- a/backend/tests/services/test_scanner_event_narrative_service.py
+++ b/backend/tests/services/test_scanner_event_narrative_service.py
@@ -1,0 +1,187 @@
+from datetime import date
+
+from app.core.config import Settings
+from app.models.scanner_event import ScannerEvent
+from app.models.scanner_event_narrative import ScannerEventNarrative
+from app.services.scanner_event_narrative import ScannerEventNarrativeService
+
+BASE_SETTINGS = {
+    "DATABASE_URL": "postgresql://test:test@localhost/test",
+    "POLYGON_API_KEY": "test-key",
+    "JWT_SECRET_KEY": "a" * 32,
+    "REDIS_PASSWORD": "r" * 16,
+}
+
+
+class FakeBriefService:
+    schema_version = "ai_signal_brief.v1"
+
+    def __init__(self, brief: dict):
+        self.brief = brief
+
+    def build(self, db, event):
+        return self.brief
+
+
+class RecordingGenerator:
+    provider_name = "local"
+    model_name = "unit-narrator"
+
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, brief, guardrails):
+        self.calls.append({"brief": brief, "guardrails": guardrails})
+        facts = brief["facts"]
+        risks = brief["risks"]
+        return f"{facts['ticker']} narrative. Risks: {'; '.join(risks)}"
+
+
+def make_settings(**overrides) -> Settings:
+    return Settings(_env_file=None, **{**BASE_SETTINGS, **overrides})
+
+
+def make_brief(*, ticker: str = "TGT", risks: list[str] | None = None) -> dict:
+    return {
+        "schema_version": "ai_signal_brief.v1",
+        "event_id": 1,
+        "facts": {
+            "ticker": ticker,
+            "event_date": "2026-07-03",
+            "scanner_type": "pre_market_volume_spike",
+            "severity": "high",
+            "summary": f"{ticker} signal",
+            "signal_quality_score": 0.86,
+            "regime": "risk_on",
+        },
+        "why": ["This must not be used by the narrative generator."],
+        "risks": risks or ["Outcome summary is incomplete or unavailable."],
+        "warnings": [],
+        "analogs": [{"ticker": "OLD"}],
+        "outcome_context": {"summary": None, "snapshots": []},
+        "forbidden_claims": ["Do not recommend live trade execution."],
+    }
+
+
+def seed_event(db) -> ScannerEvent:
+    event = ScannerEvent(
+        ticker="TGT",
+        event_date=date(2026, 7, 3),
+        scanner_type="pre_market_volume_spike",
+        summary="TGT signal",
+        severity="high",
+        indicators={},
+        criteria_met={},
+        metadata_={},
+        explanation={},
+    )
+    db.add(event)
+    db.flush()
+    return event
+
+
+def enabled_settings() -> Settings:
+    return make_settings(
+        LLM_FEATURES_ENABLED=True,
+        LLM_PROVIDER="local",
+        LLM_MODEL="unit-narrator",
+        LLM_ALLOWED_FEATURES="scanner_narrative",
+    )
+
+
+def test_disabled_feature_returns_brief_without_generated_text(db):
+    event = seed_event(db)
+    generator = RecordingGenerator()
+    service = ScannerEventNarrativeService(
+        brief_service=FakeBriefService(make_brief()),
+        generator=generator,
+        settings=make_settings(),
+    )
+
+    result = service.build(db, event)
+
+    assert result["brief"]["facts"]["ticker"] == "TGT"
+    assert result["narrative"] is None
+    assert result["cache"]["status"] == "disabled"
+    assert generator.calls == []
+    assert db.query(ScannerEventNarrative).count() == 0
+
+
+def test_cache_miss_generates_narrative_from_facts_and_risks(db):
+    event = seed_event(db)
+    brief = make_brief()
+    generator = RecordingGenerator()
+    service = ScannerEventNarrativeService(
+        brief_service=FakeBriefService(brief),
+        generator=generator,
+        settings=enabled_settings(),
+    )
+
+    result = service.build(db, event)
+
+    assert result["cache"]["status"] == "miss"
+    assert result["narrative"]["text"] == (
+        "TGT narrative. Risks: Outcome summary is incomplete or unavailable."
+    )
+    assert result["narrative"]["provider"] == "local"
+    assert result["narrative"]["model"] == "unit-narrator"
+    assert result["narrative"]["prompt_version"] == "scanner_narrative.v1"
+    assert result["narrative"]["brief_schema_version"] == "ai_signal_brief.v1"
+    assert generator.calls == [{"brief": brief, "guardrails": result["guardrails"]}]
+
+    cached = db.query(ScannerEventNarrative).one()
+    assert cached.narrative_text == result["narrative"]["text"]
+    assert cached.provider == "local"
+    assert cached.model == "unit-narrator"
+    assert cached.input_payload == {
+        "facts": brief["facts"],
+        "risks": brief["risks"],
+    }
+
+
+def test_cache_hit_returns_cached_narrative_without_generation(db):
+    event = seed_event(db)
+    brief = make_brief()
+    generator = RecordingGenerator()
+    service = ScannerEventNarrativeService(
+        brief_service=FakeBriefService(brief),
+        generator=generator,
+        settings=enabled_settings(),
+    )
+    first = service.build(db, event)
+    generator.calls.clear()
+
+    second = service.build(db, event)
+
+    assert second["cache"]["status"] == "hit"
+    assert second["narrative"]["text"] == first["narrative"]["text"]
+    assert generator.calls == []
+    assert db.query(ScannerEventNarrative).count() == 1
+
+
+def test_stale_brief_regenerates_and_updates_existing_cache_row(db):
+    event = seed_event(db)
+    generator = RecordingGenerator()
+    service = ScannerEventNarrativeService(
+        brief_service=FakeBriefService(make_brief(risks=["Initial risk."])),
+        generator=generator,
+        settings=enabled_settings(),
+    )
+    first = service.build(db, event)
+    cache_id = db.query(ScannerEventNarrative).one().id
+
+    service = ScannerEventNarrativeService(
+        brief_service=FakeBriefService(make_brief(risks=["Updated risk."])),
+        generator=generator,
+        settings=enabled_settings(),
+    )
+    second = service.build(db, event)
+
+    assert second["cache"]["status"] == "stale_regenerated"
+    assert second["narrative"]["text"] == "TGT narrative. Risks: Updated risk."
+    assert second["narrative"]["brief_fingerprint"] != first["narrative"][
+        "brief_fingerprint"
+    ]
+    cached = db.query(ScannerEventNarrative).one()
+    assert cached.id == cache_id
+    assert cached.input_payload["risks"] == ["Updated risk."]


### PR DESCRIPTION
## Summary
- add a scanner event narrative cache table with provider/model/prompt/brief fingerprint metadata
- add a scanner narrative service that returns deterministic brief data when disabled and caches generated narrative text when enabled
- add `/api/v1/outcomes/event/{event_id}/ai-signal-narrative` as a sibling to the existing deterministic brief endpoint

## Tests
- python -m pytest backend/tests/services/test_scanner_event_narrative_service.py backend/tests/api/test_ai_signal_brief.py --no-cov
- python -m ruff check backend/app/models/scanner_event_narrative.py backend/app/models/__init__.py backend/app/services/scanner_event_narrative.py backend/app/routers/outcomes.py backend/tests/services/test_scanner_event_narrative_service.py backend/tests/api/test_ai_signal_brief.py backend/app/alembic/versions/b6c7d8e9f0a1_add_scanner_event_narratives.py
- python -m alembic heads

Closes #473