### PR TITLE
Add scanner narrative provenance and forbidden-claim enforcement

### DIFF
--- a/backend/app/alembic/versions/c0d1e2f3a4b5_add_narrative_provenance.py
+++ b/backend/app/alembic/versions/c0d1e2f3a4b5_add_narrative_provenance.py
@@ -1,0 +1,35 @@
+"""add_narrative_provenance
+
+Revision ID: c0d1e2f3a4b5
+Revises: b6c7d8e9f0a1
+Create Date: 2026-07-04 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "c0d1e2f3a4b5"
+down_revision: Union[str, None] = "b6c7d8e9f0a1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scanner_event_narratives",
+        sa.Column(
+            "provenance_payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default="[]",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("scanner_event_narratives", "provenance_payload")

--- a/backend/app/models/scanner_event_narrative.py
+++ b/backend/app/models/scanner_event_narrative.py
@@ -37,6 +37,7 @@ class ScannerEventNarrative(Base):
     brief_schema_version = Column(String(50), nullable=False)
     brief_fingerprint = Column(String(64), nullable=False, index=True)
     input_payload = Column(JSONB, nullable=False, default=dict)
+    provenance_payload = Column(JSONB, nullable=False, default=list)
     created_at = Column(DateTime, default=utc_now)
     updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)
 

--- a/backend/app/services/scanner_event_narrative.py
+++ b/backend/app/services/scanner_event_narrative.py
@@ -14,6 +14,18 @@ from app.services.ai_signal_brief import AISignalBriefService
 
 SCANNER_NARRATIVE_FEATURE = "scanner_narrative"
 SCANNER_NARRATIVE_PROMPT_VERSION = "scanner_narrative.v1"
+SUPPORTED_PROVENANCE_FIELDS = frozenset(
+    {
+        "facts.ticker",
+        "facts.event_date",
+        "facts.scanner_type",
+        "facts.severity",
+        "facts.summary",
+        "facts.signal_quality_score",
+        "facts.regime",
+        "risks",
+    }
+)
 
 
 class ScannerNarrativeGenerator(Protocol):
@@ -94,7 +106,20 @@ class ScannerEventNarrativeService:
                 "guardrails": guardrails,
             }
 
-        narrative_text = self._generator.generate(brief, guardrails)
+        generated = _normalize_generated_narrative(
+            self._generator.generate(brief, guardrails),
+            input_payload,
+        )
+        rejection_reason = _rejection_reason(generated, brief, input_payload)
+        if rejection_reason:
+            return {
+                "brief": brief,
+                "narrative": None,
+                "cache": {"status": "rejected"},
+                "rejection": {"reason": rejection_reason},
+                "guardrails": guardrails,
+            }
+
         status = "stale_regenerated" if cache else "miss"
         if cache is None:
             cache = ScannerEventNarrative(
@@ -106,10 +131,11 @@ class ScannerEventNarrativeService:
             )
             db.add(cache)
 
-        cache.narrative_text = narrative_text
+        cache.narrative_text = generated["text"]
         cache.brief_schema_version = str(brief.get("schema_version") or "")
         cache.brief_fingerprint = fingerprint
         cache.input_payload = input_payload
+        cache.provenance_payload = generated["provenance"]
         db.flush()
 
         return {
@@ -141,6 +167,7 @@ class ScannerEventNarrativeService:
             "prompt_version": cache.prompt_version,
             "brief_schema_version": cache.brief_schema_version,
             "brief_fingerprint": cache.brief_fingerprint,
+            "provenance": list(cache.provenance_payload or []),
             "created_at": cache.created_at.isoformat() if cache.created_at else None,
             "updated_at": cache.updated_at.isoformat() if cache.updated_at else None,
         }
@@ -160,3 +187,100 @@ def _brief_fingerprint(brief: dict[str, Any]) -> str:
     }
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _normalize_generated_narrative(
+    generated: str | dict[str, Any],
+    input_payload: dict[str, Any],
+) -> dict[str, Any]:
+    if isinstance(generated, str):
+        return {
+            "text": generated,
+            "provenance": _default_provenance(input_payload),
+        }
+    if not isinstance(generated, dict):
+        return {"text": "", "provenance": []}
+    return {
+        "text": generated.get("text") or "",
+        "provenance": generated.get("provenance") or [],
+    }
+
+
+def _default_provenance(input_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    facts = input_payload.get("facts") or {}
+    source_fields = [
+        f"facts.{field}"
+        for field in (
+            "ticker",
+            "event_date",
+            "scanner_type",
+            "severity",
+            "summary",
+            "signal_quality_score",
+            "regime",
+        )
+        if facts.get(field) is not None
+    ]
+    provenance = []
+    if source_fields:
+        provenance.append(
+            {
+                "claim": "Scanner event facts",
+                "source_fields": source_fields,
+            }
+        )
+    if input_payload.get("risks"):
+        provenance.append({"claim": "Risk summary", "source_fields": ["risks"]})
+    return provenance
+
+
+def _rejection_reason(
+    generated: dict[str, Any],
+    brief: dict[str, Any],
+    input_payload: dict[str, Any],
+) -> str | None:
+    text = generated.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return "Generated narrative is empty."
+
+    forbidden = _forbidden_claim_match(text, brief.get("forbidden_claims") or [])
+    if forbidden:
+        return f"Generated narrative contains a forbidden claim: {forbidden}"
+
+    provenance = generated.get("provenance")
+    if not isinstance(provenance, list) or not provenance:
+        return "Generated narrative is missing provenance."
+
+    for entry in provenance:
+        if not isinstance(entry, dict):
+            return "Generated narrative provenance must be a list of objects."
+        fields = entry.get("source_fields")
+        if not isinstance(fields, list) or not fields:
+            return "Generated narrative provenance is missing source fields."
+        for field in fields:
+            if field not in SUPPORTED_PROVENANCE_FIELDS:
+                return f"Generated narrative uses unsupported provenance field: {field}"
+            if field.startswith("facts."):
+                fact_key = field.split(".", 1)[1]
+                if fact_key not in (input_payload.get("facts") or {}):
+                    return f"Generated narrative references absent provenance field: {field}"
+    return None
+
+
+def _forbidden_claim_match(text: str, forbidden_claims: list[str]) -> str | None:
+    normalized_text = _normalize_claim_text(text)
+    for claim in forbidden_claims:
+        normalized_claim = _normalize_claim_text(claim)
+        for prefix in ("do not ", "don't ", "never "):
+            if normalized_claim.startswith(prefix):
+                normalized_claim = normalized_claim[len(prefix) :]
+                break
+        if normalized_claim and normalized_claim in normalized_text:
+            return claim
+    return None
+
+
+def _normalize_claim_text(value: str) -> str:
+    return " ".join(
+        "".join(char.lower() if char.isalnum() else " " for char in value).split()
+    )

--- a/backend/tests/services/test_scanner_event_narrative_service.py
+++ b/backend/tests/services/test_scanner_event_narrative_service.py
@@ -37,6 +37,17 @@ class RecordingGenerator:
         return f"{facts['ticker']} narrative. Risks: {'; '.join(risks)}"
 
 
+class StructuredGenerator:
+    provider_name = "local"
+    model_name = "unit-narrator"
+
+    def __init__(self, payload):
+        self.payload = payload
+
+    def generate(self, brief, guardrails):
+        return self.payload
+
+
 def make_settings(**overrides) -> Settings:
     return Settings(_env_file=None, **{**BASE_SETTINGS, **overrides})
 
@@ -185,3 +196,93 @@ def test_stale_brief_regenerates_and_updates_existing_cache_row(db):
     cached = db.query(ScannerEventNarrative).one()
     assert cached.id == cache_id
     assert cached.input_payload["risks"] == ["Updated risk."]
+
+
+def test_supported_provenance_is_returned_and_cached(db):
+    event = seed_event(db)
+    provenance = [
+        {
+            "claim": "Ticker and setup summary",
+            "source_fields": ["facts.ticker", "facts.summary"],
+        },
+        {"claim": "Risk summary", "source_fields": ["risks"]},
+    ]
+    service = ScannerEventNarrativeService(
+        brief_service=FakeBriefService(make_brief()),
+        generator=StructuredGenerator(
+            {
+                "text": "TGT signal narrative. Key risks: incomplete outcome.",
+                "provenance": provenance,
+            }
+        ),
+        settings=enabled_settings(),
+    )
+
+    result = service.build(db, event)
+
+    assert result["cache"]["status"] == "miss"
+    assert result["narrative"]["provenance"] == provenance
+    cached = db.query(ScannerEventNarrative).one()
+    assert cached.provenance_payload == provenance
+
+
+def test_forbidden_claim_is_rejected_before_persistence(db):
+    event = seed_event(db)
+    service = ScannerEventNarrativeService(
+        brief_service=FakeBriefService(make_brief()),
+        generator=StructuredGenerator(
+            {
+                "text": "TGT is strong, so recommend live trade execution now.",
+                "provenance": [
+                    {"claim": "Ticker summary", "source_fields": ["facts.ticker"]}
+                ],
+            }
+        ),
+        settings=enabled_settings(),
+    )
+
+    result = service.build(db, event)
+
+    assert result["narrative"] is None
+    assert result["cache"]["status"] == "rejected"
+    assert "forbidden claim" in result["rejection"]["reason"]
+    assert db.query(ScannerEventNarrative).count() == 0
+
+
+def test_missing_provenance_is_rejected_before_persistence(db):
+    event = seed_event(db)
+    service = ScannerEventNarrativeService(
+        brief_service=FakeBriefService(make_brief()),
+        generator=StructuredGenerator({"text": "TGT narrative without provenance."}),
+        settings=enabled_settings(),
+    )
+
+    result = service.build(db, event)
+
+    assert result["narrative"] is None
+    assert result["cache"]["status"] == "rejected"
+    assert "provenance" in result["rejection"]["reason"]
+    assert db.query(ScannerEventNarrative).count() == 0
+
+
+def test_unsupported_provenance_field_is_rejected_before_persistence(db):
+    event = seed_event(db)
+    service = ScannerEventNarrativeService(
+        brief_service=FakeBriefService(make_brief()),
+        generator=StructuredGenerator(
+            {
+                "text": "TGT narrative with unsupported provenance.",
+                "provenance": [
+                    {"claim": "Analog claim", "source_fields": ["analogs"]}
+                ],
+            }
+        ),
+        settings=enabled_settings(),
+    )
+
+    result = service.build(db, event)
+
+    assert result["narrative"] is None
+    assert result["cache"]["status"] == "rejected"
+    assert "unsupported provenance field" in result["rejection"]["reason"]
+    assert db.query(ScannerEventNarrative).count() == 0


### PR DESCRIPTION
## Summary
- add provenance payload persistence for scanner event narratives
- validate generated narrative provenance against deterministic brief `facts.*` and `risks` fields
- reject forbidden claims, missing provenance, and unsupported provenance fields before cache persistence/display

## Tests
- python -m pytest backend/tests/services/test_scanner_event_narrative_service.py backend/tests/api/test_ai_signal_brief.py --no-cov
- python -m ruff check backend/app/models/scanner_event_narrative.py backend/app/services/scanner_event_narrative.py backend/tests/services/test_scanner_event_narrative_service.py backend/app/alembic/versions/c0d1e2f3a4b5_add_narrative_provenance.py
- python -m alembic heads

Closes #474