### PR TITLE
ci: adapter-validate job for .factory/adapter.yaml schema drift detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,46 @@ jobs:
         env:
           PYTHONPATH: dark-factory/scripts
 
+  adapter-validate:
+    name: Factory adapter validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # dark-factory repo is public; clone provides factory_core.adapter + adapter_defaults
+      # without requiring GHCR package-visibility grants (checkout variant, P2 Task 6).
+      - name: Checkout dark-factory (public, factory_core.adapter loader)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: omniscient/dark-factory
+          path: _dark-factory
+
+      - name: Install pyyaml
+        run: pip install pyyaml
+
+      - name: Schema-validate .factory/adapter.yaml against the extracted factory
+        run: |
+          PYTHONPATH=_dark-factory/scripts python -m factory_core.adapter \
+            --clone-dir "$GITHUB_WORKSPACE" --validate
+
+      - name: Assert mirrored values equal factory defaults
+        run: |
+          python3 -c "
+          import sys
+          sys.path.insert(0, '_dark-factory/scripts')
+          from factory_core import adapter, adapter_defaults
+          merged = adapter.load('$GITHUB_WORKSPACE')
+          for key in ('components', 'safety', 'memory_routing', 'deconflict'):
+              assert merged[key] == adapter_defaults.DEFAULTS[key], f'MIRROR DRIFT in {key}'
+          print('MIRROR-EQUAL')"
+
+      - name: Hooks are executable and parse
+        run: |
+          for h in .factory/hooks/*; do
+            [ -x "$h" ] || { echo "not executable: $h" >&2; exit 1; }
+            bash -n "$h"
+          done
+
   sast:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Adds `adapter-validate` CI job to `.github/workflows/ci.yml` (sibling of `factory-tests`)
- Three gates per task brief: schema-validate, mirror-equality assertion (components/safety/memory_routing/deconflict), hooks executable + parse-clean
- **Checkout variant** used: clones public `omniscient/dark-factory` repo as `_dark-factory/` and runs `factory_core.adapter` from source — no GHCR package-visibility grant needed
- Part of Dark Factory extraction P2, Task 6. Tracks omniscient/dark-factory#177.

## Required-checks note

`adapter-validate` is **not** yet added to branch-protection required checks. Once it has run green on a few PRs, Frank (admin) should add it via Settings → Branches → main → Edit protection rule.

## Step 1 (manual) — GHCR package access

This PR uses the checkout variant so Step 1 from the brief (granting markethawk Actions access to the dark-factory GHCR package) is **not required for this job to pass**. It becomes relevant only if a future PR switches to the image-pull variant.

## Test plan

- [ ] `adapter-validate` job appears in the CI run for this PR
- [ ] All three steps (schema-validate, mirror-equal, hooks-exec) pass green
- [ ] No other existing jobs are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyNzjNGmqJ8fSZNTb55n9c
