### PR TITLE
Generate optional AI-assisted alert copy

### DIFF
--- a/backend/app/services/alert_copy.py
+++ b/backend/app/services/alert_copy.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from sqlalchemy.orm import Session
+
+from app.core.config import Settings, settings
+from app.core.llm_guardrails import build_llm_usage_guardrails
+from app.models.scanner_event import ScannerEvent
+from app.services.scanner_event_narrative import ScannerEventNarrativeService
+
+ALERT_COPY_FEATURE = "alert_copy"
+
+
+class NarrativeBundleService(Protocol):
+    def build(self, db: Session, event: ScannerEvent) -> dict[str, Any]: ...
+
+
+class AlertCopyService:
+    def __init__(
+        self,
+        *,
+        narrative_service: NarrativeBundleService | None = None,
+        settings: Settings = settings,
+    ) -> None:
+        self._narrative_service = narrative_service or ScannerEventNarrativeService()
+        self._settings = settings
+
+    def build(self, db: Session, event: ScannerEvent) -> dict[str, Any]:
+        fallback = _deterministic_copy(event)
+        guardrails = build_llm_usage_guardrails(self._settings)
+        if not guardrails.allows(ALERT_COPY_FEATURE):
+            return fallback
+
+        try:
+            bundle = self._narrative_service.build(db, event)
+        except Exception as exc:
+            return {**fallback, "source": "fallback", "generation_error": str(exc)}
+
+        narrative = bundle.get("narrative")
+        if not narrative:
+            reason = (bundle.get("rejection") or {}).get("reason")
+            return {
+                **fallback,
+                "source": "fallback",
+                "generation_error": reason or "Narrative unavailable.",
+            }
+
+        brief = bundle.get("brief") or {}
+        facts = brief.get("facts") or {}
+        why = list(brief.get("why") or [])
+        risks = list(brief.get("risks") or [])
+        warnings = [
+            warning.get("message") or warning.get("code")
+            for warning in brief.get("warnings") or []
+            if warning.get("message") or warning.get("code")
+        ]
+        body_parts = [
+            narrative.get("text") or fallback["body"],
+            *_section_lines("Why", why),
+            *_section_lines("Risks", risks),
+            *_section_lines("Data quality", warnings),
+        ]
+        return {
+            "source": "generated",
+            "title": _title(event, facts=facts),
+            "summary": facts.get("summary") or fallback["summary"],
+            "body": "\n".join(part for part in body_parts if part),
+            "risk_caveats": risks,
+            "data_quality_caveats": warnings,
+            "narrative": narrative,
+        }
+
+
+def _deterministic_copy(event: ScannerEvent) -> dict[str, Any]:
+    summary = event.summary or f"{_scanner_type_display(event)} detected on {event.ticker}"
+    return {
+        "source": "deterministic",
+        "title": _title(event),
+        "summary": summary,
+        "body": summary,
+        "risk_caveats": [],
+        "data_quality_caveats": [],
+    }
+
+
+def _title(event: ScannerEvent, *, facts: dict[str, Any] | None = None) -> str:
+    facts = facts or {}
+    ticker = facts.get("ticker") or event.ticker
+    scanner_type = facts.get("scanner_type") or event.scanner_type
+    scanner_type_display = scanner_type.replace("_", " ").title()
+    return f"MarketHawk Alert: {ticker} - {scanner_type_display}"
+
+
+def _scanner_type_display(event: ScannerEvent) -> str:
+    return event.scanner_type.replace("_", " ").title()
+
+
+def _section_lines(label: str, values: list[str]) -> list[str]:
+    if not values:
+        return []
+    return [f"{label}:", *[f"- {value}" for value in values]]

--- a/backend/app/services/alert_service.py
+++ b/backend/app/services/alert_service.py
@@ -26,6 +26,7 @@ from app.models.alert_rule import AlertRule
 from app.models.push_subscription import PushSubscription
 from app.models.scanner_event import ScannerEvent
 from app.schemas.event import SeverityLiteral
+from app.services.alert_copy import AlertCopyService
 from app.utils.time import utc_now
 
 logger = logging.getLogger(__name__)
@@ -102,20 +103,37 @@ class NotificationDispatcher:
         """Fan-out to all channels configured on this rule."""
         channels = rule.channels or []
         config = rule.channel_config or {}
+        try:
+            alert_copy = AlertCopyService().build(db, event)
+        except Exception as exc:
+            logger.warning(
+                "Alert copy generation failed for scanner_event_id=%s: %s",
+                event.id,
+                exc,
+            )
+            alert_copy = None
 
         for channel in channels:
             status = "sent"
             error_msg = None
             try:
                 if channel == "browser_push":
-                    NotificationDispatcher._send_browser_push(event, db)
+                    NotificationDispatcher._send_browser_push(
+                        event, db, alert_copy=alert_copy
+                    )
                 elif channel == "email":
                     to = config.get("email")
                     if to:
                         NotificationDispatcher._send_email(
                             to=to,
-                            subject=f"MarketHawk Alert: {event.ticker} — {event.scanner_type.replace('_', ' ').title()}",
-                            body=NotificationDispatcher._build_email_body(event),
+                            subject=(
+                                alert_copy["title"]
+                                if alert_copy
+                                else f"MarketHawk Alert: {event.ticker} — {event.scanner_type.replace('_', ' ').title()}"
+                            ),
+                            body=NotificationDispatcher._build_email_body(
+                                event, alert_copy=alert_copy
+                            ),
                         )
                     else:
                         raise ValueError("No email address configured for this rule.")
@@ -124,7 +142,9 @@ class NotificationDispatcher:
                     if webhook_url:
                         NotificationDispatcher._send_google_chat(
                             webhook_url=webhook_url,
-                            message=NotificationDispatcher._build_chat_message(event),
+                            message=NotificationDispatcher._build_chat_message(
+                                event, alert_copy=alert_copy
+                            ),
                         )
                     else:
                         raise ValueError("No Google Chat webhook URL configured.")
@@ -134,7 +154,7 @@ class NotificationDispatcher:
                         NotificationDispatcher._send_webhook(
                             url=url,
                             payload=NotificationDispatcher._build_webhook_payload(
-                                event, rule
+                                event, rule, alert_copy=alert_copy
                             ),
                         )
                     else:
@@ -231,10 +251,12 @@ class NotificationDispatcher:
         return len(subscriptions) - failed
 
     @staticmethod
-    def _send_browser_push(event: ScannerEvent, db: Session) -> None:
+    def _send_browser_push(
+        event: ScannerEvent, db: Session, alert_copy: dict | None = None
+    ) -> None:
         """Scanner-event browser push (thin wrapper over the generic sender)."""
         NotificationDispatcher._push_to_subscriptions(
-            NotificationDispatcher._build_push_payload(event), db
+            NotificationDispatcher._build_push_payload(event, alert_copy=alert_copy), db
         )
 
     # ── Email ─────────────────────────────────────────────────────────────────
@@ -281,12 +303,17 @@ class NotificationDispatcher:
     # ── Payload Builders ──────────────────────────────────────────────────────
 
     @staticmethod
-    def _build_push_payload(event: ScannerEvent) -> dict:
+    def _build_push_payload(
+        event: ScannerEvent, alert_copy: dict | None = None
+    ) -> dict:
         scanner_type_display = event.scanner_type.replace("_", " ").title()
         return {
-            "title": f"MarketHawk: {event.ticker} — {scanner_type_display}",
-            "body": event.summary
-            or f"{scanner_type_display} detected on {event.ticker}",
+            "title": alert_copy["title"]
+            if alert_copy
+            else f"MarketHawk: {event.ticker} — {scanner_type_display}",
+            "body": alert_copy["summary"]
+            if alert_copy
+            else event.summary or f"{scanner_type_display} detected on {event.ticker}",
             "severity": event.severity,
             "ticker": event.ticker,
             "scanner_type": event.scanner_type,
@@ -295,8 +322,11 @@ class NotificationDispatcher:
         }
 
     @staticmethod
-    def _build_email_body(event: ScannerEvent) -> str:
+    def _build_email_body(
+        event: ScannerEvent, alert_copy: dict | None = None
+    ) -> str:
         scanner_type_display = event.scanner_type.replace("_", " ").title()
+        summary = alert_copy["body"] if alert_copy else event.summary or "Scanner event detected."
         indicators_html = "".join(
             f"<tr><td style='padding:4px 8px;color:#9ca3af'>{k}</td>"
             f"<td style='padding:4px 8px;color:#f3f4f6'>{v}</td></tr>"
@@ -307,7 +337,7 @@ class NotificationDispatcher:
           <h2 style="color:#3b82f6">🔔 MarketHawk Alert</h2>
           <h3 style="color:#f3f4f6">{event.ticker} — {scanner_type_display}</h3>
           <p style="color:#9ca3af">{event.event_date}</p>
-          <p>{event.summary or "Scanner event detected."}</p>
+          <p>{summary}</p>
           <table style="border-collapse:collapse;margin-top:16px">
             {indicators_html}
           </table>
@@ -318,7 +348,9 @@ class NotificationDispatcher:
         """
 
     @staticmethod
-    def _build_chat_message(event: ScannerEvent) -> str:
+    def _build_chat_message(
+        event: ScannerEvent, alert_copy: dict | None = None
+    ) -> str:
         scanner_type_display = event.scanner_type.replace("_", " ").title()
         indicators = event.indicators or {}
         indicator_lines = "\n".join(
@@ -328,13 +360,15 @@ class NotificationDispatcher:
             f"🔔 *MarketHawk Alert*\n"
             f"*{event.ticker}* — {scanner_type_display}\n"
             f"_{event.event_date}_ · Severity: {event.severity}\n\n"
-            f"{event.summary or ''}\n\n"
+            f"{alert_copy['body'] if alert_copy else event.summary or ''}\n\n"
             f"{indicator_lines}"
         )
 
     @staticmethod
-    def _build_webhook_payload(event: ScannerEvent, rule: AlertRule) -> dict:
-        return {
+    def _build_webhook_payload(
+        event: ScannerEvent, rule: AlertRule, alert_copy: dict | None = None
+    ) -> dict:
+        payload = {
             "source": "MarketHawk",
             "rule_id": rule.id,
             "rule_name": rule.name,
@@ -345,6 +379,9 @@ class NotificationDispatcher:
             "event_date": str(event.event_date),
             "indicators": event.indicators or {},
         }
+        if alert_copy:
+            payload["alert_copy"] = alert_copy
+        return payload
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/backend/tests/services/test_alert_copy_service.py
+++ b/backend/tests/services/test_alert_copy_service.py
@@ -1,0 +1,153 @@
+from datetime import date
+
+from app.core.config import Settings
+from app.models.scanner_event import ScannerEvent
+from app.services.alert_copy import AlertCopyService
+
+BASE_SETTINGS = {
+    "DATABASE_URL": "postgresql://test:test@localhost/test",
+    "POLYGON_API_KEY": "test-key",
+    "JWT_SECRET_KEY": "a" * 32,
+    "REDIS_PASSWORD": "r" * 16,
+}
+
+
+class FakeNarrativeService:
+    def __init__(self, result=None, exc: Exception | None = None):
+        self.result = result
+        self.exc = exc
+        self.calls = []
+
+    def build(self, db, event):
+        self.calls.append(event.id)
+        if self.exc:
+            raise self.exc
+        return self.result
+
+
+def make_settings(**overrides) -> Settings:
+    return Settings(_env_file=None, **{**BASE_SETTINGS, **overrides})
+
+
+def enabled_settings() -> Settings:
+    return make_settings(
+        LLM_FEATURES_ENABLED=True,
+        LLM_PROVIDER="local",
+        LLM_MODEL="unit-copy",
+        LLM_ALLOWED_FEATURES="alert_copy,scanner_narrative",
+    )
+
+
+def make_event(db) -> ScannerEvent:
+    event = ScannerEvent(
+        ticker="TGT",
+        event_date=date(2026, 7, 3),
+        scanner_type="pre_market_volume_spike",
+        summary="TGT volume expanded before the open.",
+        severity="high",
+        indicators={"volume_spike_ratio": 6.0},
+        criteria_met={},
+        metadata_={},
+        explanation={},
+    )
+    db.add(event)
+    db.flush()
+    return event
+
+
+def narrative_result() -> dict:
+    return {
+        "brief": {
+            "facts": {
+                "ticker": "TGT",
+                "scanner_type": "pre_market_volume_spike",
+                "severity": "high",
+                "summary": "TGT volume expanded before the open.",
+            },
+            "why": ["Volume and liquidity aligned with the scanner setup."],
+            "risks": ["Outcome summary is incomplete or unavailable."],
+            "warnings": [
+                {
+                    "code": "stale_quote",
+                    "message": "Quote data is older than expected.",
+                }
+            ],
+        },
+        "narrative": {
+            "text": "TGT produced a high pre-market volume signal.",
+            "provenance": [{"claim": "summary", "source_fields": ["facts.summary"]}],
+        },
+        "cache": {"status": "hit"},
+    }
+
+
+def test_disabled_alert_copy_returns_deterministic_fallback_without_narrative_call(db):
+    event = make_event(db)
+    narrative_service = FakeNarrativeService(result=narrative_result())
+    service = AlertCopyService(
+        narrative_service=narrative_service,
+        settings=make_settings(),
+    )
+
+    copy = service.build(db, event)
+
+    assert copy["source"] == "deterministic"
+    assert copy["title"] == "MarketHawk Alert: TGT - Pre Market Volume Spike"
+    assert copy["summary"] == "TGT volume expanded before the open."
+    assert copy["body"] == "TGT volume expanded before the open."
+    assert narrative_service.calls == []
+
+
+def test_enabled_alert_copy_uses_validated_narrative_brief_risks_and_warnings(db):
+    event = make_event(db)
+    service = AlertCopyService(
+        narrative_service=FakeNarrativeService(result=narrative_result()),
+        settings=enabled_settings(),
+    )
+
+    copy = service.build(db, event)
+
+    assert copy["source"] == "generated"
+    assert copy["title"] == "MarketHawk Alert: TGT - Pre Market Volume Spike"
+    assert "TGT produced a high pre-market volume signal." in copy["body"]
+    assert "Volume and liquidity aligned with the scanner setup." in copy["body"]
+    assert "Outcome summary is incomplete or unavailable." in copy["body"]
+    assert "Quote data is older than expected." in copy["body"]
+    assert copy["risk_caveats"] == ["Outcome summary is incomplete or unavailable."]
+    assert copy["data_quality_caveats"] == ["Quote data is older than expected."]
+
+
+def test_alert_copy_generation_failure_returns_deterministic_fallback(db):
+    event = make_event(db)
+    service = AlertCopyService(
+        narrative_service=FakeNarrativeService(exc=RuntimeError("provider timeout")),
+        settings=enabled_settings(),
+    )
+
+    copy = service.build(db, event)
+
+    assert copy["source"] == "fallback"
+    assert copy["summary"] == "TGT volume expanded before the open."
+    assert copy["body"] == "TGT volume expanded before the open."
+    assert copy["generation_error"] == "provider timeout"
+
+
+def test_enabled_alert_copy_falls_back_when_narrative_is_rejected(db):
+    event = make_event(db)
+    service = AlertCopyService(
+        narrative_service=FakeNarrativeService(
+            result={
+                "brief": narrative_result()["brief"],
+                "narrative": None,
+                "cache": {"status": "rejected"},
+                "rejection": {"reason": "Generated narrative is missing provenance."},
+            }
+        ),
+        settings=enabled_settings(),
+    )
+
+    copy = service.build(db, event)
+
+    assert copy["source"] == "fallback"
+    assert copy["body"] == "TGT volume expanded before the open."
+    assert copy["generation_error"] == "Generated narrative is missing provenance."

--- a/backend/tests/services/test_alert_service.py
+++ b/backend/tests/services/test_alert_service.py
@@ -13,6 +13,7 @@ from app.models.alert_rule import AlertRule
 from app.models.scanner_event import ScannerEvent
 from app.services.alert_service import (
     AlertRuleService,
+    NotificationDispatcher,
     _validate_jsonb_dict,
     save_event,
 )
@@ -244,3 +245,53 @@ def test_save_event_persists_explanation_payload(mock_trigger, db: Session):
     event = db.query(ScannerEvent).filter(ScannerEvent.id == result["id"]).one()
     assert event.explanation == explanation
     mock_trigger.assert_called_once_with(result["id"])
+
+
+def test_payload_builders_can_use_generated_alert_copy(db: Session):
+    rule = _rule(db)
+    event = _event(db)
+    copy = {
+        "source": "generated",
+        "title": "MarketHawk Alert: AAPL - Generated",
+        "summary": "Generated short copy.",
+        "body": "Generated long copy with risks and data-quality caveats.",
+        "risk_caveats": ["Incomplete outcome."],
+        "data_quality_caveats": ["Quote data is stale."],
+    }
+
+    push = NotificationDispatcher._build_push_payload(event, alert_copy=copy)
+    email = NotificationDispatcher._build_email_body(event, alert_copy=copy)
+    chat = NotificationDispatcher._build_chat_message(event, alert_copy=copy)
+    webhook = NotificationDispatcher._build_webhook_payload(event, rule, alert_copy=copy)
+
+    assert push["title"] == copy["title"]
+    assert push["body"] == copy["summary"]
+    assert "Generated long copy" in email
+    assert "Generated long copy" in chat
+    assert webhook["alert_copy"]["source"] == "generated"
+    assert webhook["alert_copy"]["body"] == copy["body"]
+
+
+@patch("app.services.alert_service.AlertCopyService")
+@patch.object(NotificationDispatcher, "_send_email")
+def test_dispatch_uses_alert_copy_for_email(mock_send_email, mock_copy_cls, db: Session):
+    rule = _rule(db, channels=["email"])
+    rule.channel_config = {"email": "desk@example.com"}
+    event = _event(db)
+    mock_copy_cls.return_value.build.return_value = {
+        "source": "generated",
+        "title": "MarketHawk Alert: AAPL - Generated",
+        "summary": "Generated short copy.",
+        "body": "Generated long copy.",
+        "risk_caveats": [],
+        "data_quality_caveats": [],
+    }
+
+    NotificationDispatcher.dispatch(rule, event, db)
+
+    assert mock_send_email.call_args.kwargs["subject"] == (
+        "MarketHawk Alert: AAPL - Generated"
+    )
+    assert "Generated long copy." in mock_send_email.call_args.kwargs["body"]
+    log = db.query(AlertDeliveryLog).filter_by(rule_id=rule.id).one()
+    assert log.status == "sent"


### PR DESCRIPTION
## Summary
- add feature-flagged alert copy generation backed by validated scanner narratives
- keep deterministic fallback copy for disabled, rejected, and failure paths
- pass generated copy through email, chat, push, and webhook payload builders

## Tests
- python -m pytest backend/tests/services/test_alert_copy_service.py backend/tests/services/test_alert_service.py --no-cov
- python -m ruff check backend/app/services/alert_copy.py backend/app/services/alert_service.py backend/tests/services/test_alert_copy_service.py backend/tests/services/test_alert_service.py
- git diff --check

Closes #475