### PR TITLE
Generate signal post-mortems from explanation versus outcome

### DIFF
--- a/backend/app/routers/outcomes.py
+++ b/backend/app/routers/outcomes.py
@@ -41,6 +41,7 @@ from app.services.explanation_trait_performance import (
 from app.services.historical_analog_service import HistoricalAnalogService
 from app.services.outcome_service import OutcomeService
 from app.services.scanner_event_narrative import ScannerEventNarrativeService
+from app.services.signal_post_mortem import SignalPostMortemService
 from app.services.stats import StatsService
 from app.utils.db import get_or_404
 
@@ -295,6 +296,15 @@ def get_ai_signal_narrative(
 ):
     event = get_or_404(db, ScannerEvent, event_id, "ScannerEvent")
     return ScannerEventNarrativeService().build(db, event)
+
+
+@router.get("/event/{event_id}/signal-post-mortem")
+def get_signal_post_mortem(
+    event_id: int,
+    db: Session = Depends(get_db),
+):
+    event = get_or_404(db, ScannerEvent, event_id, "ScannerEvent")
+    return SignalPostMortemService().build(db, event)
 
 
 @router.get("/event/{event_id}/historical-analogs")

--- a/backend/app/services/signal_post_mortem.py
+++ b/backend/app/services/signal_post_mortem.py
@@ -1,0 +1,341 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Protocol
+
+from sqlalchemy.orm import Session
+
+from app.core.config import Settings, settings
+from app.core.llm_guardrails import LLMUsageGuardrails, build_llm_usage_guardrails
+from app.models.scanner_event import ScannerEvent
+from app.models.scanner_event_narrative import ScannerEventNarrative
+from app.services.ai_signal_brief import AISignalBriefService
+
+POST_MORTEM_FEATURE = "post_mortem"
+POST_MORTEM_PROMPT_VERSION = "signal_post_mortem.v1"
+SUPPORTED_PROVENANCE_FIELDS = frozenset(
+    {
+        "signal_time.facts",
+        "signal_time.why",
+        "signal_time.risks",
+        "signal_time.warnings",
+        "expected_behavior.analogs",
+        "expected_behavior.archetype",
+        "realized_outcome.summary",
+        "realized_outcome.snapshots",
+    }
+)
+
+
+class SignalPostMortemGenerator(Protocol):
+    provider_name: str
+    model_name: str
+
+    def generate(
+        self,
+        post_mortem_input: dict[str, Any],
+        guardrails: LLMUsageGuardrails,
+    ) -> str | dict[str, Any]: ...
+
+
+class LocalSignalPostMortemGenerator:
+    """Grounded local renderer for post-mortems.
+
+    The renderer only uses the deterministic post-mortem input payload. External
+    providers can replace it without changing cache or provenance policy.
+    """
+
+    provider_name = "local"
+    model_name = "grounded-post-mortem-v1"
+
+    def generate(
+        self,
+        post_mortem_input: dict[str, Any],
+        guardrails: LLMUsageGuardrails,
+    ) -> dict[str, Any]:
+        signal_time = post_mortem_input["signal_time"]
+        expected = post_mortem_input["expected_behavior"]
+        outcome = post_mortem_input["realized_outcome"]
+        facts = signal_time.get("facts") or {}
+        summary = outcome.get("summary") or {}
+        ticker = facts.get("ticker") or "Unknown ticker"
+        scanner_type = facts.get("scanner_type") or "unknown scanner"
+        status = _outcome_status(summary)
+        why = "; ".join(signal_time.get("why") or ["No signal-time rationale listed."])
+        analog_count = len(expected.get("analogs") or [])
+        eod_change = summary.get("eod_pct_change")
+        outcome_text = (
+            f"follow-through={summary.get('follow_through')}, "
+            f"eod_pct_change={eod_change}"
+        )
+        return {
+            "text": (
+                f"{ticker} {scanner_type} post-mortem: the signal finished as "
+                f"{status}. Known at signal time: {why}. Expected behavior used "
+                f"{analog_count} analogs. Realized outcome: {outcome_text}."
+            ),
+            "provenance": [
+                {"claim": "Signal-time context", "source_fields": ["signal_time.why"]},
+                {
+                    "claim": "Expected behavior",
+                    "source_fields": ["expected_behavior.analogs"],
+                },
+                {
+                    "claim": "Realized outcome",
+                    "source_fields": ["realized_outcome.summary"],
+                },
+            ],
+        }
+
+
+class SignalPostMortemService:
+    def __init__(
+        self,
+        *,
+        brief_service: AISignalBriefService | None = None,
+        generator: SignalPostMortemGenerator | None = None,
+        settings: Settings = settings,
+    ) -> None:
+        self._brief_service = brief_service or AISignalBriefService()
+        self._generator = generator or LocalSignalPostMortemGenerator()
+        self._settings = settings
+
+    def build(self, db: Session, event: ScannerEvent) -> dict[str, Any]:
+        brief = self._brief_service.build(db, event)
+        guardrails = build_llm_usage_guardrails(self._settings)
+        if not guardrails.allows(POST_MORTEM_FEATURE):
+            return {
+                "brief": brief,
+                "post_mortem": None,
+                "cache": {"status": "disabled"},
+                "guardrails": guardrails,
+            }
+
+        outcome_summary = (brief.get("outcome_context") or {}).get("summary")
+        if not outcome_summary or not outcome_summary.get("is_complete"):
+            return {
+                "brief": brief,
+                "post_mortem": None,
+                "cache": {"status": "incomplete_outcome"},
+                "rejection": {
+                    "reason": "Outcome summary is incomplete or unavailable."
+                },
+                "guardrails": guardrails,
+            }
+
+        input_payload = _post_mortem_input_payload(brief)
+        fingerprint = _input_fingerprint(brief, input_payload)
+        cache = self._cache_query(db, event, guardrails).first()
+        if cache and cache.brief_fingerprint == fingerprint:
+            return {
+                "brief": brief,
+                "post_mortem": self._post_mortem_payload(cache),
+                "cache": {"status": "hit"},
+                "guardrails": guardrails,
+            }
+
+        generated = _normalize_generated_post_mortem(
+            self._generator.generate(input_payload, guardrails),
+            input_payload,
+        )
+        rejection_reason = _rejection_reason(generated, brief, input_payload)
+        if rejection_reason:
+            return {
+                "brief": brief,
+                "post_mortem": None,
+                "cache": {"status": "rejected"},
+                "rejection": {"reason": rejection_reason},
+                "guardrails": guardrails,
+            }
+
+        status = "stale_regenerated" if cache else "miss"
+        if cache is None:
+            cache = ScannerEventNarrative(
+                scanner_event_id=event.id,
+                feature_area=POST_MORTEM_FEATURE,
+                provider=guardrails.provider,
+                model=guardrails.model,
+                prompt_version=POST_MORTEM_PROMPT_VERSION,
+            )
+            db.add(cache)
+
+        cache.narrative_text = generated["text"]
+        cache.brief_schema_version = str(brief.get("schema_version") or "")
+        cache.brief_fingerprint = fingerprint
+        cache.input_payload = input_payload
+        cache.provenance_payload = generated["provenance"]
+        db.flush()
+
+        return {
+            "brief": brief,
+            "post_mortem": self._post_mortem_payload(cache),
+            "cache": {"status": status},
+            "guardrails": guardrails,
+        }
+
+    def _cache_query(
+        self,
+        db: Session,
+        event: ScannerEvent,
+        guardrails: LLMUsageGuardrails,
+    ):
+        return db.query(ScannerEventNarrative).filter(
+            ScannerEventNarrative.scanner_event_id == event.id,
+            ScannerEventNarrative.feature_area == POST_MORTEM_FEATURE,
+            ScannerEventNarrative.provider == guardrails.provider,
+            ScannerEventNarrative.model == guardrails.model,
+            ScannerEventNarrative.prompt_version == POST_MORTEM_PROMPT_VERSION,
+        )
+
+    def _post_mortem_payload(self, cache: ScannerEventNarrative) -> dict[str, Any]:
+        input_payload = cache.input_payload or {}
+        realized_outcome = input_payload.get("realized_outcome") or {}
+        summary = realized_outcome.get("summary") or {}
+        return {
+            "text": cache.narrative_text,
+            "provider": cache.provider,
+            "model": cache.model,
+            "prompt_version": cache.prompt_version,
+            "brief_schema_version": cache.brief_schema_version,
+            "brief_fingerprint": cache.brief_fingerprint,
+            "outcome_status": _outcome_status(summary),
+            "known_at_signal_time": input_payload.get("signal_time") or {},
+            "expected_behavior": input_payload.get("expected_behavior") or {},
+            "realized_outcome": realized_outcome,
+            "provenance": list(cache.provenance_payload or []),
+            "created_at": cache.created_at.isoformat() if cache.created_at else None,
+            "updated_at": cache.updated_at.isoformat() if cache.updated_at else None,
+        }
+
+
+def _post_mortem_input_payload(brief: dict[str, Any]) -> dict[str, Any]:
+    outcome_context = brief.get("outcome_context") or {}
+    return {
+        "signal_time": {
+            "facts": brief.get("facts") or {},
+            "why": list(brief.get("why") or []),
+            "risks": list(brief.get("risks") or []),
+            "warnings": list(brief.get("warnings") or []),
+        },
+        "expected_behavior": {
+            "analogs": list(brief.get("analogs") or []),
+            "archetype": brief.get("archetype"),
+        },
+        "realized_outcome": {
+            "summary": outcome_context.get("summary"),
+            "snapshots": list(outcome_context.get("snapshots") or []),
+        },
+    }
+
+
+def _input_fingerprint(
+    brief: dict[str, Any],
+    input_payload: dict[str, Any],
+) -> str:
+    payload = {
+        "schema_version": brief.get("schema_version"),
+        **input_payload,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _normalize_generated_post_mortem(
+    generated: str | dict[str, Any],
+    input_payload: dict[str, Any],
+) -> dict[str, Any]:
+    if isinstance(generated, str):
+        return {"text": generated, "provenance": _default_provenance(input_payload)}
+    if not isinstance(generated, dict):
+        return {"text": "", "provenance": []}
+    return {
+        "text": generated.get("text") or "",
+        "provenance": generated.get("provenance") or [],
+    }
+
+
+def _default_provenance(input_payload: dict[str, Any]) -> list[dict[str, Any]]:
+    provenance = [
+        {"claim": "Signal context", "source_fields": ["signal_time.facts"]},
+        {"claim": "Realized outcome", "source_fields": ["realized_outcome.summary"]},
+    ]
+    if (input_payload.get("expected_behavior") or {}).get("analogs"):
+        provenance.insert(
+            1,
+            {
+                "claim": "Expected behavior",
+                "source_fields": ["expected_behavior.analogs"],
+            },
+        )
+    return provenance
+
+
+def _rejection_reason(
+    generated: dict[str, Any],
+    brief: dict[str, Any],
+    input_payload: dict[str, Any],
+) -> str | None:
+    text = generated.get("text")
+    if not isinstance(text, str) or not text.strip():
+        return "Generated post-mortem is empty."
+
+    forbidden = _forbidden_claim_match(text, brief.get("forbidden_claims") or [])
+    if forbidden:
+        return f"Generated post-mortem contains a forbidden claim: {forbidden}"
+
+    provenance = generated.get("provenance")
+    if not isinstance(provenance, list) or not provenance:
+        return "Generated post-mortem is missing provenance."
+
+    for entry in provenance:
+        if not isinstance(entry, dict):
+            return "Generated post-mortem provenance must be a list of objects."
+        fields = entry.get("source_fields")
+        if not isinstance(fields, list) or not fields:
+            return "Generated post-mortem provenance is missing source fields."
+        for field in fields:
+            if field not in SUPPORTED_PROVENANCE_FIELDS:
+                return f"Generated post-mortem uses unsupported provenance field: {field}"
+            if _field_value(input_payload, field) is None:
+                return f"Generated post-mortem references absent provenance field: {field}"
+    return None
+
+
+def _field_value(input_payload: dict[str, Any], field: str) -> Any:
+    current: Any = input_payload
+    for part in field.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _outcome_status(summary: dict[str, Any]) -> str:
+    if summary.get("follow_through") is True:
+        return "winning"
+    if summary.get("follow_through") is False:
+        return "losing"
+    eod_change = summary.get("eod_pct_change")
+    if isinstance(eod_change, (int, float)):
+        return "winning" if eod_change > 0 else "losing"
+    return "unknown"
+
+
+def _forbidden_claim_match(text: str, forbidden_claims: list[str]) -> str | None:
+    normalized_text = _normalize_claim_text(text)
+    for claim in forbidden_claims:
+        normalized_claim = _normalize_claim_text(claim)
+        for prefix in ("do not ", "don't ", "never "):
+            if normalized_claim.startswith(prefix):
+                normalized_claim = normalized_claim[len(prefix) :]
+                break
+        if normalized_claim and normalized_claim in normalized_text:
+            return claim
+    return None
+
+
+def _normalize_claim_text(value: str) -> str:
+    return " ".join(
+        "".join(char.lower() if char.isalnum() else " " for char in value).split()
+    )

--- a/backend/tests/api/test_ai_signal_brief.py
+++ b/backend/tests/api/test_ai_signal_brief.py
@@ -211,6 +211,23 @@ def test_ai_signal_narrative_disabled_returns_brief_without_generated_text(db):
     assert data["cache"]["status"] == "disabled"
 
 
+def test_signal_post_mortem_disabled_returns_brief_without_generated_text(db):
+    target = _seed_event(
+        db,
+        ticker="PMT",
+        event_date=date(2026, 7, 3),
+        explanation=_explanation(),
+    )
+
+    response = client.get(f"/api/v1/outcomes/event/{target.id}/signal-post-mortem")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["brief"]["facts"]["ticker"] == "PMT"
+    assert data["post_mortem"] is None
+    assert data["cache"]["status"] == "disabled"
+
+
 def test_historical_analogs_endpoint_enriches_events_explanations_and_outcomes(db):
     _seed_event(
         db,

--- a/backend/tests/services/test_signal_post_mortem_service.py
+++ b/backend/tests/services/test_signal_post_mortem_service.py
@@ -1,0 +1,260 @@
+from datetime import date
+
+from app.core.config import Settings
+from app.models.scanner_event import ScannerEvent
+from app.models.scanner_event_narrative import ScannerEventNarrative
+from app.services.signal_post_mortem import SignalPostMortemService
+
+BASE_SETTINGS = {
+    "DATABASE_URL": "postgresql://test:test@localhost/test",
+    "POLYGON_API_KEY": "test-key",
+    "JWT_SECRET_KEY": "a" * 32,
+    "REDIS_PASSWORD": "r" * 16,
+}
+
+
+class FakeBriefService:
+    def __init__(self, brief: dict):
+        self.brief = brief
+
+    def build(self, db, event):
+        return self.brief
+
+
+class RecordingGenerator:
+    provider_name = "local"
+    model_name = "unit-post-mortem"
+
+    def __init__(self, payload: dict | None = None):
+        self.payload = payload
+        self.calls = []
+
+    def generate(self, post_mortem_input, guardrails):
+        self.calls.append(
+            {"post_mortem_input": post_mortem_input, "guardrails": guardrails}
+        )
+        if self.payload is not None:
+            return self.payload
+        facts = post_mortem_input["signal_time"]["facts"]
+        outcome = post_mortem_input["realized_outcome"]["summary"]
+        result = "won" if outcome["follow_through"] else "lost"
+        return {
+            "text": f"{facts['ticker']} post-mortem: signal {result}.",
+            "provenance": [
+                {"claim": "Signal context", "source_fields": ["signal_time.facts"]},
+                {
+                    "claim": "Realized outcome",
+                    "source_fields": ["realized_outcome.summary"],
+                },
+            ],
+        }
+
+
+def make_settings(**overrides) -> Settings:
+    return Settings(_env_file=None, **{**BASE_SETTINGS, **overrides})
+
+
+def enabled_settings() -> Settings:
+    return make_settings(
+        LLM_FEATURES_ENABLED=True,
+        LLM_PROVIDER="local",
+        LLM_MODEL="unit-post-mortem",
+        LLM_ALLOWED_FEATURES="post_mortem",
+    )
+
+
+def seed_event(db) -> ScannerEvent:
+    event = ScannerEvent(
+        ticker="TGT",
+        event_date=date(2026, 7, 3),
+        scanner_type="pre_market_volume_spike",
+        summary="TGT signal",
+        severity="high",
+        indicators={},
+        criteria_met={},
+        metadata_={},
+        explanation={},
+    )
+    db.add(event)
+    db.flush()
+    return event
+
+
+def make_brief(
+    *,
+    follow_through: bool | None = True,
+    eod_pct_change: float | None = 2.1,
+    complete: bool = True,
+) -> dict:
+    summary = None
+    if follow_through is not None:
+        summary = {
+            "scanner_event_id": 1,
+            "reference_price": 10.0,
+            "mfe_pct": 4.2,
+            "mae_pct": 0.8,
+            "mfe_mae_ratio": 5.25,
+            "r_multiple": 2.0,
+            "eod_pct_change": eod_pct_change,
+            "follow_through": follow_through,
+            "gap_filled": False,
+            "is_complete": complete,
+        }
+    return {
+        "schema_version": "ai_signal_brief.v1",
+        "event_id": 1,
+        "facts": {
+            "ticker": "TGT",
+            "event_date": "2026-07-03",
+            "scanner_type": "pre_market_volume_spike",
+            "severity": "high",
+            "summary": "TGT pre-market volume expanded.",
+            "signal_quality_score": 0.86,
+            "regime": "risk_on",
+        },
+        "why": ["Volume and liquidity aligned with the scanner setup."],
+        "risks": ["News catalyst did not pass."],
+        "warnings": [{"code": "stale_quote", "message": "Quote was stale."}],
+        "analogs": [
+            {
+                "ticker": "OLD",
+                "similarity_score": 0.91,
+                "outcome_summary": {"eod_pct_change": 1.8, "follow_through": True},
+            }
+        ],
+        "outcome_context": {"summary": summary, "snapshots": []},
+        "archetype": {
+            "label": "Volume Spike / Positive Outcomes",
+            "return_profile": {"win_rate_pct": 64.0, "sample_size": 25},
+        },
+        "forbidden_claims": ["Do not claim guaranteed future returns."],
+    }
+
+
+def test_disabled_post_mortem_returns_brief_without_generation(db):
+    event = seed_event(db)
+    generator = RecordingGenerator()
+    service = SignalPostMortemService(
+        brief_service=FakeBriefService(make_brief()),
+        generator=generator,
+        settings=make_settings(),
+    )
+
+    result = service.build(db, event)
+
+    assert result["brief"]["facts"]["ticker"] == "TGT"
+    assert result["post_mortem"] is None
+    assert result["cache"]["status"] == "disabled"
+    assert generator.calls == []
+    assert db.query(ScannerEventNarrative).count() == 0
+
+
+def test_winning_outcome_generates_grounded_post_mortem_and_cache(db):
+    event = seed_event(db)
+    brief = make_brief(follow_through=True, eod_pct_change=2.1)
+    generator = RecordingGenerator()
+    service = SignalPostMortemService(
+        brief_service=FakeBriefService(brief),
+        generator=generator,
+        settings=enabled_settings(),
+    )
+
+    result = service.build(db, event)
+
+    assert result["cache"]["status"] == "miss"
+    assert result["post_mortem"]["text"] == "TGT post-mortem: signal won."
+    assert result["post_mortem"]["outcome_status"] == "winning"
+    assert result["post_mortem"]["prompt_version"] == "signal_post_mortem.v1"
+    assert result["post_mortem"]["provenance"] == [
+        {"claim": "Signal context", "source_fields": ["signal_time.facts"]},
+        {"claim": "Realized outcome", "source_fields": ["realized_outcome.summary"]},
+    ]
+    post_mortem_input = generator.calls[0]["post_mortem_input"]
+    assert post_mortem_input["signal_time"]["why"] == brief["why"]
+    assert post_mortem_input["expected_behavior"]["analogs"] == brief["analogs"]
+    assert post_mortem_input["realized_outcome"]["summary"]["follow_through"] is True
+
+    cached = db.query(ScannerEventNarrative).one()
+    assert cached.feature_area == "post_mortem"
+    assert cached.narrative_text == result["post_mortem"]["text"]
+    assert cached.input_payload == post_mortem_input
+
+
+def test_losing_outcome_is_labeled_without_changing_signal_time_context(db):
+    event = seed_event(db)
+    service = SignalPostMortemService(
+        brief_service=FakeBriefService(
+            make_brief(follow_through=False, eod_pct_change=-1.4)
+        ),
+        generator=RecordingGenerator(),
+        settings=enabled_settings(),
+    )
+
+    result = service.build(db, event)
+
+    assert result["post_mortem"]["outcome_status"] == "losing"
+    assert "News catalyst did not pass." in result["post_mortem"]["known_at_signal_time"][
+        "risks"
+    ]
+    assert result["post_mortem"]["realized_outcome"]["summary"]["eod_pct_change"] == -1.4
+
+
+def test_incomplete_outcome_does_not_generate_post_mortem(db):
+    event = seed_event(db)
+    generator = RecordingGenerator()
+    service = SignalPostMortemService(
+        brief_service=FakeBriefService(make_brief(follow_through=True, complete=False)),
+        generator=generator,
+        settings=enabled_settings(),
+    )
+
+    result = service.build(db, event)
+
+    assert result["post_mortem"] is None
+    assert result["cache"]["status"] == "incomplete_outcome"
+    assert result["rejection"]["reason"] == "Outcome summary is incomplete or unavailable."
+    assert generator.calls == []
+    assert db.query(ScannerEventNarrative).count() == 0
+
+
+def test_cache_hit_reuses_post_mortem_without_generation(db):
+    event = seed_event(db)
+    brief = make_brief()
+    generator = RecordingGenerator()
+    service = SignalPostMortemService(
+        brief_service=FakeBriefService(brief),
+        generator=generator,
+        settings=enabled_settings(),
+    )
+    first = service.build(db, event)
+    generator.calls.clear()
+
+    second = service.build(db, event)
+
+    assert second["cache"]["status"] == "hit"
+    assert second["post_mortem"]["text"] == first["post_mortem"]["text"]
+    assert generator.calls == []
+    assert db.query(ScannerEventNarrative).count() == 1
+
+
+def test_unsupported_provenance_field_is_rejected_before_persistence(db):
+    event = seed_event(db)
+    service = SignalPostMortemService(
+        brief_service=FakeBriefService(make_brief()),
+        generator=RecordingGenerator(
+            {
+                "text": "TGT post-mortem with unsupported provenance.",
+                "provenance": [
+                    {"claim": "Unsupported", "source_fields": ["future_prediction"]}
+                ],
+            }
+        ),
+        settings=enabled_settings(),
+    )
+
+    result = service.build(db, event)
+
+    assert result["post_mortem"] is None
+    assert result["cache"]["status"] == "rejected"
+    assert "unsupported provenance field" in result["rejection"]["reason"]
+    assert db.query(ScannerEventNarrative).count() == 0


### PR DESCRIPTION
## Summary
- add feature-flagged signal post-mortem generation using AI signal briefs
- reuse the generic narrative cache with post_mortem feature area and provenance validation
- expose a post-mortem endpoint under outcomes

## Tests
- python -m pytest backend/tests/services/test_signal_post_mortem_service.py backend/tests/services/test_scanner_event_narrative_service.py backend/tests/services/test_alert_copy_service.py backend/tests/api/test_ai_signal_brief.py --no-cov
- python -m ruff check backend/app/services/signal_post_mortem.py backend/app/routers/outcomes.py backend/tests/services/test_signal_post_mortem_service.py backend/tests/api/test_ai_signal_brief.py
- git diff --check

Closes #476