### PR TITLE
Add embedding storage and retrieval foundation

### DIFF
--- a/backend/app/alembic/versions/e2f3a4b5c6d7_add_semantic_embeddings.py
+++ b/backend/app/alembic/versions/e2f3a4b5c6d7_add_semantic_embeddings.py
@@ -1,0 +1,61 @@
+"""add_semantic_embeddings
+
+Revision ID: e2f3a4b5c6d7
+Revises: c0d1e2f3a4b5
+Create Date: 2026-07-04 09:10:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "e2f3a4b5c6d7"
+down_revision: Union[str, None] = "c0d1e2f3a4b5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "semantic_embeddings",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("source_type", sa.String(length=50), nullable=False),
+        sa.Column("source_id", sa.String(length=120), nullable=False),
+        sa.Column("provider", sa.String(length=50), nullable=False),
+        sa.Column("model", sa.String(length=100), nullable=False),
+        sa.Column("embedding_version", sa.String(length=50), nullable=False),
+        sa.Column("vector", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "source_type",
+            "source_id",
+            "provider",
+            "model",
+            "embedding_version",
+            name="uq_semantic_embedding_source_model",
+        ),
+    )
+    op.create_index(op.f("ix_semantic_embeddings_id"), "semantic_embeddings", ["id"])
+    op.create_index(
+        op.f("ix_semantic_embeddings_source_id"),
+        "semantic_embeddings",
+        ["source_id"],
+    )
+    op.create_index(
+        op.f("ix_semantic_embeddings_source_type"),
+        "semantic_embeddings",
+        ["source_type"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_semantic_embeddings_source_type"), table_name="semantic_embeddings")
+    op.drop_index(op.f("ix_semantic_embeddings_source_id"), table_name="semantic_embeddings")
+    op.drop_index(op.f("ix_semantic_embeddings_id"), table_name="semantic_embeddings")
+    op.drop_table("semantic_embeddings")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -27,6 +27,7 @@ from app.models.scanner_outcome_snapshot import ScannerOutcomeSnapshot
 from app.models.scanner_outcome_summary import ScannerOutcomeSummary
 from app.models.scanner_replay_diff import ScannerReplayDiff
 from app.models.scanner_run import ScannerRun
+from app.models.semantic_embedding import SemanticEmbedding
 from app.models.signal_analysis_run import SignalAnalysisRun
 from app.models.signal_cluster import SignalCluster
 from app.models.signal_review import SignalReview
@@ -52,6 +53,7 @@ __all__ = [
     "ScannerEventNarrative",
     "ScannerConfig",
     "ScannerRun",
+    "SemanticEmbedding",
     "TickerReference",
     "StockMetric",
     "StockAggregate",

--- a/backend/app/models/semantic_embedding.py
+++ b/backend/app/models/semantic_embedding.py
@@ -1,0 +1,37 @@
+"""
+Semantic embedding cache model.
+"""
+
+from sqlalchemy import Column, DateTime, Integer, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+
+from app.core.database import Base
+from app.utils.time import utc_now
+
+
+class SemanticEmbedding(Base):
+    """Stored embedding vector for a typed source object."""
+
+    __tablename__ = "semantic_embeddings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    source_type = Column(String(50), nullable=False, index=True)
+    source_id = Column(String(120), nullable=False, index=True)
+    provider = Column(String(50), nullable=False)
+    model = Column(String(100), nullable=False)
+    embedding_version = Column(String(50), nullable=False)
+    vector = Column(JSONB, nullable=False, default=list)
+    metadata_ = Column("metadata", JSONB, nullable=False, default=dict)
+    created_at = Column(DateTime, default=utc_now)
+    updated_at = Column(DateTime, default=utc_now, onupdate=utc_now)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "source_type",
+            "source_id",
+            "provider",
+            "model",
+            "embedding_version",
+            name="uq_semantic_embedding_source_model",
+        ),
+    )

--- a/backend/app/routers/outcomes.py
+++ b/backend/app/routers/outcomes.py
@@ -34,6 +34,7 @@ from app.schemas.outcome import (
 from app.schemas.regime import RegimeBreakdownResponse
 from app.services.ai_signal_brief import AISignalBriefService
 from app.services.data_readiness import DataReadinessService
+from app.services.embedding_service import EmbeddingService
 from app.services.explanation_archetype_service import ExplanationArchetypeService
 from app.services.explanation_trait_performance import (
     ExplanationTraitPerformanceService,
@@ -278,6 +279,21 @@ def get_event_outcome(
     )
 
     return EventOutcomeResponse(summary=summary, snapshots=snapshots)
+
+
+@router.get("/semantic-search")
+def semantic_search(
+    query: str = Query(..., min_length=1),
+    top_k: int = Query(default=10, ge=1, le=50),
+    source_type: list[str] | None = Query(default=None),
+    db: Session = Depends(get_db),
+):
+    return EmbeddingService().search(
+        db,
+        query_text=query,
+        top_k=top_k,
+        source_types=source_type,
+    )
 
 
 @router.get("/event/{event_id}/ai-signal-brief")

--- a/backend/app/services/embedding_service.py
+++ b/backend/app/services/embedding_service.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import hashlib
+import math
+from typing import Any, Protocol
+
+from sqlalchemy.orm import Session
+
+from app.core.config import Settings, settings
+from app.core.llm_guardrails import build_llm_usage_guardrails
+from app.models.semantic_embedding import SemanticEmbedding
+
+EMBEDDINGS_FEATURE = "embeddings"
+SEMANTIC_SEARCH_FEATURE = "semantic_search"
+
+
+class EmbeddingProvider(Protocol):
+    provider_name: str
+    model_name: str
+    embedding_version: str
+
+    def embed(self, text: str) -> list[float]: ...
+
+
+class LocalHashEmbeddingProvider:
+    """Deterministic local embedding provider for development and tests.
+
+    This is a non-semantic fallback. External embedding providers can replace it
+    without changing storage or retrieval behavior.
+    """
+
+    provider_name = "local"
+    model_name = "hash-embedding"
+    embedding_version = "hash.v1"
+
+    def embed(self, text: str) -> list[float]:
+        tokens = [token for token in _tokenize(text) if token]
+        vector = [0.0] * 32
+        for token in tokens:
+            digest = hashlib.sha256(token.encode("utf-8")).digest()
+            index = digest[0] % len(vector)
+            sign = 1.0 if digest[1] % 2 == 0 else -1.0
+            vector[index] += sign
+        return _normalize(vector)
+
+
+class EmbeddingService:
+    def __init__(
+        self,
+        *,
+        provider: EmbeddingProvider | None = None,
+        settings: Settings = settings,
+    ) -> None:
+        self._settings = settings
+        self._provider = provider if provider is not None else _default_provider(settings)
+
+    def upsert_text(
+        self,
+        db: Session,
+        *,
+        source_type: str,
+        source_id: str,
+        text: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        guardrails = build_llm_usage_guardrails(self._settings)
+        if not guardrails.allows(EMBEDDINGS_FEATURE):
+            return {"status": "disabled", "record": None, "guardrails": guardrails}
+        if self._provider is None:
+            return {
+                "status": "provider_unavailable",
+                "record": None,
+                "guardrails": guardrails,
+            }
+
+        vector = _coerce_vector(self._provider.embed(text))
+        record = self._query_record(db, source_type=source_type, source_id=source_id).first()
+        status = "updated" if record else "inserted"
+        if record is None:
+            record = SemanticEmbedding(
+                source_type=source_type,
+                source_id=source_id,
+                provider=self._provider.provider_name,
+                model=self._provider.model_name,
+                embedding_version=self._provider.embedding_version,
+            )
+            db.add(record)
+
+        record.vector = vector
+        record.metadata_ = metadata or {}
+        db.flush()
+        return {"status": status, "record": _record_payload(record), "guardrails": guardrails}
+
+    def search(
+        self,
+        db: Session,
+        *,
+        query_text: str,
+        top_k: int = 10,
+        source_types: list[str] | None = None,
+    ) -> dict[str, Any]:
+        guardrails = build_llm_usage_guardrails(self._settings)
+        if not guardrails.allows(SEMANTIC_SEARCH_FEATURE):
+            return {"status": "disabled", "matches": [], "guardrails": guardrails}
+        if self._provider is None:
+            return {
+                "status": "provider_unavailable",
+                "matches": [],
+                "guardrails": guardrails,
+            }
+
+        query_vector = _coerce_vector(self._provider.embed(query_text))
+        query = db.query(SemanticEmbedding).filter(
+            SemanticEmbedding.provider == self._provider.provider_name,
+            SemanticEmbedding.model == self._provider.model_name,
+            SemanticEmbedding.embedding_version == self._provider.embedding_version,
+        )
+        if source_types:
+            query = query.filter(SemanticEmbedding.source_type.in_(source_types))
+
+        matches = []
+        for record in query.all():
+            score = _cosine_similarity(query_vector, _coerce_vector(record.vector))
+            matches.append({**_record_payload(record), "score": score})
+        matches.sort(key=lambda match: (-match["score"], match["source_type"], match["source_id"]))
+        return {
+            "status": "ok",
+            "matches": matches[: max(0, top_k)],
+            "guardrails": guardrails,
+        }
+
+    def _query_record(
+        self,
+        db: Session,
+        *,
+        source_type: str,
+        source_id: str,
+    ):
+        if self._provider is None:
+            raise RuntimeError("Embedding provider is unavailable.")
+        return db.query(SemanticEmbedding).filter(
+            SemanticEmbedding.source_type == source_type,
+            SemanticEmbedding.source_id == source_id,
+            SemanticEmbedding.provider == self._provider.provider_name,
+            SemanticEmbedding.model == self._provider.model_name,
+            SemanticEmbedding.embedding_version == self._provider.embedding_version,
+        )
+
+
+def _default_provider(settings: Settings) -> EmbeddingProvider | None:
+    if settings.LLM_PROVIDER == "local":
+        return LocalHashEmbeddingProvider()
+    return None
+
+
+def _record_payload(record: SemanticEmbedding) -> dict[str, Any]:
+    return {
+        "id": record.id,
+        "source_type": record.source_type,
+        "source_id": record.source_id,
+        "provider": record.provider,
+        "model": record.model,
+        "embedding_version": record.embedding_version,
+        "metadata": record.metadata_ or {},
+        "created_at": record.created_at.isoformat() if record.created_at else None,
+        "updated_at": record.updated_at.isoformat() if record.updated_at else None,
+    }
+
+
+def _coerce_vector(vector: list[float]) -> list[float]:
+    if not isinstance(vector, list) or not vector:
+        raise ValueError("Embedding vector must be a non-empty list.")
+    coerced = [float(value) for value in vector]
+    if not all(math.isfinite(value) for value in coerced):
+        raise ValueError("Embedding vector contains non-finite values.")
+    return coerced
+
+
+def _cosine_similarity(left: list[float], right: list[float]) -> float:
+    if len(left) != len(right):
+        return 0.0
+    left_norm = math.sqrt(sum(value * value for value in left))
+    right_norm = math.sqrt(sum(value * value for value in right))
+    if left_norm == 0 or right_norm == 0:
+        return 0.0
+    return sum(a * b for a, b in zip(left, right)) / (left_norm * right_norm)
+
+
+def _normalize(vector: list[float]) -> list[float]:
+    norm = math.sqrt(sum(value * value for value in vector))
+    if norm == 0:
+        return vector
+    return [value / norm for value in vector]
+
+
+def _tokenize(text: str) -> list[str]:
+    return ["".join(char.lower() if char.isalnum() else " " for char in text).strip()]

--- a/backend/tests/api/test_semantic_embeddings.py
+++ b/backend/tests/api/test_semantic_embeddings.py
@@ -1,0 +1,17 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_semantic_search_endpoint_returns_disabled_without_feature_flag(db):
+    response = client.get(
+        "/api/v1/outcomes/semantic-search",
+        params={"query": "growth signal", "top_k": 3, "source_type": "scanner_narrative"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "disabled"
+    assert data["matches"] == []

--- a/backend/tests/services/test_embedding_service.py
+++ b/backend/tests/services/test_embedding_service.py
@@ -1,0 +1,159 @@
+from app.core.config import Settings
+from app.models.semantic_embedding import SemanticEmbedding
+from app.services.embedding_service import EmbeddingService
+
+BASE_SETTINGS = {
+    "DATABASE_URL": "postgresql://test:test@localhost/test",
+    "POLYGON_API_KEY": "test-key",
+    "JWT_SECRET_KEY": "a" * 32,
+    "REDIS_PASSWORD": "r" * 16,
+}
+
+
+class FakeEmbeddingProvider:
+    provider_name = "local"
+    model_name = "unit-embedder"
+    embedding_version = "unit.v1"
+
+    def __init__(self):
+        self.calls = []
+
+    def embed(self, text: str) -> list[float]:
+        self.calls.append(text)
+        vectors = {
+            "growth query": [1.0, 0.0, 0.0],
+            "growth narrative": [0.9, 0.1, 0.0],
+            "risk narrative": [0.0, 1.0, 0.0],
+            "growth news": [0.8, 0.2, 0.0],
+            "updated narrative": [0.0, 0.0, 1.0],
+        }
+        return vectors[text]
+
+
+def make_settings(**overrides) -> Settings:
+    return Settings(_env_file=None, **{**BASE_SETTINGS, **overrides})
+
+
+def enabled_settings(**overrides) -> Settings:
+    values = {
+        "LLM_FEATURES_ENABLED": True,
+        "LLM_PROVIDER": "local",
+        "LLM_MODEL": "unit-embedder",
+        "LLM_ALLOWED_FEATURES": "embeddings,semantic_search",
+    }
+    values.update(overrides)
+    return make_settings(**values)
+
+
+def test_disabled_embeddings_do_not_call_provider_or_persist(db):
+    provider = FakeEmbeddingProvider()
+    service = EmbeddingService(provider=provider, settings=make_settings())
+
+    result = service.upsert_text(
+        db,
+        source_type="scanner_narrative",
+        source_id="event:1",
+        text="growth narrative",
+        metadata={"ticker": "TGT"},
+    )
+
+    assert result["status"] == "disabled"
+    assert result["record"] is None
+    assert provider.calls == []
+    assert db.query(SemanticEmbedding).count() == 0
+
+
+def test_upsert_inserts_and_updates_embedding_record(db):
+    provider = FakeEmbeddingProvider()
+    service = EmbeddingService(provider=provider, settings=enabled_settings())
+
+    first = service.upsert_text(
+        db,
+        source_type="scanner_narrative",
+        source_id="event:1",
+        text="growth narrative",
+        metadata={"ticker": "TGT"},
+    )
+    second = service.upsert_text(
+        db,
+        source_type="scanner_narrative",
+        source_id="event:1",
+        text="updated narrative",
+        metadata={"ticker": "TGT", "refreshed": True},
+    )
+
+    assert first["status"] == "inserted"
+    assert second["status"] == "updated"
+    assert db.query(SemanticEmbedding).count() == 1
+    record = db.query(SemanticEmbedding).one()
+    assert record.source_type == "scanner_narrative"
+    assert record.source_id == "event:1"
+    assert record.provider == "local"
+    assert record.model == "unit-embedder"
+    assert record.embedding_version == "unit.v1"
+    assert record.vector == [0.0, 0.0, 1.0]
+    assert record.metadata_ == {"ticker": "TGT", "refreshed": True}
+
+
+def test_search_returns_top_k_matches_with_source_filtering(db):
+    provider = FakeEmbeddingProvider()
+    service = EmbeddingService(provider=provider, settings=enabled_settings())
+    service.upsert_text(
+        db,
+        source_type="scanner_narrative",
+        source_id="event:1",
+        text="growth narrative",
+        metadata={"ticker": "TGT"},
+    )
+    service.upsert_text(
+        db,
+        source_type="scanner_narrative",
+        source_id="event:2",
+        text="risk narrative",
+        metadata={"ticker": "RISK"},
+    )
+    service.upsert_text(
+        db,
+        source_type="news",
+        source_id="article:1",
+        text="growth news",
+        metadata={"ticker": "NEWS"},
+    )
+
+    result = service.search(
+        db,
+        query_text="growth query",
+        top_k=2,
+        source_types=["scanner_narrative"],
+    )
+
+    assert result["status"] == "ok"
+    assert [match["source_id"] for match in result["matches"]] == ["event:1", "event:2"]
+    assert result["matches"][0]["score"] > result["matches"][1]["score"]
+    assert all(match["source_type"] == "scanner_narrative" for match in result["matches"])
+
+
+def test_search_disabled_returns_no_matches_without_provider_call(db):
+    provider = FakeEmbeddingProvider()
+    service = EmbeddingService(provider=provider, settings=make_settings())
+
+    result = service.search(db, query_text="growth query", top_k=5)
+
+    assert result["status"] == "disabled"
+    assert result["matches"] == []
+    assert provider.calls == []
+
+
+def test_enabled_embeddings_without_provider_report_provider_unavailable(db):
+    service = EmbeddingService(provider=None, settings=enabled_settings(LLM_PROVIDER="openai"))
+
+    result = service.upsert_text(
+        db,
+        source_type="scanner_narrative",
+        source_id="event:1",
+        text="growth narrative",
+    )
+
+    assert result["status"] == "provider_unavailable"
+    assert result["record"] is None
+    assert db.query(SemanticEmbedding).count() == 0


### PR DESCRIPTION
## Summary
- add semantic embedding storage with source/model/version metadata and Alembic migration
- add feature-flagged embedding upsert and top-k cosine retrieval with source filtering
- expose a disabled-safe semantic search endpoint while keeping deterministic analogs independent

## Tests
- python -m pytest backend/tests/services/test_embedding_service.py backend/tests/api/test_semantic_embeddings.py backend/tests/services/test_historical_analog_service.py backend/tests/api/test_ai_signal_brief.py --no-cov
- python -m ruff check backend/app/models/semantic_embedding.py backend/app/services/embedding_service.py backend/app/routers/outcomes.py backend/tests/services/test_embedding_service.py backend/tests/api/test_semantic_embeddings.py backend/app/alembic/versions/e2f3a4b5c6d7_add_semantic_embeddings.py
- python -m alembic heads
- git diff --check

Closes #477