### PR TITLE
Embed news, catalysts, explanations, and narratives

### DIFF
--- a/backend/app/services/domain_embedding_service.py
+++ b/backend/app/services/domain_embedding_service.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.news_article import NewsArticle
+from app.models.scanner_event import ScannerEvent
+from app.models.scanner_event_narrative import ScannerEventNarrative
+from app.models.semantic_embedding import SemanticEmbedding
+from app.services.ai_signal_brief import AISignalBriefService
+from app.services.embedding_service import EmbeddingService
+from app.utils.time import utc_now
+
+
+class DomainEmbeddingService:
+    """Build embedding inputs for domain-specific MarketHawk sources."""
+
+    def __init__(
+        self,
+        *,
+        embedding_service: EmbeddingService | None = None,
+        brief_service: AISignalBriefService | None = None,
+    ) -> None:
+        self._embedding_service = embedding_service or EmbeddingService()
+        self._brief_service = brief_service or AISignalBriefService()
+
+    def embed_news_article(self, db: Session, article: NewsArticle) -> dict[str, Any]:
+        text = _news_text(article)
+        metadata = {
+            "source": "news_article",
+            "news_article_id": article.id,
+            "tickers": list(article.tickers or []),
+            "provider": article.provider,
+            "published_utc": article.published_utc.isoformat()
+            if article.published_utc
+            else None,
+        }
+        return self._embed_source(
+            db,
+            source_type="news",
+            source_id=f"news:{article.id}",
+            text=text,
+            metadata=metadata,
+        )
+
+    def embed_scanner_catalyst(
+        self,
+        db: Session,
+        event: ScannerEvent,
+    ) -> dict[str, Any]:
+        text = _catalyst_text(event)
+        if not text:
+            return {"status": "skipped", "reason": "No catalyst text available."}
+        metadata = {
+            "source": "scanner_catalyst",
+            "scanner_event_id": event.id,
+            "ticker": event.ticker,
+            "scanner_type": event.scanner_type,
+            "event_date": event.event_date.isoformat() if event.event_date else None,
+        }
+        return self._embed_source(
+            db,
+            source_type="catalyst",
+            source_id=f"scanner_event:{event.id}",
+            text=text,
+            metadata=metadata,
+        )
+
+    def embed_signal_brief(self, db: Session, event: ScannerEvent) -> dict[str, Any]:
+        brief = self._brief_service.build(db, event)
+        text = _brief_text(brief)
+        metadata = {
+            "source": "ai_signal_brief",
+            "schema_version": brief.get("schema_version"),
+            "scanner_event_id": event.id,
+            "ticker": event.ticker,
+            "scanner_type": event.scanner_type,
+        }
+        return self._embed_source(
+            db,
+            source_type="scanner_explanation",
+            source_id=f"scanner_event:{event.id}",
+            text=text,
+            metadata=metadata,
+        )
+
+    def embed_generated_narrative(
+        self,
+        db: Session,
+        narrative: ScannerEventNarrative,
+    ) -> dict[str, Any]:
+        metadata = {
+            "source": "scanner_event_narrative",
+            "scanner_event_narrative_id": narrative.id,
+            "scanner_event_id": narrative.scanner_event_id,
+            "feature_area": narrative.feature_area,
+            "provider": narrative.provider,
+            "model": narrative.model,
+            "prompt_version": narrative.prompt_version,
+            "brief_fingerprint": narrative.brief_fingerprint,
+        }
+        return self._embed_source(
+            db,
+            source_type="generated_narrative",
+            source_id=f"scanner_event_narrative:{narrative.id}",
+            text=narrative.narrative_text,
+            metadata=metadata,
+        )
+
+    def _embed_source(
+        self,
+        db: Session,
+        *,
+        source_type: str,
+        source_id: str,
+        text: str,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any]:
+        fingerprint = _fingerprint(text)
+        existing = _existing_record(db, source_type, source_id)
+        existing_fingerprint = (existing.metadata_ or {}).get("source_fingerprint") if existing else None
+        freshness = (
+            "new"
+            if existing is None
+            else "unchanged"
+            if existing_fingerprint == fingerprint
+            else "stale_recomputed"
+        )
+        if freshness == "unchanged":
+            return {
+                "status": "skipped",
+                "freshness": freshness,
+                "source_fingerprint": fingerprint,
+                "record_id": existing.id,
+            }
+
+        embedding_metadata = {
+            **metadata,
+            "source_fingerprint": fingerprint,
+            "embedded_at": utc_now().isoformat(),
+        }
+        try:
+            result = self._embedding_service.upsert_text(
+                db,
+                source_type=source_type,
+                source_id=source_id,
+                text=text,
+                metadata=embedding_metadata,
+            )
+        except Exception as exc:
+            return {
+                "status": "failed",
+                "freshness": freshness,
+                "source_fingerprint": fingerprint,
+                "error": str(exc),
+            }
+
+        return {
+            **result,
+            "freshness": freshness,
+            "source_fingerprint": fingerprint,
+        }
+
+
+def _existing_record(
+    db: Session,
+    source_type: str,
+    source_id: str,
+) -> SemanticEmbedding | None:
+    return (
+        db.query(SemanticEmbedding)
+        .filter(
+            SemanticEmbedding.source_type == source_type,
+            SemanticEmbedding.source_id == source_id,
+        )
+        .order_by(SemanticEmbedding.updated_at.desc(), SemanticEmbedding.id.desc())
+        .first()
+    )
+
+
+def _news_text(article: NewsArticle) -> str:
+    return "\n".join(
+        part
+        for part in [
+            article.title,
+            article.description,
+            "Tickers: " + ", ".join(article.tickers or []),
+        ]
+        if part
+    )
+
+
+def _catalyst_text(event: ScannerEvent) -> str:
+    metadata = event.metadata_ or {}
+    catalyst_payload = (
+        metadata.get("catalyst")
+        or metadata.get("catalysts")
+        or metadata.get("news_catalyst")
+        or metadata.get("news_catalysts")
+    )
+    if not catalyst_payload:
+        return ""
+    parts = [event.summary or ""]
+    parts.extend(_flatten_text(catalyst_payload))
+    return "\n".join(part for part in parts if part)
+
+
+def _brief_text(brief: dict[str, Any]) -> str:
+    facts = brief.get("facts") or {}
+    warning_messages = [
+        warning.get("message") or warning.get("code")
+        for warning in brief.get("warnings") or []
+        if warning.get("message") or warning.get("code")
+    ]
+    return "\n".join(
+        part
+        for part in [
+            json.dumps(facts, sort_keys=True, default=str),
+            "Why: " + "; ".join(brief.get("why") or []),
+            "Risks: " + "; ".join(brief.get("risks") or []),
+            "Warnings: " + "; ".join(warning_messages),
+        ]
+        if part and not part.endswith(": ")
+    )
+
+
+def _flatten_text(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, dict):
+        return [
+            text
+            for key in sorted(value)
+            for text in _flatten_text(value[key])
+            if text
+        ]
+    if isinstance(value, list):
+        return [text for item in value for text in _flatten_text(item) if text]
+    return [str(value)] if value is not None else []
+
+
+def _fingerprint(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()

--- a/backend/app/tasks/__init__.py
+++ b/backend/app/tasks/__init__.py
@@ -1,4 +1,9 @@
 from app.tasks.backtest import run_backtest
+from app.tasks.embeddings import (
+    embed_generated_narrative_source,
+    embed_news_article_source,
+    embed_scanner_event_sources,
+)
 from app.tasks.explanations import backfill_scanner_explanations
 from app.tasks.quality import (
     analyze_signal_features,
@@ -63,4 +68,8 @@ __all__ = [
     # regime
     "update_regime_model",
     "backfill_regime_labels",
+    # embeddings
+    "embed_news_article_source",
+    "embed_scanner_event_sources",
+    "embed_generated_narrative_source",
 ]

--- a/backend/app/tasks/embeddings.py
+++ b/backend/app/tasks/embeddings.py
@@ -1,0 +1,85 @@
+import logging
+
+from app.core.celery_app import celery_app
+from app.core.database import SessionLocal
+from app.models.news_article import NewsArticle
+from app.models.scanner_event import ScannerEvent
+from app.models.scanner_event_narrative import ScannerEventNarrative
+from app.services.domain_embedding_service import DomainEmbeddingService
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(name="app.tasks.embed_news_article_source")
+def embed_news_article_source(article_id: int) -> dict:
+    db = SessionLocal()
+    try:
+        article = db.get(NewsArticle, article_id)
+        if article is None:
+            return {"status": "not_found", "source": "news", "id": article_id}
+        result = DomainEmbeddingService().embed_news_article(db, article)
+        db.commit()
+        return result
+    except Exception as exc:
+        db.rollback()
+        logger.exception("embed_news_article_source failed for article_id=%s", article_id)
+        return {"status": "failed", "source": "news", "id": article_id, "error": str(exc)}
+    finally:
+        db.close()
+
+
+@celery_app.task(name="app.tasks.embed_scanner_event_sources")
+def embed_scanner_event_sources(event_id: int) -> dict:
+    db = SessionLocal()
+    try:
+        event = db.get(ScannerEvent, event_id)
+        if event is None:
+            return {"status": "not_found", "source": "scanner_event", "id": event_id}
+        service = DomainEmbeddingService()
+        result = {
+            "catalyst": service.embed_scanner_catalyst(db, event),
+            "signal_brief": service.embed_signal_brief(db, event),
+        }
+        db.commit()
+        return {"status": "completed", "scanner_event_id": event_id, "results": result}
+    except Exception as exc:
+        db.rollback()
+        logger.exception("embed_scanner_event_sources failed for event_id=%s", event_id)
+        return {
+            "status": "failed",
+            "source": "scanner_event",
+            "id": event_id,
+            "error": str(exc),
+        }
+    finally:
+        db.close()
+
+
+@celery_app.task(name="app.tasks.embed_generated_narrative_source")
+def embed_generated_narrative_source(narrative_id: int) -> dict:
+    db = SessionLocal()
+    try:
+        narrative = db.get(ScannerEventNarrative, narrative_id)
+        if narrative is None:
+            return {
+                "status": "not_found",
+                "source": "generated_narrative",
+                "id": narrative_id,
+            }
+        result = DomainEmbeddingService().embed_generated_narrative(db, narrative)
+        db.commit()
+        return result
+    except Exception as exc:
+        db.rollback()
+        logger.exception(
+            "embed_generated_narrative_source failed for narrative_id=%s",
+            narrative_id,
+        )
+        return {
+            "status": "failed",
+            "source": "generated_narrative",
+            "id": narrative_id,
+            "error": str(exc),
+        }
+    finally:
+        db.close()

--- a/backend/tests/services/test_domain_embedding_service.py
+++ b/backend/tests/services/test_domain_embedding_service.py
@@ -1,0 +1,204 @@
+from datetime import date, datetime
+
+from app.core.config import Settings
+from app.models.news_article import NewsArticle
+from app.models.scanner_event import ScannerEvent
+from app.models.scanner_event_narrative import ScannerEventNarrative
+from app.models.semantic_embedding import SemanticEmbedding
+from app.services.domain_embedding_service import DomainEmbeddingService
+from app.services.embedding_service import EmbeddingService
+
+BASE_SETTINGS = {
+    "DATABASE_URL": "postgresql://test:test@localhost/test",
+    "POLYGON_API_KEY": "test-key",
+    "JWT_SECRET_KEY": "a" * 32,
+    "REDIS_PASSWORD": "r" * 16,
+}
+
+
+class FakeEmbeddingProvider:
+    provider_name = "local"
+    model_name = "unit-embedder"
+    embedding_version = "unit.v1"
+
+    def __init__(self, exc: Exception | None = None):
+        self.calls = []
+        self.exc = exc
+
+    def embed(self, text: str) -> list[float]:
+        self.calls.append(text)
+        if self.exc:
+            raise self.exc
+        return [float(len(text)), 1.0]
+
+
+class FakeBriefService:
+    def build(self, db, event):
+        return {
+            "schema_version": "ai_signal_brief.v1",
+            "event_id": event.id,
+            "facts": {
+                "ticker": event.ticker,
+                "event_date": event.event_date.isoformat(),
+                "scanner_type": event.scanner_type,
+                "summary": event.summary,
+            },
+            "why": ["Volume expanded before the open."],
+            "risks": ["News catalyst did not pass."],
+            "warnings": [{"code": "stale_quote", "message": "Quote was stale."}],
+            "analogs": [],
+            "outcome_context": {"summary": None, "snapshots": []},
+        }
+
+
+def make_settings(**overrides) -> Settings:
+    return Settings(_env_file=None, **{**BASE_SETTINGS, **overrides})
+
+
+def enabled_settings() -> Settings:
+    return make_settings(
+        LLM_FEATURES_ENABLED=True,
+        LLM_PROVIDER="local",
+        LLM_MODEL="unit-embedder",
+        LLM_ALLOWED_FEATURES="embeddings,semantic_search",
+    )
+
+
+def embedding_service(provider: FakeEmbeddingProvider) -> EmbeddingService:
+    return EmbeddingService(provider=provider, settings=enabled_settings())
+
+
+def seed_event(db, *, metadata=None) -> ScannerEvent:
+    event = ScannerEvent(
+        ticker="TGT",
+        event_date=date(2026, 7, 3),
+        scanner_type="pre_market_volume_spike",
+        summary="TGT pre-market volume expanded.",
+        severity="high",
+        indicators={},
+        criteria_met={},
+        metadata_=metadata or {},
+        explanation={},
+    )
+    db.add(event)
+    db.flush()
+    return event
+
+
+def seed_news(db) -> NewsArticle:
+    article = NewsArticle(
+        title="TGT announces growth plan",
+        description="Management raised revenue guidance.",
+        published_utc=datetime(2026, 7, 3, 12, 0, 0),
+        article_url="https://example.com/tgt-growth",
+        provider="unit",
+        tickers=["TGT"],
+    )
+    db.add(article)
+    db.flush()
+    return article
+
+
+def seed_narrative(db, event: ScannerEvent) -> ScannerEventNarrative:
+    narrative = ScannerEventNarrative(
+        scanner_event_id=event.id,
+        feature_area="scanner_narrative",
+        narrative_text="TGT generated narrative with risks and provenance.",
+        provider="local",
+        model="unit-narrator",
+        prompt_version="scanner_narrative.v1",
+        brief_schema_version="ai_signal_brief.v1",
+        brief_fingerprint="abc123",
+        input_payload={},
+        provenance_payload=[],
+    )
+    db.add(narrative)
+    db.flush()
+    return narrative
+
+
+def test_embeds_news_catalyst_signal_brief_and_generated_narrative(db):
+    provider = FakeEmbeddingProvider()
+    service = DomainEmbeddingService(
+        embedding_service=embedding_service(provider),
+        brief_service=FakeBriefService(),
+    )
+    event = seed_event(
+        db,
+        metadata={
+            "catalyst": {
+                "headline": "FDA clearance",
+                "summary": "Device clearance expanded the addressable market.",
+            }
+        },
+    )
+    article = seed_news(db)
+    narrative = seed_narrative(db, event)
+
+    news = service.embed_news_article(db, article)
+    catalyst = service.embed_scanner_catalyst(db, event)
+    brief = service.embed_signal_brief(db, event)
+    generated = service.embed_generated_narrative(db, narrative)
+
+    assert news["status"] == "inserted"
+    assert catalyst["status"] == "inserted"
+    assert brief["status"] == "inserted"
+    assert generated["status"] == "inserted"
+    rows = {
+        (row.source_type, row.source_id): row
+        for row in db.query(SemanticEmbedding).order_by(SemanticEmbedding.source_type)
+    }
+    assert ("news", f"news:{article.id}") in rows
+    assert ("catalyst", f"scanner_event:{event.id}") in rows
+    assert ("scanner_explanation", f"scanner_event:{event.id}") in rows
+    assert ("generated_narrative", f"scanner_event_narrative:{narrative.id}") in rows
+    assert rows[("news", f"news:{article.id}")].metadata_["tickers"] == ["TGT"]
+    assert rows[
+        ("generated_narrative", f"scanner_event_narrative:{narrative.id}")
+    ].metadata_["feature_area"] == "scanner_narrative"
+    assert any("FDA clearance" in text for text in provider.calls)
+    assert any("Volume expanded before the open." in text for text in provider.calls)
+
+
+def test_repeated_news_embedding_tracks_unchanged_and_stale_recomputed(db):
+    provider = FakeEmbeddingProvider()
+    service = DomainEmbeddingService(embedding_service=embedding_service(provider))
+    article = seed_news(db)
+
+    first = service.embed_news_article(db, article)
+    second = service.embed_news_article(db, article)
+    article.description = "Management cut guidance after the first report."
+    third = service.embed_news_article(db, article)
+
+    assert first["freshness"] == "new"
+    assert second["freshness"] == "unchanged"
+    assert third["freshness"] == "stale_recomputed"
+    assert db.query(SemanticEmbedding).count() == 1
+    assert db.query(SemanticEmbedding).one().metadata_["source_fingerprint"] == third[
+        "source_fingerprint"
+    ]
+
+
+def test_missing_catalyst_is_skipped_without_embedding_call(db):
+    provider = FakeEmbeddingProvider()
+    service = DomainEmbeddingService(embedding_service=embedding_service(provider))
+    event = seed_event(db)
+
+    result = service.embed_scanner_catalyst(db, event)
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "No catalyst text available."
+    assert provider.calls == []
+    assert db.query(SemanticEmbedding).count() == 0
+
+
+def test_embedding_failure_is_reported_without_raising(db):
+    provider = FakeEmbeddingProvider(exc=RuntimeError("provider timeout"))
+    service = DomainEmbeddingService(embedding_service=embedding_service(provider))
+    article = seed_news(db)
+
+    result = service.embed_news_article(db, article)
+
+    assert result["status"] == "failed"
+    assert result["error"] == "provider timeout"
+    assert db.query(SemanticEmbedding).count() == 0

--- a/backend/tests/tasks/test_package_exports.py
+++ b/backend/tests/tasks/test_package_exports.py
@@ -29,6 +29,10 @@ PUBLIC_TASKS = [
     # regime
     "update_regime_model",
     "backfill_regime_labels",
+    # embeddings
+    "embed_news_article_source",
+    "embed_scanner_event_sources",
+    "embed_generated_narrative_source",
 ]
 
 SUBMODULE_TASKS = {
@@ -62,6 +66,11 @@ SUBMODULE_TASKS = {
     "app.tasks.regime": [
         "update_regime_model",
         "backfill_regime_labels",
+    ],
+    "app.tasks.embeddings": [
+        "embed_news_article_source",
+        "embed_scanner_event_sources",
+        "embed_generated_narrative_source",
     ],
 }
 


### PR DESCRIPTION
## Summary
- add domain embedding jobs for news, scanner catalysts, AI signal briefs, and generated narratives
- track source fingerprints for unchanged versus stale-recomputed inputs
- expose Celery task entry points that report failures without blocking deterministic workflows

## Tests
- python -m pytest backend/tests/services/test_domain_embedding_service.py backend/tests/services/test_embedding_service.py backend/tests/api/test_semantic_embeddings.py backend/tests/tasks/test_package_exports.py --no-cov
- python -m ruff check backend/app/services/domain_embedding_service.py backend/app/tasks/embeddings.py backend/app/tasks/__init__.py backend/tests/services/test_domain_embedding_service.py backend/tests/tasks/test_package_exports.py
- git diff --check

Closes #478