### PR TITLE
Add semantic find-signals-like-this search

### DIFF
--- a/backend/app/routers/outcomes.py
+++ b/backend/app/routers/outcomes.py
@@ -42,6 +42,7 @@ from app.services.explanation_trait_performance import (
 from app.services.historical_analog_service import HistoricalAnalogService
 from app.services.outcome_service import OutcomeService
 from app.services.scanner_event_narrative import ScannerEventNarrativeService
+from app.services.semantic_signal_search import SemanticSignalSearchService
 from app.services.signal_post_mortem import SignalPostMortemService
 from app.services.stats import StatsService
 from app.utils.db import get_or_404
@@ -296,6 +297,21 @@ def semantic_search(
     )
 
 
+@router.get("/semantic-signal-search")
+def semantic_signal_search(
+    query: str = Query(..., min_length=1),
+    top_k: int = Query(default=10, ge=1, le=50),
+    source_type: list[str] | None = Query(default=None),
+    db: Session = Depends(get_db),
+):
+    return SemanticSignalSearchService().find_for_text(
+        db,
+        query_text=query,
+        top_k=top_k,
+        source_types=source_type,
+    )
+
+
 @router.get("/event/{event_id}/ai-signal-brief")
 def get_ai_signal_brief(
     event_id: int,
@@ -321,6 +337,22 @@ def get_signal_post_mortem(
 ):
     event = get_or_404(db, ScannerEvent, event_id, "ScannerEvent")
     return SignalPostMortemService().build(db, event)
+
+
+@router.get("/event/{event_id}/semantic-matches")
+def get_event_semantic_matches(
+    event_id: int,
+    top_k: int = Query(default=10, ge=1, le=50),
+    source_type: list[str] | None = Query(default=None),
+    db: Session = Depends(get_db),
+):
+    event = get_or_404(db, ScannerEvent, event_id, "ScannerEvent")
+    return SemanticSignalSearchService().find_for_event(
+        db,
+        event,
+        top_k=top_k,
+        source_types=source_type,
+    )
 
 
 @router.get("/event/{event_id}/historical-analogs")

--- a/backend/app/services/semantic_signal_search.py
+++ b/backend/app/services/semantic_signal_search.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.models.scanner_event import ScannerEvent
+from app.services.ai_signal_brief import AISignalBriefService
+from app.services.embedding_service import EmbeddingService
+from app.services.historical_analog_service import HistoricalAnalogService
+
+DOMAIN_SOURCE_TYPES = [
+    "scanner_explanation",
+    "generated_narrative",
+    "news",
+    "catalyst",
+]
+
+
+class SemanticSignalSearchService:
+    """Find semantic matches while keeping deterministic analogs separate."""
+
+    def __init__(
+        self,
+        *,
+        embedding_service: EmbeddingService | None = None,
+        brief_service: AISignalBriefService | None = None,
+        analog_service: HistoricalAnalogService | None = None,
+    ) -> None:
+        self._embedding_service = embedding_service or EmbeddingService()
+        self._brief_service = brief_service or AISignalBriefService()
+        self._analog_service = analog_service or HistoricalAnalogService()
+
+    def find_for_event(
+        self,
+        db: Session,
+        event: ScannerEvent,
+        *,
+        top_k: int = 10,
+        source_types: list[str] | None = None,
+        analog_limit: int = 5,
+    ) -> dict[str, Any]:
+        brief = self._brief_service.build(db, event)
+        search = self._embedding_service.search(
+            db,
+            query_text=_brief_query_text(brief),
+            top_k=top_k + 5,
+            source_types=source_types or DOMAIN_SOURCE_TYPES,
+        )
+        matches = [
+            match
+            for match in _semantic_matches(search.get("matches") or [])
+            if not _same_event(match, event.id)
+        ][:top_k]
+        analogs = self._analog_service.find_similar_events(
+            db,
+            target_event_id=event.id,
+            limit=analog_limit,
+            min_sample_size=5,
+        )
+        return _result_payload(
+            status="ok" if matches else "no_results",
+            semantic_matches=matches,
+            deterministic_analogs=analogs,
+            search_status=search.get("status"),
+        )
+
+    def find_for_text(
+        self,
+        db: Session,
+        *,
+        query_text: str,
+        top_k: int = 10,
+        source_types: list[str] | None = None,
+    ) -> dict[str, Any]:
+        search = self._embedding_service.search(
+            db,
+            query_text=query_text,
+            top_k=top_k,
+            source_types=source_types or DOMAIN_SOURCE_TYPES,
+        )
+        matches = _semantic_matches(search.get("matches") or [])
+        return _result_payload(
+            status="ok" if matches else "no_results",
+            semantic_matches=matches,
+            deterministic_analogs=None,
+            search_status=search.get("status"),
+        )
+
+
+def _result_payload(
+    *,
+    status: str,
+    semantic_matches: list[dict[str, Any]],
+    deterministic_analogs: dict[str, Any] | None,
+    search_status: str | None,
+) -> dict[str, Any]:
+    warnings = []
+    if not semantic_matches:
+        warnings.append("No semantic matches were found.")
+    return {
+        "status": status,
+        "label": "Semantic matches",
+        "semantic_matches": semantic_matches,
+        "deterministic_analogs": deterministic_analogs,
+        "search_status": search_status,
+        "warnings": warnings,
+    }
+
+
+def _semantic_matches(matches: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        {
+            "match_type": "semantic",
+            "source_type": match["source_type"],
+            "source_id": match["source_id"],
+            "score": match["score"],
+            "metadata": match.get("metadata") or {},
+            "why": _why(match),
+        }
+        for match in matches
+    ]
+
+
+def _why(match: dict[str, Any]) -> str:
+    metadata = match.get("metadata") or {}
+    ticker = metadata.get("ticker")
+    suffix = f" for {ticker}" if ticker else ""
+    return (
+        f"Semantic similarity matched {match['source_type']} "
+        f"{match['source_id']}{suffix}."
+    )
+
+
+def _same_event(match: dict[str, Any], event_id: int) -> bool:
+    metadata = match.get("metadata") or {}
+    if metadata.get("scanner_event_id") == event_id:
+        return True
+    return match.get("source_id") == f"scanner_event:{event_id}"
+
+
+def _brief_query_text(brief: dict[str, Any]) -> str:
+    facts = brief.get("facts") or {}
+    return "\n".join(
+        part
+        for part in [
+            json.dumps(facts, sort_keys=True, default=str),
+            "Why: " + "; ".join(brief.get("why") or []),
+            "Risks: " + "; ".join(brief.get("risks") or []),
+        ]
+        if part and not part.endswith(": ")
+    )

--- a/backend/tests/api/test_semantic_signal_search.py
+++ b/backend/tests/api/test_semantic_signal_search.py
@@ -1,0 +1,50 @@
+from datetime import date
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models.scanner_event import ScannerEvent
+
+client = TestClient(app)
+
+
+def _seed_event(db) -> ScannerEvent:
+    event = ScannerEvent(
+        ticker="TGT",
+        event_date=date(2026, 7, 3),
+        scanner_type="pre_market_volume_spike",
+        summary="TGT target signal",
+        severity="high",
+        indicators={},
+        criteria_met={},
+        metadata_={},
+        explanation={},
+    )
+    db.add(event)
+    db.flush()
+    return event
+
+
+def test_text_semantic_signal_search_endpoint_labels_no_result_state(db):
+    response = client.get(
+        "/api/v1/outcomes/semantic-signal-search",
+        params={"query": "growth query", "top_k": 3},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["label"] == "Semantic matches"
+    assert data["deterministic_analogs"] is None
+    assert data["semantic_matches"] == []
+
+
+def test_event_semantic_signal_search_endpoint_keeps_analogs_separate(db):
+    event = _seed_event(db)
+
+    response = client.get(f"/api/v1/outcomes/event/{event.id}/semantic-matches")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["label"] == "Semantic matches"
+    assert data["semantic_matches"] == []
+    assert data["deterministic_analogs"]["analogs"] == []

--- a/backend/tests/services/test_semantic_signal_search_service.py
+++ b/backend/tests/services/test_semantic_signal_search_service.py
@@ -1,0 +1,160 @@
+from datetime import date
+
+from app.core.config import Settings
+from app.models.scanner_event import ScannerEvent
+from app.services.embedding_service import EmbeddingService
+from app.services.semantic_signal_search import SemanticSignalSearchService
+
+BASE_SETTINGS = {
+    "DATABASE_URL": "postgresql://test:test@localhost/test",
+    "POLYGON_API_KEY": "test-key",
+    "JWT_SECRET_KEY": "a" * 32,
+    "REDIS_PASSWORD": "r" * 16,
+}
+
+
+class FakeEmbeddingProvider:
+    provider_name = "local"
+    model_name = "unit-embedder"
+    embedding_version = "unit.v1"
+
+    def embed(self, text: str) -> list[float]:
+        if "target signal" in text or "growth query" in text:
+            return [1.0, 0.0]
+        if "similar signal" in text or "growth news" in text:
+            return [0.9, 0.1]
+        return [0.0, 1.0]
+
+
+class FakeBriefService:
+    def build(self, db, event):
+        return {
+            "schema_version": "ai_signal_brief.v1",
+            "facts": {
+                "ticker": event.ticker,
+                "event_date": event.event_date.isoformat(),
+                "scanner_type": event.scanner_type,
+                "summary": event.summary,
+            },
+            "why": ["target signal setup had volume and liquidity support."],
+            "risks": [],
+            "warnings": [],
+        }
+
+
+class FakeAnalogService:
+    def find_similar_events(self, db, *, target_event_id, limit, min_sample_size):
+        return {
+            "analogs": [
+                {
+                    "event_id": 99,
+                    "ticker": "ANA",
+                    "similarity_score": 0.72,
+                    "outcome_summary": {"follow_through": True},
+                }
+            ],
+            "warnings": [],
+        }
+
+
+def make_settings(**overrides) -> Settings:
+    return Settings(_env_file=None, **{**BASE_SETTINGS, **overrides})
+
+
+def enabled_settings() -> Settings:
+    return make_settings(
+        LLM_FEATURES_ENABLED=True,
+        LLM_PROVIDER="local",
+        LLM_MODEL="unit-embedder",
+        LLM_ALLOWED_FEATURES="embeddings,semantic_search",
+    )
+
+
+def make_embedding_service() -> EmbeddingService:
+    return EmbeddingService(provider=FakeEmbeddingProvider(), settings=enabled_settings())
+
+
+def seed_event(db, *, ticker: str, summary: str) -> ScannerEvent:
+    event = ScannerEvent(
+        ticker=ticker,
+        event_date=date(2026, 7, 3),
+        scanner_type="pre_market_volume_spike",
+        summary=summary,
+        severity="high",
+        indicators={},
+        criteria_met={},
+        metadata_={},
+        explanation={},
+    )
+    db.add(event)
+    db.flush()
+    return event
+
+
+def test_event_search_separates_semantic_matches_from_deterministic_analogs(db):
+    target = seed_event(db, ticker="TGT", summary="target signal")
+    other = seed_event(db, ticker="SIM", summary="similar signal")
+    embedding_service = make_embedding_service()
+    embedding_service.upsert_text(
+        db,
+        source_type="scanner_explanation",
+        source_id=f"scanner_event:{other.id}",
+        text="similar signal",
+        metadata={"ticker": other.ticker, "scanner_event_id": other.id},
+    )
+    embedding_service.upsert_text(
+        db,
+        source_type="scanner_explanation",
+        source_id=f"scanner_event:{target.id}",
+        text="target signal",
+        metadata={"ticker": target.ticker, "scanner_event_id": target.id},
+    )
+    service = SemanticSignalSearchService(
+        embedding_service=embedding_service,
+        brief_service=FakeBriefService(),
+        analog_service=FakeAnalogService(),
+    )
+
+    result = service.find_for_event(db, target, top_k=5)
+
+    assert result["label"] == "Semantic matches"
+    assert result["deterministic_analogs"]["analogs"][0]["event_id"] == 99
+    assert [match["source_id"] for match in result["semantic_matches"]] == [
+        f"scanner_event:{other.id}"
+    ]
+    match = result["semantic_matches"][0]
+    assert match["match_type"] == "semantic"
+    assert match["source_type"] == "scanner_explanation"
+    assert match["score"] > 0.8
+    assert "SIM" in match["why"]
+
+
+def test_text_query_search_returns_labeled_semantic_matches(db):
+    embedding_service = make_embedding_service()
+    embedding_service.upsert_text(
+        db,
+        source_type="news",
+        source_id="news:1",
+        text="growth news",
+        metadata={"ticker": "TGT", "title": "TGT growth news"},
+    )
+    service = SemanticSignalSearchService(embedding_service=embedding_service)
+
+    result = service.find_for_text(db, query_text="growth query", top_k=3)
+
+    assert result["label"] == "Semantic matches"
+    assert result["deterministic_analogs"] is None
+    assert result["semantic_matches"][0]["source_type"] == "news"
+    assert result["semantic_matches"][0]["why"] == (
+        "Semantic similarity matched news news:1 for TGT."
+    )
+
+
+def test_text_query_search_no_results_state(db):
+    service = SemanticSignalSearchService(embedding_service=make_embedding_service())
+
+    result = service.find_for_text(db, query_text="growth query", top_k=3)
+
+    assert result["status"] == "no_results"
+    assert result["semantic_matches"] == []
+    assert result["warnings"] == ["No semantic matches were found."]


### PR DESCRIPTION
## Summary
- add semantic signal search service for event-based and text-query matching
- label semantic matches separately from deterministic analogs
- expose outcomes endpoints for semantic signal search and per-event semantic matches

## Tests
- python -m pytest backend/tests/services/test_semantic_signal_search_service.py backend/tests/api/test_semantic_signal_search.py backend/tests/services/test_embedding_service.py backend/tests/services/test_domain_embedding_service.py backend/tests/api/test_semantic_embeddings.py --no-cov
- python -m ruff check backend/app/services/semantic_signal_search.py backend/app/routers/outcomes.py backend/tests/services/test_semantic_signal_search_service.py backend/tests/api/test_semantic_signal_search.py
- git diff --check

Closes #479