### PR TITLE
Add analyst Q&A over explained events and outcomes

### DIFF
--- a/backend/app/routers/outcomes.py
+++ b/backend/app/routers/outcomes.py
@@ -33,6 +33,7 @@ from app.schemas.outcome import (
 )
 from app.schemas.regime import RegimeBreakdownResponse
 from app.services.ai_signal_brief import AISignalBriefService
+from app.services.analyst_qa_service import AnalystQAService
 from app.services.data_readiness import DataReadinessService
 from app.services.embedding_service import EmbeddingService
 from app.services.explanation_archetype_service import ExplanationArchetypeService
@@ -312,6 +313,21 @@ def semantic_signal_search(
     )
 
 
+@router.get("/analyst-qa")
+def analyst_qa_for_events(
+    question: str = Query(..., min_length=1),
+    scanner_type: str | None = None,
+    limit: int = Query(default=20, ge=1, le=100),
+    db: Session = Depends(get_db),
+):
+    return AnalystQAService().answer_for_events(
+        db,
+        question=question,
+        scanner_type=scanner_type,
+        limit=limit,
+    )
+
+
 @router.get("/event/{event_id}/ai-signal-brief")
 def get_ai_signal_brief(
     event_id: int,
@@ -353,6 +369,16 @@ def get_event_semantic_matches(
         top_k=top_k,
         source_types=source_type,
     )
+
+
+@router.get("/event/{event_id}/analyst-qa")
+def analyst_qa_for_event(
+    event_id: int,
+    question: str = Query(..., min_length=1),
+    db: Session = Depends(get_db),
+):
+    event = get_or_404(db, ScannerEvent, event_id, "ScannerEvent")
+    return AnalystQAService().answer_for_event(db, event, question=question)
 
 
 @router.get("/event/{event_id}/historical-analogs")

--- a/backend/app/services/analyst_qa_service.py
+++ b/backend/app/services/analyst_qa_service.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.core.config import Settings, settings
+from app.core.llm_guardrails import build_llm_usage_guardrails
+from app.models.scanner_event import ScannerEvent
+from app.services.ai_signal_brief import AISignalBriefService
+from app.services.semantic_signal_search import SemanticSignalSearchService
+
+ANALYST_QA_FEATURE = "analyst_qa"
+
+
+class AnalystQAService:
+    """Grounded analyst Q&A over deterministic signal context."""
+
+    def __init__(
+        self,
+        *,
+        brief_service: AISignalBriefService | None = None,
+        semantic_search_service: SemanticSignalSearchService | None = None,
+        settings: Settings = settings,
+    ) -> None:
+        self._brief_service = brief_service or AISignalBriefService()
+        self._semantic_search_service = (
+            semantic_search_service or SemanticSignalSearchService()
+        )
+        self._settings = settings
+
+    def answer_for_event(
+        self,
+        db: Session,
+        event: ScannerEvent,
+        *,
+        question: str,
+    ) -> dict[str, Any]:
+        unavailable = self._unavailable(question)
+        if unavailable:
+            return unavailable
+
+        brief = self._brief_service.build(db, event)
+        semantic = self._semantic_search_service.find_for_event(db, event, top_k=5)
+        return _answer_payload(question=question, briefs=[brief], semantic=semantic)
+
+    def answer_for_events(
+        self,
+        db: Session,
+        *,
+        question: str,
+        scanner_type: str | None = None,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        unavailable = self._unavailable(question)
+        if unavailable:
+            return unavailable
+
+        query = db.query(ScannerEvent)
+        if scanner_type:
+            query = query.filter(ScannerEvent.scanner_type == scanner_type)
+        events = query.order_by(ScannerEvent.event_date.desc(), ScannerEvent.id.desc()).limit(limit).all()
+        briefs = [self._brief_service.build(db, event) for event in events]
+        return {
+            **_answer_payload(question=question, briefs=briefs, semantic=None),
+            "event_count": len(events),
+        }
+
+    def _unavailable(self, question: str) -> dict[str, Any] | None:
+        guardrails = build_llm_usage_guardrails(self._settings)
+        if not guardrails.allows(ANALYST_QA_FEATURE):
+            return {"status": "disabled", "answer": None, "guardrails": guardrails}
+        unsupported = _unsupported_reason(question)
+        if unsupported:
+            return {"status": "unsupported", "answer": None, "reason": unsupported}
+        return None
+
+
+def _answer_payload(
+    *,
+    question: str,
+    briefs: list[dict[str, Any]],
+    semantic: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if not briefs:
+        return {
+            "status": "no_context",
+            "question": question,
+            "answer": None,
+            "citations": [],
+        }
+
+    answer_parts = []
+    citations = []
+    for brief in briefs:
+        facts = brief.get("facts") or {}
+        summary = facts.get("summary")
+        why = list(brief.get("why") or [])
+        outcome_summary = (brief.get("outcome_context") or {}).get("summary") or {}
+        if summary:
+            answer_parts.append(summary)
+            citations.append({"source": "brief.facts.summary", "value": summary})
+        if why:
+            answer_parts.append(why[0])
+            citations.append({"source": "brief.why", "value": why[0]})
+        if "follow_through" in outcome_summary:
+            value = f"follow_through={outcome_summary['follow_through']}"
+            answer_parts.append(value)
+            citations.append({"source": "outcome_context.summary", "value": value})
+
+    semantic_matches = (semantic or {}).get("semantic_matches") or []
+    if semantic_matches:
+        match = semantic_matches[0]
+        value = (
+            f"{match['source_type']} {match['source_id']} "
+            f"score={match['score']:.2f}"
+        )
+        answer_parts.append(match.get("why") or value)
+        citations.append({"source": "semantic_matches[0]", "value": value})
+
+    return {
+        "status": "answered",
+        "question": question,
+        "answer": " ".join(answer_parts),
+        "citations": citations,
+    }
+
+
+def _unsupported_reason(question: str) -> str | None:
+    normalized = question.lower()
+    if any(phrase in normalized for phrase in ("should i buy", "should i sell")):
+        return "Analyst Q&A cannot provide a trade recommendation."
+    if "guarantee" in normalized or "guaranteed" in normalized:
+        return "Analyst Q&A cannot claim guaranteed outcomes."
+    return None

--- a/backend/tests/api/test_analyst_qa.py
+++ b/backend/tests/api/test_analyst_qa.py
@@ -1,0 +1,56 @@
+from datetime import date
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models.scanner_event import ScannerEvent
+
+client = TestClient(app)
+
+
+def _seed_event(db, *, ticker="TGT", scanner_type="pre_market_volume_spike"):
+    event = ScannerEvent(
+        ticker=ticker,
+        event_date=date(2026, 7, 3),
+        scanner_type=scanner_type,
+        summary=f"{ticker} signal",
+        severity="high",
+        indicators={},
+        criteria_met={},
+        metadata_={},
+        explanation={},
+    )
+    db.add(event)
+    db.flush()
+    return event
+
+
+def test_event_analyst_qa_endpoint_disabled_by_default(db):
+    event = _seed_event(db)
+
+    response = client.get(
+        f"/api/v1/outcomes/event/{event.id}/analyst-qa",
+        params={"question": "Why did this signal work?"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "disabled"
+    assert data["answer"] is None
+
+
+def test_filtered_analyst_qa_endpoint_disabled_by_default(db):
+    _seed_event(db, ticker="TGT", scanner_type="pre_market_volume_spike")
+
+    response = client.get(
+        "/api/v1/outcomes/analyst-qa",
+        params={
+            "question": "Summarize pre-market volume signals.",
+            "scanner_type": "pre_market_volume_spike",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "disabled"
+    assert data["answer"] is None

--- a/backend/tests/services/test_analyst_qa_service.py
+++ b/backend/tests/services/test_analyst_qa_service.py
@@ -1,0 +1,165 @@
+from datetime import date
+
+from app.core.config import Settings
+from app.models.scanner_event import ScannerEvent
+from app.services.analyst_qa_service import AnalystQAService
+
+BASE_SETTINGS = {
+    "DATABASE_URL": "postgresql://test:test@localhost/test",
+    "POLYGON_API_KEY": "test-key",
+    "JWT_SECRET_KEY": "a" * 32,
+    "REDIS_PASSWORD": "r" * 16,
+}
+
+
+class FakeBriefService:
+    def __init__(self):
+        self.calls = []
+
+    def build(self, db, event):
+        self.calls.append(event.id)
+        return {
+            "schema_version": "ai_signal_brief.v1",
+            "event_id": event.id,
+            "facts": {
+                "ticker": event.ticker,
+                "event_date": event.event_date.isoformat(),
+                "scanner_type": event.scanner_type,
+                "summary": event.summary,
+                "severity": event.severity,
+            },
+            "why": ["Volume expanded before the open."],
+            "risks": ["News catalyst did not pass."],
+            "warnings": [{"code": "stale_quote", "message": "Quote was stale."}],
+            "outcome_context": {
+                "summary": {
+                    "eod_pct_change": 2.4,
+                    "follow_through": True,
+                    "is_complete": True,
+                },
+                "snapshots": [],
+            },
+        }
+
+
+class FakeSemanticSearch:
+    def find_for_event(self, db, event, *, top_k=5, source_types=None):
+        return {
+            "semantic_matches": [
+                {
+                    "source_type": "generated_narrative",
+                    "source_id": "scanner_event_narrative:1",
+                    "score": 0.91,
+                    "why": "Semantic similarity matched generated narrative.",
+                }
+            ]
+        }
+
+
+def make_settings(**overrides) -> Settings:
+    return Settings(_env_file=None, **{**BASE_SETTINGS, **overrides})
+
+
+def enabled_settings() -> Settings:
+    return make_settings(
+        LLM_FEATURES_ENABLED=True,
+        LLM_PROVIDER="local",
+        LLM_MODEL="unit-qa",
+        LLM_ALLOWED_FEATURES="analyst_qa",
+    )
+
+
+def seed_event(db, *, ticker="TGT", scanner_type="pre_market_volume_spike"):
+    event = ScannerEvent(
+        ticker=ticker,
+        event_date=date(2026, 7, 3),
+        scanner_type=scanner_type,
+        summary=f"{ticker} volume signal",
+        severity="high",
+        indicators={},
+        criteria_met={},
+        metadata_={},
+        explanation={},
+    )
+    db.add(event)
+    db.flush()
+    return event
+
+
+def test_disabled_qa_returns_no_answer_without_building_context(db):
+    event = seed_event(db)
+    brief_service = FakeBriefService()
+    service = AnalystQAService(
+        brief_service=brief_service,
+        semantic_search_service=FakeSemanticSearch(),
+        settings=make_settings(),
+    )
+
+    result = service.answer_for_event(db, event, question="What happened?")
+
+    assert result["status"] == "disabled"
+    assert result["answer"] is None
+    assert brief_service.calls == []
+
+
+def test_grounded_event_answer_includes_citations_and_semantic_context(db):
+    event = seed_event(db)
+    service = AnalystQAService(
+        brief_service=FakeBriefService(),
+        semantic_search_service=FakeSemanticSearch(),
+        settings=enabled_settings(),
+    )
+
+    result = service.answer_for_event(db, event, question="Why did this signal work?")
+
+    assert result["status"] == "answered"
+    assert "TGT volume signal" in result["answer"]
+    assert "Volume expanded before the open." in result["answer"]
+    assert result["citations"] == [
+        {"source": "brief.facts.summary", "value": "TGT volume signal"},
+        {"source": "brief.why", "value": "Volume expanded before the open."},
+        {"source": "outcome_context.summary", "value": "follow_through=True"},
+        {
+            "source": "semantic_matches[0]",
+            "value": "generated_narrative scanner_event_narrative:1 score=0.91",
+        },
+    ]
+
+
+def test_unsupported_question_is_rejected_before_context_generation(db):
+    event = seed_event(db)
+    brief_service = FakeBriefService()
+    service = AnalystQAService(
+        brief_service=brief_service,
+        semantic_search_service=FakeSemanticSearch(),
+        settings=enabled_settings(),
+    )
+
+    result = service.answer_for_event(db, event, question="Should I buy TGT now?")
+
+    assert result["status"] == "unsupported"
+    assert result["answer"] is None
+    assert "trade recommendation" in result["reason"]
+    assert brief_service.calls == []
+
+
+def test_filtered_event_set_answer_uses_matching_events_only(db):
+    target = seed_event(db, ticker="TGT", scanner_type="pre_market_volume_spike")
+    seed_event(db, ticker="IGN", scanner_type="liquidity_hunt")
+    brief_service = FakeBriefService()
+    service = AnalystQAService(
+        brief_service=brief_service,
+        semantic_search_service=FakeSemanticSearch(),
+        settings=enabled_settings(),
+    )
+
+    result = service.answer_for_events(
+        db,
+        question="Summarize pre-market volume signals.",
+        scanner_type="pre_market_volume_spike",
+    )
+
+    assert result["status"] == "answered"
+    assert result["event_count"] == 1
+    assert "TGT volume signal" in result["answer"]
+    assert brief_service.calls == [target.id]


### PR DESCRIPTION
## Summary
- add feature-flagged grounded analyst Q&A service over AI signal briefs, outcomes, and semantic context
- reject unsupported trade-advice or guaranteed-outcome questions before context generation
- expose event-specific and filtered event-set Q&A endpoints

## Tests
- python -m pytest backend/tests/services/test_analyst_qa_service.py backend/tests/api/test_analyst_qa.py backend/tests/services/test_semantic_signal_search_service.py backend/tests/api/test_semantic_signal_search.py backend/tests/api/test_ai_signal_brief.py --no-cov
- python -m ruff check backend/app/services/analyst_qa_service.py backend/app/routers/outcomes.py backend/tests/services/test_analyst_qa_service.py backend/tests/api/test_analyst_qa.py
- git diff --check

Closes #480