### PR TITLE
Add LLM cost latency cache and observability controls

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -162,6 +162,7 @@ class Settings(BaseSettings):
     LLM_TIMEOUT_SECONDS: float = Field(default=10.0, gt=0)
     LLM_MAX_RETRIES: int = Field(default=1, ge=0)
     LLM_RETRY_BACKOFF_SECONDS: float = Field(default=0.5, gt=0)
+    LLM_MAX_COST_USD_PER_CALL: float = Field(default=0.0, ge=0)
     LLM_ALLOWED_FEATURES: str = ""
 
     # ── WebSocket resource limits ──────────────────────────────────────────

--- a/backend/app/routers/system.py
+++ b/backend/app/routers/system.py
@@ -17,6 +17,7 @@ from app.core.database import SessionLocal, get_db
 from app.core.rate_limits import limiter
 from app.models.system_config import SystemConfig
 from app.models.user import User
+from app.services.llm_observability import LLMObservabilityService
 from app.services.system_service import SystemService
 
 router = APIRouter(prefix="/api/v1/system", tags=["system"])
@@ -71,6 +72,12 @@ def get_system_status(db: Session = Depends(get_db)):
         }
 
     return get_cached("mh:system:status", 30, _fetch)
+
+
+@router.get("/llm-status")
+def get_llm_status():
+    """Return optional LLM provider, limits, and usage metric status."""
+    return LLMObservabilityService().status()
 
 
 @router.get("/config")

--- a/backend/app/services/llm_observability.py
+++ b/backend/app/services/llm_observability.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from app.core.config import Settings, settings
+from app.core.llm_guardrails import build_llm_usage_guardrails
+
+
+class LLMObservabilityService:
+    """In-process LLM/embedding control and metrics snapshot service."""
+
+    _metrics: dict[str, dict[str, Any]] = {}
+
+    def __init__(self, *, settings: Settings = settings) -> None:
+        self._settings = settings
+
+    def reset(self) -> None:
+        self._metrics.clear()
+
+    def record_request(
+        self,
+        *,
+        feature_area: str,
+        status: str,
+        latency_seconds: float,
+        cache_status: str | None = None,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        cost_usd: float = 0.0,
+        error: str | None = None,
+    ) -> None:
+        metric = self._metrics.setdefault(
+            feature_area,
+            {
+                "request_count": 0,
+                "latency_seconds_total": 0.0,
+                "cache_hits": 0,
+                "cache_observations": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cost_usd": 0.0,
+                "error_count": 0,
+                "last_error": None,
+            },
+        )
+        metric["request_count"] += 1
+        metric["latency_seconds_total"] += latency_seconds
+        if cache_status is not None:
+            metric["cache_observations"] += 1
+            if cache_status == "hit":
+                metric["cache_hits"] += 1
+        metric["input_tokens"] += input_tokens
+        metric["output_tokens"] += output_tokens
+        metric["cost_usd"] += cost_usd
+        if status == "error":
+            metric["error_count"] += 1
+            metric["last_error"] = error
+
+    def check_limits(
+        self,
+        *,
+        feature_area: str,
+        estimated_cost_usd: float,
+        estimated_latency_seconds: float,
+    ) -> dict[str, Any]:
+        if (
+            self._settings.LLM_MAX_COST_USD_PER_CALL > 0
+            and estimated_cost_usd > self._settings.LLM_MAX_COST_USD_PER_CALL
+        ):
+            return _blocked("Estimated cost exceeds per-call limit.")
+        if estimated_latency_seconds > self._settings.LLM_TIMEOUT_SECONDS:
+            return _blocked("Estimated latency exceeds configured timeout.")
+        guardrails = build_llm_usage_guardrails(self._settings)
+        return {
+            "allowed": guardrails.allows(feature_area),
+            "status": "allowed" if guardrails.allows(feature_area) else "disabled",
+            "reason": None if guardrails.allows(feature_area) else "Feature is disabled.",
+            "deterministic_workflows_safe": True,
+        }
+
+    def status(self) -> dict[str, Any]:
+        guardrails = build_llm_usage_guardrails(self._settings)
+        provider_state = "disabled"
+        if guardrails.enabled:
+            provider_state = "available" if guardrails.provider == "local" else "degraded"
+        return {
+            "enabled": guardrails.enabled,
+            "provider": guardrails.provider,
+            "model": guardrails.model,
+            "provider_state": provider_state,
+            "allowed_features": sorted(guardrails.allowed_features),
+            "limits": {
+                "timeout_seconds": guardrails.timeout_seconds,
+                "max_tokens": guardrails.max_tokens,
+                "max_cost_usd_per_call": self._settings.LLM_MAX_COST_USD_PER_CALL,
+            },
+            "metrics": self.snapshot()["features"],
+        }
+
+    def snapshot(self) -> dict[str, Any]:
+        features = {}
+        for feature_area, metric in deepcopy(self._metrics).items():
+            request_count = metric["request_count"]
+            cache_observations = metric["cache_observations"]
+            features[feature_area] = {
+                "request_count": request_count,
+                "cache_hit_rate": _rate(metric["cache_hits"], cache_observations),
+                "input_tokens": metric["input_tokens"],
+                "output_tokens": metric["output_tokens"],
+                "cost_usd": metric["cost_usd"],
+                "error_rate": _rate(metric["error_count"], request_count),
+                "avg_latency_seconds": _rate(
+                    metric["latency_seconds_total"],
+                    request_count,
+                ),
+                "last_error": metric["last_error"],
+            }
+        return {"features": features}
+
+
+def _blocked(reason: str) -> dict[str, Any]:
+    return {
+        "allowed": False,
+        "status": "limit_exceeded",
+        "reason": reason,
+        "deterministic_workflows_safe": True,
+    }
+
+
+def _rate(numerator: float, denominator: float) -> float:
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator

--- a/backend/tests/api/test_llm_status.py
+++ b/backend/tests/api/test_llm_status.py
@@ -1,0 +1,16 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_llm_status_endpoint_reports_disabled_provider_state(db):
+    response = client.get("/api/v1/system/llm-status")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["enabled"] is False
+    assert data["provider_state"] == "disabled"
+    assert data["allowed_features"] == []
+    assert "metrics" in data

--- a/backend/tests/services/test_llm_observability.py
+++ b/backend/tests/services/test_llm_observability.py
@@ -1,0 +1,96 @@
+from app.core.config import Settings
+from app.services.llm_observability import LLMObservabilityService
+
+BASE_SETTINGS = {
+    "DATABASE_URL": "postgresql://test:test@localhost/test",
+    "POLYGON_API_KEY": "test-key",
+    "JWT_SECRET_KEY": "a" * 32,
+    "REDIS_PASSWORD": "r" * 16,
+}
+
+
+def make_settings(**overrides) -> Settings:
+    return Settings(_env_file=None, **{**BASE_SETTINGS, **overrides})
+
+
+def enabled_settings(**overrides) -> Settings:
+    values = {
+        "LLM_FEATURES_ENABLED": True,
+        "LLM_PROVIDER": "local",
+        "LLM_MODEL": "unit-model",
+        "LLM_ALLOWED_FEATURES": "scanner_narrative",
+        "LLM_TIMEOUT_SECONDS": 2.0,
+        "LLM_MAX_COST_USD_PER_CALL": 0.01,
+    }
+    values.update(overrides)
+    return make_settings(**values)
+
+
+def test_metrics_snapshot_tracks_counts_cache_tokens_cost_latency_and_errors():
+    service = LLMObservabilityService(settings=enabled_settings())
+    service.reset()
+
+    service.record_request(
+        feature_area="scanner_narrative",
+        status="success",
+        latency_seconds=0.25,
+        cache_status="hit",
+        input_tokens=100,
+        output_tokens=50,
+        cost_usd=0.002,
+    )
+    service.record_request(
+        feature_area="scanner_narrative",
+        status="error",
+        latency_seconds=0.75,
+        cache_status="miss",
+        input_tokens=20,
+        output_tokens=0,
+        cost_usd=0.0,
+        error="provider timeout",
+    )
+
+    snapshot = service.snapshot()["features"]["scanner_narrative"]
+
+    assert snapshot["request_count"] == 2
+    assert snapshot["cache_hit_rate"] == 0.5
+    assert snapshot["input_tokens"] == 120
+    assert snapshot["output_tokens"] == 50
+    assert snapshot["cost_usd"] == 0.002
+    assert snapshot["error_rate"] == 0.5
+    assert snapshot["avg_latency_seconds"] == 0.5
+    assert snapshot["last_error"] == "provider timeout"
+
+
+def test_limit_check_fails_closed_for_cost_or_latency_without_throwing():
+    service = LLMObservabilityService(settings=enabled_settings())
+
+    cost = service.check_limits(
+        feature_area="scanner_narrative",
+        estimated_cost_usd=0.02,
+        estimated_latency_seconds=0.5,
+    )
+    latency = service.check_limits(
+        feature_area="scanner_narrative",
+        estimated_cost_usd=0.001,
+        estimated_latency_seconds=3.0,
+    )
+
+    assert cost == {
+        "allowed": False,
+        "status": "limit_exceeded",
+        "reason": "Estimated cost exceeds per-call limit.",
+        "deterministic_workflows_safe": True,
+    }
+    assert latency["allowed"] is False
+    assert latency["reason"] == "Estimated latency exceeds configured timeout."
+
+
+def test_disabled_status_exposes_provider_state():
+    service = LLMObservabilityService(settings=make_settings())
+
+    status = service.status()
+
+    assert status["enabled"] is False
+    assert status["provider_state"] == "disabled"
+    assert status["allowed_features"] == []


### PR DESCRIPTION
## Summary
- add reusable LLM observability service for request counts, latency, cache hit rate, tokens, cost, and errors
- add fail-closed cost/latency limit checks that preserve deterministic workflows
- expose system LLM status with disabled/degraded provider state and metrics snapshot

## Tests
- python -m pytest backend/tests/services/test_llm_observability.py backend/tests/api/test_llm_status.py backend/tests/core/test_llm_guardrails.py --no-cov
- python -m ruff check backend/app/services/llm_observability.py backend/app/routers/system.py backend/app/core/config.py backend/tests/services/test_llm_observability.py backend/tests/api/test_llm_status.py
- git diff --check

Closes #481