### PR TITLE
Add AI narrative layer controls

### DIFF
--- a/frontend/src/api/outcomes.ts
+++ b/frontend/src/api/outcomes.ts
@@ -237,6 +237,42 @@ export interface AISignalBrief {
   forbidden_claims: string[];
 }
 
+export interface GeneratedNarrativeProvenance {
+  claim: string;
+  source_fields: string[];
+}
+
+export interface GeneratedNarrativePayload {
+  text: string;
+  prompt_version: string;
+  brief_schema_version: string;
+  brief_fingerprint: string;
+  provenance: GeneratedNarrativeProvenance[];
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface AISignalNarrativeResponse {
+  brief: AISignalBrief;
+  narrative: GeneratedNarrativePayload | null;
+  cache: { status: string };
+  rejection?: { reason: string };
+}
+
+export interface SignalPostMortemPayload extends GeneratedNarrativePayload {
+  outcome_status: string;
+  known_at_signal_time: Record<string, unknown>;
+  expected_behavior: Record<string, unknown>;
+  realized_outcome: Record<string, unknown>;
+}
+
+export interface SignalPostMortemResponse {
+  brief: AISignalBrief;
+  post_mortem: SignalPostMortemPayload | null;
+  cache: { status: string };
+  rejection?: { reason: string };
+}
+
 export interface RegimeSlice {
   sample_size: number;
   win_rate_pct: number | null;
@@ -369,6 +405,20 @@ export const fetchHistoricalAnalogs = async (
 
 export const fetchAISignalBrief = async (eventId: number): Promise<AISignalBrief> => {
   const response = await apiClient.get(`/outcomes/event/${eventId}/ai-signal-brief`);
+  return response.data;
+};
+
+export const fetchAISignalNarrative = async (
+  eventId: number,
+): Promise<AISignalNarrativeResponse> => {
+  const response = await apiClient.get(`/outcomes/event/${eventId}/ai-signal-narrative`);
+  return response.data;
+};
+
+export const fetchSignalPostMortem = async (
+  eventId: number,
+): Promise<SignalPostMortemResponse> => {
+  const response = await apiClient.get(`/outcomes/event/${eventId}/signal-post-mortem`);
   return response.data;
 };
 

--- a/frontend/src/api/system.ts
+++ b/frontend/src/api/system.ts
@@ -26,6 +26,18 @@ export interface StorageStats {
   total: { bytes: number; formatted: string };
 }
 
+export interface LLMStatus {
+  enabled: boolean;
+  provider_state: 'disabled' | 'degraded' | 'available';
+  allowed_features: string[];
+  limits: {
+    timeout_seconds: number;
+    max_tokens: number;
+    max_cost_usd_per_call: number;
+  };
+  metrics: Record<string, unknown>;
+}
+
 // ---- API calls ------------------------------------------------------------ //
 
 export const getSystemInfo = async (): Promise<SystemInfo> => {
@@ -40,6 +52,11 @@ export const getSystemStatus = async (): Promise<SystemStatus> => {
 
 export const getStorageStats = async (): Promise<StorageStats> => {
   const response = await apiClient.get('/system/storage');
+  return response.data;
+};
+
+export const getLLMStatus = async (): Promise<LLMStatus> => {
+  const response = await apiClient.get('/system/llm-status');
   return response.data;
 };
 

--- a/frontend/src/components/scorecard/SignalTable.test.tsx
+++ b/frontend/src/components/scorecard/SignalTable.test.tsx
@@ -7,6 +7,9 @@ import type { AISignalBrief, SignalListItem } from '../../api/outcomes';
 const mocks = vi.hoisted(() => ({
   useSignals: vi.fn(),
   fetchAISignalBrief: vi.fn(),
+  fetchAISignalNarrative: vi.fn(),
+  fetchSignalPostMortem: vi.fn(),
+  getLLMStatus: vi.fn(),
 }));
 
 vi.mock('../../hooks/useScorecard', () => ({
@@ -15,6 +18,12 @@ vi.mock('../../hooks/useScorecard', () => ({
 
 vi.mock('../../api/outcomes', () => ({
   fetchAISignalBrief: (...args: unknown[]) => mocks.fetchAISignalBrief(...args),
+  fetchAISignalNarrative: (...args: unknown[]) => mocks.fetchAISignalNarrative(...args),
+  fetchSignalPostMortem: (...args: unknown[]) => mocks.fetchSignalPostMortem(...args),
+}));
+
+vi.mock('../../api/system', () => ({
+  getLLMStatus: (...args: unknown[]) => mocks.getLLMStatus(...args),
 }));
 
 const makeSignal = (overrides: Partial<SignalListItem> = {}): SignalListItem => ({
@@ -48,6 +57,9 @@ describe('SignalTable - event intelligence brief', () => {
       isLoading: false,
     });
     mocks.fetchAISignalBrief.mockResolvedValue(makeBrief());
+    mocks.fetchAISignalNarrative.mockResolvedValue(makeNarrative({ cache: { status: 'disabled' } }));
+    mocks.fetchSignalPostMortem.mockResolvedValue(makePostMortem({ cache: { status: 'disabled' } }));
+    mocks.getLLMStatus.mockResolvedValue(makeLLMStatus({ enabled: false, allowed_features: [] }));
   });
 
   it('shows deterministic explanation, analogs, expected behavior, archetype, and outcome context for a complete event', async () => {
@@ -133,6 +145,153 @@ describe('SignalTable - event intelligence brief', () => {
     expect(screen.getByText('Outcome summary is incomplete or unavailable.')).toBeInTheDocument();
     expect(screen.getByText(/Generated narrative can be added later/i)).toBeInTheDocument();
   });
+
+  it('keeps generated AI layers visibly disabled while preserving deterministic facts', async () => {
+    renderWithQuery(<SignalTable scannerType="pre_market_volume_spike" />);
+    fireEvent.click(screen.getByRole('button', { name: /Brief/i }));
+
+    expect(await screen.findByText('Deterministic Signal Brief')).toBeInTheDocument();
+    expect(await screen.findByText(/AI narrative layers disabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/Relative volume exceeded the configured threshold/i)).toBeInTheDocument();
+    expect(screen.queryByText(/provider/i)).not.toBeInTheDocument();
+  });
+
+  it('loads an enabled generated narrative on demand and labels cached content', async () => {
+    mocks.getLLMStatus.mockResolvedValueOnce(makeLLMStatus({
+      enabled: true,
+      allowed_features: ['scanner_narrative'],
+    }));
+    mocks.fetchAISignalNarrative.mockResolvedValueOnce(makeNarrative({
+      narrative: {
+        text: 'TSLA produced a grounded generated scanner narrative.',
+        prompt_version: 'scanner_narrative.v1',
+        brief_schema_version: 'ai_signal_brief.v1',
+        brief_fingerprint: 'abc',
+        provenance: [{ claim: 'Scanner event facts', source_fields: ['facts.ticker'] }],
+        created_at: '2026-07-04T10:00:00Z',
+        updated_at: '2026-07-04T10:00:00Z',
+      },
+      cache: { status: 'hit' },
+    }));
+
+    renderWithQuery(<SignalTable scannerType="pre_market_volume_spike" />);
+    fireEvent.click(screen.getByRole('button', { name: /Brief/i }));
+
+    expect(await screen.findByRole('button', { name: /load ai narrative/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /load ai narrative/i }));
+
+    expect(await screen.findByText('Generated AI Narrative')).toBeInTheDocument();
+    expect(screen.getByText(/TSLA produced a grounded generated scanner narrative/i)).toBeInTheDocument();
+    expect(screen.getByText(/Cached/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sources: Scanner event facts/i)).toBeInTheDocument();
+  });
+
+  it('shows loading state while an AI narrative layer is being generated', async () => {
+    mocks.getLLMStatus.mockResolvedValueOnce(makeLLMStatus({
+      enabled: true,
+      allowed_features: ['scanner_narrative'],
+    }));
+    mocks.fetchAISignalNarrative.mockReturnValueOnce(new Promise(() => {}));
+
+    renderWithQuery(<SignalTable scannerType="pre_market_volume_spike" />);
+    fireEvent.click(screen.getByRole('button', { name: /Brief/i }));
+
+    expect(await screen.findByRole('button', { name: /load ai narrative/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /load ai narrative/i }));
+
+    expect(await screen.findByText(/Generating AI narrative/i)).toBeInTheDocument();
+  });
+
+  it('labels stale regenerated content without hiding generated text', async () => {
+    mocks.getLLMStatus.mockResolvedValueOnce(makeLLMStatus({
+      enabled: true,
+      allowed_features: ['scanner_narrative'],
+    }));
+    mocks.fetchAISignalNarrative.mockResolvedValueOnce(makeNarrative({
+      narrative: {
+        text: 'Updated generated scanner narrative after brief changes.',
+        prompt_version: 'scanner_narrative.v1',
+        brief_schema_version: 'ai_signal_brief.v1',
+        brief_fingerprint: 'def',
+        provenance: [{ claim: 'Risk summary', source_fields: ['risks'] }],
+        created_at: '2026-07-04T10:00:00Z',
+        updated_at: '2026-07-04T11:00:00Z',
+      },
+      cache: { status: 'stale_regenerated' },
+    }));
+
+    renderWithQuery(<SignalTable scannerType="pre_market_volume_spike" />);
+    fireEvent.click(screen.getByRole('button', { name: /Brief/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /load ai narrative/i }));
+
+    expect(await screen.findByText(/Updated generated scanner narrative/i)).toBeInTheDocument();
+    expect(screen.getByText(/Regenerated from stale cache/i)).toBeInTheDocument();
+  });
+
+  it('shows rejected and failed AI generation states as generated-layer status only', async () => {
+    mocks.getLLMStatus.mockResolvedValueOnce(makeLLMStatus({
+      enabled: true,
+      allowed_features: ['scanner_narrative'],
+    }));
+    mocks.fetchAISignalNarrative.mockResolvedValueOnce(makeNarrative({
+      narrative: null,
+      cache: { status: 'rejected' },
+      rejection: { reason: 'Generated narrative is missing provenance.' },
+    }));
+
+    const { unmount } = renderWithQuery(<SignalTable scannerType="pre_market_volume_spike" />);
+    fireEvent.click(screen.getByRole('button', { name: /Brief/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /load ai narrative/i }));
+
+    expect(await screen.findByText(/AI narrative was rejected/i)).toBeInTheDocument();
+    expect(screen.getByText(/Generated narrative is missing provenance/i)).toBeInTheDocument();
+    expect(screen.getByText('Deterministic Signal Brief')).toBeInTheDocument();
+
+    unmount();
+    mocks.getLLMStatus.mockResolvedValueOnce(makeLLMStatus({
+      enabled: true,
+      allowed_features: ['scanner_narrative'],
+    }));
+    mocks.fetchAISignalNarrative.mockRejectedValueOnce(new Error('service unavailable'));
+
+    renderWithQuery(<SignalTable scannerType="pre_market_volume_spike" />);
+    fireEvent.click(screen.getByRole('button', { name: /Brief/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /load ai narrative/i }));
+
+    expect(await screen.findByText(/AI narrative failed/i)).toBeInTheDocument();
+    expect(screen.getByText('Deterministic Signal Brief')).toBeInTheDocument();
+  });
+
+  it('offers post-mortem controls only when that narrative feature is enabled', async () => {
+    mocks.getLLMStatus.mockResolvedValueOnce(makeLLMStatus({
+      enabled: true,
+      allowed_features: ['scanner_narrative', 'post_mortem'],
+    }));
+    mocks.fetchSignalPostMortem.mockResolvedValueOnce(makePostMortem({
+      post_mortem: {
+        text: 'The realized outcome matched the expected analog pattern.',
+        prompt_version: 'signal_post_mortem.v1',
+        brief_schema_version: 'ai_signal_brief.v1',
+        brief_fingerprint: 'post',
+        outcome_status: 'winning',
+        known_at_signal_time: {},
+        expected_behavior: {},
+        realized_outcome: {},
+        provenance: [{ claim: 'Realized outcome', source_fields: ['realized_outcome.summary'] }],
+        created_at: '2026-07-04T10:00:00Z',
+        updated_at: '2026-07-04T10:00:00Z',
+      },
+      cache: { status: 'miss' },
+    }));
+
+    renderWithQuery(<SignalTable scannerType="pre_market_volume_spike" />);
+    fireEvent.click(screen.getByRole('button', { name: /Brief/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /load post-mortem/i }));
+
+    expect(await screen.findByText('Generated Post-Mortem')).toBeInTheDocument();
+    expect(screen.getByText(/The realized outcome matched/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Generated$/)).toBeInTheDocument();
+  });
 });
 
 const makeBrief = (overrides: Partial<AISignalBrief> = {}): AISignalBrief => ({
@@ -204,6 +363,36 @@ const makeBrief = (overrides: Partial<AISignalBrief> = {}): AISignalBrief => ({
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.fetchAISignalBrief.mockResolvedValue(makeBrief());
+  mocks.fetchAISignalNarrative.mockResolvedValue(makeNarrative({ cache: { status: 'disabled' } }));
+  mocks.fetchSignalPostMortem.mockResolvedValue(makePostMortem({ cache: { status: 'disabled' } }));
+  mocks.getLLMStatus.mockResolvedValue(makeLLMStatus({ enabled: false, allowed_features: [] }));
+});
+
+const makeLLMStatus = (overrides: Record<string, unknown> = {}) => ({
+  enabled: false,
+  provider_state: 'disabled',
+  allowed_features: [],
+  limits: {
+    timeout_seconds: 20,
+    max_tokens: 1000,
+    max_cost_usd_per_call: 0,
+  },
+  metrics: {},
+  ...overrides,
+});
+
+const makeNarrative = (overrides: Record<string, unknown> = {}) => ({
+  brief: makeBrief(),
+  narrative: null,
+  cache: { status: 'disabled' },
+  ...overrides,
+});
+
+const makePostMortem = (overrides: Record<string, unknown> = {}) => ({
+  brief: makeBrief(),
+  post_mortem: null,
+  cache: { status: 'disabled' },
+  ...overrides,
 });
 
 describe('SignalTable — loading state', () => {

--- a/frontend/src/components/scorecard/SignalTable.tsx
+++ b/frontend/src/components/scorecard/SignalTable.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
-import { ChevronUp, ChevronDown, ChevronLeft, ChevronRight, Check, X, Sparkles } from 'lucide-react';
-import { fetchAISignalBrief } from '../../api/outcomes';
-import type { AISignalBrief } from '../../api/outcomes';
+import { ChevronUp, ChevronDown, ChevronLeft, ChevronRight, Check, X, Sparkles, RefreshCw, AlertTriangle } from 'lucide-react';
+import { fetchAISignalBrief, fetchAISignalNarrative, fetchSignalPostMortem } from '../../api/outcomes';
+import type { AISignalBrief, AISignalNarrativeResponse, GeneratedNarrativePayload, SignalPostMortemPayload, SignalPostMortemResponse } from '../../api/outcomes';
+import { getLLMStatus } from '../../api/system';
+import type { LLMStatus } from '../../api/system';
 import { useSignals } from '../../hooks/useScorecard';
 
 interface SignalTableProps {
@@ -359,8 +361,278 @@ const SignalIntelligencePanel: React.FC<{ eventId: number }> = ({ eventId }) => 
           </ul>
         </div>
       )}
+
+      <AINarrativeLayerControls eventId={eventId} />
     </div>
   );
+};
+
+type AILayer = 'narrative' | 'post_mortem';
+
+const AINarrativeLayerControls: React.FC<{ eventId: number }> = ({ eventId }) => {
+  const [activeLayer, setActiveLayer] = useState<AILayer | null>(null);
+
+  const llmStatusQuery = useQuery<LLMStatus>({
+    queryKey: ['llmStatus'],
+    queryFn: getLLMStatus,
+  });
+  const narrativeQuery = useQuery<AISignalNarrativeResponse>({
+    queryKey: ['aiSignalNarrative', eventId],
+    queryFn: () => fetchAISignalNarrative(eventId),
+    enabled: activeLayer === 'narrative',
+  });
+  const postMortemQuery = useQuery<SignalPostMortemResponse>({
+    queryKey: ['signalPostMortem', eventId],
+    queryFn: () => fetchSignalPostMortem(eventId),
+    enabled: activeLayer === 'post_mortem',
+  });
+
+  const status = llmStatusQuery.data;
+  const narrativeEnabled = Boolean(status?.enabled && status.allowed_features.includes('scanner_narrative'));
+  const postMortemEnabled = Boolean(status?.enabled && status.allowed_features.includes('post_mortem'));
+
+  if (llmStatusQuery.isLoading) {
+    return (
+      <div className="mt-3 rounded border border-gray-800 bg-gray-900/30 p-3 text-xs text-gray-400">
+        Checking AI layer availability...
+      </div>
+    );
+  }
+
+  if (llmStatusQuery.isError || !narrativeEnabled && !postMortemEnabled) {
+    return (
+      <div className="mt-3 rounded border border-gray-800 bg-gray-900/30 p-3">
+        <div className="flex items-start gap-2">
+          <Sparkles className="mt-0.5 h-4 w-4 text-gray-500" />
+          <div>
+            <div className="text-xs font-semibold text-gray-300">AI narrative layers disabled</div>
+            <div className="mt-1 text-xs text-gray-500">
+              Deterministic explanations, analogs, and outcome facts remain available.
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const loadLayer = (layer: AILayer) => {
+    if (activeLayer === layer) {
+      if (layer === 'narrative') void narrativeQuery.refetch();
+      if (layer === 'post_mortem') void postMortemQuery.refetch();
+      return;
+    }
+    setActiveLayer(layer);
+  };
+
+  return (
+    <div className="mt-3 rounded border border-blue-900/50 bg-blue-950/10 p-3">
+      <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="text-xs font-semibold text-blue-100">Optional AI narrative layers</div>
+          <div className="mt-1 text-xs text-blue-200/70">
+            Generated text is separate from the deterministic brief above.
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {narrativeEnabled && (
+            <button
+              type="button"
+              onClick={() => loadLayer('narrative')}
+              aria-pressed={activeLayer === 'narrative'}
+              className={aiLayerButtonClass(activeLayer === 'narrative')}
+            >
+              <Sparkles className="h-3.5 w-3.5" />
+              Load AI narrative
+            </button>
+          )}
+          {postMortemEnabled && (
+            <button
+              type="button"
+              onClick={() => loadLayer('post_mortem')}
+              aria-pressed={activeLayer === 'post_mortem'}
+              className={aiLayerButtonClass(activeLayer === 'post_mortem')}
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+              Load post-mortem
+            </button>
+          )}
+        </div>
+      </div>
+
+      {activeLayer === null && (
+        <div className="rounded border border-gray-800 bg-gray-950/30 p-3 text-xs text-gray-400">
+          Select an enabled layer to generate or refresh AI text for this event.
+        </div>
+      )}
+      {activeLayer === 'narrative' && (
+        <GeneratedLayerPanel
+          title="Generated AI Narrative"
+          loadingText="Generating AI narrative..."
+          failedText="AI narrative failed"
+          rejectedText="AI narrative was rejected"
+          data={narrativeQuery.data}
+          payload={narrativeQuery.data?.narrative ?? null}
+          cacheStatus={narrativeQuery.data?.cache.status}
+          rejectionReason={narrativeQuery.data?.rejection?.reason}
+          isLoading={narrativeQuery.isFetching && !narrativeQuery.data}
+          isError={narrativeQuery.isError}
+          onRefresh={() => void narrativeQuery.refetch()}
+        />
+      )}
+      {activeLayer === 'post_mortem' && (
+        <GeneratedLayerPanel
+          title="Generated Post-Mortem"
+          loadingText="Generating post-mortem..."
+          failedText="Post-mortem failed"
+          rejectedText="Post-mortem was rejected"
+          data={postMortemQuery.data}
+          payload={postMortemQuery.data?.post_mortem ?? null}
+          cacheStatus={postMortemQuery.data?.cache.status}
+          rejectionReason={postMortemQuery.data?.rejection?.reason}
+          isLoading={postMortemQuery.isFetching && !postMortemQuery.data}
+          isError={postMortemQuery.isError}
+          onRefresh={() => void postMortemQuery.refetch()}
+        />
+      )}
+    </div>
+  );
+};
+
+const aiLayerButtonClass = (active: boolean) => (
+  `inline-flex items-center gap-1.5 rounded border px-2.5 py-1.5 text-xs font-semibold transition-colors ${
+    active
+      ? 'border-blue-400 bg-blue-500/20 text-blue-100'
+      : 'border-gray-700 bg-gray-900/60 text-gray-300 hover:border-blue-500 hover:text-blue-100'
+  }`
+);
+
+const GeneratedLayerPanel: React.FC<{
+  title: string;
+  loadingText: string;
+  failedText: string;
+  rejectedText: string;
+  data: AISignalNarrativeResponse | SignalPostMortemResponse | undefined;
+  payload: GeneratedNarrativePayload | SignalPostMortemPayload | null;
+  cacheStatus: string | undefined;
+  rejectionReason: string | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  onRefresh: () => void;
+}> = ({
+  title,
+  loadingText,
+  failedText,
+  rejectedText,
+  data,
+  payload,
+  cacheStatus,
+  rejectionReason,
+  isLoading,
+  isError,
+  onRefresh,
+}) => {
+  if (isLoading) {
+    return (
+      <div className="rounded border border-blue-900/50 bg-gray-950/40 p-3 text-xs text-blue-100">
+        {loadingText}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <GeneratedLayerMessage tone="error" title={failedText}>
+        The generated layer could not be loaded. Deterministic facts are still shown above.
+      </GeneratedLayerMessage>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  if (!payload) {
+    if (cacheStatus === 'rejected') {
+      return (
+        <GeneratedLayerMessage tone="warning" title={rejectedText}>
+          {rejectionReason ?? 'Generated text did not pass provenance checks.'}
+        </GeneratedLayerMessage>
+      );
+    }
+    return (
+      <GeneratedLayerMessage tone="muted" title={cacheStatusLabel(cacheStatus)}>
+        {cacheStatus === 'incomplete_outcome'
+          ? rejectionReason ?? 'Outcome summary is incomplete or unavailable.'
+          : 'No generated text is available for this layer.'}
+      </GeneratedLayerMessage>
+    );
+  }
+
+  const sourceClaims = payload.provenance.map((entry) => entry.claim).filter(Boolean);
+
+  return (
+    <div className="rounded border border-blue-900/50 bg-gray-950/40 p-3">
+      <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="text-sm font-semibold text-blue-50">{title}</div>
+            <span className="rounded border border-blue-800/70 bg-blue-950/50 px-2 py-0.5 text-[10px] font-bold uppercase text-blue-200">
+              {cacheStatusLabel(cacheStatus)}
+            </span>
+          </div>
+          {sourceClaims.length > 0 && (
+            <div className="mt-1 text-xs text-blue-200/70">
+              Sources: {sourceClaims.join(', ')}
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onRefresh}
+          className="inline-flex items-center gap-1 rounded border border-gray-700 px-2 py-1 text-[11px] font-semibold text-gray-300 hover:border-blue-500 hover:text-blue-100"
+        >
+          <RefreshCw className="h-3 w-3" />
+          Refresh
+        </button>
+      </div>
+      <p className="text-sm leading-6 text-gray-200">{payload.text}</p>
+    </div>
+  );
+};
+
+const GeneratedLayerMessage: React.FC<{
+  tone: 'error' | 'warning' | 'muted';
+  title: string;
+  children: React.ReactNode;
+}> = ({ tone, title, children }) => {
+  const toneClass = {
+    error: 'border-red-900/60 bg-red-950/20 text-red-200',
+    warning: 'border-yellow-800/60 bg-yellow-950/20 text-yellow-100',
+    muted: 'border-gray-800 bg-gray-950/30 text-gray-400',
+  }[tone];
+
+  return (
+    <div className={`rounded border p-3 text-xs ${toneClass}`}>
+      <div className="mb-1 flex items-center gap-1.5 font-semibold">
+        {tone !== 'muted' && <AlertTriangle className="h-3.5 w-3.5" />}
+        {title}
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+};
+
+const cacheStatusLabel = (status: string | undefined): string => {
+  const labels: Record<string, string> = {
+    disabled: 'Disabled',
+    hit: 'Cached',
+    miss: 'Generated',
+    stale_regenerated: 'Regenerated from stale cache',
+    rejected: 'Rejected',
+    incomplete_outcome: 'Outcome incomplete',
+  };
+  if (!status) return 'Unknown';
+  return labels[status] ?? status.replace(/_/g, ' ');
 };
 
 const BriefBlock: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (

--- a/frontend/src/pages/ActiveWatchlist/AlertBadges.test.tsx
+++ b/frontend/src/pages/ActiveWatchlist/AlertBadges.test.tsx
@@ -42,16 +42,16 @@ describe('AlertBadge', () => {
 
   it('has accessible label for high severity', () => {
     render(<AlertBadge alert={makeAlert({ severity: 'high' })} />);
-    expect(screen.getByLabelText('high severity')).toBeInTheDocument();
+    expect(screen.getByLabelText('volume alert, high severity')).toBeInTheDocument();
   });
 
   it('has accessible label for medium severity', () => {
     render(<AlertBadge alert={makeAlert({ severity: 'medium' })} />);
-    expect(screen.getByLabelText('medium severity')).toBeInTheDocument();
+    expect(screen.getByLabelText('volume alert, medium severity')).toBeInTheDocument();
   });
 
   it('has accessible label for low severity', () => {
     render(<AlertBadge alert={makeAlert({ severity: 'low' })} />);
-    expect(screen.getByLabelText('low severity')).toBeInTheDocument();
+    expect(screen.getByLabelText('volume alert, low severity')).toBeInTheDocument();
   });
 });

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -6,3 +6,17 @@ Object.defineProperty(globalThis, 'Notification', {
   writable: true,
   configurable: true,
 });
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  }),
+});


### PR DESCRIPTION
## Summary
- Add typed frontend clients for optional AI narrative, post-mortem, and LLM status endpoints.
- Add scorecard signal brief controls for disabled, loading, cached, stale, rejected, failed, and refreshable generated AI layers while keeping deterministic facts visually separate.
- Clean up frontend test harness drift for matchMedia and alert badge accessible-name expectations.

## Verification
- npm test
- npx tsc --noEmit
- npm run build
- npx eslint . --report-unused-disable-directives-severity error
- npm audit --audit-level=high
- git diff --check

Closes #482