### PR TITLE
Fix deploy migration entrypoint

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,9 +64,12 @@ jobs:
 
             # Run migrations before starting services so the backend never briefly serves
             # traffic against a stale schema. Uses run --rm (not exec) so this works even
-            # when the backend is not yet running. Postgres must be up (service_healthy).
+            # when the backend is not yet running. Override the backend entrypoint here:
+            # /entrypoint.sh runs `alembic check`, which correctly fails on a stale DB
+            # and would otherwise prevent the upgrade command from reaching Alembic.
+            # Postgres must be up (service_healthy).
             if [ "$RUN_MIGRATIONS" = "true" ]; then
-              docker compose run --rm backend python -m alembic upgrade head
+              docker compose run --rm --entrypoint python backend -m alembic upgrade head
             fi
 
             # Restart services with updated images

--- a/backend/tests/test_deploy_workflow.py
+++ b/backend/tests/test_deploy_workflow.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_deploy_migration_step_bypasses_backend_entrypoint():
+    workflow = Path(__file__).parents[2] / ".github" / "workflows" / "deploy.yml"
+    deploy_yml = workflow.read_text(encoding="utf-8")
+
+    assert (
+        "docker compose run --rm --entrypoint python backend -m alembic upgrade head"
+        in deploy_yml
+    )
+    assert "docker compose run --rm backend python -m alembic upgrade head" not in deploy_yml


### PR DESCRIPTION
## Summary
- Update deploy migration command to bypass the backend entrypoint when running Alembic upgrades.
- Add a regression test that prevents the migration command from reusing the normal backend entrypoint.

## Root cause
Seq shows deployed code querying scanner_events.explanation while the database lacks that column. The missing column is added by Alembic revision a2b3c4d5e6f7. The deploy workflow's migration command used the backend service entrypoint, and /entrypoint.sh runs alembic check before every command. On a stale database, that check can fail before alembic upgrade head gets a chance to apply pending migrations.

## Immediate recovery
Run the migration command with the entrypoint bypassed, then restart backend services:

`sh
docker compose run --rm --entrypoint python backend -m alembic upgrade head
docker compose up -d backend celery-worker celery-beat live-scanner flower frontend
`

## Verification
- python -m pytest backend/tests/test_deploy_workflow.py --no-cov
- python -m ruff check backend/tests/test_deploy_workflow.py
- git diff --check