### PR TITLE
cleanup(p3): drop backlog-scheduler stanza from dev override (follow-up to #790)

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -40,11 +40,6 @@ services:
       - /app/node_modules
     command: npm run dev -- --host
 
-  backlog-scheduler:
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - .:/workspace/project:ro
-
 # Named volumes used in service overrides above must be declared here.
 # Docker Compose requires named volumes referenced in an override file to
 # appear in its own top-level volumes: block (even as an empty stub), otherwise


### PR DESCRIPTION
#790 removed `backlog-scheduler` from the base `docker-compose.yml` but left the **tracked** `docker-compose.override.yml` referencing it. Because the override only adds volumes (no image/build), any dev-checkout `docker compose up` on current `main` now fails:

```
service "backlog-scheduler" has neither an image nor a build context specified: invalid compose project
```

Discovered live while recovering the local app stack. The extracted factory scheduler runs from omniscient/dark-factory's deploy compose, so the stanza is dead — removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyNzjNGmqJ8fSZNTb55n9c