### PR TITLE
fix(quality): reach grade A on illiquid universes + fix scanner data-health banner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,18 @@ jobs:
       - name: Dependency audit
         run: |
           pip install pip-audit
+          # Accepted advisories (all transitive via python-jose[cryptography]==3.4.0;
+          # revisit when we migrate off python-jose — see backend/requirements.txt):
+          #   PYSEC-2022-42969 / PYSEC-2026-1325 — ecdsa Minerva P-256 timing
+          #     side-channels. No fix (maintainers declare side-channels out of
+          #     scope); require local timing of signature *generation*. Not
+          #     reachable: JWT signing uses server-held trusted keys via the
+          #     cryptography backend, not an attacker-facing signing oracle.
+          #   CVE-2026-30922 — pyasn1 0.4.8 ReDoS; fix (0.6.3) uninstallable
+          #     (python-jose pins pyasn1<0.5.0). Also in .trivyignore.
           pip-audit -r backend/requirements.txt \
             --ignore-vuln PYSEC-2022-42969 \
+            --ignore-vuln PYSEC-2026-1325 \
             --ignore-vuln CVE-2026-30922
 
       - name: Run tests

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -101,6 +101,13 @@ celery_app.conf.beat_schedule = {
         "task": "app.tasks.update_regime_model",
         "schedule": crontab(minute="0", hour="21", day_of_week="1-5"),
     },
+    # Nightly universe aggregate top-up: 01:30 UTC Tue–Sat covers each Mon–Fri
+    # session after the 20:00 ET after-market close (00:00/01:00 UTC).
+    # Keeps active universes fresh so the staleness banner reflects real issues.
+    "sync-universe-aggregates-nightly": {
+        "task": "app.tasks.sync_universe_aggregates_nightly",
+        "schedule": crontab(minute="30", hour="1", day_of_week="2-6"),
+    },
     # Aggregate staleness/gap sweep: 03:00 UTC weekdays (post-close + after nightly sync)
     "check-aggregate-staleness-nightly": {
         "task": "app.tasks.check_aggregate_staleness",

--- a/backend/app/core/circuit_breakers.py
+++ b/backend/app/core/circuit_breakers.py
@@ -14,13 +14,27 @@ State is in-process per worker — no distributed coordination is needed or desi
 import pybreaker
 
 from app.core.config import settings
+from app.exceptions import ProviderError
+
+
+def _non_retryable_provider_error(exc: BaseException) -> bool:
+    """
+    Breaker exclusion predicate: permanent, request-specific failures (e.g.
+    Polygon NOT_AUTHORIZED plan-limit responses) must not count toward opening
+    the breaker — they say nothing about provider availability, and a batch of
+    unfetchable historical windows must not block subsequent legitimate calls.
+    """
+    return isinstance(exc, ProviderError) and not exc.is_retryable
+
 
 POLYGON_BREAKER: pybreaker.CircuitBreaker = pybreaker.CircuitBreaker(
     fail_max=settings.POLYGON_CB_FAIL_MAX,
     reset_timeout=settings.POLYGON_CB_RESET_TIMEOUT,
+    exclude=[_non_retryable_provider_error],
 )
 
 IBKR_BREAKER: pybreaker.CircuitBreaker = pybreaker.CircuitBreaker(
     fail_max=settings.IBKR_CB_FAIL_MAX,
     reset_timeout=settings.IBKR_CB_RESET_TIMEOUT,
+    exclude=[_non_retryable_provider_error],
 )

--- a/backend/app/providers/massive.py
+++ b/backend/app/providers/massive.py
@@ -22,6 +22,17 @@ from app.providers.base import BaseDataProvider
 logger = logging.getLogger(__name__)
 
 
+def _is_plan_limit_error(exc: BaseException) -> bool:
+    """
+    True when Polygon rejected the request because the account's plan does not
+    cover the requested data (e.g. historical windows beyond the plan's
+    lookback).  These failures are permanent for the given request and say
+    nothing about provider availability, so they are raised non-retryable and
+    excluded from circuit-breaker fail counting.
+    """
+    return "NOT_AUTHORIZED" in str(exc)
+
+
 class MassiveDataProvider(BaseDataProvider):
     """
     Polygon.io data provider ('Massive' is the internal alias used in this project).
@@ -188,7 +199,7 @@ class MassiveDataProvider(BaseDataProvider):
                 f"Polygon fetch failed for {symbol} {timespan}×{multiplier}: {e}",
                 provider="massive",
                 endpoint="get_aggs",
-                is_retryable=True,
+                is_retryable=not _is_plan_limit_error(e),
             ) from e
 
     def get_ticker_details(self, symbol: str) -> Dict[str, Any]:

--- a/backend/app/services/data_quality.py
+++ b/backend/app/services/data_quality.py
@@ -64,14 +64,25 @@ def _estimate_expected_bars(
     timespan: str,
     multiplier: int,
     holiday_map: Optional[Dict] = None,
+    is_futures: bool = False,
 ):
     """
     Empirical P90 approach: group by date, take the 90th-percentile bar count
     per active day, multiply by number of active days.  Self-calibrates to
     whatever session type was originally requested (pre-market, full day, etc.).
 
-    Stub-day correction
-    ───────────────────
+    Asset-class correction
+    ──────────────────────
+    The P90 yardstick only makes sense when sessions produce a uniform bar
+    count — true for futures (continuous CME sessions), false for stocks:
+    an illiquid ticker emits intraday bars only for periods with trades, so
+    day-to-day bar-count variation is organic trading activity, not missing
+    data (verified bar-for-bar against the provider).  For stocks every day
+    with data therefore counts as complete (expected = actual); shortfalls
+    surface via gap detection, integrity checks, and the staleness sweep.
+
+    Stub-day correction (futures)
+    ─────────────────────────────
     Some calendar dates naturally hold far fewer bars than a full session:
       • Sunday opens: the CME session starts at 18:00 ET Sunday but the UTC
         date only captures 1–2 hours of bars before rolling to Monday.
@@ -130,6 +141,12 @@ def _estimate_expected_bars(
             # Abbreviated session — whatever bars exist are correct, no penalty
             expected += cnt
             holiday_days += 1
+
+        elif not is_futures:
+            # Stocks: intraday bars only exist for periods with trades, so a
+            # below-P90 day is organic activity, not missing data — no penalty
+            expected += cnt
+            full_days += 1
 
         elif cnt < stub_threshold:
             # Organic stub (Sunday open boundary, single-day holiday without a
@@ -268,7 +285,7 @@ def _analyze_ticker_timespan(
 
     # ── Coverage ──────────────────────────────────────────────────────────────
     expected_bars, coverage_detail = _estimate_expected_bars(
-        timestamps, timespan, multiplier, holiday_map
+        timestamps, timespan, multiplier, holiday_map, is_futures=is_futures
     )
     coverage_pct = min(
         100.0, (actual_bars / expected_bars * 100) if expected_bars > 0 else 100.0

--- a/backend/app/services/normalization.py
+++ b/backend/app/services/normalization.py
@@ -40,6 +40,33 @@ logger = logging.getLogger(__name__)
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 
+async def _wait_out_open_breaker(is_futures: bool) -> None:
+    """
+    If the relevant provider breaker is open, sleep until it can half-open
+    instead of letting every subsequent fix fail instantly.  One transient
+    provider outage must not silently void the rest of the normalization run.
+    """
+    from app.core.circuit_breakers import IBKR_BREAKER, POLYGON_BREAKER
+    from app.core.config import settings
+
+    breaker = IBKR_BREAKER if is_futures else POLYGON_BREAKER
+    if breaker.current_state == "open":
+        wait_s = (
+            settings.IBKR_CB_RESET_TIMEOUT
+            if is_futures
+            else settings.POLYGON_CB_RESET_TIMEOUT
+        ) + 1
+        logger.warning(
+            f"[normalize] {'IBKR' if is_futures else 'Polygon'} circuit breaker "
+            f"open — waiting {wait_s}s for reset before continuing"
+        )
+        await asyncio.sleep(wait_s)
+
+
+def _is_breaker_open_error(exc: Exception) -> bool:
+    return "circuit breaker open" in str(exc)
+
+
 def _parse_date(dt_str: Optional[str]) -> Optional[datetime]:
     """Parse an ISO datetime string (with or without fractional seconds)."""
     if not dt_str:
@@ -460,6 +487,8 @@ class NormalizationService:
                 f" gaps={result.get('gap_count', 0)}"
             )
 
+            combo_hit_open_breaker = False
+
             try:
                 # 1. Dedup
                 if result.get("duplicate_count", 0) > 0:
@@ -475,6 +504,7 @@ class NormalizationService:
                     fixes = _plan_fixes(result)
                     for fix in fixes:
                         try:
+                            await _wait_out_open_breaker(is_futures)
                             if is_futures:
                                 exchange = _get_futures_exchange(db, ticker)
                                 added = await _sync_futures_range(
@@ -512,6 +542,8 @@ class NormalizationService:
                             logger.error(
                                 f"  fix {fix['type']} failed for {combo_key}: {e}"
                             )
+                            if _is_breaker_open_error(e):
+                                combo_hit_open_breaker = True
                             errors.append(
                                 {
                                     "combo": combo_key,
@@ -522,11 +554,17 @@ class NormalizationService:
 
             except Exception as e:
                 logger.error(f"[normalize] error on {combo_key}: {e}")
+                if _is_breaker_open_error(e):
+                    combo_hit_open_breaker = True
                 errors.append({"combo": combo_key, "fix": "top-level", "error": str(e)})
 
-            # Checkpoint after every combo so we can resume
-            processed.append(combo_key)
-            processed_set.add(combo_key)
+            # Checkpoint after every combo so we can resume.  Combos whose
+            # fixes were rejected by an open circuit breaker are NOT marked
+            # processed — a resume run must retry them once the provider
+            # recovers, instead of permanently skipping their fixes.
+            if not combo_hit_open_breaker:
+                processed.append(combo_key)
+                processed_set.add(combo_key)
 
             checkpoint_data = {
                 "status": "running",

--- a/backend/app/services/quality_helpers.py
+++ b/backend/app/services/quality_helpers.py
@@ -6,8 +6,8 @@ Extracted from data_quality.py so the lightweight nightly staleness/gap sweep
 DataQualityService.
 """
 
-from datetime import timedelta
-from typing import Dict, List
+from datetime import date, timedelta
+from typing import Dict, List, Optional, Set
 
 
 def _count_weekdays_between(d1, d2) -> int:
@@ -52,11 +52,11 @@ def _detect_gaps(timestamps: List, timespan: str, multiplier: int) -> List[Dict]
         if diff_seconds < threshold_seconds:
             continue
 
-        calendar_days = (curr.date() - prev.date()).days
-        if calendar_days <= 3:
-            weekdays = _count_weekdays_between(prev.date(), curr.date())
-            if weekdays <= 1:
-                continue
+        # ≤1 weekday between the bars means the span is a weekend or a
+        # holiday long weekend (e.g. Fri→Tue over Memorial Day) — not a gap.
+        weekdays = _count_weekdays_between(prev.date(), curr.date())
+        if weekdays <= 1:
+            continue
 
         missing_bars = max(0, int(diff_seconds / expected_seconds) - 1)
         gaps.append(
@@ -69,3 +69,41 @@ def _detect_gaps(timestamps: List, timespan: str, multiplier: int) -> List[Dict]
         )
 
     return gaps
+
+
+def _detect_universe_day_holes(
+    counts_by_day: Dict[date, int],
+    start: date,
+    end: date,
+    holidays: Optional[Set[date]] = None,
+) -> List[date]:
+    """
+    Detect universe-wide day-bar holes: weekdays where far fewer tickers than
+    usual have a day bar.
+
+    Per-ticker missing day bars are indistinguishable from organic no-trade
+    days on illiquid tickers (verified bar-for-bar against the provider), so
+    ticker-level gap counting over-alarms on small-cap universes.  A genuine
+    sync outage instead shows up as a calendar day where the number of tickers
+    with bars collapses relative to the norm.
+
+    ``counts_by_day`` maps date → number of tickers with a day bar that date.
+    A weekday inside [start, end] (excluding known holidays) is a hole when
+    its ticker count is below 50 % of the median active day's count.
+    """
+    holidays = holidays or set()
+
+    active_counts = sorted(v for v in counts_by_day.values() if v > 0)
+    if not active_counts:
+        return []
+    median = active_counts[len(active_counts) // 2]
+    threshold = median * 0.5
+
+    holes: List[date] = []
+    d = start
+    while d <= end:
+        if d.weekday() < 5 and d not in holidays:
+            if counts_by_day.get(d, 0) < threshold:
+                holes.append(d)
+        d += timedelta(days=1)
+    return holes

--- a/backend/app/tasks/__init__.py
+++ b/backend/app/tasks/__init__.py
@@ -28,6 +28,7 @@ from app.tasks.sync import (
     sync_stock_splits,
     sync_ticker_details,
     sync_tickers_batch,
+    sync_universe_aggregates_nightly,
     trigger_tweet_monitor,
 )
 from app.tasks.trading import (
@@ -49,6 +50,7 @@ __all__ = [
     "poll_massive_news",
     "sync_futures_aggregates",
     "sync_stock_splits",
+    "sync_universe_aggregates_nightly",
     "trigger_tweet_monitor",
     # scanning
     "evaluate_scanner_alerts",

--- a/backend/app/tasks/quality.py
+++ b/backend/app/tasks/quality.py
@@ -1,6 +1,6 @@
 import logging
 import time as _time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session
@@ -57,15 +57,22 @@ def compute_universe_data_health(db: Session, universe_id: int) -> dict:
     """
     Lightweight health sweep for a single universe.
 
-    Queries MAX(timestamp) per ticker (day/1 timespan) and detects gaps using
-    quality_helpers. Returns a summary dict with staleness/gap metrics.
+    Staleness: MAX(timestamp) per ticker (day/1 timespan).
+    Gaps: universe-wide day holes — weekdays where far fewer tickers than
+    usual have a day bar (a systemic sync outage signature).  Per-ticker gap
+    counting is deliberately NOT used: on illiquid small-cap universes a
+    missing day bar almost always means the stock didn't trade that day
+    (verified against the provider), not that data is missing.
+
+    Returns a summary dict with staleness/gap metrics.
     Does NOT write to UniverseQualityReport.
     """
+    from app.models.market_holiday import MarketHoliday
     from app.models.stock_aggregate import StockAggregate
     from app.models.stock_universe_ticker import StockUniverseTicker
-    from app.services.quality_helpers import _count_weekdays_between, _detect_gaps
+    from app.services.quality_helpers import _detect_universe_day_holes
 
-    staleness_hours_threshold, gap_min_weekdays, _ = _load_quality_thresholds(db)
+    staleness_hours_threshold, _gap_min_weekdays, _ = _load_quality_thresholds(db)
 
     tickers = (
         db.query(StockUniverseTicker.ticker)
@@ -89,9 +96,7 @@ def compute_universe_data_health(db: Session, universe_id: int) -> dict:
 
     now_utc = datetime.now(timezone.utc).replace(tzinfo=None)
     stale_count = 0
-    gapped_count = 0
     worst_staleness_hours = 0.0
-    worst_gap_days = 0.0
 
     for ticker in ticker_list:
         # MAX(timestamp) staleness check — day bars only (lightweight)
@@ -116,33 +121,71 @@ def compute_universe_data_health(db: Session, universe_id: int) -> dict:
         if staleness_h > staleness_hours_threshold:
             stale_count += 1
 
-        # Gap detection — day bars
-        timestamps = (
-            db.query(StockAggregate.timestamp)
-            .filter(
-                StockAggregate.ticker == ticker,
-                StockAggregate.timespan == "day",
-                StockAggregate.multiplier == 1,
-            )
-            .order_by(StockAggregate.timestamp.asc())
-            .limit(2000)
-            .all()
-        )
-        ts_list = [r.timestamp for r in timestamps]
-        gaps = _detect_gaps(ts_list, "day", 1)
+    # ── Systemic day-hole detection (last 90 days) ────────────────────────────
+    # The last 2 calendar days are excluded: bars not yet synced there are
+    # staleness, already alarmed above, not a mid-history hole.
+    window_start = (now_utc - timedelta(days=90)).date()
+    window_end = (now_utc - timedelta(days=2)).date()
 
-        for gap in gaps:
-            weekdays_in_gap = _count_weekdays_between(
-                gap["from"].date(), gap["to"].date()
-            )
-            if weekdays_in_gap >= gap_min_weekdays:
-                gapped_count += 1
-                worst_gap_days = max(worst_gap_days, weekdays_in_gap)
-                break  # one gap per ticker is enough to flag it
+    day_count_rows = (
+        db.query(
+            func.date(StockAggregate.timestamp).label("d"),
+            func.count(func.distinct(StockAggregate.ticker)).label("n"),
+        )
+        .filter(
+            StockAggregate.ticker.in_(ticker_list),
+            StockAggregate.timespan == "day",
+            StockAggregate.multiplier == 1,
+            StockAggregate.timestamp >= window_start,
+        )
+        .group_by(func.date(StockAggregate.timestamp))
+        .all()
+    )
+    counts_by_day = {r.d: r.n for r in day_count_rows}
+
+    holiday_rows = (
+        db.query(MarketHoliday.date)
+        .filter(
+            MarketHoliday.exchange == "NYSE",
+            MarketHoliday.event_type == "full_close",
+            MarketHoliday.date >= window_start,
+            MarketHoliday.date <= window_end,
+        )
+        .all()
+    )
+    holidays = {r.date for r in holiday_rows}
+
+    holes = _detect_universe_day_holes(
+        counts_by_day, window_start, window_end, holidays
+    )
+
+    trading_days_checked = sum(
+        1
+        for i in range((window_end - window_start).days + 1)
+        if (window_start + timedelta(days=i)).weekday() < 5
+        and (window_start + timedelta(days=i)) not in holidays
+    )
+    gapped_count = len(holes)
+
+    # Longest run of consecutive hole trading-days
+    worst_gap_days = 0.0
+    run = 0
+    prev_hole = None
+    for hole in holes:
+        if prev_hole is not None and (hole - prev_hole).days <= 3:
+            run += 1
+        else:
+            run = 1
+        worst_gap_days = max(worst_gap_days, float(run))
+        prev_hole = hole
 
     n = len(ticker_list)
     stale_pct = round(stale_count / n * 100, 1) if n > 0 else 0.0
-    gapped_pct = round(gapped_count / n * 100, 1) if n > 0 else 0.0
+    gapped_pct = (
+        round(gapped_count / trading_days_checked * 100, 1)
+        if trading_days_checked > 0
+        else 0.0
+    )
 
     _, _, alert_pct = _load_quality_thresholds(db)
     degraded = stale_pct > alert_pct or gapped_pct > alert_pct

--- a/backend/app/tasks/sync.py
+++ b/backend/app/tasks/sync.py
@@ -596,6 +596,62 @@ def sync_futures_aggregates(  # pragma: no cover
         db.close()
 
 
+@celery_app.task(
+    bind=True, max_retries=0, name="app.tasks.sync_universe_aggregates_nightly"
+)
+def sync_universe_aggregates_nightly(self):
+    """
+    Nightly top-up of aggregate bars for every active universe.
+
+    Without this, universe data only refreshes on manual sync/normalization
+    runs and drifts stale within days — tripping the staleness banner on the
+    Scanner page even when the stored history is otherwise complete.
+
+    Reuses universe_orchestrator.sync_missing_aggregates, which queues one
+    sync task per ticker × (timespan, multiplier) combo from the last stored
+    bar up to today.
+    """
+    from app.models.stock_universe import StockUniverse
+    from app.services.universe_orchestrator import sync_missing_aggregates
+
+    _task_name = "sync_universe_aggregates_nightly"
+    _start = _time.monotonic()
+    db: Session = SessionLocal()
+    try:
+        universes = (
+            db.query(StockUniverse).filter(StockUniverse.is_active.is_(True)).all()
+        )
+        logger.info(
+            "🌙 Nightly universe aggregate sync: %d active universe(s)",
+            len(universes),
+        )
+        for universe in universes:
+            try:
+                result = sync_missing_aggregates(universe.id, db)
+                logger.info(
+                    "  universe %s (id=%s): %s",
+                    universe.name,
+                    universe.id,
+                    result.get("message", result.get("status")),
+                )
+            except Exception as exc:
+                logger.error(
+                    "  universe %s (id=%s) sync failed: %s",
+                    universe.name,
+                    universe.id,
+                    exc,
+                )
+        celery_tasks_total.labels(task_name=_task_name, status="success").inc()
+    except Exception:
+        celery_tasks_total.labels(task_name=_task_name, status="failure").inc()
+        raise
+    finally:
+        celery_task_duration_seconds.labels(task_name=_task_name).observe(
+            _time.monotonic() - _start
+        )
+        db.close()
+
+
 @celery_app.task(bind=True, max_retries=3, name="app.tasks.sync_stock_splits")
 def sync_stock_splits(self):
     """

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -57,6 +57,10 @@ pywebpush==2.0.0
 # (HIGH ReDoS CVE-2026-30922, fixed only in 0.6.3 — uninstallable here). The CVE
 # is accepted in both pip-audit (ci.yml --ignore-vuln) and .trivyignore; the
 # ReDoS is not reachable because JWT keys are trusted config, not attacker input.
+# It also pulls in ecdsa 0.19.2 (Minerva P-256 timing side-channels
+# PYSEC-2022-42969 / PYSEC-2026-1325 — no fix, out of scope upstream; accepted in
+# pip-audit). Not reachable: signing uses server-held trusted keys via the
+# cryptography backend, not an attacker-facing signing oracle.
 # Revisit if we migrate off python-jose (e.g. to PyJWT).
 python-jose[cryptography]==3.4.0
 bcrypt==5.0.0

--- a/backend/tests/providers/test_polygon_breaker.py
+++ b/backend/tests/providers/test_polygon_breaker.py
@@ -1,0 +1,65 @@
+"""
+Circuit-breaker behaviour for provider errors.
+
+Permanent, request-specific failures (e.g. Polygon NOT_AUTHORIZED plan-limit
+responses) must not open the breaker: they say nothing about provider
+availability, and one batch of unfetchable historical windows must not block
+hundreds of subsequent legitimate calls.
+"""
+
+import pybreaker
+import pytest
+
+from app.core.circuit_breakers import _non_retryable_provider_error
+from app.exceptions import ProviderError
+from app.providers.massive import _is_plan_limit_error
+
+
+def _make_breaker(fail_max=2):
+    return pybreaker.CircuitBreaker(
+        fail_max=fail_max,
+        reset_timeout=60,
+        exclude=[_non_retryable_provider_error],
+    )
+
+
+def test_non_retryable_provider_error_does_not_trip_breaker():
+    breaker = _make_breaker(fail_max=2)
+
+    def plan_limit():
+        raise ProviderError("plan limit", is_retryable=False, provider="massive")
+
+    for _ in range(5):
+        with pytest.raises(ProviderError):
+            breaker.call(plan_limit)
+
+    assert breaker.current_state == "closed"
+
+
+def test_retryable_provider_error_still_trips_breaker():
+    breaker = _make_breaker(fail_max=2)
+
+    def transient():
+        raise ProviderError("timeout", is_retryable=True, provider="massive")
+
+    for _ in range(2):
+        with pytest.raises(Exception):
+            breaker.call(transient)
+
+    assert breaker.current_state == "open"
+
+
+def test_exclude_predicate():
+    assert _non_retryable_provider_error(ProviderError("x", is_retryable=False))
+    assert not _non_retryable_provider_error(ProviderError("x", is_retryable=True))
+    assert not _non_retryable_provider_error(ValueError("x"))
+
+
+def test_is_plan_limit_error_matches_polygon_not_authorized():
+    # Exact shape observed from the polygon client for out-of-plan windows
+    exc = Exception(
+        '{"status":"NOT_AUTHORIZED","request_id":"abc",'
+        '"message":"Your plan doesn\'t include this data timeframe."}'
+    )
+    assert _is_plan_limit_error(exc)
+    assert not _is_plan_limit_error(Exception("connection reset by peer"))

--- a/backend/tests/services/test_data_quality_helpers.py
+++ b/backend/tests/services/test_data_quality_helpers.py
@@ -2,10 +2,11 @@
 Tests for data_quality module pure helper functions — no DB required.
 """
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 from app.services.data_quality import (
     _count_weekdays_between,
+    _estimate_expected_bars,
     _grade_color,
     _score_to_grade,
 )
@@ -85,3 +86,53 @@ def test_weekend_days_not_counted():
     monday = date(2024, 1, 8)
     # strictly between Fri and Mon: Sat, Sun → 0 weekdays
     assert _count_weekdays_between(friday, monday) == 0
+
+
+# ── _estimate_expected_bars ───────────────────────────────────────────────────
+
+
+def _day_of_hour_bars(year, month, day, count):
+    """Generate `count` hourly timestamps within one calendar date."""
+    return [datetime(year, month, day, 4 + i) for i in range(count)]
+
+
+def test_stocks_sparse_days_are_organic_no_partial_penalty():
+    # Illiquid stock: bar count varies 8–16 per day. Verified against the
+    # provider this is organic trading activity, not missing data — so for
+    # stocks expected must equal actual (no partial-day penalty).
+    timestamps = (
+        _day_of_hour_bars(2026, 6, 22, 16)
+        + _day_of_hour_bars(2026, 6, 23, 8)
+        + _day_of_hour_bars(2026, 6, 24, 11)
+        + _day_of_hour_bars(2026, 6, 25, 9)
+    )
+    expected, detail = _estimate_expected_bars(timestamps, "hour", 1, is_futures=False)
+    assert expected == len(timestamps)
+    assert detail["partial_days"] == []
+    assert detail["partial_day_count"] == 0
+
+
+def test_futures_partial_days_still_penalized():
+    # Futures sessions are uniform — a below-P90 day (above the stub
+    # threshold) is a genuine shortfall and keeps the P90 yardstick.
+    timestamps = (
+        _day_of_hour_bars(2026, 6, 22, 16)
+        + _day_of_hour_bars(2026, 6, 23, 16)
+        + _day_of_hour_bars(2026, 6, 24, 16)
+        + _day_of_hour_bars(2026, 6, 25, 12)
+    )
+    expected, detail = _estimate_expected_bars(timestamps, "hour", 1, is_futures=True)
+    assert expected == 16 * 4
+    assert detail["partial_day_count"] == 1
+
+
+def test_stocks_full_close_holiday_day_still_excluded():
+    # Bars on a full_close holiday are anomalous and excluded from the
+    # expected count for stocks too.
+    timestamps = _day_of_hour_bars(2026, 6, 22, 16) + _day_of_hour_bars(2026, 6, 19, 3)
+    holiday_map = {date(2026, 6, 19): "full_close"}
+    expected, detail = _estimate_expected_bars(
+        timestamps, "hour", 1, holiday_map, is_futures=False
+    )
+    assert expected == 16
+    assert detail["holiday_day_count"] == 1

--- a/backend/tests/services/test_quality_helpers.py
+++ b/backend/tests/services/test_quality_helpers.py
@@ -4,7 +4,11 @@ Tests for quality_helpers — pure functions, no DB required.
 
 from datetime import date, datetime, timedelta
 
-from app.services.quality_helpers import _count_weekdays_between, _detect_gaps
+from app.services.quality_helpers import (
+    _count_weekdays_between,
+    _detect_gaps,
+    _detect_universe_day_holes,
+)
 
 # ── _count_weekdays_between ───────────────────────────────────────────────────
 
@@ -62,6 +66,95 @@ def test_multi_week_gap_flagged():
     gaps = _detect_gaps([ts1, ts2], "day", 1)
     assert len(gaps) == 1
     assert gaps[0]["missing_bars"] > 0
+
+
+def test_holiday_weekend_hour_bars_not_flagged():
+    # Fri 2026-05-22 20:00 → Tue 2026-05-26 08:00 spans Memorial Day
+    # (Mon 2026-05-25): 4 calendar days but only 1 weekday between.
+    friday = _ts(2026, 5, 22, 20)
+    tuesday = _ts(2026, 5, 26, 8)
+    gaps = _detect_gaps([friday, tuesday], "hour", 1)
+    assert gaps == []
+
+
+def test_holiday_weekend_minute_bars_not_flagged():
+    # Thu 2026-07-02 23:10 → Mon 2026-07-06 08:00 spans July 4th observed
+    # (Fri 2026-07-03): 4 calendar days but only 1 weekday between.
+    thursday = _ts(2026, 7, 2, 23)
+    monday = _ts(2026, 7, 6, 8)
+    gaps = _detect_gaps([thursday, monday], "minute", 1)
+    assert gaps == []
+
+
+def test_two_missing_weekdays_hour_bars_flagged():
+    # Wed 18:00 → next Mon 08:00: Thu + Fri missing (2 weekdays) → gap
+    wednesday = _ts(2026, 6, 10, 18)
+    monday = _ts(2026, 6, 15, 8)
+    gaps = _detect_gaps([wednesday, monday], "hour", 1)
+    assert len(gaps) == 1
+
+
+# ── _detect_universe_day_holes ────────────────────────────────────────────────
+#
+# Week of Mon 2026-06-01 … Fri 2026-06-12 (all weekdays, no US holidays).
+
+
+def _weekday_counts(base_count, overrides=None):
+    """Counts for each weekday 2026-06-01..2026-06-12, with per-date overrides."""
+    overrides = overrides or {}
+    counts = {}
+    d = date(2026, 6, 1)
+    while d <= date(2026, 6, 12):
+        if d.weekday() < 5:
+            counts[d] = overrides.get(d, base_count)
+        d += timedelta(days=1)
+    return counts
+
+
+def test_organic_variation_produces_no_holes():
+    # Illiquid universe: 350–470 of 475 tickers trade on any given day
+    counts = _weekday_counts(470, {date(2026, 6, 3): 350, date(2026, 6, 9): 390})
+    holes = _detect_universe_day_holes(counts, date(2026, 6, 1), date(2026, 6, 12))
+    assert holes == []
+
+
+def test_universe_wide_hole_detected():
+    # One day where almost no tickers have bars → systemic sync hole
+    counts = _weekday_counts(470, {date(2026, 6, 4): 12})
+    holes = _detect_universe_day_holes(counts, date(2026, 6, 1), date(2026, 6, 12))
+    assert holes == [date(2026, 6, 4)]
+
+
+def test_missing_weekday_is_a_hole():
+    # A weekday with no bars at all (absent from counts) → hole
+    counts = _weekday_counts(470)
+    del counts[date(2026, 6, 10)]
+    holes = _detect_universe_day_holes(counts, date(2026, 6, 1), date(2026, 6, 12))
+    assert holes == [date(2026, 6, 10)]
+
+
+def test_holiday_is_not_a_hole():
+    counts = _weekday_counts(470)
+    del counts[date(2026, 6, 10)]
+    holes = _detect_universe_day_holes(
+        counts,
+        date(2026, 6, 1),
+        date(2026, 6, 12),
+        holidays={date(2026, 6, 10)},
+    )
+    assert holes == []
+
+
+def test_weekends_never_holes():
+    counts = _weekday_counts(470)
+    holes = _detect_universe_day_holes(counts, date(2026, 5, 30), date(2026, 6, 12))
+    assert date(2026, 5, 30) not in holes  # Saturday
+    assert date(2026, 5, 31) not in holes  # Sunday
+
+
+def test_no_data_returns_no_holes():
+    holes = _detect_universe_day_holes({}, date(2026, 6, 1), date(2026, 6, 12))
+    assert holes == []
 
 
 def test_backward_compat_data_quality_import():

--- a/backend/tests/tasks/test_staleness_tasks.py
+++ b/backend/tests/tasks/test_staleness_tasks.py
@@ -2,7 +2,7 @@
 Tests for check_aggregate_staleness task and compute_universe_data_health helper.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 
@@ -301,52 +301,69 @@ class TestComputeDataDegraded:
         )
 
 
-class TestWorstGapDaysIsWeekdays:
-    def test_worst_gap_days_counts_weekdays_not_calendar_days(self):
-        """aggregate_gap_days gauge must report weekday span, not calendar-day span.
-        Monday→next Monday = 7 calendar days but 5 weekdays."""
+class TestUniverseWideDayHoles:
+    """The health sweep flags *universe-wide* day holes (a systemic sync outage
+    where far fewer tickers than usual have a bar), not per-ticker no-trade
+    gaps — an isolated illiquid ticker that didn't trade is not a data hole.
+    ``worst_gap_days`` is the longest run of consecutive hole days.
+
+    Hole *detection* is unit-tested in test_quality_helpers.py; here we assert
+    that compute_universe_data_health wires the detected holes into the
+    gapped_count / gapped_pct / worst_gap_days metrics correctly.
+    """
+
+    def _run_with_holes(self, holes):
         import app.tasks.quality as q
 
-        monday1 = datetime(2024, 1, 1, 0, 0, 0)  # Monday
-        tuesday = datetime(2024, 1, 2, 0, 0, 0)  # next day (no gap)
-        monday2 = datetime(
-            2024, 1, 8, 0, 0, 0
-        )  # Monday next week (7 cal, 5 weekday gap)
-
+        # Fresh bar so the ticker is not stale — isolates the gap metrics.
+        fresh_ts = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=1)
         ticker_objs = [MagicMock(ticker="AAPL")]
         db = MagicMock()
 
-        call_count = [0]
-
         def _query_side(*args):
-            call_count[0] += 1
             mock = MagicMock()
             mock.filter.return_value.all.return_value = ticker_objs
-            # MAX timestamp returns monday2
-            mock.filter.return_value.scalar.return_value = monday2
-            # Gap timestamps: monday1, tuesday, then a big jump to monday2
-            ts_rows = [
-                MagicMock(timestamp=monday1),
-                MagicMock(timestamp=tuesday),
-                MagicMock(timestamp=monday2),
-            ]
-            mock.filter.return_value.order_by.return_value.limit.return_value.all.return_value = ts_rows
+            mock.filter.return_value.scalar.return_value = fresh_ts
+            mock.filter.return_value.group_by.return_value.all.return_value = []
             return mock
 
         db.query.side_effect = _query_side
 
-        with patch(
-            "app.tasks.quality._load_quality_thresholds", return_value=(48, 2, 20)
+        # compute_universe_data_health imports the helper locally, so patch it
+        # at its source module.
+        with (
+            patch(
+                "app.tasks.quality._load_quality_thresholds", return_value=(48, 2, 20)
+            ),
+            patch(
+                "app.services.quality_helpers._detect_universe_day_holes",
+                return_value=holes,
+            ),
         ):
-            result = q.compute_universe_data_health(db, universe_id=1)
+            return q.compute_universe_data_health(db, universe_id=1)
 
-        # The gap from tuesday (Jan 2) to monday2 (Jan 8) spans 5 weekdays (Wed-Thu-Fri + Mon)
-        # wait: Jan 2 (Tue) to Jan 8 (Mon): weekdays strictly between = Wed3,Thu4,Fri5 = 3 weekdays
-        # Actually _count_weekdays_between(Jan2, Jan8) counts strictly between:
-        # Jan3(Wed), Jan4(Thu), Jan5(Fri) = 3 weekdays
-        # Calendar days = 6 (Jan2 to Jan8)
-        # worst_gap_days should be 3 (weekdays), not 6 (calendar)
-        assert result["worst_gap_days"] < 6, (
-            f"worst_gap_days={result['worst_gap_days']} should be weekday count (<6), not calendar days"
-        )
-        assert result["worst_gap_days"] >= 1, "should detect at least 1 weekday in gap"
+    def test_no_holes_not_gapped(self):
+        result = self._run_with_holes([])
+        assert result["gapped_count"] == 0
+        assert result["worst_gap_days"] == 0.0
+        assert result["gapped_pct"] == 0.0
+
+    def test_isolated_holes_counted_but_run_length_one(self):
+        # Two holes two weeks apart → 2 holes, but no consecutive run
+        holes = [date(2026, 6, 4), date(2026, 6, 18)]
+        result = self._run_with_holes(holes)
+        assert result["gapped_count"] == 2
+        assert result["worst_gap_days"] == 1.0
+        assert result["gapped_pct"] > 0
+
+    def test_consecutive_holes_report_run_length(self):
+        # Three consecutive weekdays down → a 3-day systemic outage
+        holes = [date(2026, 6, 2), date(2026, 6, 3), date(2026, 6, 4)]
+        result = self._run_with_holes(holes)
+        assert result["worst_gap_days"] == 3.0
+
+    def test_run_bridges_weekend(self):
+        # Fri + following Mon (3 calendar days) is one continuous outage
+        holes = [date(2026, 6, 5), date(2026, 6, 8)]
+        result = self._run_with_holes(holes)
+        assert result["worst_gap_days"] == 2.0


### PR DESCRIPTION
Closes #793

## Summary

The quality/normalization feature could not bring **Small Cap: Tech and Healthcare** (universe 6) to grade A, and the Scanner page showed a contradictory grade-F banner. Four root causes, each verified against live data / Polygon before fixing (details in #793):

1. **Holiday-weekend phantom gaps** — `_detect_gaps` skipped the weekday filter for >3-calendar-day spans, flagging every Fri→Tue holiday weekend as a data gap. The filter now always applies.
2. **Coverage penalized organic illiquidity** — micro-caps only emit intraday bars when they trade; DB matched Polygon bar-for-bar on the penalized "partial days". Stocks are now exempt from the P90 partial-day penalty (futures keep it — their sessions are uniform).
3. **Circuit-breaker cascade** — six Polygon `NOT_AUTHORIZED` plan-limit errors opened the breaker and voided 903 of ~1,380 normalization fixes. Plan-limit errors are now non-retryable and excluded from breaker fail-counting; the normalization loop waits out an open breaker and leaves breaker-failed combos unprocessed for resume.
4. **Banner staleness/gap noise** — the health sweep's gapped metric now detects universe-wide day holes (systemic sync-outage signature) instead of per-ticker no-trade patterns, and a new nightly beat task (`sync_universe_aggregates_nightly`, 01:30 UTC Tue–Sat) keeps active universes fresh so staleness reflects real issues.

## Validation

- 48 quality/provider unit tests pass (14 new: holiday gaps, stock-vs-futures coverage, breaker exclusion predicates, universe day-hole detection)
- Live end-to-end on universe 6: re-analysis **B/94.7 → A/99.9** (1,339 A / 43 B combos, zero C/D/F); normalization rerun backfilled 19,392 bars with 23 isolated errors vs 903 cascading before; banner now `degraded=false` (stale 10.5% — residual delisted tickers, gaps 0%)
- `ruff check` / `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyNzjNGmqJ8fSZNTb55n9c
