### PR TITLE
Persist scheduled scanner run audits

### DIFF
--- a/backend/app/tasks/scanning.py
+++ b/backend/app/tasks/scanning.py
@@ -244,6 +244,51 @@ def _compute_data_degraded(universe_id: int, db: Session) -> bool:
         return True
 
 
+def _start_scheduled_scanner_run(
+    db: Session,
+    scanner_type: str,
+    universe_id: int,
+    event_date: date,
+    stocks_scanned: int,
+):
+    from app.models.scanner_run import ScannerRun
+
+    run = ScannerRun(
+        scanner_type=scanner_type,
+        universe_id=universe_id,
+        status="running",
+        stocks_scanned=stocks_scanned,
+        scan_start_date=event_date,
+        scan_end_date=event_date,
+    )
+    db.add(run)
+    db.commit()
+    return run
+
+
+def _finish_scheduled_scanner_run(
+    db: Session,
+    run,
+    started_at: float,
+    events_detected: int,
+) -> None:
+    run.status = "completed"
+    run.events_detected = events_detected
+    run.execution_time_ms = int((_time.monotonic() - started_at) * 1000)
+    db.commit()
+
+
+def _fail_scheduled_scanner_run(db: Session, run, started_at: float, exc: Exception):
+    try:
+        db.rollback()
+    except Exception:
+        pass
+    run.status = "failed"
+    run.error_message = str(exc)
+    run.execution_time_ms = int((_time.monotonic() - started_at) * 1000)
+    db.commit()
+
+
 def _run_universe_scan_logic(
     scan_id: str,
     scanner_type: str,
@@ -609,13 +654,29 @@ def run_liquidity_hunt_scheduled(self):
                     cfg.universe_id,
                     cfg.id,
                 )
+                run_started = _time.monotonic()
+                scanner_run = _start_scheduled_scanner_run(
+                    db, "liquidity_hunt", cfg.universe_id, event_date, 0
+                )
+                _finish_scheduled_scanner_run(db, scanner_run, run_started, 0)
                 continue
 
-            results = asyncio.run(
-                run_liquidity_hunt_scan(
-                    tickers, db, start_date=event_date, end_date=event_date
-                )
+            run_started = _time.monotonic()
+            scanner_run = _start_scheduled_scanner_run(
+                db, "liquidity_hunt", cfg.universe_id, event_date, len(tickers)
             )
+            try:
+                results = asyncio.run(
+                    run_liquidity_hunt_scan(
+                        tickers, db, start_date=event_date, end_date=event_date
+                    )
+                )
+                _finish_scheduled_scanner_run(
+                    db, scanner_run, run_started, len(results)
+                )
+            except Exception as exc:
+                _fail_scheduled_scanner_run(db, scanner_run, run_started, exc)
+                raise
             logger.info(
                 "liquidity_hunt scheduled scan for universe %s on %s: %d events",
                 cfg.universe_id,
@@ -802,13 +863,29 @@ def run_pocket_pivot_scheduled(self):
                     cfg.universe_id,
                     cfg.id,
                 )
+                run_started = _time.monotonic()
+                scanner_run = _start_scheduled_scanner_run(
+                    db, "pocket_pivot", cfg.universe_id, event_date, 0
+                )
+                _finish_scheduled_scanner_run(db, scanner_run, run_started, 0)
                 continue
 
-            results = asyncio.run(
-                run_pocket_pivot_scan(
-                    tickers, db, start_date=event_date, end_date=event_date
-                )
+            run_started = _time.monotonic()
+            scanner_run = _start_scheduled_scanner_run(
+                db, "pocket_pivot", cfg.universe_id, event_date, len(tickers)
             )
+            try:
+                results = asyncio.run(
+                    run_pocket_pivot_scan(
+                        tickers, db, start_date=event_date, end_date=event_date
+                    )
+                )
+                _finish_scheduled_scanner_run(
+                    db, scanner_run, run_started, len(results)
+                )
+            except Exception as exc:
+                _fail_scheduled_scanner_run(db, scanner_run, run_started, exc)
+                raise
             logger.info(
                 "pocket_pivot scheduled scan for universe %s on %s: %d events",
                 cfg.universe_id,
@@ -887,13 +964,29 @@ def run_trend_pullback_scheduled(self):
                     cfg.universe_id,
                     cfg.id,
                 )
+                run_started = _time.monotonic()
+                scanner_run = _start_scheduled_scanner_run(
+                    db, "trend_pullback", cfg.universe_id, event_date, 0
+                )
+                _finish_scheduled_scanner_run(db, scanner_run, run_started, 0)
                 continue
 
-            results = asyncio.run(
-                run_trend_pullback_scan(
-                    tickers, db, start_date=event_date, end_date=event_date
-                )
+            run_started = _time.monotonic()
+            scanner_run = _start_scheduled_scanner_run(
+                db, "trend_pullback", cfg.universe_id, event_date, len(tickers)
             )
+            try:
+                results = asyncio.run(
+                    run_trend_pullback_scan(
+                        tickers, db, start_date=event_date, end_date=event_date
+                    )
+                )
+                _finish_scheduled_scanner_run(
+                    db, scanner_run, run_started, len(results)
+                )
+            except Exception as exc:
+                _fail_scheduled_scanner_run(db, scanner_run, run_started, exc)
+                raise
             logger.info(
                 "trend_pullback scheduled scan for universe %s on %s: %d events",
                 cfg.universe_id,

--- a/backend/tests/tasks/test_scheduled_scanner_tasks.py
+++ b/backend/tests/tasks/test_scheduled_scanner_tasks.py
@@ -1,5 +1,6 @@
 """Unit tests for scheduled scanner task logic and startup validation."""
 
+from datetime import date
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -164,6 +165,73 @@ def _make_cfg(id, universe_id, scanner_type="liquidity_hunt", is_active=True):
         "Fixed task must not call cfg.parameters.get('universe_id')"
     )
     return cfg
+
+
+@pytest.mark.parametrize(
+    ("task_name", "scanner_type", "scan_patch"),
+    [
+        (
+            "run_liquidity_hunt_scheduled",
+            "liquidity_hunt",
+            "app.services.liquidity_hunt.run_liquidity_hunt_scan",
+        ),
+        (
+            "run_pocket_pivot_scheduled",
+            "pocket_pivot",
+            "app.services.pocket_pivot.run_pocket_pivot_scan",
+        ),
+        (
+            "run_trend_pullback_scheduled",
+            "trend_pullback",
+            "app.services.trend_pullback_scan.run_trend_pullback_scan",
+        ),
+    ],
+)
+def test_scheduled_scanner_persists_completed_scanner_run(
+    task_name, scanner_type, scan_patch
+):
+    """Each 02:00 beat scanner must leave an auditable ScannerRun row."""
+    import app.tasks.scanning as scanning_module
+    from app.models.scanner_config import ScannerConfig
+    from app.models.scanner_run import ScannerRun
+
+    cfg = _make_cfg(id=7, universe_id=42, scanner_type=scanner_type)
+    tickers = [MagicMock(ticker="AAPL"), MagicMock(ticker="MSFT")]
+
+    def _make_query_mock(return_rows):
+        q = MagicMock()
+        q.filter.return_value.all.return_value = return_rows
+        return q
+
+    mock_db = MagicMock()
+    mock_db.query.side_effect = lambda model: (
+        _make_query_mock([cfg]) if model is ScannerConfig else _make_query_mock(tickers)
+    )
+
+    with (
+        patch("app.tasks.scanning.SessionLocal", return_value=mock_db),
+        patch("app.utils.session.get_market_today", return_value=date(2026, 6, 3)),
+        patch("app.tasks.scanning.asyncio.run", return_value=[{}, {}]),
+        patch(scan_patch, return_value=[]),
+    ):
+        getattr(scanning_module, task_name).run()
+
+    added_runs = [
+        call.args[0]
+        for call in mock_db.add.call_args_list
+        if isinstance(call.args[0], ScannerRun)
+    ]
+    assert len(added_runs) == 1
+    run = added_runs[0]
+    assert run.scanner_type == scanner_type
+    assert run.universe_id == cfg.universe_id
+    assert run.status == "completed"
+    assert run.stocks_scanned == len(tickers)
+    assert run.events_detected == 2
+    assert run.scan_start_date == date(2026, 6, 3)
+    assert run.scan_end_date == date(2026, 6, 3)
+    assert isinstance(run.execution_time_ms, int)
+    assert run.execution_time_ms >= 0
 
 
 class TestRunLiquidityHuntScheduledFixed:


### PR DESCRIPTION
## Summary
- Persist a `ScannerRun` audit row for each active scheduled scanner config processed by the 02:00 UTC beat tasks.
- Mark scheduled rows completed with scanned ticker count, event count, one-day scan range, and execution time.
- Mark the scheduled row failed before re-raising scanner exceptions for Celery retry handling.
- Add a regression test covering `liquidity_hunt`, `pocket_pivot`, and `trend_pullback` scheduled tasks.

## Root Cause
The scheduled scanner tasks called scanner services directly and only persisted `ScannerEvent` rows. They bypassed the `run_universe_scan` path that creates `ScannerRun`, so history/status surfaces could look dormant even when beat and workers were active.

## Live Triage Note
Read-only production DB checks also found the active scheduled configs currently point at `universe_id=1`, which has no monitored stocks. This PR makes that visible as zero-ticker audit rows, but rebinding configs to universe 6 or 7 is a human-controlled data correction.

Fixes #795

## Validation
- `python -m ruff check app/tasks/scanning.py tests/tasks/test_scheduled_scanner_tasks.py`
- `python -m pytest tests/tasks/test_scanning_tasks.py tests/tasks/test_scheduled_scanner_tasks.py -q --no-cov`
- `git diff --check`