### PR TITLE
docs: fix stale factory references post-extraction

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,12 +32,9 @@ graph TD
         agentmemoryengine["agentmemory-engine :3111 (profile: agentmemory-spike)"]
     end
 
-    subgraph factory["factory-network"]
+    subgraph factory["factory-network (external — see omniscient/dark-factory)"]
         proxyfactory["docker-socket-proxy-factory :2375"]
-        proxyscheduler["docker-socket-proxy-scheduler :2375"]
-        darkfactory["dark-factory (factory profile)"]
-        scheduler["backlog-scheduler (scheduler profile)"]
-        buildkit["buildkit :1234 (factory/scheduler profiles)"]
+        buildkit["buildkit :1234"]
     end
 
     dockersock[/"Docker socket\n/var/run/docker.sock"\]
@@ -78,10 +75,6 @@ graph TD
     jaeger -->|OTLP| beat
 
     proxyfactory -->|":ro"| dockersock
-    proxyscheduler -->|":ro"| dockersock
-    darkfactory -->|"tcp :2375"| proxyfactory
-    darkfactory -->|"buildx tcp :1234"| buildkit
-    scheduler -->|"tcp :2375"| proxyscheduler
 
     seqgelf -->|"GELF → HTTP"| seq
     forecastworker --> postgres
@@ -98,7 +91,7 @@ graph TD
 |---|---|---|---|
 | `markethawk-backend` | `backend`, `celery-worker`, `celery-beat`, `live-scanner`, `tweet-monitor`, `flower` | `appuser` (uid 1000) | Non-root; created in `backend/Dockerfile` |
 | `markethawk-frontend` | `frontend` | `node` | Non-root; default node image user |
-| `markethawk-dark-factory` | `dark-factory`, `backlog-scheduler` | `factory` (uid 1000) | Non-root; created in `dark-factory/Dockerfile` |
+| `markethawk-dark-factory` | _(extracted — now built in [omniscient/dark-factory](https://github.com/omniscient/dark-factory))_ | — | Scheduler and factory containers run from the standalone factory repo; this stack no longer builds or owns this image |
 | `markethawk-forecast` | `forecast-worker` | `root` | Exception: HuggingFace model weights (~800 MB) cached at `/root/.cache/huggingface` via `timesfm_cache` named volume; converting to non-root requires relocating the cache path (tracked as a separate follow-up) |
 | `markethawk-db-restore-drill` | `db-restore-drill` | `postgres` | Runs as the postgres system user (required to run `initdb` / `postgres` daemon); no Docker socket access. |
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -121,8 +121,6 @@ The base `docker-compose.yml` runs **baked images** — source bind-mounts are a
 - `celery-beat` — restores `./backend:/app:ro`
 - `live-scanner` — restores `./backend:/app:ro`
 - `frontend` — restores `./frontend:/app` and `/app/node_modules`, switches command back to `npm run dev`
-- `backlog-scheduler` — restores `.:/workspace/project:ro`
-
 Services with no source bind-mount (`flower`, `forecast-worker`, and all infrastructure services) are unchanged in both files.
 
 **Run the stable baked-image stack without the override (live/CI mode):**
@@ -427,23 +425,21 @@ bash scripts/codeindex.sh
 
 ## Dark Factory Eval Flywheel
 
+> **The Dark Factory has been extracted to [omniscient/dark-factory](https://github.com/omniscient/dark-factory).** The eval corpus (`evals/factory-failures.jsonl`) and replay harness now live there. The information below describes how the circuit-breaker behaviour works; for the implementation details see the factory repo.
+
 When the factory circuit-breaker trips (after `MAX_RETRIES` failed runs), it:
 1. Moves the issue to **Blocked** and labels it `needs-discussion`
 2. Applies the `factory-regression` label — marks this failure for the replay benchmark suite
 3. Generates a post-mortem comment (`<!-- df-post-mortem -->`) via a haiku agent explaining the probable root cause
-4. Appends one line to `dark-factory/evals/factory-failures.jsonl` and commits it to the feature branch
+4. Appends one line to `evals/factory-failures.jsonl` in the dark-factory repo and commits it to the feature branch
 
 ### Querying the failure corpus
 
 ```bash
-# List all promoted failures
-cat dark-factory/evals/factory-failures.jsonl | jq .
-
-# Failures by phase
-cat dark-factory/evals/factory-failures.jsonl | jq 'select(.phase == "fix")'
-
 # GitHub label query (requires gh CLI)
 gh issue list --repo omniscient/markethawk --label factory-regression
+
+# Post-mortem comments are on the issue directly — no local file needed
 ```
 
 ### Reading post-mortems
@@ -452,10 +448,7 @@ Post-mortem comments are posted directly on the issue and are included automatic
 
 ### Replay harness (C3 — future work)
 
-The `dark-factory/evals/factory-failures.jsonl` corpus is designed for a future replay harness (architecture review candidate C3) that will re-run failed issues against new factory versions to measure regression rates. The JSONL schema is:
-```json
-{"issue": 123, "title": "...", "phase": "fix", "exit_code": 1, "postmortem": "...", "promoted_at": "2026-06-12T09:00:00Z"}
-```
+The failure corpus is designed for a future replay harness that will re-run failed issues against new factory versions to measure regression rates. See `evals/` in [omniscient/dark-factory](https://github.com/omniscient/dark-factory) for the JSONL schema and tooling.
 
 ## Security Notes
 

--- a/deployment-guide.md
+++ b/deployment-guide.md
@@ -213,7 +213,7 @@ The Caddyfile redirects all HTTP (`:80`) requests to HTTPS and sets `Strict-Tran
 ## Deploying from GHCR
 
 Images are published to GitHub Container Registry on every merge to `main`.  
-Three images are maintained: `markethawk-backend`, `markethawk-frontend`, `markethawk-dark-factory`.
+Two images are maintained by this repo: `markethawk-backend`, `markethawk-frontend`. The `markethawk-dark-factory` image is now built and published by [omniscient/dark-factory](https://github.com/omniscient/dark-factory).
 
 Each push produces two tags:
 - `sha-{SHORT_SHA}` — permanent, points to that exact commit
@@ -225,8 +225,8 @@ To deploy a specific tag, set `IMAGE_TAG` before running Compose commands:
 ```bash
 # Deploy a specific SHA tag
 export IMAGE_TAG=sha-abc1234
-docker compose pull backend celery-worker celery-beat live-scanner flower frontend backlog-scheduler
-docker compose up -d backend celery-worker celery-beat live-scanner flower frontend backlog-scheduler
+docker compose pull backend celery-worker celery-beat live-scanner flower frontend
+docker compose up -d backend celery-worker celery-beat live-scanner flower frontend
 
 # Run migrations after deploying
 docker compose exec -T backend python -m alembic upgrade head
@@ -247,8 +247,8 @@ To roll back to a prior release, pin `IMAGE_TAG` to any previous SHA tag before 
 
 # 2. Pin IMAGE_TAG and restart services
 export IMAGE_TAG=sha-abc1234
-docker compose pull backend celery-worker celery-beat live-scanner flower frontend backlog-scheduler
-docker compose up -d backend celery-worker celery-beat live-scanner flower frontend backlog-scheduler
+docker compose pull backend celery-worker celery-beat live-scanner flower frontend
+docker compose up -d backend celery-worker celery-beat live-scanner flower frontend
 ```
 
 If the rollback target is behind a database migration, roll back the schema first:

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -51,7 +51,7 @@ Dark Factory memory entries carry `project:` and `agentId:` tags:
 
 Today, `dark-factory-validate.md` and `dark-factory-conformance.md` do not read memory at all, so no leak is possible. When a validation or security agent begins reading memory, a follow-up ticket must add an `allow_agent_ids=` parameter to `load_memory()` that filters by `agentId:` at load time. Until that ticket is implemented, validation/security agents must not call `load_memory()`.
 
-Role ID constants are defined in `dark-factory/scripts/agent_roles.sh`. The current 13 stable roles are:
+Role ID constants are defined in [`scripts/agent_roles.sh`](https://github.com/omniscient/dark-factory/blob/main/scripts/agent_roles.sh) in the dark-factory repo. The current 13 stable roles are:
 
 | Constant | Value |
 |---|---|

--- a/docs/ai-development.md
+++ b/docs/ai-development.md
@@ -121,39 +121,15 @@ You're ready. Pick an issue from the [backlog](https://github.com/omniscient/mar
 
 ## Dark Factory (Autonomous Docker Development)
 
-An isolated Docker container that autonomously develops features from GitHub issues. Runs Claude Code inside a sandboxed environment with no host access. Preview stacks and the dark-factory container deliberately omit `docker-compose.override.yml` and always run baked images — do not rely on bind-mount behavior in autonomous workflows.
+> **The Dark Factory has been extracted to its own repo: [omniscient/dark-factory](https://github.com/omniscient/dark-factory).** The scheduler, Dockerfile, entrypoint, bench suite, and all harness code live there. This repo carries only the target-side adapter (`.factory/`) and agent memory (`.archon/memory/`).
+
+The factory is an isolated Docker container that autonomously develops features from GitHub issues — running Claude Code in a sandboxed environment with its own preview stacks per issue.
 
 ### Quick Start
 
-```bash
-# Build the dark factory image (first time only)
-docker compose --profile factory build dark-factory
+See the standalone factory repo for setup and operation: [`omniscient/dark-factory — deploy/`](https://github.com/omniscient/dark-factory/tree/main/deploy)
 
-# Start a new feature from a GitHub issue
-docker compose --profile factory run --rm dark-factory "Fix issue #3"
-
-# Iterate after reviewing the preview and leaving feedback
-docker compose --profile factory run --rm dark-factory "Continue issue #3"
-
-# Tear down preview and merge when satisfied
-docker compose --profile factory run --rm dark-factory "Close issue #3"
-```
-
-### Prerequisites
-
-Add to `.archon/.env` (not `.env` — keep AI credentials separate):
-```
-# Option A: Use your Claude Max subscription (recommended — no per-token cost)
-# Generate with: claude setup-token
-CLAUDE_CODE_OAUTH_TOKEN=<token-from-setup-token>
-
-# Option B: Use Anthropic API key (pay-per-token)
-# ANTHROPIC_API_KEY=sk-ant-...
-
-GH_TOKEN=ghp_...
-```
-
-The `GH_TOKEN` should be a fine-grained PAT scoped to `omniscient/markethawk` with `repo` permissions.
+The MarketHawk-specific instance config lives at `deploy/instances/markethawk/instance.env` in that repo.
 
 ### Preview Environments
 
@@ -161,13 +137,9 @@ Each issue gets its own preview stack on deterministic ports:
 - Frontend: `http://localhost:1{NN}33` (e.g. `:10333` for issue #3)
 - Backend: `http://localhost:1{NN}80` (e.g. `:10380` for issue #3)
 
-Preview URLs are included in the PR body. The preview persists after the factory exits so you can browse and test.
-
-### Architecture
-
-See [dark factory design spec](archive/2026-05-02-dark-factory-design.md) for the full architecture, security model, and container topology.
+Preview URLs are included in the PR body. The `docker-socket-proxy-factory` and `buildkit` services in this repo's `docker-compose.yml` remain in place to support preview builds on this host.
 
 ### Memory
 
-- **Memory contract** — stable schema, lifecycle, and writer-role rules: [`docs/agents/dark-factory-memory-contract.md`](agents/dark-factory-memory-contract.md)
-- **Memory v2 operator guide** — rollout, fallback, maintenance, security: [`docs/agents/dark-factory-memory-v2.md`](agents/dark-factory-memory-v2.md)
+- **Memory contract** — stable schema, lifecycle, and writer-role rules: [omniscient/dark-factory — docs/dark-factory-memory-contract.md](https://github.com/omniscient/dark-factory/blob/main/docs/dark-factory-memory-contract.md)
+- **Memory v2 operator guide** — rollout, fallback, maintenance: [omniscient/dark-factory — docs/dark-factory-memory-v2.md](https://github.com/omniscient/dark-factory/blob/main/docs/dark-factory-memory-v2.md)


### PR DESCRIPTION
Update cross-links and commands that still pointed to the in-repo factory after extraction to omniscient/dark-factory (#790).

**ARCHITECTURE.md**
- Collapse `factory-network` Mermaid subgraph to just the infrastructure that remains (proxy + buildkit); `dark-factory` and `backlog-scheduler` nodes removed (they run externally)
- Update container-users table: `markethawk-dark-factory` row now points to the standalone repo

**DEVELOPMENT.md**
- Remove `backlog-scheduler` from bind-mount override list (service no longer in this compose file)
- Redirect the Dark Factory Eval Flywheel section: `evals/factory-failures.jsonl` now lives in dark-factory; replace file-path commands with the `gh issue list --label factory-regression` query

**deployment-guide.md**
- Correct image count (2 not 3) and remove `backlog-scheduler` from both `docker compose pull/up` command blocks

**docs/ai-development.md**
- Replace in-repo Quick Start docker compose commands with a pointer to `omniscient/dark-factory deploy/`
- Update memory doc links to the canonical copies in the factory repo

**docs/agents/domain.md**
- Repoint `dark-factory/scripts/agent_roles.sh` path to the live file in the factory repo

Part of #799.